### PR TITLE
System audio capture with echo cancellation for meetings

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -61,7 +61,9 @@ A polished, privacy-first desktop application for local speech-to-text transcrip
 ### Audio
 | Component | Technology | Version | Purpose |
 |-----------|-----------|---------|---------|
-| Audio capture | cpal | 0.15.x | Microphone capture on macOS; system audio via BlackHole virtual device workaround |
+| Audio capture | cpal | 0.15.x | Microphone capture on macOS |
+| System audio capture | objc2-core-audio | 0.3.x | Core Audio process tap (macOS 14.4+) — native capture of all process output, no virtual device |
+| Echo cancellation | sonora | 0.1.x | Pure-Rust WebRTC AEC3; cancels speaker leakage from the mic during meetings |
 | Resampling | rubato | 0.15+ | High-quality resample to 24kHz mono f32 (Mimi/Kyutai requirement) |
 | Audio I/O | hound | 3.5+ | WAV debug capture / offline inspection |
 | VAD / end-of-turn | Kyutai semantic VAD heads | via moshi | Built-in end-of-turn scoring from the model |
@@ -348,11 +350,42 @@ Reference implementation: https://github.com/kyutai-labs/delayed-streams-modelin
   - users can re-run summarization on an existing meeting with a different model
 
 **Current technical limitations**
-- System audio capture is still not true native CoreAudio loopback; the practical workaround is selecting BlackHole as the input device.
 - The session-boundary fix is validated manually, not yet by an automated regression or soak test.
 - Summary quality still depends heavily on using a proper text-generation model in Ollama.
 
-### 3.7 Engine Actor Refactor (2026-06-11)
+### 3.7 Native system-audio capture for meetings (2026-06-12)
+
+Meeting mode now captures two audio sources with zero user configuration — no
+more Audio MIDI Setup aggregate devices or BlackHole:
+
+- **Microphone**: unchanged cpal capture.
+- **System audio**: a mono global Core Audio process tap (macOS 14.4+,
+  `CATapDescription` + `AudioHardwareCreateProcessTap`) wrapped in a private,
+  programmatically created aggregate device whose IOProc delivers the mixed
+  output of all processes. Requires the "System Audio Recording Only" TCC
+  permission (`NSAudioCaptureUsageDescription` in `Info.plist`); the prompt
+  fires on first tap creation. Denial or any tap failure degrades gracefully
+  to mic-only and surfaces a `SystemAudioStatus` event to the UI.
+
+**Topology** (`audio/mixer.rs`): both real-time callbacks (cpal, tap IOProc)
+only push raw samples into lock-free SPSC rings. While a meeting is active the
+audio thread's command loop switches from blocking `recv()` to a 5ms
+`recv_timeout()` tick that drives `MeetingMixer`: resample both legs to 48kHz,
+pair into 10ms frames (mic paces; missing tap = zeros), optional AEC, sum +
+clamp, resample to the engine rate, and forward `AudioMessage::Chunk` exactly
+as before — the engine actor and EndOfStream drain contract are untouched.
+Dictation keeps the original direct-callback path.
+
+**Echo cancellation** (`audio/aec.rs`): when the default output routes to the
+built-in speakers (transport `BuiltIn` + data source `'ispk'`), the tap leg is
+fed to a WebRTC AEC3 (`sonora`) as the render signal and the mic leg is
+processed as capture, so remote participants played out loud are not
+transcribed twice. With headphones the AEC is skipped entirely. The meeting
+tick re-checks the output route every ~2s, rebuilding the tap when the default
+output device changes and toggling AEC on speaker/headphone switches. Tap
+drift against the mic clock is bounded by dropping tap lead beyond 250ms.
+
+### 3.8 Engine Actor Refactor (2026-06-11)
 
 **Why:** adding the second engine (Whisper) and the Silero VAD filter exposed
 two failure classes. (1) The pipeline could silently stop transcribing: the
@@ -404,7 +437,7 @@ threads with manual ordering) kept the hazard alive for every new engine.
 **Trigger:** Manual start from app window or tray menu
 **Flow:**
 1. User selects "Start Meeting Recording" from tray menu or app window
-2. Audio capture starts from the currently selected input device (microphone, or BlackHole if the user wants system audio)
+2. Audio capture starts from the currently selected input device, plus a native system-audio tap (Core Audio process tap, macOS 14.4+) mixed in — capturing Teams/Zoom output with zero configuration
 3. Audio is streamed through the same persistent Kyutai inference pipeline used by dictation
 4. Live transcript segments are shown in the Recordings view while the meeting is active
 5. Tray icon shows "recording meeting" state (pulsing indicator)
@@ -698,7 +731,7 @@ Built with Tauri, Candle, and open-source technologies."
 
 ### Phase 3: Polish & Features (Target: 2 weeks) ✅ COMPLETE
 - [x] Dictation mode: auto-paste via clipboard + Cmd+V simulation
-- [x] Meeting recording mode: mic recording with live transcription (system audio deferred — BlackHole workaround documented)
+- [x] Meeting recording mode: mic recording with live transcription (native system-audio capture added 2026-06-12 via Core Audio process tap)
 - [x] Meeting transcript storage and history view (later migrated from JSON to SQLite in Phase 4)
 - [x] Ollama integration for meeting summarization (streaming)
 - [x] Settings UI: audio device, auto-paste, Ollama config, theme
@@ -797,7 +830,7 @@ Built with Tauri, Candle, and open-source technologies."
 **Distribution strategy: Direct website + notarized DMG (not App Store)**
 
 App Store is not viable for Souffle — sandboxing restrictions conflict with core features:
-- System audio capture (BlackHole virtual device workaround blocked in sandbox)
+- System audio capture via Core Audio process taps (TCC-gated, hostile to sandbox review)
 - Accessibility permission for auto-paste (`enigo` Cmd+V simulation) — gray area in App Store review
 - Global shortcuts outside the app window
 - Localhost network access to Ollama (`localhost:11434`) needs entitlement justification
@@ -1102,7 +1135,8 @@ Benefits ALL engines (Whisper, Kyutai, future Parakeet).
 |------|--------|------------|------------|
 | Candle Metal perf on M4 Pro insufficient for real-time 1B model | Critical | Medium | **Validate in Phase 2 ASAP.** Fallback: Whisper via whisper-rs (proven). Candle Metal is less optimized than whisper.cpp Metal. |
 | Kyutai stt-rs is demo-quality, not production-ready | High | Medium | Budget extra time to harden. Isolate in engine trait so replacement is cheap. |
-| Native CoreAudio loopback / system-audio capture on macOS remains fragile | High | Low | Current workaround is BlackHole as the selected input device. Longer-term fallback: ScreenCaptureKit or a different capture backend. |
+| ~~Native CoreAudio loopback / system-audio capture on macOS remains fragile~~ | ~~High~~ | ~~Low~~ | ✅ **Resolved on 2026-06-12**: native Core Audio process tap + programmatic aggregate device (macOS 14.4+), with mic-only graceful degradation. Fallback if needed: ScreenCaptureKit. |
+| sonora (pure-Rust WebRTC AEC3) is v0.1 and may have quality gaps | Medium | Medium | Isolated behind `audio/aec.rs` wrapper; drop-in fallback is the C++-backed `webrtc-audio-processing` crate. |
 | ~~Multi-session transcription leaked/contaminated audio between sessions~~ | ~~Critical~~ | ~~High~~ | ✅ **Resolved on 2026-03-19**: session-tagged audio chunks, callback-level `active_session_id` gating, stale-queue draining, serialized reset/start ordering, and clean Kyutai/Metal state rebuild. Add soak tests later. |
 | ~~Mimi codec sample rate mismatch~~ | ~~Medium~~ | ~~Medium~~ | ✅ **Resolved in Phase 2**: Confirmed 24kHz. Pipeline updated from 16kHz to 24kHz. |
 | macOS notarization rejects binary with Candle Metal shaders | Medium | Low | Test notarization early in Phase 2, not Phase 4. |
@@ -1121,7 +1155,11 @@ voxtral/
       lib.rs               # Re-exports
       audio/
         mod.rs             # Audio module exports
-        capture.rs         # cpal microphone + system audio capture
+        capture.rs         # cpal microphone capture + meeting mixer tick loop
+        system_tap.rs      # Core Audio process tap (system audio, macOS 14.4+)
+        mixer.rs           # Two-source meeting mixer (mic + system audio)
+        aec.rs             # Echo cancellation wrapper (sonora / WebRTC AEC3)
+        output_route.rs    # Default-output route detection (speakers vs headphones)
         resampler.rs       # rubato wrapper
       db/
         mod.rs             # SQLite database entry point

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1030,6 +1030,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,6 +1341,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -3911,6 +3921,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "block2 0.6.2",
+ "dispatch2",
+ "libc",
+ "objc2 0.6.4",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+]
+
+[[package]]
 name = "objc2-core-data"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3929,7 +3964,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
  "dispatch2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -5220,6 +5257,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ringbuf"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3ecbcab081b935fb9c618b07654924f27686b4aac8818e700580a83eedcb7f"
+dependencies = [
+ "crossbeam-utils",
+ "portable-atomic",
+ "portable-atomic-util",
+]
+
+[[package]]
 name = "ringbuffer"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5791,7 +5839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -5891,6 +5939,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "sonora"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "559f6011d42721f7b4599ef4cf3224ac07539ee5bc25967169701c7aeb6c6bb1"
+dependencies = [
+ "sonora-aec3",
+ "sonora-agc2",
+ "sonora-common-audio",
+ "sonora-ns",
+ "sonora-simd",
+ "tracing",
+]
+
+[[package]]
+name = "sonora-aec3"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65d8b7e53b058aa4631cf2a8f483bd7a0dec093aa413d21b44b86d5704deedeb"
+dependencies = [
+ "sonora-common-audio",
+ "sonora-fft",
+ "sonora-simd",
+]
+
+[[package]]
+name = "sonora-agc2"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "132876fc38c4e191dee939a38243df5eb5830cd29f1d1ac9a67377389d74a10e"
+dependencies = [
+ "bytemuck",
+ "derive_more 2.1.1",
+ "sonora-common-audio",
+ "sonora-fft",
+ "sonora-simd",
+ "tracing",
+]
+
+[[package]]
+name = "sonora-common-audio"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a16fa975fe4aa12e4d980d5453452bd3e6df2b33abfb89840e1757ebd212e6"
+dependencies = [
+ "derive_more 2.1.1",
+ "sonora-simd",
+]
+
+[[package]]
+name = "sonora-fft"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cca158c4b6ace2cb3f4fa8084842da2b4ffcc25cf8ac4366675aea541aabc6af"
+
+[[package]]
+name = "sonora-ns"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc549f9bca1d60e7a2483e4949e9649467c5cca371a4341e44aaf24dae338fd4"
+dependencies = [
+ "sonora-fft",
+]
+
+[[package]]
+name = "sonora-simd"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a053f93cc01f4e1cc51c61844a196b6d1da7e054cdd406d2cd27677ba4d898e0"
+dependencies = [
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "souffle"
 version = "0.1.0"
 dependencies = [
@@ -5909,10 +6030,16 @@ dependencies = [
  "log",
  "memmap2",
  "moshi",
+ "objc2 0.6.4",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
  "ort",
  "parakeet-rs",
  "regex",
  "reqwest 0.12.28",
+ "ringbuf",
  "rubato",
  "rusqlite",
  "safetensors 0.7.0",
@@ -5920,6 +6047,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sonora",
  "specta",
  "specta-typescript",
  "strsim",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6016,6 +6016,7 @@ name = "souffle"
 version = "0.1.0"
 dependencies = [
  "arboard",
+ "block2 0.6.2",
  "candle-core",
  "candle-nn",
  "candle-transformers",
@@ -6023,6 +6024,7 @@ dependencies = [
  "cpal",
  "crossbeam-channel",
  "dirs-next",
+ "dispatch2",
  "enigo",
  "futures-util",
  "hf-hub",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -72,6 +72,15 @@ regex = "1"
 arboard = "3"
 enigo = { version = "0.3", features = ["serde"] }
 
+# System audio capture via Core Audio process taps (macOS 14.4+) + echo cancellation
+objc2 = "0.6"
+objc2-foundation = "0.3"
+objc2-core-foundation = "0.3"
+objc2-core-audio = "0.3"
+objc2-core-audio-types = "0.3"
+ringbuf = "0.5"
+sonora = "0.1"
+
 [dev-dependencies]
 tempfile = "3"
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -80,6 +80,8 @@ objc2-core-audio = "0.3"
 objc2-core-audio-types = "0.3"
 ringbuf = "0.5"
 sonora = "0.1"
+block2 = "0.6"
+dispatch2 = "0.3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Soufflé uses the microphone to transcribe your voice for dictation and meeting notes.</string>
+	<key>NSAudioCaptureUsageDescription</key>
+	<string>Soufflé captures system audio during meeting recordings to transcribe the other participants.</string>
+</dict>
+</plist>

--- a/src-tauri/src/app_events.rs
+++ b/src-tauri/src/app_events.rs
@@ -66,3 +66,13 @@ pub struct PipelineError {
     pub scope: PipelineErrorScope,
     pub message: String,
 }
+
+/// State of the system-audio capture leg of a meeting session, emitted when
+/// the session starts and whenever the leg changes (e.g. tap rebuild after
+/// an output device switch).
+#[derive(Debug, Clone, Serialize, Deserialize, Type, Event)]
+pub struct SystemAudioStatus {
+    pub active: bool,
+    /// Present when inactive because of an error (e.g. permission denied).
+    pub reason: Option<String>,
+}

--- a/src-tauri/src/audio/aec.rs
+++ b/src-tauri/src/audio/aec.rs
@@ -1,0 +1,111 @@
+//! Acoustic echo cancellation for meeting mode.
+//!
+//! When the user plays meeting audio through the built-in speakers, the
+//! other participants' voices re-enter the microphone and would be
+//! transcribed twice. The system-audio tap gives us the exact far-end
+//! (render) signal, so a WebRTC-style AEC can subtract it from the mic.
+//!
+//! Thin wrapper around `sonora` (pure-Rust port of the WebRTC audio
+//! processing module) so the backend can be swapped without touching the
+//! mixer. Works on 10ms mono frames at the mixer rate.
+
+use sonora::config::EchoCanceller;
+use sonora::{AudioProcessing, Config, StreamConfig};
+
+pub struct Aec {
+    apm: AudioProcessing,
+    /// 10ms at the configured sample rate.
+    frame_len: usize,
+    render_out: Vec<f32>,
+}
+
+impl Aec {
+    pub fn new(sample_rate: u32) -> Self {
+        let stream = StreamConfig::new(sample_rate, 1);
+        let apm = AudioProcessing::builder()
+            .config(Config {
+                echo_canceller: Some(EchoCanceller::default()),
+                ..Config::default()
+            })
+            .capture_config(stream)
+            .render_config(stream)
+            .build();
+        let frame_len = sample_rate as usize / 100;
+        Self {
+            apm,
+            frame_len,
+            render_out: vec![0.0; frame_len],
+        }
+    }
+
+    /// Feed a 10ms far-end frame (the system audio about to leave the
+    /// speakers). Must be called before the capture frame of the same tick.
+    pub fn process_render(&mut self, frame: &[f32]) {
+        debug_assert_eq!(frame.len(), self.frame_len);
+        let _ = self
+            .apm
+            .process_render_f32(&[frame], &mut [&mut self.render_out]);
+    }
+
+    /// Remove the echo of previously-rendered audio from a 10ms mic frame,
+    /// in place.
+    pub fn process_capture(&mut self, frame: &mut [f32]) {
+        debug_assert_eq!(frame.len(), self.frame_len);
+        let mut out = vec![0.0; self.frame_len];
+        if self
+            .apm
+            .process_capture_f32(&[frame], &mut [&mut out])
+            .is_ok()
+        {
+            frame.copy_from_slice(&out);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The far-end signal leaking into the mic with a small delay must come
+    /// out attenuated once the canceller has converged.
+    #[test]
+    fn attenuates_far_end_leakage() {
+        let rate = 48_000u32;
+        let frame = rate as usize / 100;
+        let mut aec = Aec::new(rate);
+
+        // 2s of a 440Hz tone as far-end; mic hears it scaled, delayed 30ms.
+        let tone: Vec<f32> = (0..rate as usize * 2)
+            .map(|i| (i as f32 * 440.0 * std::f32::consts::TAU / rate as f32).sin() * 0.5)
+            .collect();
+        let delay = rate as usize * 30 / 1000;
+
+        let mut leaked_energy_early = 0.0f32;
+        let mut leaked_energy_late = 0.0f32;
+        let total_frames = tone.len() / frame;
+        for f in 0..total_frames {
+            let start = f * frame;
+            aec.process_render(&tone[start..start + frame]);
+
+            let mut mic: Vec<f32> = (0..frame)
+                .map(|i| {
+                    let idx = start + i;
+                    if idx >= delay { tone[idx - delay] * 0.3 } else { 0.0 }
+                })
+                .collect();
+            aec.process_capture(&mut mic);
+
+            let energy: f32 = mic.iter().map(|s| s * s).sum();
+            if f < total_frames / 4 {
+                leaked_energy_early += energy;
+            } else if f >= total_frames * 3 / 4 {
+                leaked_energy_late += energy;
+            }
+        }
+
+        assert!(
+            leaked_energy_late < leaked_energy_early * 0.2,
+            "echo should converge: early={leaked_energy_early}, late={leaked_energy_late}"
+        );
+    }
+}

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -54,49 +54,22 @@ struct MeetingState {
     session_id: u64,
     mixer: MeetingMixer,
     /// None when tap creation failed — the mixer then runs mic-only.
+    /// The tap itself lives on its own thread; dropping the handle tears
+    /// it down without blocking this thread. Its aggregate references no
+    /// physical device, so output-device changes don't require a rebuild.
     #[cfg(target_os = "macos")]
-    tap: Option<super::system_tap::SystemTap>,
-    /// UID of the output device the tap's aggregate is built on; when the
-    /// default output changes, the tap must be rebuilt.
-    #[cfg(target_os = "macos")]
-    output_uid: Option<String>,
+    tap: Option<super::system_tap::TapHandle>,
     /// Whether echo cancellation is currently engaged (speakers route).
     aec_active: bool,
     ticks: u32,
 }
 
 impl MeetingState {
-    /// React to default-output route changes: rebuild the tap when the
-    /// device itself changed (its aggregate is clocked on the old device),
-    /// and engage/disengage echo cancellation when switching between
-    /// speakers and headphones.
+    /// Engage/disengage echo cancellation when the default output switches
+    /// between built-in speakers and anything else (headphones, Bluetooth…).
     #[cfg(target_os = "macos")]
-    fn check_output_route(&mut self, app: Option<&tauri::AppHandle>) {
-        use super::{aec, mixer, output_route, system_tap};
-
-        let current_uid = output_route::default_output_device()
-            .and_then(output_route::device_uid)
-            .ok();
-
-        if self.tap.is_some() && current_uid != self.output_uid {
-            info!("Default output device changed — rebuilding system audio tap");
-            self.tap.take();
-            let (tap_prod, tap_cons) =
-                HeapRb::<f32>::new(mixer::MIX_RATE as usize * 2).split();
-            match system_tap::SystemTap::start(tap_prod) {
-                Ok(tap) => {
-                    let rate = tap.sample_rate() as u32;
-                    self.mixer.replace_tap(tap_cons, rate);
-                    self.tap = Some(tap);
-                    emit_system_audio_status(app, true, None);
-                }
-                Err(e) => {
-                    warn!("Tap rebuild failed, continuing mic-only: {e}");
-                    emit_system_audio_status(app, false, Some(e));
-                }
-            }
-            self.output_uid = current_uid;
-        }
+    fn check_output_route(&mut self, _app: Option<&tauri::AppHandle>) {
+        use super::{aec, mixer, output_route};
 
         let speakers = self.tap.is_some() && output_route::output_is_builtin_speakers();
         if speakers != self.aec_active {
@@ -467,54 +440,8 @@ impl AudioCapture {
         let (mut mic_prod, mic_cons) = HeapRb::<f32>::new(mic_capacity).split();
         let (tap_prod, tap_cons) = HeapRb::<f32>::new(super::mixer::MIX_RATE as usize * 2).split();
 
-        #[cfg(target_os = "macos")]
-        let (tap, tap_rate) = match super::system_tap::SystemTap::start(tap_prod) {
-            Ok(tap) => {
-                let rate = tap.sample_rate() as u32;
-                emit_system_audio_status(self.app.as_ref(), true, None);
-                (Some(tap), rate)
-            }
-            Err(e) => {
-                warn!("System audio capture unavailable, recording mic only: {e}");
-                emit_system_audio_status(self.app.as_ref(), false, Some(e));
-                (None, super::mixer::MIX_RATE)
-            }
-        };
-        #[cfg(not(target_os = "macos"))]
-        let tap_rate = {
-            drop(tap_prod);
-            super::mixer::MIX_RATE
-        };
-
-        let mut mixer = MeetingMixer::new(
-            mic_cons,
-            sample_rate,
-            channels,
-            mic_gain,
-            tap_cons,
-            tap_rate,
-            target_sample_rate,
-        );
-
-        // Echo cancellation only matters when system audio can leak from
-        // the speakers back into the mic — and only if we actually have the
-        // system-audio reference signal to cancel against.
-        #[cfg(target_os = "macos")]
-        let (aec_active, output_uid) = {
-            let speakers =
-                tap.is_some() && super::output_route::output_is_builtin_speakers();
-            if speakers {
-                info!("Built-in speakers detected — echo cancellation engaged");
-                mixer.set_aec(Some(super::aec::Aec::new(super::mixer::MIX_RATE)));
-            }
-            let uid = super::output_route::default_output_device()
-                .and_then(super::output_route::device_uid)
-                .ok();
-            (speakers, uid)
-        };
-        #[cfg(not(target_os = "macos"))]
-        let aec_active = false;
-
+        // Mic stream first: it's the session's pacing clock and must never
+        // be held hostage by tap startup (see system_tap.rs module docs).
         let active_session_id = Arc::clone(&self.active_session_id);
         let stream_failed = Arc::clone(&self.stream_failed);
         let err_fn = move |err: cpal::StreamError| {
@@ -536,19 +463,63 @@ impl AudioCapture {
                 None,
             )
             .map_err(|e| format!("Failed to build input stream: {e}"))?;
-
-        self.active_session_id.store(session_id, Ordering::Release);
         stream
             .play()
             .map_err(|e| format!("Failed to start stream: {e}"))?;
+
+        #[cfg(target_os = "macos")]
+        let (tap, tap_rate) =
+            match super::system_tap::spawn_tap(tap_prod, Duration::from_secs(5)) {
+                Ok(tap) => {
+                    let rate = tap.sample_rate;
+                    emit_system_audio_status(self.app.as_ref(), true, None);
+                    (Some(tap), rate)
+                }
+                Err(e) => {
+                    warn!("System audio capture unavailable, recording mic only: {e}");
+                    emit_system_audio_status(self.app.as_ref(), false, Some(e));
+                    (None, super::mixer::MIX_RATE)
+                }
+            };
+        #[cfg(not(target_os = "macos"))]
+        let tap_rate = {
+            drop(tap_prod);
+            super::mixer::MIX_RATE
+        };
+
+        let mut mixer = MeetingMixer::new(
+            mic_cons,
+            sample_rate,
+            channels,
+            mic_gain,
+            tap_cons,
+            tap_rate,
+            target_sample_rate,
+        );
+
+        // Echo cancellation only matters when system audio can leak from
+        // the speakers back into the mic — and only if we actually have the
+        // system-audio reference signal to cancel against.
+        #[cfg(target_os = "macos")]
+        let aec_active = {
+            let speakers =
+                tap.is_some() && super::output_route::output_is_builtin_speakers();
+            if speakers {
+                info!("Built-in speakers detected — echo cancellation engaged");
+                mixer.set_aec(Some(super::aec::Aec::new(super::mixer::MIX_RATE)));
+            }
+            speakers
+        };
+        #[cfg(not(target_os = "macos"))]
+        let aec_active = false;
+
+        self.active_session_id.store(session_id, Ordering::Release);
         self.stream = Some(stream);
         self.meeting = Some(MeetingState {
             session_id,
             mixer,
             #[cfg(target_os = "macos")]
             tap,
-            #[cfg(target_os = "macos")]
-            output_uid,
             aec_active,
             ticks: 0,
         });

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -1,13 +1,30 @@
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{Device, SampleFormat, Stream, StreamConfig};
-use crossbeam_channel::{Receiver, Sender};
+use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
+use ringbuf::HeapRb;
+use ringbuf::traits::{Producer, Split};
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
 
+use super::mixer::MeetingMixer;
 use super::resampler::Resampler;
 use crate::state::AudioCommand;
+
+/// Mixer cadence while a meeting session is active. Rings hold ~2s, so the
+/// 5ms tick has plenty of slack; it only exists to pace the mixer, the
+/// real-time callbacks never wait on it.
+const MEETING_TICK: Duration = Duration::from_millis(5);
+
+/// Per-session state for meeting mode (mic + system audio).
+struct MeetingState {
+    session_id: u64,
+    mixer: MeetingMixer,
+    /// None when tap creation failed — the mixer then runs mic-only.
+    #[cfg(target_os = "macos")]
+    tap: Option<super::system_tap::SystemTap>,
+}
 
 #[derive(Debug, Clone)]
 pub struct AudioChunk {
@@ -77,6 +94,8 @@ pub struct AudioCapture {
     resampler: Option<Arc<Mutex<Resampler>>>,
     /// Counts chunks dropped because the audio channel was full.
     dropped_counter: Arc<AtomicU64>,
+    /// Active meeting-mode session (mic + system audio mixed on this thread).
+    meeting: Option<MeetingState>,
 }
 
 impl AudioCapture {
@@ -104,13 +123,41 @@ impl AudioCapture {
                     audio_rms,
                     resampler: None,
                     dropped_counter,
+                    meeting: None,
                 };
 
-                // Block on commands from main thread
-                while let Ok(cmd) = cmd_rx.recv() {
+                // Block on commands; while a meeting is active, wake every
+                // few ms to run the mixer instead.
+                loop {
+                    let cmd = if capture.meeting.is_some() {
+                        match cmd_rx.recv_timeout(MEETING_TICK) {
+                            Ok(cmd) => cmd,
+                            Err(RecvTimeoutError::Timeout) => {
+                                capture.meeting_tick();
+                                continue;
+                            }
+                            Err(RecvTimeoutError::Disconnected) => break,
+                        }
+                    } else {
+                        match cmd_rx.recv() {
+                            Ok(cmd) => cmd,
+                            Err(_) => break,
+                        }
+                    };
+
                     match cmd {
-                        AudioCommand::Start { session_id, target_sample_rate, mic_gain } => {
-                            if let Err(e) = capture.start(session_id, target_sample_rate, mic_gain) {
+                        AudioCommand::Start {
+                            session_id,
+                            target_sample_rate,
+                            mic_gain,
+                            capture_system_audio,
+                        } => {
+                            if let Err(e) = capture.start(
+                                session_id,
+                                target_sample_rate,
+                                mic_gain,
+                                capture_system_audio,
+                            ) {
                                 warn!("Failed to start audio capture: {e}");
                             }
                         }
@@ -154,10 +201,18 @@ impl AudioCapture {
             .ok_or_else(|| "No input device available".to_string())
     }
 
-    fn start(&mut self, session_id: u64, target_sample_rate: u32, mic_gain: f32) -> Result<(), String> {
-        // Ensure any previous callback stops emitting immediately.
+    fn start(
+        &mut self,
+        session_id: u64,
+        target_sample_rate: u32,
+        mic_gain: f32,
+        capture_system_audio: bool,
+    ) -> Result<(), String> {
+        // Ensure any previous callback stops emitting immediately, and tear
+        // down any leftover meeting state (tap included).
         self.active_session_id.store(0, Ordering::Release);
         self.stream.take();
+        self.meeting.take();
 
         let device = self.find_device()?;
 
@@ -169,6 +224,16 @@ impl AudioCapture {
         let channels = config.channels;
 
         info!("Audio config: {sample_rate}Hz, {channels}ch");
+
+        if capture_system_audio {
+            return self.start_meeting(
+                &device,
+                &config,
+                session_id,
+                target_sample_rate,
+                mic_gain,
+            );
+        }
 
         let resampler = Arc::new(Mutex::new(Resampler::new(
             sample_rate,
@@ -250,12 +315,153 @@ impl AudioCapture {
         Ok(())
     }
 
+    /// Meeting mode: the cpal callback only pushes raw samples into a ring
+    /// buffer; a system-audio tap fills a second ring; `meeting_tick()` on
+    /// this thread resamples, mixes, and forwards to the engine.
+    fn start_meeting(
+        &mut self,
+        device: &Device,
+        config: &StreamConfig,
+        session_id: u64,
+        target_sample_rate: u32,
+        mic_gain: f32,
+    ) -> Result<(), String> {
+        let sample_rate = config.sample_rate.0;
+        let channels = config.channels;
+
+        // ~2s of headroom per ring; the 5ms tick drains far faster.
+        let mic_capacity = (sample_rate as usize * channels as usize) * 2;
+        let (mut mic_prod, mic_cons) = HeapRb::<f32>::new(mic_capacity).split();
+        let (tap_prod, tap_cons) = HeapRb::<f32>::new(super::mixer::MIX_RATE as usize * 2).split();
+
+        #[cfg(target_os = "macos")]
+        let (tap, tap_rate) = match super::system_tap::SystemTap::start(tap_prod) {
+            Ok(tap) => {
+                let rate = tap.sample_rate() as u32;
+                (Some(tap), rate)
+            }
+            Err(e) => {
+                warn!("System audio capture unavailable, recording mic only: {e}");
+                (None, super::mixer::MIX_RATE)
+            }
+        };
+        #[cfg(not(target_os = "macos"))]
+        let tap_rate = {
+            drop(tap_prod);
+            super::mixer::MIX_RATE
+        };
+
+        let mixer = MeetingMixer::new(
+            mic_cons,
+            sample_rate,
+            channels,
+            mic_gain,
+            tap_cons,
+            tap_rate,
+            target_sample_rate,
+        );
+
+        let active_session_id = Arc::clone(&self.active_session_id);
+        let err_fn = |err: cpal::StreamError| {
+            error!("Audio stream error: {err}");
+        };
+        let stream = device
+            .build_input_stream(
+                config,
+                move |data: &[f32], _: &cpal::InputCallbackInfo| {
+                    if active_session_id.load(Ordering::Acquire) != session_id {
+                        return;
+                    }
+                    // Ring full means the mixer is wedged; losing mic samples
+                    // here is the only safe option in a realtime callback.
+                    let _ = mic_prod.push_slice(data);
+                },
+                err_fn,
+                None,
+            )
+            .map_err(|e| format!("Failed to build input stream: {e}"))?;
+
+        self.active_session_id.store(session_id, Ordering::Release);
+        stream
+            .play()
+            .map_err(|e| format!("Failed to start stream: {e}"))?;
+        self.stream = Some(stream);
+        self.meeting = Some(MeetingState {
+            session_id,
+            mixer,
+            #[cfg(target_os = "macos")]
+            tap,
+        });
+
+        info!("Meeting audio capture started (mic + system audio)");
+        Ok(())
+    }
+
+    /// Periodic mixer pump while a meeting session is active.
+    fn meeting_tick(&mut self) {
+        let Some(meeting) = self.meeting.as_mut() else {
+            return;
+        };
+        let samples = meeting.mixer.tick();
+        if samples.is_empty() {
+            return;
+        }
+
+        let sum_sq: f32 = samples.iter().map(|s| s * s).sum();
+        let rms = (sum_sq / samples.len() as f32).sqrt();
+        self.audio_rms
+            .store((rms * 8.0).min(1.0).to_bits(), Ordering::Relaxed);
+
+        if self
+            .audio_sender
+            .try_send(AudioMessage::Chunk(AudioChunk {
+                session_id: meeting.session_id,
+                samples,
+                captured_at: Instant::now(),
+            }))
+            .is_err()
+        {
+            let dropped = self.dropped_counter.fetch_add(1, Ordering::Relaxed) + 1;
+            if dropped == 1 || dropped.is_multiple_of(100) {
+                warn!("Audio buffer full, dropping samples ({dropped} chunks dropped this session)");
+            }
+        }
+    }
+
     fn stop(&mut self) {
         let session_id = self.active_session_id.swap(0, Ordering::AcqRel);
         self.audio_rms.store(0f32.to_bits(), Ordering::Relaxed);
 
         // Dropping the stream is synchronous — after this, no callback runs.
         let had_stream = self.stream.take().is_some();
+
+        if let Some(mut meeting) = self.meeting.take() {
+            // Tear down the tap first so its ring stops filling; then one
+            // final flush drains both rings and all resampler tails.
+            #[cfg(target_os = "macos")]
+            meeting.tap.take();
+
+            if session_id != 0 {
+                let tail = meeting.mixer.flush();
+                if !tail.is_empty() {
+                    let _ = self.audio_sender.send(AudioMessage::Chunk(AudioChunk {
+                        session_id,
+                        samples: tail,
+                        captured_at: Instant::now(),
+                    }));
+                }
+                let discarded = meeting.mixer.tap_discarded();
+                if discarded > 0 {
+                    warn!("Discarded {discarded} system-audio samples to bound drift");
+                }
+                self.send_end_of_stream(session_id);
+            }
+
+            if had_stream {
+                info!("Meeting audio capture stopped");
+            }
+            return;
+        }
 
         if session_id != 0 {
             // Flush the resampler's remaining partial chunk so the last
@@ -273,25 +479,29 @@ impl AudioCapture {
                 }
             }
 
-            // EndOfStream is the signal the actor's stop waits on. The actor
-            // is normally draining, so this sends immediately; the timeout
-            // only matters if no one is consuming (e.g. session aborted) —
-            // then we give up rather than wedge the audio thread, and the
-            // actor's own EOS-wait deadline covers the stop path.
-            if self
-                .audio_sender
-                .send_timeout(
-                    AudioMessage::EndOfStream { session_id },
-                    std::time::Duration::from_secs(1),
-                )
-                .is_err()
-            {
-                warn!("Could not deliver end-of-stream marker (channel full or closed)");
-            }
+            self.send_end_of_stream(session_id);
         }
 
         if had_stream {
             info!("Audio capture stopped");
+        }
+    }
+
+    /// EndOfStream is the signal the actor's stop waits on. The actor is
+    /// normally draining, so this sends immediately; the timeout only
+    /// matters if no one is consuming (e.g. session aborted) — then we give
+    /// up rather than wedge the audio thread, and the actor's own EOS-wait
+    /// deadline covers the stop path.
+    fn send_end_of_stream(&self, session_id: u64) {
+        if self
+            .audio_sender
+            .send_timeout(
+                AudioMessage::EndOfStream { session_id },
+                Duration::from_secs(1),
+            )
+            .is_err()
+        {
+            warn!("Could not deliver end-of-stream marker (channel full or closed)");
         }
     }
 

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -12,6 +12,14 @@ use super::mixer::MeetingMixer;
 use super::resampler::Resampler;
 use crate::state::AudioCommand;
 
+/// Tell the frontend whether the system-audio leg of a meeting is live.
+fn emit_system_audio_status(app: Option<&tauri::AppHandle>, active: bool, reason: Option<String>) {
+    use tauri_specta::Event;
+    if let Some(app) = app {
+        let _ = crate::app_events::SystemAudioStatus { active, reason }.emit(app);
+    }
+}
+
 /// Mixer cadence while a meeting session is active. Rings hold ~2s, so the
 /// 5ms tick has plenty of slack; it only exists to pace the mixer, the
 /// real-time callbacks never wait on it.
@@ -44,7 +52,7 @@ impl MeetingState {
     /// and engage/disengage echo cancellation when switching between
     /// speakers and headphones.
     #[cfg(target_os = "macos")]
-    fn check_output_route(&mut self) {
+    fn check_output_route(&mut self, app: Option<&tauri::AppHandle>) {
         use super::{aec, mixer, output_route, system_tap};
 
         let current_uid = output_route::default_output_device()
@@ -61,9 +69,11 @@ impl MeetingState {
                     let rate = tap.sample_rate() as u32;
                     self.mixer.replace_tap(tap_cons, rate);
                     self.tap = Some(tap);
+                    emit_system_audio_status(app, true, None);
                 }
                 Err(e) => {
                     warn!("Tap rebuild failed, continuing mic-only: {e}");
+                    emit_system_audio_status(app, false, Some(e));
                 }
             }
             self.output_uid = current_uid;
@@ -83,7 +93,7 @@ impl MeetingState {
     }
 
     #[cfg(not(target_os = "macos"))]
-    fn check_output_route(&mut self) {}
+    fn check_output_route(&mut self, _app: Option<&tauri::AppHandle>) {}
 }
 
 #[derive(Debug, Clone)]
@@ -156,6 +166,8 @@ pub struct AudioCapture {
     dropped_counter: Arc<AtomicU64>,
     /// Active meeting-mode session (mic + system audio mixed on this thread).
     meeting: Option<MeetingState>,
+    /// For emitting SystemAudioStatus events (set during app setup).
+    app: Option<tauri::AppHandle>,
 }
 
 impl AudioCapture {
@@ -184,6 +196,7 @@ impl AudioCapture {
                     resampler: None,
                     dropped_counter,
                     meeting: None,
+                    app: None,
                 };
 
                 // Block on commands; while a meeting is active, wake every
@@ -227,6 +240,9 @@ impl AudioCapture {
                         AudioCommand::SelectDevice(name) => {
                             info!("Selected input device: {name}");
                             capture.selected_device = Some(name);
+                        }
+                        AudioCommand::AttachApp(app) => {
+                            capture.app = Some(app);
                         }
                     }
                 }
@@ -398,10 +414,12 @@ impl AudioCapture {
         let (tap, tap_rate) = match super::system_tap::SystemTap::start(tap_prod) {
             Ok(tap) => {
                 let rate = tap.sample_rate() as u32;
+                emit_system_audio_status(self.app.as_ref(), true, None);
                 (Some(tap), rate)
             }
             Err(e) => {
                 warn!("System audio capture unavailable, recording mic only: {e}");
+                emit_system_audio_status(self.app.as_ref(), false, Some(e));
                 (None, super::mixer::MIX_RATE)
             }
         };
@@ -488,7 +506,7 @@ impl AudioCapture {
 
         meeting.ticks += 1;
         if meeting.ticks.is_multiple_of(ROUTE_CHECK_TICKS) {
-            meeting.check_output_route();
+            meeting.check_output_route(self.app.as_ref());
         }
 
         let samples = meeting.mixer.tick();

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -30,6 +30,25 @@ const MEETING_TICK: Duration = Duration::from_millis(5);
 /// polling keeps everything on this thread instead of a listener callback.
 const ROUTE_CHECK_TICKS: u32 = 400;
 
+/// Wake-up cadence during dictation sessions — only needed for mic health
+/// checks, so much coarser than the meeting tick.
+const DICTATION_TICK: Duration = Duration::from_millis(500);
+
+/// How often an active session verifies its input device is still alive and
+/// still the system default (closing the laptop lid switches the default
+/// input to a headset or webcam mic — the stream must follow it).
+const MIC_CHECK_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Everything needed to rebuild the capture leg mid-session when the input
+/// device fails or the default input changes.
+#[derive(Clone)]
+struct StartParams {
+    session_id: u64,
+    target_sample_rate: u32,
+    mic_gain: f32,
+    capture_system_audio: bool,
+}
+
 /// Per-session state for meeting mode (mic + system audio).
 struct MeetingState {
     session_id: u64,
@@ -168,6 +187,14 @@ pub struct AudioCapture {
     meeting: Option<MeetingState>,
     /// For emitting SystemAudioStatus events (set during app setup).
     app: Option<tauri::AppHandle>,
+    /// Parameters of the running session, kept for mid-session rebuilds.
+    active_params: Option<StartParams>,
+    /// Name of the input device the current stream was built on.
+    mic_device_name: Option<String>,
+    /// Set by the cpal error callback when the stream dies (e.g. its device
+    /// disappeared); the next mic health check rebuilds the capture leg.
+    stream_failed: Arc<std::sync::atomic::AtomicBool>,
+    last_mic_check: Instant,
 }
 
 impl AudioCapture {
@@ -197,16 +224,31 @@ impl AudioCapture {
                     dropped_counter,
                     meeting: None,
                     app: None,
+                    active_params: None,
+                    mic_device_name: None,
+                    stream_failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+                    last_mic_check: Instant::now(),
                 };
 
-                // Block on commands; while a meeting is active, wake every
-                // few ms to run the mixer instead.
+                // Block on commands while idle; during sessions, wake
+                // periodically to run the meeting mixer and mic health checks.
                 loop {
-                    let cmd = if capture.meeting.is_some() {
-                        match cmd_rx.recv_timeout(MEETING_TICK) {
+                    let timeout = if capture.meeting.is_some() {
+                        Some(MEETING_TICK)
+                    } else if capture.active_params.is_some() {
+                        Some(DICTATION_TICK)
+                    } else {
+                        None
+                    };
+                    let cmd = if let Some(timeout) = timeout {
+                        match cmd_rx.recv_timeout(timeout) {
                             Ok(cmd) => cmd,
                             Err(RecvTimeoutError::Timeout) => {
                                 capture.meeting_tick();
+                                if capture.last_mic_check.elapsed() >= MIC_CHECK_INTERVAL {
+                                    capture.last_mic_check = Instant::now();
+                                    capture.check_mic_health();
+                                }
                                 continue;
                             }
                             Err(RecvTimeoutError::Disconnected) => break,
@@ -290,10 +332,23 @@ impl AudioCapture {
         self.stream.take();
         self.meeting.take();
 
+        // Stored before any fallible step so a failed (re)build is retried
+        // by the next mic health check instead of killing the session.
+        self.active_params = Some(StartParams {
+            session_id,
+            target_sample_rate,
+            mic_gain,
+            capture_system_audio,
+        });
+        self.stream_failed
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+        self.mic_device_name = None;
+
         let device = self.find_device()?;
 
         let device_name = device.name().unwrap_or_else(|_| "Unknown".into());
         info!("Using input device: {device_name}");
+        self.mic_device_name = Some(device_name.clone());
 
         let config = Self::preferred_config(&device)?;
         let sample_rate = config.sample_rate.0;
@@ -323,8 +378,10 @@ impl AudioCapture {
         let rms_ref = Arc::clone(&self.audio_rms);
         let dropped_counter = Arc::clone(&self.dropped_counter);
 
-        let err_fn = |err: cpal::StreamError| {
+        let stream_failed = Arc::clone(&self.stream_failed);
+        let err_fn = move |err: cpal::StreamError| {
             error!("Audio stream error: {err}");
+            stream_failed.store(true, std::sync::atomic::Ordering::Relaxed);
         };
 
         // Reset the first-chunk logging flag for each new recording session
@@ -459,8 +516,10 @@ impl AudioCapture {
         let aec_active = false;
 
         let active_session_id = Arc::clone(&self.active_session_id);
-        let err_fn = |err: cpal::StreamError| {
+        let stream_failed = Arc::clone(&self.stream_failed);
+        let err_fn = move |err: cpal::StreamError| {
             error!("Audio stream error: {err}");
+            stream_failed.store(true, std::sync::atomic::Ordering::Relaxed);
         };
         let stream = device
             .build_input_stream(
@@ -496,6 +555,47 @@ impl AudioCapture {
 
         info!("Meeting audio capture started (mic + system audio)");
         Ok(())
+    }
+
+    /// Rebuild the capture leg when the stream died or the default input
+    /// device changed (lid closed, headset plugged in…). The session keeps
+    /// its id, so the engine actor sees one continuous stream; at most a
+    /// couple of seconds of audio are lost.
+    fn check_mic_health(&mut self) {
+        let Some(params) = self.active_params.clone() else {
+            return;
+        };
+
+        let failed = self
+            .stream_failed
+            .swap(false, std::sync::atomic::Ordering::Relaxed);
+
+        // Only follow the system default when the user hasn't pinned a
+        // device; a pinned device that vanishes surfaces as a stream error
+        // and falls back to the default on rebuild.
+        let default_changed = self.selected_device.is_none()
+            && self.mic_device_name.is_some()
+            && cpal::default_host()
+                .default_input_device()
+                .and_then(|d| d.name().ok())
+                != self.mic_device_name;
+
+        if !failed && !default_changed {
+            return;
+        }
+
+        info!(
+            "Input device {} — rebuilding audio capture",
+            if failed { "failed" } else { "changed" }
+        );
+        if let Err(e) = self.start(
+            params.session_id,
+            params.target_sample_rate,
+            params.mic_gain,
+            params.capture_system_audio,
+        ) {
+            warn!("Capture rebuild failed (will retry): {e}");
+        }
     }
 
     /// Periodic mixer pump while a meeting session is active.
@@ -536,8 +636,17 @@ impl AudioCapture {
     }
 
     fn stop(&mut self) {
-        let session_id = self.active_session_id.swap(0, Ordering::AcqRel);
+        let mut session_id = self.active_session_id.swap(0, Ordering::AcqRel);
+        // A session whose stream died mid-rebuild has id 0 in the atomic but
+        // still owes the actor its EndOfStream marker.
+        if session_id == 0
+            && let Some(params) = &self.active_params
+        {
+            session_id = params.session_id;
+        }
         self.audio_rms.store(0f32.to_bits(), Ordering::Relaxed);
+        self.active_params = None;
+        self.mic_device_name = None;
 
         // Dropping the stream is synchronous — after this, no callback runs.
         let had_stream = self.stream.take().is_some();

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -17,6 +17,11 @@ use crate::state::AudioCommand;
 /// real-time callbacks never wait on it.
 const MEETING_TICK: Duration = Duration::from_millis(5);
 
+/// How often the meeting tick re-checks the default output route
+/// (~2s at the 5ms tick). Property reads are a handful of cheap HAL calls;
+/// polling keeps everything on this thread instead of a listener callback.
+const ROUTE_CHECK_TICKS: u32 = 400;
+
 /// Per-session state for meeting mode (mic + system audio).
 struct MeetingState {
     session_id: u64,
@@ -24,6 +29,61 @@ struct MeetingState {
     /// None when tap creation failed — the mixer then runs mic-only.
     #[cfg(target_os = "macos")]
     tap: Option<super::system_tap::SystemTap>,
+    /// UID of the output device the tap's aggregate is built on; when the
+    /// default output changes, the tap must be rebuilt.
+    #[cfg(target_os = "macos")]
+    output_uid: Option<String>,
+    /// Whether echo cancellation is currently engaged (speakers route).
+    aec_active: bool,
+    ticks: u32,
+}
+
+impl MeetingState {
+    /// React to default-output route changes: rebuild the tap when the
+    /// device itself changed (its aggregate is clocked on the old device),
+    /// and engage/disengage echo cancellation when switching between
+    /// speakers and headphones.
+    #[cfg(target_os = "macos")]
+    fn check_output_route(&mut self) {
+        use super::{aec, mixer, output_route, system_tap};
+
+        let current_uid = output_route::default_output_device()
+            .and_then(output_route::device_uid)
+            .ok();
+
+        if self.tap.is_some() && current_uid != self.output_uid {
+            info!("Default output device changed — rebuilding system audio tap");
+            self.tap.take();
+            let (tap_prod, tap_cons) =
+                HeapRb::<f32>::new(mixer::MIX_RATE as usize * 2).split();
+            match system_tap::SystemTap::start(tap_prod) {
+                Ok(tap) => {
+                    let rate = tap.sample_rate() as u32;
+                    self.mixer.replace_tap(tap_cons, rate);
+                    self.tap = Some(tap);
+                }
+                Err(e) => {
+                    warn!("Tap rebuild failed, continuing mic-only: {e}");
+                }
+            }
+            self.output_uid = current_uid;
+        }
+
+        let speakers = self.tap.is_some() && output_route::output_is_builtin_speakers();
+        if speakers != self.aec_active {
+            if speakers {
+                info!("Output switched to built-in speakers — echo cancellation engaged");
+                self.mixer.set_aec(Some(aec::Aec::new(mixer::MIX_RATE)));
+            } else {
+                info!("Output no longer on speakers — echo cancellation disengaged");
+                self.mixer.set_aec(None);
+            }
+            self.aec_active = speakers;
+        }
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    fn check_output_route(&mut self) {}
 }
 
 #[derive(Debug, Clone)]
@@ -351,7 +411,7 @@ impl AudioCapture {
             super::mixer::MIX_RATE
         };
 
-        let mixer = MeetingMixer::new(
+        let mut mixer = MeetingMixer::new(
             mic_cons,
             sample_rate,
             channels,
@@ -360,6 +420,25 @@ impl AudioCapture {
             tap_rate,
             target_sample_rate,
         );
+
+        // Echo cancellation only matters when system audio can leak from
+        // the speakers back into the mic — and only if we actually have the
+        // system-audio reference signal to cancel against.
+        #[cfg(target_os = "macos")]
+        let (aec_active, output_uid) = {
+            let speakers =
+                tap.is_some() && super::output_route::output_is_builtin_speakers();
+            if speakers {
+                info!("Built-in speakers detected — echo cancellation engaged");
+                mixer.set_aec(Some(super::aec::Aec::new(super::mixer::MIX_RATE)));
+            }
+            let uid = super::output_route::default_output_device()
+                .and_then(super::output_route::device_uid)
+                .ok();
+            (speakers, uid)
+        };
+        #[cfg(not(target_os = "macos"))]
+        let aec_active = false;
 
         let active_session_id = Arc::clone(&self.active_session_id);
         let err_fn = |err: cpal::StreamError| {
@@ -391,6 +470,10 @@ impl AudioCapture {
             mixer,
             #[cfg(target_os = "macos")]
             tap,
+            #[cfg(target_os = "macos")]
+            output_uid,
+            aec_active,
+            ticks: 0,
         });
 
         info!("Meeting audio capture started (mic + system audio)");
@@ -402,6 +485,12 @@ impl AudioCapture {
         let Some(meeting) = self.meeting.as_mut() else {
             return;
         };
+
+        meeting.ticks += 1;
+        if meeting.ticks.is_multiple_of(ROUTE_CHECK_TICKS) {
+            meeting.check_output_route();
+        }
+
         let samples = meeting.mixer.tick();
         if samples.is_empty() {
             return;

--- a/src-tauri/src/audio/mixer.rs
+++ b/src-tauri/src/audio/mixer.rs
@@ -1,0 +1,249 @@
+//! Two-source mixer for meeting mode: microphone + system audio.
+//!
+//! Real-time callbacks (cpal, tap IOProc) only push raw samples into SPSC
+//! ring buffers; this mixer runs on the audio-capture thread's tick and does
+//! everything else: resample both sources to a common 48kHz, pair them into
+//! 10ms frames (the unit echo cancellation works on), sum, and resample to
+//! the engine rate. The microphone is the pacing clock — when the system is
+//! silent or the tap is missing, its leg is just zeros, so mic-only is the
+//! natural degenerate case rather than an error path.
+
+use ringbuf::HeapCons;
+use ringbuf::traits::Consumer;
+
+use super::resampler::Resampler;
+
+/// Common processing rate; 48kHz matches the tap's native rate and is a
+/// supported AEC band split rate.
+pub const MIX_RATE: u32 = 48_000;
+/// 10ms at the mix rate.
+pub const FRAME_SAMPLES: usize = 480;
+/// How far the system-audio leg may run ahead of the mic before old samples
+/// are discarded. Bounds clock drift between the two devices; transcription
+/// tolerates the resulting sub-frame discontinuity.
+const MAX_TAP_LEAD_SAMPLES: usize = MIX_RATE as usize / 4;
+
+pub struct MeetingMixer {
+    mic: HeapCons<f32>,
+    tap: HeapCons<f32>,
+    mic_to_mix: Resampler,
+    tap_to_mix: Resampler,
+    to_engine: Resampler,
+    mic_fifo: Vec<f32>,
+    tap_fifo: Vec<f32>,
+    scratch: Vec<f32>,
+    /// Tap samples discarded to bound drift; logged at session end.
+    tap_discarded: u64,
+}
+
+impl MeetingMixer {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        mic: HeapCons<f32>,
+        mic_rate: u32,
+        mic_channels: u16,
+        mic_gain: f32,
+        tap: HeapCons<f32>,
+        tap_rate: u32,
+        engine_rate: u32,
+    ) -> Self {
+        Self {
+            mic,
+            tap,
+            // The mic gain is engine-specific amplification for voice input;
+            // the system-audio leg is already line-level, so it stays at 1.0.
+            mic_to_mix: Resampler::new(mic_rate, mic_channels, MIX_RATE, mic_gain),
+            tap_to_mix: Resampler::new(tap_rate, 1, MIX_RATE, 1.0),
+            to_engine: Resampler::new(MIX_RATE, 1, engine_rate, 1.0),
+            mic_fifo: Vec::new(),
+            tap_fifo: Vec::new(),
+            scratch: vec![0.0; 4096],
+            tap_discarded: 0,
+        }
+    }
+
+    /// Drain both rings, mix every complete 10ms frame, and return the
+    /// resulting engine-rate samples (possibly empty).
+    pub fn tick(&mut self) -> Vec<f32> {
+        self.ingest();
+
+        let mut out = Vec::new();
+        while self.mic_fifo.len() >= FRAME_SAMPLES {
+            let frame = self.mix_frame(FRAME_SAMPLES);
+            out.extend(self.to_engine.process(&frame));
+        }
+        out
+    }
+
+    /// Final drain when the session stops: both producers are gone, so
+    /// everything left in the rings, FIFOs, and resampler tails comes out.
+    pub fn flush(&mut self) -> Vec<f32> {
+        let mut out = self.tick();
+
+        let mic_tail = self.mic_to_mix.flush();
+        self.mic_fifo.extend(mic_tail);
+        let tap_tail = self.tap_to_mix.flush();
+        self.tap_fifo.extend(tap_tail);
+
+        while !self.mic_fifo.is_empty() {
+            let n = self.mic_fifo.len().min(FRAME_SAMPLES);
+            let frame = self.mix_frame(n);
+            out.extend(self.to_engine.process(&frame));
+        }
+        // Without a mic the remaining system audio still matters (e.g. the
+        // last words of a remote participant).
+        while !self.tap_fifo.is_empty() {
+            let n = self.tap_fifo.len().min(FRAME_SAMPLES);
+            let frame: Vec<f32> = self.tap_fifo.drain(..n).collect();
+            out.extend(self.to_engine.process(&frame));
+        }
+        out.extend(self.to_engine.flush());
+        out
+    }
+
+    pub fn tap_discarded(&self) -> u64 {
+        self.tap_discarded
+    }
+
+    fn ingest(&mut self) {
+        loop {
+            let n = self.mic.pop_slice(&mut self.scratch);
+            if n == 0 {
+                break;
+            }
+            let resampled = self.mic_to_mix.process(&self.scratch[..n]);
+            self.mic_fifo.extend(resampled);
+        }
+        loop {
+            let n = self.tap.pop_slice(&mut self.scratch);
+            if n == 0 {
+                break;
+            }
+            let resampled = self.tap_to_mix.process(&self.scratch[..n]);
+            self.tap_fifo.extend(resampled);
+        }
+
+        // Bound how far the tap leg can run ahead of the mic (clock drift,
+        // or a stalled mic device): drop the oldest excess.
+        let max_len = self.mic_fifo.len() + MAX_TAP_LEAD_SAMPLES;
+        if self.tap_fifo.len() > max_len {
+            let excess = self.tap_fifo.len() - max_len;
+            self.tap_fifo.drain(..excess);
+            self.tap_discarded += excess as u64;
+        }
+    }
+
+    /// Take `n` mic samples, sum the available tap samples over them
+    /// (zeros when the system is silent), clamp.
+    /// This is where echo cancellation will hook in: the tap frame is the
+    /// render (reference) signal, the mic frame is the capture signal.
+    fn mix_frame(&mut self, n: usize) -> Vec<f32> {
+        let mut frame: Vec<f32> = self.mic_fifo.drain(..n).collect();
+        let tap_n = n.min(self.tap_fifo.len());
+        for (sample, tap) in frame.iter_mut().zip(self.tap_fifo.drain(..tap_n)) {
+            *sample = (*sample + tap).clamp(-1.0, 1.0);
+        }
+        frame
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ringbuf::HeapRb;
+    use ringbuf::traits::{Producer, Split};
+
+    use super::*;
+
+    fn make_mixer(
+        mic_rate: u32,
+        tap_rate: u32,
+        engine_rate: u32,
+    ) -> (
+        ringbuf::HeapProd<f32>,
+        ringbuf::HeapProd<f32>,
+        MeetingMixer,
+    ) {
+        let (mic_prod, mic_cons) = HeapRb::<f32>::new(mic_rate as usize * 2).split();
+        let (tap_prod, tap_cons) = HeapRb::<f32>::new(tap_rate as usize * 2).split();
+        let mixer = MeetingMixer::new(mic_cons, mic_rate, 1, 1.0, tap_cons, tap_rate, engine_rate);
+        (mic_prod, tap_prod, mixer)
+    }
+
+    #[test]
+    fn mixes_both_sources_sample_count() {
+        let (mut mic, mut tap, mut mixer) = make_mixer(48_000, 48_000, 16_000);
+
+        // 1s of mic, 1s of tap at matching rates.
+        mic.push_slice(&vec![0.1f32; 48_000]);
+        tap.push_slice(&vec![0.2f32; 48_000]);
+        let mut out = mixer.tick();
+        out.extend(mixer.flush());
+
+        // 1s at 16kHz, within resampler latency tolerance.
+        assert!(
+            (out.len() as i64 - 16_000).unsigned_abs() < 2_000,
+            "expected ~16000 samples, got {}",
+            out.len()
+        );
+        // Steady-state samples carry both sources (0.1 + 0.2).
+        let mid = out[out.len() / 2];
+        assert!((mid - 0.3).abs() < 0.05, "expected ~0.3, got {mid}");
+    }
+
+    #[test]
+    fn mic_only_when_tap_silent() {
+        let (mut mic, _tap, mut mixer) = make_mixer(48_000, 48_000, 16_000);
+
+        mic.push_slice(&vec![0.5f32; 24_000]);
+        let mut out = mixer.tick();
+        out.extend(mixer.flush());
+
+        assert!(!out.is_empty());
+        let mid = out[out.len() / 2];
+        assert!((mid - 0.5).abs() < 0.05, "expected ~0.5, got {mid}");
+    }
+
+    #[test]
+    fn tap_tail_flushed_without_mic() {
+        let (_mic, mut tap, mut mixer) = make_mixer(48_000, 48_000, 16_000);
+
+        tap.push_slice(&vec![0.4f32; 4_800]);
+        assert!(mixer.tick().is_empty(), "no mic frames → no paced output");
+        let out = mixer.flush();
+        assert!(!out.is_empty(), "flush must drain the tap leg");
+    }
+
+    #[test]
+    fn tap_lead_is_bounded() {
+        let (mut mic, mut tap, mut mixer) = make_mixer(48_000, 48_000, 16_000);
+
+        // Tap runs far ahead of the mic.
+        tap.push_slice(&vec![0.2f32; 48_000]);
+        mic.push_slice(&vec![0.1f32; 480]);
+        mixer.tick();
+
+        assert!(mixer.tap_discarded() > 0, "excess tap lead should be dropped");
+        assert!(mixer.tap_fifo.len() <= MAX_TAP_LEAD_SAMPLES + FRAME_SAMPLES);
+    }
+
+    #[test]
+    fn resamples_mismatched_rates() {
+        // Mic at 44.1k stereo, tap at 48k, engine at 24k.
+        let (mic_prod, mic_cons) = HeapRb::<f32>::new(44_100 * 4).split();
+        let (tap_prod, tap_cons) = HeapRb::<f32>::new(48_000 * 2).split();
+        let mut mic = mic_prod;
+        let mut tap = tap_prod;
+        let mut mixer = MeetingMixer::new(mic_cons, 44_100, 2, 1.0, tap_cons, 48_000, 24_000);
+
+        mic.push_slice(&vec![0.1f32; 44_100 * 2]); // 1s stereo
+        tap.push_slice(&vec![0.2f32; 48_000]); // 1s mono
+        let mut out = mixer.tick();
+        out.extend(mixer.flush());
+
+        assert!(
+            (out.len() as i64 - 24_000).unsigned_abs() < 3_000,
+            "expected ~24000 samples, got {}",
+            out.len()
+        );
+    }
+}

--- a/src-tauri/src/audio/mixer.rs
+++ b/src-tauri/src/audio/mixer.rs
@@ -74,15 +74,6 @@ impl MeetingMixer {
         self.aec = aec;
     }
 
-    /// Swap in a new system-audio source mid-session (the tap is rebuilt
-    /// when the default output device changes). Buffered tap samples from
-    /// the old device are dropped; the mic leg is unaffected.
-    pub fn replace_tap(&mut self, tap: HeapCons<f32>, tap_rate: u32) {
-        self.tap = tap;
-        self.tap_to_mix = Resampler::new(tap_rate, 1, MIX_RATE, 1.0);
-        self.tap_fifo.clear();
-    }
-
     /// Drain both rings, mix every complete 10ms frame, and return the
     /// resulting engine-rate samples (possibly empty).
     pub fn tick(&mut self) -> Vec<f32> {

--- a/src-tauri/src/audio/mixer.rs
+++ b/src-tauri/src/audio/mixer.rs
@@ -11,6 +11,7 @@
 use ringbuf::HeapCons;
 use ringbuf::traits::Consumer;
 
+use super::aec::Aec;
 use super::resampler::Resampler;
 
 /// Common processing rate; 48kHz matches the tap's native rate and is a
@@ -32,6 +33,9 @@ pub struct MeetingMixer {
     mic_fifo: Vec<f32>,
     tap_fifo: Vec<f32>,
     scratch: Vec<f32>,
+    /// Echo cancellation, active only when the output routes to the
+    /// built-in speakers (headphones can't leak into the mic).
+    aec: Option<Aec>,
     /// Tap samples discarded to bound drift; logged at session end.
     tap_discarded: u64,
 }
@@ -58,8 +62,25 @@ impl MeetingMixer {
             mic_fifo: Vec::new(),
             tap_fifo: Vec::new(),
             scratch: vec![0.0; 4096],
+            aec: None,
             tap_discarded: 0,
         }
+    }
+
+    /// Enable/disable echo cancellation (e.g. when the output route changes
+    /// between speakers and headphones mid-session). Passing a fresh `Aec`
+    /// also resets convergence state.
+    pub fn set_aec(&mut self, aec: Option<Aec>) {
+        self.aec = aec;
+    }
+
+    /// Swap in a new system-audio source mid-session (the tap is rebuilt
+    /// when the default output device changes). Buffered tap samples from
+    /// the old device are dropped; the mic leg is unaffected.
+    pub fn replace_tap(&mut self, tap: HeapCons<f32>, tap_rate: u32) {
+        self.tap = tap;
+        self.tap_to_mix = Resampler::new(tap_rate, 1, MIX_RATE, 1.0);
+        self.tap_fifo.clear();
     }
 
     /// Drain both rings, mix every complete 10ms frame, and return the
@@ -133,17 +154,28 @@ impl MeetingMixer {
         }
     }
 
-    /// Take `n` mic samples, sum the available tap samples over them
-    /// (zeros when the system is silent), clamp.
-    /// This is where echo cancellation will hook in: the tap frame is the
-    /// render (reference) signal, the mic frame is the capture signal.
+    /// Take `n` mic samples, cancel the echo of the system audio in them
+    /// (speakers only), then sum the tap leg over them (zeros when the
+    /// system is silent) and clamp.
     fn mix_frame(&mut self, n: usize) -> Vec<f32> {
-        let mut frame: Vec<f32> = self.mic_fifo.drain(..n).collect();
+        let mut mic: Vec<f32> = self.mic_fifo.drain(..n).collect();
         let tap_n = n.min(self.tap_fifo.len());
-        for (sample, tap) in frame.iter_mut().zip(self.tap_fifo.drain(..tap_n)) {
-            *sample = (*sample + tap).clamp(-1.0, 1.0);
+        let mut tap: Vec<f32> = self.tap_fifo.drain(..tap_n).collect();
+        tap.resize(n, 0.0);
+
+        // AEC works on exact 10ms frames; the only shorter frames are the
+        // final flush tail, where skipping cancellation is harmless.
+        if n == FRAME_SAMPLES
+            && let Some(aec) = self.aec.as_mut()
+        {
+            aec.process_render(&tap);
+            aec.process_capture(&mut mic);
         }
-        frame
+
+        for (sample, tap) in mic.iter_mut().zip(&tap) {
+            *sample = (*sample + *tap).clamp(-1.0, 1.0);
+        }
+        mic
     }
 }
 

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,5 +1,7 @@
 pub mod capture;
+pub mod output_route;
 pub mod resampler;
+pub mod system_tap;
 
 pub use capture::{AudioCapture, AudioChunk, AudioMessage};
 pub use resampler::Resampler;

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,4 +1,5 @@
 pub mod capture;
+pub mod mixer;
 pub mod output_route;
 pub mod resampler;
 pub mod system_tap;

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,3 +1,4 @@
+pub mod aec;
 pub mod capture;
 pub mod mixer;
 pub mod output_route;

--- a/src-tauri/src/audio/output_route.rs
+++ b/src-tauri/src/audio/output_route.rs
@@ -1,0 +1,118 @@
+//! Default-output-device introspection for system-audio capture.
+//!
+//! The system tap's aggregate device must reference the current default
+//! output device, and echo cancellation is only useful when that output is
+//! the built-in speakers (headphones physically can't leak into the mic).
+
+#![cfg(target_os = "macos")]
+
+use std::ffi::c_void;
+use std::ptr::NonNull;
+
+use objc2_core_audio::{
+    AudioObjectGetPropertyData, AudioObjectID, AudioObjectPropertyAddress,
+    kAudioDevicePropertyDataSource, kAudioDevicePropertyDeviceUID,
+    kAudioDevicePropertyTransportType, kAudioDeviceTransportTypeBuiltIn,
+    kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyElementMain,
+    kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyScopeOutput, kAudioObjectSystemObject,
+};
+use objc2_core_foundation::{CFRetained, CFString};
+
+/// Built-in output data source: internal speaker ('ispk').
+const DATA_SOURCE_INTERNAL_SPEAKER: u32 = 0x6973_706b;
+
+fn global_address(selector: u32) -> AudioObjectPropertyAddress {
+    AudioObjectPropertyAddress {
+        mSelector: selector,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain,
+    }
+}
+
+fn get_property<T>(
+    object: AudioObjectID,
+    mut address: AudioObjectPropertyAddress,
+    out: &mut T,
+) -> Result<(), String> {
+    let mut size = size_of::<T>() as u32;
+    let status = unsafe {
+        AudioObjectGetPropertyData(
+            object,
+            NonNull::from(&mut address),
+            0,
+            std::ptr::null(),
+            NonNull::from(&mut size),
+            NonNull::new(out as *mut T as *mut c_void).expect("non-null out pointer"),
+        )
+    };
+    if status != 0 {
+        return Err(format!(
+            "AudioObjectGetPropertyData({:#x}) failed: {status}",
+            address.mSelector
+        ));
+    }
+    Ok(())
+}
+
+/// The current default output device.
+pub fn default_output_device() -> Result<AudioObjectID, String> {
+    let mut device: AudioObjectID = 0;
+    get_property(
+        kAudioObjectSystemObject as AudioObjectID,
+        global_address(kAudioHardwarePropertyDefaultOutputDevice),
+        &mut device,
+    )?;
+    if device == 0 {
+        return Err("No default output device".into());
+    }
+    Ok(device)
+}
+
+/// The persistent UID of a device, as used in aggregate-device compositions.
+pub fn device_uid(device: AudioObjectID) -> Result<String, String> {
+    // The property hands back a +1 retained CFString.
+    let mut uid: *const CFString = std::ptr::null();
+    get_property(
+        device,
+        global_address(kAudioDevicePropertyDeviceUID),
+        &mut uid,
+    )?;
+    let ptr = NonNull::new(uid.cast_mut()).ok_or("Device UID is null")?;
+    let uid = unsafe { CFRetained::from_raw(ptr) };
+    Ok(uid.to_string())
+}
+
+/// Whether the default output routes to the built-in speakers — the only
+/// case where system audio can acoustically leak back into the microphone
+/// and echo cancellation is worth running.
+pub fn output_is_builtin_speakers() -> bool {
+    let Ok(device) = default_output_device() else {
+        return false;
+    };
+
+    let mut transport: u32 = 0;
+    if get_property(
+        device,
+        global_address(kAudioDevicePropertyTransportType),
+        &mut transport,
+    )
+    .is_err()
+        || transport != kAudioDeviceTransportTypeBuiltIn
+    {
+        return false;
+    }
+
+    // Built-in transport covers both the speakers and the headphone jack;
+    // the data source ('ispk' vs 'hdpn') tells them apart. If the device
+    // doesn't report one, assume speakers.
+    let mut source: u32 = 0;
+    let address = AudioObjectPropertyAddress {
+        mSelector: kAudioDevicePropertyDataSource,
+        mScope: kAudioObjectPropertyScopeOutput,
+        mElement: kAudioObjectPropertyElementMain,
+    };
+    match get_property(device, address, &mut source) {
+        Ok(()) => source == DATA_SOURCE_INTERNAL_SPEAKER,
+        Err(_) => true,
+    }
+}

--- a/src-tauri/src/audio/system_tap.rs
+++ b/src-tauri/src/audio/system_tap.rs
@@ -1,0 +1,346 @@
+//! System-audio capture via Core Audio process taps (macOS 14.4+).
+//!
+//! A mono global tap captures the mixed output of all processes *before* it
+//! reaches the speakers, so the signal is clean regardless of the user's
+//! audio hardware — no virtual driver or manual aggregate device needed.
+//! The tap can't be read directly: it must be wrapped in a private,
+//! programmatically-created aggregate device whose IOProc delivers the
+//! samples. Creating the tap triggers the "System Audio Recording Only"
+//! TCC prompt (NSAudioCaptureUsageDescription in Info.plist).
+//!
+//! All calls must be gated behind `platform::system_audio_capture_supported()`.
+
+#![cfg(target_os = "macos")]
+
+use std::ffi::{CStr, c_void};
+use std::ptr::NonNull;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use objc2::AnyThread;
+use objc2::rc::Retained;
+use objc2::runtime::AnyObject;
+use objc2_core_audio::{
+    AudioDeviceCreateIOProcID, AudioDeviceDestroyIOProcID, AudioDeviceIOProcID, AudioDeviceStart,
+    AudioDeviceStop, AudioHardwareCreateAggregateDevice, AudioHardwareCreateProcessTap,
+    AudioHardwareDestroyAggregateDevice, AudioHardwareDestroyProcessTap,
+    AudioObjectGetPropertyData, AudioObjectID, AudioObjectPropertyAddress, CATapDescription,
+    kAudioAggregateDeviceIsPrivateKey, kAudioAggregateDeviceMainSubDeviceKey,
+    kAudioAggregateDeviceNameKey, kAudioAggregateDeviceSubDeviceListKey,
+    kAudioAggregateDeviceTapAutoStartKey, kAudioAggregateDeviceTapListKey,
+    kAudioAggregateDeviceUIDKey, kAudioObjectPropertyElementMain, kAudioObjectPropertyScopeGlobal,
+    kAudioSubDeviceUIDKey, kAudioSubTapDriftCompensationKey, kAudioSubTapUIDKey,
+    kAudioTapPropertyFormat,
+};
+use objc2_core_audio_types::{AudioBufferList, AudioStreamBasicDescription, AudioTimeStamp};
+use objc2_core_foundation::CFDictionary;
+use objc2_foundation::{NSArray, NSDictionary, NSNumber, NSString};
+use ringbuf::HeapProd;
+use ringbuf::traits::Producer;
+use tracing::{info, warn};
+
+use super::output_route;
+
+/// State shared with the HAL IOProc thread. Heap-allocated and owned by
+/// `SystemTap`; freed only after the IOProc is destroyed.
+struct TapShared {
+    producer: HeapProd<f32>,
+    /// Counts samples dropped because the ring buffer was full.
+    dropped: AtomicU64,
+    /// Counts IOProc invocations — observable from other threads for health checks.
+    callbacks: AtomicU64,
+}
+
+/// A running system-audio capture. Samples (mono f32 at `sample_rate()`)
+/// are pushed into the ring-buffer producer from the HAL's IO thread.
+/// Dropping tears down the IOProc, aggregate device, and tap.
+///
+/// Not `Send`: create, use, and drop on the same thread.
+pub struct SystemTap {
+    tap_id: AudioObjectID,
+    aggregate_id: AudioObjectID,
+    proc_id: AudioDeviceIOProcID,
+    shared: *mut TapShared,
+    sample_rate: f64,
+}
+
+impl SystemTap {
+    /// Create a mono global tap and start delivering samples to `producer`.
+    pub fn start(producer: HeapProd<f32>) -> Result<Self, String> {
+        if !crate::platform::system_audio_capture_supported() {
+            return Err("System audio capture requires macOS 14.4 or later".into());
+        }
+
+        // Mono mixdown of every process, excluding none.
+        let description = unsafe {
+            CATapDescription::initMonoGlobalTapButExcludeProcesses(
+                CATapDescription::alloc(),
+                &NSArray::new(),
+            )
+        };
+        unsafe {
+            description.setName(&NSString::from_str("Souffle system audio tap"));
+            description.setPrivate(true);
+        }
+
+        // This is the call that triggers the TCC permission prompt.
+        let mut tap_id: AudioObjectID = 0;
+        let status = unsafe { AudioHardwareCreateProcessTap(Some(&description), &mut tap_id) };
+        if status != 0 {
+            return Err(format!(
+                "AudioHardwareCreateProcessTap failed ({status}) — system audio \
+                 recording permission may be denied"
+            ));
+        }
+
+        match Self::build_aggregate(&description, tap_id, producer) {
+            Ok(tap) => Ok(tap),
+            Err(e) => {
+                unsafe { AudioHardwareDestroyProcessTap(tap_id) };
+                Err(e)
+            }
+        }
+    }
+
+    fn build_aggregate(
+        description: &CATapDescription,
+        tap_id: AudioObjectID,
+        producer: HeapProd<f32>,
+    ) -> Result<Self, String> {
+        let sample_rate = tap_stream_format(tap_id)?.mSampleRate;
+
+        let output_device = output_route::default_output_device()?;
+        let output_uid = output_route::device_uid(output_device)?;
+        let aggregate_dict = aggregate_description(description, &output_uid);
+
+        let mut aggregate_id: AudioObjectID = 0;
+        // NSDictionary is toll-free bridged to CFDictionary.
+        let cf_dict: &CFDictionary =
+            unsafe { &*(Retained::as_ptr(&aggregate_dict) as *const CFDictionary) };
+        let status = unsafe {
+            AudioHardwareCreateAggregateDevice(cf_dict, NonNull::from(&mut aggregate_id))
+        };
+        if status != 0 {
+            return Err(format!(
+                "AudioHardwareCreateAggregateDevice failed ({status})"
+            ));
+        }
+
+        let shared = Box::into_raw(Box::new(TapShared {
+            producer,
+            dropped: AtomicU64::new(0),
+            callbacks: AtomicU64::new(0),
+        }));
+        let mut proc_id: AudioDeviceIOProcID = None;
+        let status = unsafe {
+            AudioDeviceCreateIOProcID(
+                aggregate_id,
+                Some(tap_io_proc),
+                shared as *mut c_void,
+                NonNull::from(&mut proc_id),
+            )
+        };
+        if status != 0 {
+            unsafe {
+                drop(Box::from_raw(shared));
+                AudioHardwareDestroyAggregateDevice(aggregate_id);
+            }
+            return Err(format!("AudioDeviceCreateIOProcID failed ({status})"));
+        }
+
+        let status = unsafe { AudioDeviceStart(aggregate_id, proc_id) };
+        if status != 0 {
+            unsafe {
+                AudioDeviceDestroyIOProcID(aggregate_id, proc_id);
+                drop(Box::from_raw(shared));
+                AudioHardwareDestroyAggregateDevice(aggregate_id);
+            }
+            return Err(format!("AudioDeviceStart failed ({status})"));
+        }
+
+        info!("System audio tap started ({sample_rate} Hz, output device {output_uid})");
+        Ok(Self {
+            tap_id,
+            aggregate_id,
+            proc_id,
+            shared,
+            sample_rate,
+        })
+    }
+
+    pub fn sample_rate(&self) -> f64 {
+        self.sample_rate
+    }
+
+    /// Number of IOProc invocations so far. Zero after a few hundred ms of
+    /// running means the tap is not delivering audio (e.g. permission denied).
+    pub fn callback_count(&self) -> u64 {
+        unsafe { (*self.shared).callbacks.load(Ordering::Relaxed) }
+    }
+}
+
+impl Drop for SystemTap {
+    fn drop(&mut self) {
+        unsafe {
+            AudioDeviceStop(self.aggregate_id, self.proc_id);
+            // After this returns the IOProc is guaranteed not to run again,
+            // so freeing the shared state is safe.
+            AudioDeviceDestroyIOProcID(self.aggregate_id, self.proc_id);
+            AudioHardwareDestroyAggregateDevice(self.aggregate_id);
+            AudioHardwareDestroyProcessTap(self.tap_id);
+            let shared = Box::from_raw(self.shared);
+            let dropped = shared.dropped.load(Ordering::Relaxed);
+            if dropped > 0 {
+                warn!("System tap dropped {dropped} samples (ring buffer full)");
+            }
+        }
+        info!("System audio tap stopped");
+    }
+}
+
+/// Read the tap's stream format to learn its sample rate.
+fn tap_stream_format(tap_id: AudioObjectID) -> Result<AudioStreamBasicDescription, String> {
+    let mut address = AudioObjectPropertyAddress {
+        mSelector: kAudioTapPropertyFormat,
+        mScope: kAudioObjectPropertyScopeGlobal,
+        mElement: kAudioObjectPropertyElementMain,
+    };
+    let mut format: AudioStreamBasicDescription = unsafe { std::mem::zeroed() };
+    let mut size = size_of::<AudioStreamBasicDescription>() as u32;
+    let status = unsafe {
+        AudioObjectGetPropertyData(
+            tap_id,
+            NonNull::from(&mut address),
+            0,
+            std::ptr::null(),
+            NonNull::from(&mut size),
+            NonNull::new(&mut format as *mut _ as *mut c_void).expect("non-null out pointer"),
+        )
+    };
+    if status != 0 {
+        return Err(format!("Failed to read tap format ({status})"));
+    }
+    if format.mSampleRate <= 0.0 {
+        return Err("Tap reported an invalid sample rate".into());
+    }
+    Ok(format)
+}
+
+/// The aggregate-device composition wrapping the tap, mirroring what
+/// Audio MIDI Setup would build — but private and fully programmatic.
+fn aggregate_description(
+    description: &CATapDescription,
+    output_uid: &str,
+) -> Retained<NSDictionary<NSString, AnyObject>> {
+    let key = |k: &CStr| NSString::from_str(k.to_str().expect("ASCII key"));
+    let aggregate_uid = NSString::from_str(&uuid::Uuid::new_v4().to_string());
+    let output_uid = NSString::from_str(output_uid);
+    let tap_uid = unsafe { description.UUID().UUIDString() };
+
+    let sub_device: Retained<NSDictionary<NSString, AnyObject>> = NSDictionary::from_slices(
+        &[&*key(kAudioSubDeviceUIDKey)],
+        &[&*output_uid as &AnyObject],
+    );
+    let sub_tap: Retained<NSDictionary<NSString, AnyObject>> = NSDictionary::from_slices(
+        &[
+            &*key(kAudioSubTapUIDKey),
+            &*key(kAudioSubTapDriftCompensationKey),
+        ],
+        &[
+            &*tap_uid as &AnyObject,
+            &*NSNumber::new_bool(true) as &AnyObject,
+        ],
+    );
+
+    NSDictionary::from_slices(
+        &[
+            &*key(kAudioAggregateDeviceNameKey),
+            &*key(kAudioAggregateDeviceUIDKey),
+            &*key(kAudioAggregateDeviceMainSubDeviceKey),
+            &*key(kAudioAggregateDeviceIsPrivateKey),
+            &*key(kAudioAggregateDeviceTapAutoStartKey),
+            &*key(kAudioAggregateDeviceSubDeviceListKey),
+            &*key(kAudioAggregateDeviceTapListKey),
+        ],
+        &[
+            &*NSString::from_str("Souffle Tap") as &AnyObject,
+            &*aggregate_uid as &AnyObject,
+            &*output_uid as &AnyObject,
+            &*NSNumber::new_bool(true) as &AnyObject,
+            &*NSNumber::new_bool(true) as &AnyObject,
+            &*NSArray::from_slice(&[&*sub_device]) as &AnyObject,
+            &*NSArray::from_slice(&[&*sub_tap]) as &AnyObject,
+        ],
+    )
+}
+
+/// HAL IO callback: forward the tap's input buffers into the ring buffer.
+/// Runs on a realtime thread — no allocation, no locks, no logging.
+unsafe extern "C-unwind" fn tap_io_proc(
+    _device: AudioObjectID,
+    _now: NonNull<AudioTimeStamp>,
+    input_data: NonNull<AudioBufferList>,
+    _input_time: NonNull<AudioTimeStamp>,
+    _output_data: NonNull<AudioBufferList>,
+    _output_time: NonNull<AudioTimeStamp>,
+    client_data: *mut c_void,
+) -> i32 {
+    let shared = unsafe { &mut *(client_data as *mut TapShared) };
+    shared.callbacks.fetch_add(1, Ordering::Relaxed);
+    let list = unsafe { input_data.as_ref() };
+    let buffers =
+        unsafe { std::slice::from_raw_parts(list.mBuffers.as_ptr(), list.mNumberBuffers as usize) };
+
+    for buffer in buffers {
+        if buffer.mData.is_null() {
+            continue;
+        }
+        let samples = unsafe {
+            std::slice::from_raw_parts(
+                buffer.mData as *const f32,
+                buffer.mDataByteSize as usize / size_of::<f32>(),
+            )
+        };
+        let channels = buffer.mNumberChannels.max(1) as usize;
+        if channels == 1 {
+            let pushed = shared.producer.push_slice(samples);
+            shared
+                .dropped
+                .fetch_add((samples.len() - pushed) as u64, Ordering::Relaxed);
+        } else {
+            // Defensive: the mono tap shouldn't produce interleaved frames,
+            // but downmix without allocating if it ever does.
+            for frame in samples.chunks_exact(channels) {
+                let mono = frame.iter().sum::<f32>() / channels as f32;
+                if shared.producer.try_push(mono).is_err() {
+                    shared.dropped.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use ringbuf::HeapRb;
+    use ringbuf::traits::{Observer, Split};
+
+    use super::*;
+
+    /// Needs real audio hardware + the system-audio TCC grant; run manually:
+    /// cargo test --lib tap_delivers_samples -- --ignored --nocapture
+    #[test]
+    #[ignore = "requires audio hardware and TCC permission"]
+    fn tap_delivers_samples() {
+        let (producer, consumer) = HeapRb::<f32>::new(48_000 * 2).split();
+        let tap = SystemTap::start(producer).expect("tap should start");
+        assert!(tap.sample_rate() > 0.0);
+        eprintln!("tap sample rate: {}", tap.sample_rate());
+        std::thread::sleep(std::time::Duration::from_millis(500));
+        eprintln!("callbacks: {}", tap.callback_count());
+        drop(tap);
+        eprintln!("samples: {}", consumer.occupied_len());
+        // The tap delivers buffers even when no app is playing (silence).
+        assert!(consumer.occupied_len() > 0, "no samples were delivered");
+    }
+}

--- a/src-tauri/src/audio/system_tap.rs
+++ b/src-tauri/src/audio/system_tap.rs
@@ -4,32 +4,48 @@
 //! reaches the speakers, so the signal is clean regardless of the user's
 //! audio hardware — no virtual driver or manual aggregate device needed.
 //! The tap can't be read directly: it must be wrapped in a private,
-//! programmatically-created aggregate device whose IOProc delivers the
+//! programmatically-created aggregate device whose IO callback delivers the
 //! samples. Creating the tap triggers the "System Audio Recording Only"
 //! TCC prompt (NSAudioCaptureUsageDescription in Info.plist).
+//!
+//! The IO callback uses `AudioDeviceCreateIOProcIDWithBlock` with a private
+//! dispatch queue. The classic C-IOProc path (`AudioDeviceCreateIOProcID`)
+//! must NOT be used here: its HALB_IOThread state machine deadlocks against
+//! a cpal/AUHAL input stream in the same process — whichever starts second
+//! blocks forever. Verified by the `mic_and_tap_coexist` /
+//! `tap_then_mic_coexist` regression tests.
+//!
+//! Tap CoreAudio calls can also wedge indefinitely when coreaudiod holds
+//! state from a crashed client (observed in the wild), so sessions must
+//! drive the tap through [`spawn_tap`], which isolates the whole lifecycle
+//! on a disposable thread with a startup timeout — a stuck tap degrades the
+//! meeting to mic-only instead of freezing the audio thread.
 //!
 //! All calls must be gated behind `platform::system_audio_capture_supported()`.
 
 #![cfg(target_os = "macos")]
 
-use std::ffi::{CStr, c_void};
+use std::ffi::CStr;
 use std::ptr::NonNull;
+use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use block2::RcBlock;
+use dispatch2::{DispatchQueue, DispatchRetained};
 use objc2::AnyThread;
 use objc2::rc::Retained;
 use objc2::runtime::AnyObject;
 use objc2_core_audio::{
-    AudioDeviceCreateIOProcID, AudioDeviceDestroyIOProcID, AudioDeviceIOProcID, AudioDeviceStart,
-    AudioDeviceStop, AudioHardwareCreateAggregateDevice, AudioHardwareCreateProcessTap,
-    AudioHardwareDestroyAggregateDevice, AudioHardwareDestroyProcessTap,
-    AudioObjectGetPropertyData, AudioObjectID, AudioObjectPropertyAddress, CATapDescription,
-    kAudioAggregateDeviceIsPrivateKey, kAudioAggregateDeviceMainSubDeviceKey,
-    kAudioAggregateDeviceNameKey, kAudioAggregateDeviceSubDeviceListKey,
-    kAudioAggregateDeviceTapAutoStartKey, kAudioAggregateDeviceTapListKey,
-    kAudioAggregateDeviceUIDKey, kAudioObjectPropertyElementMain, kAudioObjectPropertyScopeGlobal,
-    kAudioSubDeviceUIDKey, kAudioSubTapDriftCompensationKey, kAudioSubTapUIDKey,
-    kAudioTapPropertyFormat,
+    AudioDeviceCreateIOProcIDWithBlock, AudioDeviceDestroyIOProcID, AudioDeviceIOProcID,
+    AudioDeviceStart, AudioDeviceStop, AudioHardwareCreateAggregateDevice,
+    AudioHardwareCreateProcessTap, AudioHardwareDestroyAggregateDevice,
+    AudioHardwareDestroyProcessTap, AudioObjectGetPropertyData, AudioObjectID,
+    AudioObjectPropertyAddress, CATapDescription, kAudioAggregateDeviceIsPrivateKey,
+    kAudioAggregateDeviceNameKey, kAudioAggregateDeviceTapAutoStartKey,
+    kAudioAggregateDeviceTapListKey, kAudioAggregateDeviceUIDKey,
+    kAudioObjectPropertyElementMain, kAudioObjectPropertyScopeGlobal,
+    kAudioSubTapDriftCompensationKey, kAudioSubTapUIDKey, kAudioTapPropertyFormat,
 };
 use objc2_core_audio_types::{AudioBufferList, AudioStreamBasicDescription, AudioTimeStamp};
 use objc2_core_foundation::CFDictionary;
@@ -38,28 +54,93 @@ use ringbuf::HeapProd;
 use ringbuf::traits::Producer;
 use tracing::{info, warn};
 
-use super::output_route;
-
-/// State shared with the HAL IOProc thread. Heap-allocated and owned by
-/// `SystemTap`; freed only after the IOProc is destroyed.
+/// State shared with the IO block running on the tap's dispatch queue.
+/// The queue is serial, so the producer mutex is never contended.
 struct TapShared {
-    producer: HeapProd<f32>,
+    producer: Mutex<HeapProd<f32>>,
     /// Counts samples dropped because the ring buffer was full.
     dropped: AtomicU64,
-    /// Counts IOProc invocations — observable from other threads for health checks.
+    /// Counts IO callback invocations — observable for health checks.
     callbacks: AtomicU64,
 }
 
+type IoBlock = RcBlock<
+    dyn Fn(
+        NonNull<AudioTimeStamp>,
+        NonNull<AudioBufferList>,
+        NonNull<AudioTimeStamp>,
+        NonNull<AudioBufferList>,
+        NonNull<AudioTimeStamp>,
+    ),
+>;
+
+/// Handle to a tap running on its own thread. Dropping it asks that thread
+/// to tear the tap down without ever blocking the caller.
+pub struct TapHandle {
+    /// Closing this channel (on drop) unparks the tap thread.
+    _stop_tx: std::sync::mpsc::Sender<()>,
+    pub sample_rate: u32,
+}
+
+/// Start a system tap on a dedicated thread, waiting up to `timeout` for it
+/// to come up. The thread owns the `SystemTap` (which is not `Send`) and
+/// drops it when the returned handle is dropped. If CoreAudio wedges —
+/// which happens when coreaudiod still holds state from a crashed client —
+/// the thread is abandoned and the caller continues without system audio.
+pub fn spawn_tap(
+    producer: HeapProd<f32>,
+    timeout: std::time::Duration,
+) -> Result<TapHandle, String> {
+    let (event_tx, event_rx) = std::sync::mpsc::channel();
+    let (stop_tx, stop_rx) = std::sync::mpsc::channel::<()>();
+
+    std::thread::Builder::new()
+        .name("system-tap".into())
+        .spawn(move || match SystemTap::start(producer) {
+            Ok(tap) => {
+                if event_tx.send(Ok(tap.sample_rate() as u32)).is_err() {
+                    // Caller timed out and gave up; tear down immediately.
+                    return;
+                }
+                // Park until the handle is dropped (recv errors when the
+                // sender side closes).
+                let _ = stop_rx.recv();
+                drop(tap);
+            }
+            Err(e) => {
+                let _ = event_tx.send(Err(e));
+            }
+        })
+        .map_err(|e| format!("Failed to spawn tap thread: {e}"))?;
+
+    match event_rx.recv_timeout(timeout) {
+        Ok(Ok(sample_rate)) => Ok(TapHandle {
+            _stop_tx: stop_tx,
+            sample_rate,
+        }),
+        Ok(Err(e)) => Err(e),
+        Err(_) => Err(
+            "System tap startup timed out (CoreAudio unresponsive) —              recording microphone only"
+                .into(),
+        ),
+    }
+}
+
 /// A running system-audio capture. Samples (mono f32 at `sample_rate()`)
-/// are pushed into the ring-buffer producer from the HAL's IO thread.
-/// Dropping tears down the IOProc, aggregate device, and tap.
+/// are pushed into the ring-buffer producer from the tap's dispatch queue.
+/// Dropping tears down the IO proc, aggregate device, and tap.
 ///
 /// Not `Send`: create, use, and drop on the same thread.
 pub struct SystemTap {
     tap_id: AudioObjectID,
     aggregate_id: AudioObjectID,
     proc_id: AudioDeviceIOProcID,
-    shared: *mut TapShared,
+    shared: Arc<TapShared>,
+    /// Keeps the IO block alive for the lifetime of the IO proc (CoreAudio
+    /// also retains it, but ownership here makes the lifetime explicit).
+    _block: IoBlock,
+    /// Retained until AudioDeviceDestroyIOProcID per CoreAudio's contract.
+    _queue: DispatchRetained<DispatchQueue>,
     sample_rate: f64,
 }
 
@@ -108,9 +189,7 @@ impl SystemTap {
     ) -> Result<Self, String> {
         let sample_rate = tap_stream_format(tap_id)?.mSampleRate;
 
-        let output_device = output_route::default_output_device()?;
-        let output_uid = output_route::device_uid(output_device)?;
-        let aggregate_dict = aggregate_description(description, &output_uid);
+        let aggregate_dict = aggregate_description(description);
 
         let mut aggregate_id: AudioObjectID = 0;
         // NSDictionary is toll-free bridged to CFDictionary.
@@ -125,44 +204,56 @@ impl SystemTap {
             ));
         }
 
-        let shared = Box::into_raw(Box::new(TapShared {
-            producer,
+        let shared = Arc::new(TapShared {
+            producer: Mutex::new(producer),
             dropped: AtomicU64::new(0),
             callbacks: AtomicU64::new(0),
-        }));
+        });
+        let block_shared = Arc::clone(&shared);
+        let block: IoBlock = RcBlock::new(
+            move |_now: NonNull<AudioTimeStamp>,
+                  input_data: NonNull<AudioBufferList>,
+                  _input_time: NonNull<AudioTimeStamp>,
+                  _output_data: NonNull<AudioBufferList>,
+                  _output_time: NonNull<AudioTimeStamp>| {
+                forward_input(&block_shared, input_data);
+            },
+        );
+
+        let queue = DispatchQueue::new("com.souffle.system-tap", None);
         let mut proc_id: AudioDeviceIOProcID = None;
         let status = unsafe {
-            AudioDeviceCreateIOProcID(
-                aggregate_id,
-                Some(tap_io_proc),
-                shared as *mut c_void,
+            AudioDeviceCreateIOProcIDWithBlock(
                 NonNull::from(&mut proc_id),
+                aggregate_id,
+                Some(&queue),
+                RcBlock::as_ptr(&block),
             )
         };
         if status != 0 {
-            unsafe {
-                drop(Box::from_raw(shared));
-                AudioHardwareDestroyAggregateDevice(aggregate_id);
-            }
-            return Err(format!("AudioDeviceCreateIOProcID failed ({status})"));
+            unsafe { AudioHardwareDestroyAggregateDevice(aggregate_id) };
+            return Err(format!(
+                "AudioDeviceCreateIOProcIDWithBlock failed ({status})"
+            ));
         }
 
         let status = unsafe { AudioDeviceStart(aggregate_id, proc_id) };
         if status != 0 {
             unsafe {
                 AudioDeviceDestroyIOProcID(aggregate_id, proc_id);
-                drop(Box::from_raw(shared));
                 AudioHardwareDestroyAggregateDevice(aggregate_id);
             }
             return Err(format!("AudioDeviceStart failed ({status})"));
         }
 
-        info!("System audio tap started ({sample_rate} Hz, output device {output_uid})");
+        info!("System audio tap started ({sample_rate} Hz)");
         Ok(Self {
             tap_id,
             aggregate_id,
             proc_id,
             shared,
+            _block: block,
+            _queue: queue,
             sample_rate,
         })
     }
@@ -171,10 +262,11 @@ impl SystemTap {
         self.sample_rate
     }
 
-    /// Number of IOProc invocations so far. Zero after a few hundred ms of
-    /// running means the tap is not delivering audio (e.g. permission denied).
+    /// Number of IO callback invocations so far. Zero after a few hundred
+    /// ms of running means the tap is not delivering audio (e.g. permission
+    /// denied).
     pub fn callback_count(&self) -> u64 {
-        unsafe { (*self.shared).callbacks.load(Ordering::Relaxed) }
+        self.shared.callbacks.load(Ordering::Relaxed)
     }
 }
 
@@ -182,18 +274,58 @@ impl Drop for SystemTap {
     fn drop(&mut self) {
         unsafe {
             AudioDeviceStop(self.aggregate_id, self.proc_id);
-            // After this returns the IOProc is guaranteed not to run again,
-            // so freeing the shared state is safe.
+            // After this returns no further IO blocks are dispatched; any
+            // in-flight one only touches the Arc'd shared state.
             AudioDeviceDestroyIOProcID(self.aggregate_id, self.proc_id);
             AudioHardwareDestroyAggregateDevice(self.aggregate_id);
             AudioHardwareDestroyProcessTap(self.tap_id);
-            let shared = Box::from_raw(self.shared);
-            let dropped = shared.dropped.load(Ordering::Relaxed);
-            if dropped > 0 {
-                warn!("System tap dropped {dropped} samples (ring buffer full)");
-            }
+        }
+        let dropped = self.shared.dropped.load(Ordering::Relaxed);
+        if dropped > 0 {
+            warn!("System tap dropped {dropped} samples (ring buffer full)");
         }
         info!("System audio tap stopped");
+    }
+}
+
+/// Forward the tap's input buffers into the ring buffer. Runs on the tap's
+/// serial dispatch queue — the producer mutex is uncontended.
+fn forward_input(shared: &TapShared, input_data: NonNull<AudioBufferList>) {
+    shared.callbacks.fetch_add(1, Ordering::Relaxed);
+    let Ok(mut producer) = shared.producer.lock() else {
+        return;
+    };
+
+    let list = unsafe { input_data.as_ref() };
+    let buffers =
+        unsafe { std::slice::from_raw_parts(list.mBuffers.as_ptr(), list.mNumberBuffers as usize) };
+
+    for buffer in buffers {
+        if buffer.mData.is_null() {
+            continue;
+        }
+        let samples = unsafe {
+            std::slice::from_raw_parts(
+                buffer.mData as *const f32,
+                buffer.mDataByteSize as usize / size_of::<f32>(),
+            )
+        };
+        let channels = buffer.mNumberChannels.max(1) as usize;
+        if channels == 1 {
+            let pushed = producer.push_slice(samples);
+            shared
+                .dropped
+                .fetch_add((samples.len() - pushed) as u64, Ordering::Relaxed);
+        } else {
+            // Defensive: the mono tap shouldn't produce interleaved frames,
+            // but downmix without allocating if it ever does.
+            for frame in samples.chunks_exact(channels) {
+                let mono = frame.iter().sum::<f32>() / channels as f32;
+                if producer.try_push(mono).is_err() {
+                    shared.dropped.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
     }
 }
 
@@ -213,7 +345,8 @@ fn tap_stream_format(tap_id: AudioObjectID) -> Result<AudioStreamBasicDescriptio
             0,
             std::ptr::null(),
             NonNull::from(&mut size),
-            NonNull::new(&mut format as *mut _ as *mut c_void).expect("non-null out pointer"),
+            NonNull::new(&mut format as *mut _ as *mut std::ffi::c_void)
+                .expect("non-null out pointer"),
         )
     };
     if status != 0 {
@@ -225,21 +358,15 @@ fn tap_stream_format(tap_id: AudioObjectID) -> Result<AudioStreamBasicDescriptio
     Ok(format)
 }
 
-/// The aggregate-device composition wrapping the tap, mirroring what
-/// Audio MIDI Setup would build — but private and fully programmatic.
-fn aggregate_description(
-    description: &CATapDescription,
-    output_uid: &str,
-) -> Retained<NSDictionary<NSString, AnyObject>> {
+/// The aggregate-device composition wrapping the tap. No output subdevice:
+/// the tap drives the aggregate by itself, which keeps it independent of
+/// the default output device (no rebuild needed when it changes) and avoids
+/// IO contention with other streams of this process.
+fn aggregate_description(description: &CATapDescription) -> Retained<NSDictionary<NSString, AnyObject>> {
     let key = |k: &CStr| NSString::from_str(k.to_str().expect("ASCII key"));
     let aggregate_uid = NSString::from_str(&uuid::Uuid::new_v4().to_string());
-    let output_uid = NSString::from_str(output_uid);
     let tap_uid = unsafe { description.UUID().UUIDString() };
 
-    let sub_device: Retained<NSDictionary<NSString, AnyObject>> = NSDictionary::from_slices(
-        &[&*key(kAudioSubDeviceUIDKey)],
-        &[&*output_uid as &AnyObject],
-    );
     let sub_tap: Retained<NSDictionary<NSString, AnyObject>> = NSDictionary::from_slices(
         &[
             &*key(kAudioSubTapUIDKey),
@@ -255,69 +382,18 @@ fn aggregate_description(
         &[
             &*key(kAudioAggregateDeviceNameKey),
             &*key(kAudioAggregateDeviceUIDKey),
-            &*key(kAudioAggregateDeviceMainSubDeviceKey),
             &*key(kAudioAggregateDeviceIsPrivateKey),
             &*key(kAudioAggregateDeviceTapAutoStartKey),
-            &*key(kAudioAggregateDeviceSubDeviceListKey),
             &*key(kAudioAggregateDeviceTapListKey),
         ],
         &[
             &*NSString::from_str("Souffle Tap") as &AnyObject,
             &*aggregate_uid as &AnyObject,
-            &*output_uid as &AnyObject,
             &*NSNumber::new_bool(true) as &AnyObject,
             &*NSNumber::new_bool(true) as &AnyObject,
-            &*NSArray::from_slice(&[&*sub_device]) as &AnyObject,
             &*NSArray::from_slice(&[&*sub_tap]) as &AnyObject,
         ],
     )
-}
-
-/// HAL IO callback: forward the tap's input buffers into the ring buffer.
-/// Runs on a realtime thread — no allocation, no locks, no logging.
-unsafe extern "C-unwind" fn tap_io_proc(
-    _device: AudioObjectID,
-    _now: NonNull<AudioTimeStamp>,
-    input_data: NonNull<AudioBufferList>,
-    _input_time: NonNull<AudioTimeStamp>,
-    _output_data: NonNull<AudioBufferList>,
-    _output_time: NonNull<AudioTimeStamp>,
-    client_data: *mut c_void,
-) -> i32 {
-    let shared = unsafe { &mut *(client_data as *mut TapShared) };
-    shared.callbacks.fetch_add(1, Ordering::Relaxed);
-    let list = unsafe { input_data.as_ref() };
-    let buffers =
-        unsafe { std::slice::from_raw_parts(list.mBuffers.as_ptr(), list.mNumberBuffers as usize) };
-
-    for buffer in buffers {
-        if buffer.mData.is_null() {
-            continue;
-        }
-        let samples = unsafe {
-            std::slice::from_raw_parts(
-                buffer.mData as *const f32,
-                buffer.mDataByteSize as usize / size_of::<f32>(),
-            )
-        };
-        let channels = buffer.mNumberChannels.max(1) as usize;
-        if channels == 1 {
-            let pushed = shared.producer.push_slice(samples);
-            shared
-                .dropped
-                .fetch_add((samples.len() - pushed) as u64, Ordering::Relaxed);
-        } else {
-            // Defensive: the mono tap shouldn't produce interleaved frames,
-            // but downmix without allocating if it ever does.
-            for frame in samples.chunks_exact(channels) {
-                let mono = frame.iter().sum::<f32>() / channels as f32;
-                if shared.producer.try_push(mono).is_err() {
-                    shared.dropped.fetch_add(1, Ordering::Relaxed);
-                }
-            }
-        }
-    }
-    0
 }
 
 #[cfg(test)]
@@ -342,5 +418,92 @@ mod tests {
         eprintln!("samples: {}", consumer.occupied_len());
         // The tap delivers buffers even when no app is playing (silence).
         assert!(consumer.occupied_len() > 0, "no samples were delivered");
+    }
+
+    /// Regression test for the meeting-mode deadlock: a cpal input stream
+    /// (AUHAL) and the tap must coexist in the same process. With the old
+    /// C-IOProc registration, whichever started second hung forever or got
+    /// no IO cycles. Run manually:
+    /// cargo test --lib mic_and_tap_coexist -- --ignored --nocapture
+    #[test]
+    #[ignore = "requires audio hardware and TCC permission"]
+    fn mic_and_tap_coexist() {
+        use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+
+        let host = cpal::default_host();
+        let device = host.default_input_device().expect("input device");
+        let config = device.default_input_config().expect("config");
+        let got_data = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let got = got_data.clone();
+        let stream = device
+            .build_input_stream(
+                &config.into(),
+                move |_data: &[f32], _: &cpal::InputCallbackInfo| {
+                    got.store(true, std::sync::atomic::Ordering::Relaxed);
+                },
+                |e| eprintln!("stream error: {e}"),
+                None,
+            )
+            .expect("build stream");
+        stream.play().expect("play");
+
+        let (producer, consumer) = HeapRb::<f32>::new(48_000 * 2).split();
+        let tap = SystemTap::start(producer).expect("tap should start");
+        eprintln!("tap rate: {}", tap.sample_rate());
+
+        std::thread::sleep(std::time::Duration::from_millis(700));
+        let mic_ok = got_data.load(std::sync::atomic::Ordering::Relaxed);
+        let callbacks = tap.callback_count();
+        eprintln!(
+            "mic fired: {mic_ok}, tap callbacks: {callbacks}, tap samples: {}",
+            consumer.occupied_len()
+        );
+        drop(tap);
+        drop(stream);
+        assert!(mic_ok, "mic must deliver");
+        assert!(callbacks > 0, "tap must deliver alongside the mic");
+    }
+
+    /// Same coexistence but tap first — the order start_meeting uses.
+    /// cargo test --lib tap_then_mic_coexist -- --ignored --nocapture
+    #[test]
+    #[ignore = "requires audio hardware and TCC permission"]
+    fn tap_then_mic_coexist() {
+        use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+
+        let (producer, consumer) = HeapRb::<f32>::new(48_000 * 2).split();
+        let tap = SystemTap::start(producer).expect("tap should start");
+        eprintln!("tap rate: {}", tap.sample_rate());
+
+        let host = cpal::default_host();
+        let device = host.default_input_device().expect("input device");
+        let config = device.default_input_config().expect("config");
+        let got_data = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let got = got_data.clone();
+        eprintln!("building mic stream...");
+        let stream = device
+            .build_input_stream(
+                &config.into(),
+                move |_data: &[f32], _: &cpal::InputCallbackInfo| {
+                    got.store(true, std::sync::atomic::Ordering::Relaxed);
+                },
+                |e| eprintln!("stream error: {e}"),
+                None,
+            )
+            .expect("build stream");
+        stream.play().expect("play");
+        eprintln!("mic playing");
+
+        std::thread::sleep(std::time::Duration::from_millis(700));
+        let mic_ok = got_data.load(std::sync::atomic::Ordering::Relaxed);
+        let callbacks = tap.callback_count();
+        eprintln!(
+            "mic fired: {mic_ok}, tap callbacks: {callbacks}, tap samples: {}",
+            consumer.occupied_len()
+        );
+        drop(stream);
+        drop(tap);
+        assert!(mic_ok, "mic must deliver");
+        assert!(callbacks > 0, "tap must deliver alongside the mic");
     }
 }

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -28,3 +28,82 @@ pub fn get_audio_level(state: State<'_, AppState>) -> Result<f32, String> {
         state.audio_rms.load(std::sync::atomic::Ordering::Relaxed),
     ))
 }
+
+/// Whether system-audio capture (Core Audio process taps) is available on this OS
+#[tauri::command]
+#[specta::specta]
+pub fn get_system_audio_support() -> bool {
+    crate::platform::system_audio_capture_supported()
+}
+
+/// Debug: record system audio for `seconds` and write it to a WAV file.
+/// Returns the file path. Exercises the tap end-to-end (TCC prompt included).
+#[tauri::command]
+#[specta::specta]
+pub async fn debug_record_system_audio(seconds: u32) -> Result<String, String> {
+    tauri::async_runtime::spawn_blocking(move || record_system_audio_wav(seconds))
+        .await
+        .map_err(|e| format!("Task failed: {e}"))?
+}
+
+#[cfg(target_os = "macos")]
+fn record_system_audio_wav(seconds: u32) -> Result<String, String> {
+    use ringbuf::HeapRb;
+    use ringbuf::traits::{Consumer, Split};
+
+    use crate::audio::system_tap::SystemTap;
+
+    let seconds = seconds.clamp(1, 60);
+    // 1s of headroom at 48kHz; the drain loop below empties it every 50ms.
+    let (producer, mut consumer) = HeapRb::<f32>::new(48_000 * 2).split();
+    let tap = SystemTap::start(producer)?;
+    let sample_rate = tap.sample_rate() as u32;
+
+    let mut samples: Vec<f32> = Vec::with_capacity(sample_rate as usize * seconds as usize);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(seconds as u64);
+    let mut chunk = vec![0f32; 4800];
+    while std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        loop {
+            let n = consumer.pop_slice(&mut chunk);
+            samples.extend_from_slice(&chunk[..n]);
+            if n < chunk.len() {
+                break;
+            }
+        }
+    }
+    drop(tap);
+
+    let path = crate::constants::app_data_dir().join(format!(
+        "system_audio_debug_{}.wav",
+        chrono::Utc::now().format("%Y%m%d_%H%M%S")
+    ));
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate,
+        bits_per_sample: 32,
+        sample_format: hound::SampleFormat::Float,
+    };
+    let mut writer =
+        hound::WavWriter::create(&path, spec).map_err(|e| format!("WAV create failed: {e}"))?;
+    for s in &samples {
+        writer
+            .write_sample(*s)
+            .map_err(|e| format!("WAV write failed: {e}"))?;
+    }
+    writer
+        .finalize()
+        .map_err(|e| format!("WAV finalize failed: {e}"))?;
+
+    tracing::info!(
+        "Recorded {} system-audio samples to {}",
+        samples.len(),
+        path.display()
+    );
+    Ok(path.display().to_string())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn record_system_audio_wav(_seconds: u32) -> Result<String, String> {
+    Err("System audio capture is only supported on macOS".into())
+}

--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -48,7 +48,7 @@ fn start_meeting_session(
         }
     });
 
-    if let Err(error) = start_pipeline(state, on_segment) {
+    if let Err(error) = start_pipeline(state, on_segment, PipelineMode::Meeting) {
         let mut acc = state.meeting_accumulator.acquire()?;
         *acc = None;
         return Err(error);
@@ -106,10 +106,20 @@ pub(crate) fn build_meeting_transcript(
     }
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PipelineMode {
+    Dictation,
+    Meeting,
+}
+
 /// Shared logic for starting a recording session.
 /// Validates preconditions, starts the actor session (which drains stale
 /// audio, resets the engine, and builds filter chains), then begins audio capture.
-fn start_pipeline(state: &AppState, on_segment: SegmentCallback) -> Result<u64, String> {
+fn start_pipeline(
+    state: &AppState,
+    on_segment: SegmentCallback,
+    mode: PipelineMode,
+) -> Result<u64, String> {
     let machine = state.current_machine_state()?;
     if !machine.is_model_ready() {
         return Err("Model not loaded".into());
@@ -131,6 +141,12 @@ fn start_pipeline(state: &AppState, on_segment: SegmentCallback) -> Result<u64, 
         dictionary_entries: state.db.list_dictionary_entries()?,
     };
 
+    // Meetings also capture system audio (the other participants) when the
+    // setting is on and the OS supports Core Audio taps.
+    let capture_system_audio = mode == PipelineMode::Meeting
+        && settings.capture_system_audio
+        && crate::platform::system_audio_capture_supported();
+
     // The actor replies once the engine is reset and ready for audio.
     let info = state
         .engine_actor
@@ -142,6 +158,7 @@ fn start_pipeline(state: &AppState, on_segment: SegmentCallback) -> Result<u64, 
             session_id,
             target_sample_rate: info.audio.sample_rate_hz,
             mic_gain: info.mic_gain,
+            capture_system_audio,
         })
         .map_err(|e| format!("Audio start: {e}"))?;
 
@@ -191,7 +208,7 @@ pub fn start_transcription(
         let _ = channel_clone.send(seg);
     });
 
-    let session_id = start_pipeline(&state, on_segment)?;
+    let session_id = start_pipeline(&state, on_segment, PipelineMode::Dictation)?;
 
     // Transition state machine
     state.apply_transition(StateAction::StartDictation { session_id })?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -67,6 +67,8 @@ fn specta_builder() -> Builder<tauri::Wry> {
             commands::save_shortcuts,
             commands::get_shortcuts,
             commands::get_audio_level,
+            commands::get_system_audio_support,
+            commands::debug_record_system_audio,
             commands::get_machine_state,
             commands::recover_state,
             commands::list_dictionary,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -85,6 +85,7 @@ fn specta_builder() -> Builder<tauri::Wry> {
             app_events::StateChanged,
             app_events::TranscriptionHealth,
             app_events::PipelineError,
+            app_events::SystemAudioStatus,
         ])
 }
 
@@ -165,6 +166,9 @@ pub fn run() {
                 *handle_guard = Some(app.handle().clone());
             }
             state.engine_actor.attach_app(app.handle().clone());
+            let _ = state
+                .audio_cmd_sender
+                .send(state::AudioCommand::AttachApp(app.handle().clone()));
 
             // Load shortcut settings from DB and register
             let state = app.state::<AppState>();

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -20,3 +20,22 @@ pub fn with_autorelease_pool<T, F: FnOnce() -> T>(f: F) -> T {
 pub fn with_autorelease_pool<T, F: FnOnce() -> T>(f: F) -> T {
     f()
 }
+
+/// Whether Core Audio process taps are available (macOS 14.4+).
+/// All tap calls must be gated behind this check — the symbols are weakly
+/// linked and crash on older systems.
+#[cfg(target_os = "macos")]
+pub fn system_audio_capture_supported() -> bool {
+    use objc2_foundation::{NSOperatingSystemVersion, NSProcessInfo};
+
+    NSProcessInfo::processInfo().isOperatingSystemAtLeastVersion(NSOperatingSystemVersion {
+        majorVersion: 14,
+        minorVersion: 4,
+        patchVersion: 0,
+    })
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn system_audio_capture_supported() -> bool {
+    false
+}

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -21,6 +21,7 @@ const VAD_ENABLED_KEY: &str = "vad_enabled";
 const FILLER_REMOVAL_KEY: &str = "filler_removal";
 const STUTTER_COLLAPSE_KEY: &str = "stutter_collapse";
 const DICTIONARY_CORRECTION_KEY: &str = "dictionary_correction";
+const CAPTURE_SYSTEM_AUDIO_KEY: &str = "capture_system_audio";
 const LOCALE_KEY: &str = "locale";
 const SHORTCUT_TOGGLE_KEY: &str = "shortcut_toggle";
 const SHORTCUT_PUSH_TO_TALK_KEY: &str = "shortcut_push_to_talk";
@@ -51,6 +52,9 @@ pub struct AppSettings {
     pub filler_removal: bool,
     pub stutter_collapse: bool,
     pub dictionary_correction: bool,
+    /// Meeting mode: capture system audio (other participants) alongside
+    /// the microphone via a Core Audio tap.
+    pub capture_system_audio: bool,
 }
 
 impl Default for AppSettings {
@@ -71,6 +75,7 @@ impl Default for AppSettings {
             filler_removal: true,
             stutter_collapse: false,
             dictionary_correction: true,
+            capture_system_audio: true,
         }
     }
 }
@@ -147,6 +152,9 @@ impl AppSettings {
         }
         if let Some(dictionary_correction) = read_json_setting::<bool>(db, DICTIONARY_CORRECTION_KEY)? {
             settings.dictionary_correction = dictionary_correction;
+        }
+        if let Some(capture_system_audio) = read_json_setting::<bool>(db, CAPTURE_SYSTEM_AUDIO_KEY)? {
+            settings.capture_system_audio = capture_system_audio;
         }
 
         Ok(settings.sanitized())
@@ -254,6 +262,7 @@ impl AppSettings {
         write_json_setting(db, FILLER_REMOVAL_KEY, &normalized.filler_removal)?;
         write_json_setting(db, STUTTER_COLLAPSE_KEY, &normalized.stutter_collapse)?;
         write_json_setting(db, DICTIONARY_CORRECTION_KEY, &normalized.dictionary_correction)?;
+        write_json_setting(db, CAPTURE_SYSTEM_AUDIO_KEY, &normalized.capture_system_audio)?;
 
         if let Some(audio_device) = normalized.audio_device.as_ref() {
             write_json_setting(db, AUDIO_DEVICE_KEY, audio_device)?;
@@ -374,6 +383,7 @@ mod tests {
             filler_removal: true,
             stutter_collapse: false,
             dictionary_correction: true,
+            capture_system_audio: true,
         };
 
         settings.save(&db).expect("save settings");

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -20,6 +20,9 @@ pub enum AudioCommand {
         session_id: u64,
         target_sample_rate: u32,
         mic_gain: f32,
+        /// Meeting mode: also capture system audio via a Core Audio tap
+        /// and mix it with the microphone.
+        capture_system_audio: bool,
     },
     Stop,
     SelectDevice(String),

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -26,6 +26,9 @@ pub enum AudioCommand {
     },
     Stop,
     SelectDevice(String),
+    /// Give the audio thread an AppHandle so meeting mode can emit
+    /// SystemAudioStatus events.
+    AttachApp(AppHandle),
 }
 
 /// Accumulated meeting segments while recording

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -22,6 +22,8 @@
   let unlistenHealth: (() => void) | null = null;
   let unlistenPipelineError: (() => void) | null = null;
 
+  let unlistenSystemAudio: (() => void) | null = null;
+
   const healthDegraded = $derived(
     app.transcriptionHealth !== null && app.transcriptionHealth.status !== "healthy",
   );
@@ -94,11 +96,18 @@
       unlistenPipelineError = fn;
     });
 
+    events.systemAudioStatus.listen((event) => {
+      app.systemAudioStatus = event.payload;
+    }).then((fn) => {
+      unlistenSystemAudio = fn;
+    });
+
     return () => {
       unlistenNav?.();
       unlistenState?.();
       unlistenHealth?.();
       unlistenPipelineError?.();
+      unlistenSystemAudio?.();
     };
   });
 </script>

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -24,3 +24,7 @@ export async function listAudioDevices(): Promise<AudioDeviceInfo[]> {
 export async function selectAudioDevice(deviceName: string): Promise<void> {
   await unwrap(commands.selectAudioDevice(deviceName));
 }
+
+export async function getSystemAudioSupport(): Promise<boolean> {
+  return commands.getSystemAudioSupport();
+}

--- a/src/lib/components/MeetingView.svelte
+++ b/src/lib/components/MeetingView.svelte
@@ -54,6 +54,7 @@
     <MeetingHeaderSection
       meeting={controller.meeting}
       isRecordingMeeting={controller.isRecordingMeeting}
+      systemAudioStatus={controller.app.systemAudioStatus}
       {lockedByDictation}
       segmentCount={displaySegments.length}
       sessionCount={sessionCount}

--- a/src/lib/components/SettingsView.svelte
+++ b/src/lib/components/SettingsView.svelte
@@ -45,12 +45,15 @@
   <AudioSettingsSection
     audioDevices={controller.audioDevices}
     selectedDevice={controller.app.selectedDevice}
+    captureSystemAudio={controller.app.settings.capture_system_audio}
+    systemAudioSupported={controller.systemAudioSupported}
     vadEnabled={controller.app.settings.vad_enabled}
     fillerRemoval={controller.app.settings.filler_removal}
     stutterCollapse={controller.app.settings.stutter_collapse}
     dictionaryCorrection={controller.app.settings.dictionary_correction}
     onDeviceChange={controller.onDeviceChange}
     onRefreshDevices={controller.refreshDevices}
+    onCaptureSystemAudioChange={controller.onCaptureSystemAudioChange}
     onVadEnabledChange={controller.onVadEnabledChange}
     onFillerRemovalChange={controller.onFillerRemovalChange}
     onStutterCollapseChange={controller.onStutterCollapseChange}

--- a/src/lib/features/meeting/components/MeetingHeaderSection.svelte
+++ b/src/lib/features/meeting/components/MeetingHeaderSection.svelte
@@ -7,6 +7,7 @@
   let {
     meeting,
     isRecordingMeeting,
+    systemAudioStatus,
     lockedByDictation,
     segmentCount,
     sessionCount,
@@ -18,6 +19,7 @@
   }: {
     meeting: MeetingTranscript;
     isRecordingMeeting: boolean;
+    systemAudioStatus: import("../../../types").SystemAudioStatus | null;
     lockedByDictation: boolean;
     segmentCount: number;
     sessionCount: number;
@@ -34,6 +36,13 @@
     {#if isRecordingMeeting}
       <span class="pill pill-danger inline-flex items-center gap-1.5">
         <span class="recording-dot"></span> {$t("meeting_header.recording_badge")}
+        {#if systemAudioStatus}
+          {#if systemAudioStatus.active}
+            <span class="pill pill-blue">{$t("meeting_header.system_audio_active")}</span>
+          {:else}
+            <span class="pill pill-muted" title={systemAudioStatus.reason ?? ""}>{$t("meeting_header.system_audio_unavailable")}</span>
+          {/if}
+        {/if}
       </span>
     {:else}
       <button onclick={onBack} class="btn btn-ghost py-1 px-0 text-sm gap-1 mb-1">

--- a/src/lib/features/settings/components/AudioSettingsSection.svelte
+++ b/src/lib/features/settings/components/AudioSettingsSection.svelte
@@ -7,12 +7,15 @@
   let {
     audioDevices,
     selectedDevice,
+    captureSystemAudio,
+    systemAudioSupported,
     vadEnabled,
     fillerRemoval,
     stutterCollapse,
     dictionaryCorrection,
     onDeviceChange,
     onRefreshDevices,
+    onCaptureSystemAudioChange,
     onVadEnabledChange,
     onFillerRemovalChange,
     onStutterCollapseChange,
@@ -20,12 +23,15 @@
   }: {
     audioDevices: AudioDeviceInfo[];
     selectedDevice: string;
+    captureSystemAudio: boolean;
+    systemAudioSupported: boolean;
     vadEnabled: boolean;
     fillerRemoval: boolean;
     stutterCollapse: boolean;
     dictionaryCorrection: boolean;
     onDeviceChange: (event: Event) => void | Promise<void>;
     onRefreshDevices: () => void | Promise<void>;
+    onCaptureSystemAudioChange: (event: Event) => void | Promise<void>;
     onVadEnabledChange: (event: Event) => void | Promise<void>;
     onFillerRemovalChange: (event: Event) => void | Promise<void>;
     onStutterCollapseChange: (event: Event) => void | Promise<void>;
@@ -52,6 +58,17 @@
       </button>
     </div>
   </div>
+
+  {#if systemAudioSupported}
+    <SettingsField
+      label={$t("settings_audio.capture_system_audio")}
+      description={$t("settings_audio.capture_system_audio_desc")}
+    >
+      {#snippet control()}
+        <input type="checkbox" checked={captureSystemAudio} onchange={onCaptureSystemAudioChange} class="switch" aria-label={$t("settings_audio.capture_system_audio")} />
+      {/snippet}
+    </SettingsField>
+  {/if}
 
   <SettingsField
     label={$t("settings_audio.vad_enabled")}

--- a/src/lib/features/settings/controller.svelte.ts
+++ b/src/lib/features/settings/controller.svelte.ts
@@ -3,6 +3,7 @@ import { deleteModel, getTranscriptionCatalog } from "../../api/transcription";
 import {
   getSettings,
   getShortcuts,
+  getSystemAudioSupport,
   listAudioDevices,
   saveSettings,
   saveShortcuts as persistShortcutSettings,
@@ -42,6 +43,7 @@ export function createSettingsController() {
   const app = getAppState();
 
   let audioDevices = $state<AudioDeviceInfo[]>([]);
+  let systemAudioSupported = $state(false);
   let ollamaAvailable = $state(false);
   let ollamaModels = $state<OllamaModelDescriptor[]>([]);
   let statusMessage = $state("");
@@ -58,6 +60,9 @@ export function createSettingsController() {
 
   async function mount() {
     await syncSettings();
+    getSystemAudioSupport()
+      .then((supported) => { systemAudioSupported = supported; })
+      .catch(() => { systemAudioSupported = false; });
     await Promise.all([
       loadShortcuts(),
       refreshDevices(),
@@ -329,6 +334,13 @@ export function createSettingsController() {
     });
   }
 
+  function onCaptureSystemAudioChange(event: Event) {
+    const checked = (event.target as HTMLInputElement).checked;
+    void persistSettings((settings) => {
+      settings.capture_system_audio = checked;
+    });
+  }
+
   async function loadDictionary() {
     try {
       dictionaryEntries = await listDictionary();
@@ -477,6 +489,8 @@ export function createSettingsController() {
     onDebugTranscriptionChange,
     onOllamaUrlChange,
     onOllamaModelChange,
+    get systemAudioSupported() { return systemAudioSupported; },
+    onCaptureSystemAudioChange,
     onVadEnabledChange,
     onFillerRemovalChange,
     onStutterCollapseChange,

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -27,7 +27,9 @@
     "stutter_collapse": "Stutter Collapse",
     "stutter_collapse_desc": "Collapse repeated words (3+ repetitions) into a single occurrence.",
     "dictionary_correction": "Dictionary Correction",
-    "dictionary_correction_desc": "Correct misrecognized words using your custom dictionary."
+    "dictionary_correction_desc": "Correct misrecognized words using your custom dictionary.",
+    "capture_system_audio": "System Audio Capture",
+    "capture_system_audio_desc": "During meetings, capture the computer's audio output (Teams, Zoom…) alongside the microphone. No configuration needed."
   },
   "settings_dictionary": {
     "title": "Custom Dictionary",
@@ -218,7 +220,9 @@
     "stop_recording": "Stop Recording",
     "resume_recording": "Resume Recording",
     "new_meeting": "New Meeting",
-    "locked_by_dictation": "Stop the dictation before recording a meeting."
+    "locked_by_dictation": "Stop the dictation before recording a meeting.",
+    "system_audio_active": "System audio",
+    "system_audio_unavailable": "Mic only"
   },
   "meeting_transcript": {
     "title": "Transcript",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -27,7 +27,9 @@
     "stutter_collapse": "Réduction des bégaiements",
     "stutter_collapse_desc": "Réduit les mots répétés (3+ répétitions) en une seule occurrence.",
     "dictionary_correction": "Correction par dictionnaire",
-    "dictionary_correction_desc": "Corrige les mots mal reconnus à l'aide de votre dictionnaire personnalisé."
+    "dictionary_correction_desc": "Corrige les mots mal reconnus à l'aide de votre dictionnaire personnalisé.",
+    "capture_system_audio": "Capture de l'audio système",
+    "capture_system_audio_desc": "Pendant les meetings, capture la sortie audio de l'ordinateur (Teams, Zoom…) en plus du micro. Aucune configuration requise."
   },
   "settings_dictionary": {
     "title": "Dictionnaire personnalisé",
@@ -218,7 +220,9 @@
     "stop_recording": "Arrêter l'enregistrement",
     "resume_recording": "Reprendre l'enregistrement",
     "new_meeting": "Nouvelle réunion",
-    "locked_by_dictation": "Arrêtez la dictée avant d'enregistrer une réunion."
+    "locked_by_dictation": "Arrêtez la dictée avant d'enregistrer une réunion.",
+    "system_audio_active": "Audio système",
+    "system_audio_unavailable": "Micro seul"
   },
   "meeting_transcript": {
     "title": "Transcription",

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -3,6 +3,7 @@ import type {
   AppStateMachine,
   AppView,
   PipelineError,
+  SystemAudioStatus,
   TranscriptionHealth,
   TranscriptionRuntimePhase,
 } from "../types";
@@ -28,6 +29,9 @@ let transcriptionRuntimePhase = $state<TranscriptionRuntimePhase>("download_requ
 
 // Latest pipeline health snapshot while recording (cleared when recording ends)
 let transcriptionHealth = $state<TranscriptionHealth | null>(null);
+
+// System-audio capture status for the current meeting session
+let systemAudioStatus = $state<SystemAudioStatus | null>(null);
 
 // Last pipeline error surfaced by the backend (dismissable)
 let pipelineError = $state<PipelineError | null>(null);
@@ -56,6 +60,7 @@ let settings = $state<AppSettings>({
   filler_removal: true,
   stutter_collapse: false,
   dictionary_correction: true,
+  capture_system_audio: true,
 });
 
 function deriveRecordingMode(state: AppStateMachine): "idle" | "dictation" | "meeting" {
@@ -128,11 +133,15 @@ export function getAppState() {
       // Health snapshots only make sense while recording
       if (deriveRecordingMode(s) === "idle") {
         transcriptionHealth = null;
+        systemAudioStatus = null;
       }
     },
 
     get transcriptionHealth() { return transcriptionHealth; },
     set transcriptionHealth(h: TranscriptionHealth | null) { transcriptionHealth = h; },
+
+    get systemAudioStatus() { return systemAudioStatus; },
+    set systemAudioStatus(s: SystemAudioStatus | null) { systemAudioStatus = s; },
 
     get pipelineError() { return pipelineError; },
     set pipelineError(e: PipelineError | null) { pipelineError = e; },

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -339,6 +339,12 @@ async getAudioLevel() : Promise<Result<number, string>> {
 }
 },
 /**
+ * Whether system-audio capture (Core Audio process taps) is available on this OS
+ */
+async getSystemAudioSupport() : Promise<boolean> {
+    return await TAURI_INVOKE("get_system_audio_support");
+},
+/**
  * Return the current state machine state.
  */
 async getMachineState() : Promise<Result<AppStateMachine, string>> {

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -345,6 +345,18 @@ async getSystemAudioSupport() : Promise<boolean> {
     return await TAURI_INVOKE("get_system_audio_support");
 },
 /**
+ * Debug: record system audio for `seconds` and write it to a WAV file.
+ * Returns the file path. Exercises the tap end-to-end (TCC prompt included).
+ */
+async debugRecordSystemAudio(seconds: number) : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("debug_record_system_audio", { seconds }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Return the current state machine state.
  */
 async getMachineState() : Promise<Result<AppStateMachine, string>> {
@@ -435,7 +447,12 @@ transcriptionHealth: "transcription-health"
 
 /** user-defined types **/
 
-export type AppSettings = { theme: Theme; locale: string; auto_paste: boolean; paste_delay_ms: number; ollama_url: string; ollama_model: string; debug_transcription: boolean; audio_device: string | null; transcription_engine_id: string; transcription_model_id: string; transcription_backend_id: string; vad_enabled: boolean; filler_removal: boolean; stutter_collapse: boolean; dictionary_correction: boolean }
+export type AppSettings = { theme: Theme; locale: string; auto_paste: boolean; paste_delay_ms: number; ollama_url: string; ollama_model: string; debug_transcription: boolean; audio_device: string | null; transcription_engine_id: string; transcription_model_id: string; transcription_backend_id: string; vad_enabled: boolean; filler_removal: boolean; stutter_collapse: boolean; dictionary_correction: boolean; 
+/**
+ * Meeting mode: capture system audio (other participants) alongside
+ * the microphone via a Core Audio tap.
+ */
+capture_system_audio: boolean }
 /**
  * Unified application state machine.
  * Replaces scattered `is_recording`, `model_loaded`, `recording_mode`, `active_profile` booleans

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -430,6 +430,7 @@ shortcutPttStart: ShortcutPttStart,
 shortcutPttStop: ShortcutPttStop,
 shortcutToggle: ShortcutToggle,
 stateChanged: StateChanged,
+systemAudioStatus: SystemAudioStatus,
 transcriptionHealth: TranscriptionHealth
 }>({
 navigate: "navigate",
@@ -438,6 +439,7 @@ shortcutPttStart: "shortcut-ptt-start",
 shortcutPttStop: "shortcut-ptt-stop",
 shortcutToggle: "shortcut-toggle",
 stateChanged: "state-changed",
+systemAudioStatus: "system-audio-status",
 transcriptionHealth: "transcription-health"
 })
 
@@ -522,6 +524,16 @@ export type ShortcutSettings = { toggle: string; push_to_talk: string }
 export type ShortcutToggle = null
 export type StateChanged = AppStateMachine
 export type SummarizeProgress = { text: string; done: boolean }
+/**
+ * State of the system-audio capture leg of a meeting session, emitted when
+ * the session starts and whenever the leg changes (e.g. tap rebuild after
+ * an output device switch).
+ */
+export type SystemAudioStatus = { active: boolean; 
+/**
+ * Present when inactive because of an error (e.g. permission denied).
+ */
+reason: string | null }
 export type Theme = "dark" | "light" | "system"
 export type TranscriptionCapabilities = { supports_streaming: boolean; supports_batch_transcription: boolean; supports_language_auto_detect: boolean; supports_word_timestamps: boolean; supports_partial_results: boolean }
 export type TranscriptionCatalog = { engines: TranscriptionEngineDescriptor[]; selected_engine_id: string; selected_model_id: string; selected_backend_id: string }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -21,6 +21,7 @@ export type {
   Theme,
   HealthStatus,
   PipelineError,
+  SystemAudioStatus,
   TranscriptionHealth,
   TranscriptionCapabilities,
   TranscriptionCatalog,


### PR DESCRIPTION
## Summary

**System audio capture (meetings)**
- Native system-audio capture via Core Audio process taps (macOS 14.4+), no virtual driver or Audio MIDI Setup needed
- Two-source mixer combines mic + system audio: both legs push into lock-free rings, a 5ms tick resamples both to 48kHz, pairs into 10ms frames, sums, and resamples to the engine rate. The mic paces the mix; a silent/unavailable tap degrades to mic-only. Dictation keeps its existing single-resampler path untouched
- WebRTC AEC3 (sonora, pure Rust) cancels speaker echo when the default output routes to built-in speakers, using the system-audio tap as the AEC reference signal. Output route is polled every ~2s; the tap rebuilds and AEC engages/disengages on route changes
- Fixed a HAL deadlock between the tap's C-IOProc and cpal's AUHAL input stream that froze meeting start (and could wedge coreaudiod): the tap now registers via `AudioDeviceCreateIOProcIDWithBlock` on a private dispatch queue, drops the output subdevice from the aggregate, and runs on a disposable thread with a 5s startup timeout — a wedged CoreAudio degrades to mic-only instead of freezing the session
- Sessions survive input-device changes mid-recording (e.g. closing the lid, plugging a headset): a 2s health check rebuilds the capture leg under the same session id, following the system default unless the user pinned a device
- New "System Audio Capture" toggle in settings (hidden on macOS < 14.4, default on), `SystemAudioStatus` event with an active/mic-only badge on the meeting header, en/fr strings, and SPEC.md updated to document the tap + mixer + AEC architecture in place of the old BlackHole workaround

## Test plan
- [x] Automated: HAL deadlock regression tests (both tap/mic start orders), AEC convergence test (delayed far-end tone into the mic leg)
- [ ] Manual: meeting recording with system audio on/off, headphones vs. speakers (AEC on/off), input-device hot-swap mid-session, default-output device switch mid-meeting