### PR TITLE
Robustness and maintainability fixes across the recording pipeline

### DIFF
--- a/src-tauri/src/commands/permissions.rs
+++ b/src-tauri/src/commands/permissions.rs
@@ -1,4 +1,4 @@
-use crate::permissions::{self, PermState, PermissionStatus};
+use crate::permissions::{self, PermState, PermissionKind, PermissionStatus};
 
 /// Cheap, non-prompting snapshot for the onboarding's initial render.
 #[tauri::command]
@@ -8,12 +8,11 @@ pub fn get_permission_status() -> Result<PermissionStatus, String> {
 }
 
 /// Trigger the native prompt (or open System Settings) for one permission.
-/// `kind` is "microphone" | "system_audio" | "accessibility". The probe opens
-/// a device, so it runs off the command thread.
+/// The probe opens a device, so it runs off the command thread.
 #[tauri::command]
 #[specta::specta]
-pub async fn request_permission(kind: String) -> Result<PermState, String> {
-    tauri::async_runtime::spawn_blocking(move || permissions::request(&kind))
+pub async fn request_permission(kind: PermissionKind) -> Result<PermState, String> {
+    tauri::async_runtime::spawn_blocking(move || permissions::request(kind))
         .await
         .map_err(|e| format!("Permission probe failed: {e}"))
 }

--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -17,7 +17,7 @@ use crate::lock_ext::MutexExt;
 use crate::pipeline::{EngineActorHandle, SegmentCallback, SessionConfig};
 use crate::state::{AppState, AudioCommand, MeetingAccumulator};
 use crate::state_machine::StateAction;
-use crate::transcript::{MeetingRecordingSession, MeetingTranscript};
+use crate::transcript::MeetingTranscript;
 
 /// Flush accumulated meeting segments to the DB once this many have piled up
 /// since the last flush. Segments are word-level, so this is a few seconds of
@@ -26,7 +26,7 @@ const MEETING_FLUSH_THRESHOLD: usize = 16;
 
 /// Build a header-only transcript (no segments) for `upsert_meeting_header`.
 /// `started_at` follows the first recording session on resume, else this
-/// session's start — matching `build_meeting_transcript`.
+/// session's start — matching `MeetingAccumulator::into_transcript`.
 fn meeting_header(acc: &MeetingAccumulator) -> MeetingTranscript {
     let started_at = acc
         .recording_sessions
@@ -78,7 +78,12 @@ fn build_meeting_on_segment(
                 let start = (meeting.existing_segments.len() + meeting.persisted_new_count) as i64;
                 let slice = meeting.new_segments[meeting.persisted_new_count..].to_vec();
                 meeting.persisted_new_count = meeting.new_segments.len();
-                Some((meeting.id.clone(), slice, start, meeting.persisted_new_count))
+                Some((
+                    meeting.id.clone(),
+                    slice,
+                    start,
+                    meeting.persisted_new_count,
+                ))
             }
         };
 
@@ -177,56 +182,6 @@ fn current_active_profile(state: &AppState) -> Result<crate::engine::Transcripti
         .active_profile()
         .cloned()
         .ok_or_else(|| "No active transcription profile".to_string())
-}
-
-/// Also used by the engine actor to salvage a meeting when its recording
-/// session aborts mid-way.
-pub(crate) fn build_meeting_transcript(
-    meeting: MeetingAccumulator,
-    ended_at: chrono::DateTime<chrono::Utc>,
-) -> MeetingTranscript {
-    let mut segments = meeting.existing_segments;
-    let start_segment_index = segments.len() as u64;
-    let had_new_segments = !meeting.new_segments.is_empty();
-    let has_summary = meeting.summary.is_some();
-    segments.extend(meeting.new_segments);
-    let end_segment_index = segments.len() as u64;
-
-    let mut recording_sessions = meeting.recording_sessions;
-    recording_sessions.push(MeetingRecordingSession::completed(
-        Uuid::new_v4().to_string(),
-        meeting.session_started_at,
-        ended_at,
-        start_segment_index,
-        end_segment_index,
-    ));
-
-    let started_at = recording_sessions
-        .first()
-        .map(|session| session.started_at)
-        .unwrap_or(meeting.session_started_at);
-    let ended_at = recording_sessions.last().map(|session| session.ended_at);
-    let duration_seconds = recording_sessions
-        .iter()
-        .map(|session| session.duration_seconds)
-        .sum();
-
-    MeetingTranscript {
-        id: meeting.id,
-        title: meeting.title,
-        started_at,
-        ended_at,
-        duration_seconds,
-        transcription_profile: meeting.transcription_profile,
-        recording_sessions,
-        segments,
-        summary: meeting.summary,
-        summary_is_stale: meeting.summary_is_stale || (has_summary && had_new_segments),
-        summary_model: meeting.summary_model,
-        summary_generated_at: meeting.summary_generated_at,
-        edited_transcript: None,
-        notes: meeting.notes,
-    }
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -570,7 +525,7 @@ pub async fn stop_meeting_recording(state: State<'_, AppState>) -> Result<String
             if let Ok(mut guard) = state.meeting_accumulator.lock()
                 && let Some(meeting) = guard.take()
             {
-                let transcript = build_meeting_transcript(meeting, chrono::Utc::now());
+                let transcript = meeting.into_transcript(chrono::Utc::now());
                 if let Err(e) = state.db.save_meeting(&transcript) {
                     tracing::error!(id = %transcript.id, "Failed to save meeting: {e}");
                 } else {
@@ -618,102 +573,13 @@ pub fn paste_text(text: String, delay_ms: u64) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{MEETING_FLUSH_THRESHOLD, build_meeting_on_segment, build_meeting_transcript};
+    use super::{MEETING_FLUSH_THRESHOLD, build_meeting_on_segment};
     use crate::engine::{TranscriptionSegment, default_transcription_profile};
     use crate::state::MeetingAccumulator;
     use crate::test_helpers::fixtures::test_db;
-    use crate::transcript::MeetingRecordingSession;
-    use chrono::{Duration, Utc};
+    use chrono::Utc;
     use std::sync::{Arc, Mutex};
     use tauri::ipc::Channel;
-
-    #[test]
-    fn build_meeting_transcript_appends_resumed_session_and_marks_summary_stale() {
-        let first_start = Utc::now();
-        let first_end = first_start + Duration::seconds(30);
-        let second_start = first_end + Duration::minutes(5);
-        let second_end = second_start + Duration::seconds(45);
-
-        let transcript = build_meeting_transcript(
-            MeetingAccumulator {
-                id: "meeting-1".to_string(),
-                title: "Roadmap".to_string(),
-                existing_segments: vec![TranscriptionSegment {
-                    text: "Existing".to_string(),
-                    start_time: 0.0,
-                    end_time: 1.0,
-                    is_final: true,
-                    language: None,
-                    confidence: None,
-                    speaker: None,
-                }],
-                new_segments: vec![TranscriptionSegment {
-                    text: "Appended".to_string(),
-                    start_time: 1.0,
-                    end_time: 2.0,
-                    is_final: true,
-                    language: None,
-                    confidence: None,
-                    speaker: None,
-                }],
-                recording_sessions: vec![MeetingRecordingSession::completed(
-                    "session-1".to_string(),
-                    first_start,
-                    first_end,
-                    0,
-                    1,
-                )],
-                session_started_at: second_start,
-                transcription_profile: default_transcription_profile(),
-                summary: Some("Old summary".to_string()),
-                summary_is_stale: false,
-                summary_model: Some("qwen".to_string()),
-                summary_generated_at: Some(first_end),
-                notes: None,
-                persisted_new_count: 0,
-            },
-            second_end,
-        );
-
-        assert_eq!(transcript.id, "meeting-1");
-        assert_eq!(transcript.recording_sessions.len(), 2);
-        assert_eq!(transcript.recording_sessions[1].start_segment_index, 1);
-        assert_eq!(transcript.recording_sessions[1].end_segment_index, 2);
-        assert_eq!(transcript.segments.len(), 2);
-        assert!(transcript.summary_is_stale);
-        assert_eq!(transcript.started_at, first_start);
-        assert_eq!(transcript.ended_at, Some(second_end));
-        assert_eq!(transcript.duration_seconds, 75.0);
-    }
-
-    #[test]
-    fn build_meeting_transcript_preserves_fresh_summary_when_no_new_segments_arrive() {
-        let started_at = Utc::now();
-        let ended_at = started_at + Duration::seconds(10);
-
-        let transcript = build_meeting_transcript(
-            MeetingAccumulator {
-                id: "meeting-2".to_string(),
-                title: "Silent Resume".to_string(),
-                existing_segments: Vec::new(),
-                new_segments: Vec::new(),
-                recording_sessions: Vec::new(),
-                session_started_at: started_at,
-                transcription_profile: default_transcription_profile(),
-                summary: Some("Still current".to_string()),
-                summary_is_stale: false,
-                summary_model: Some("qwen".to_string()),
-                summary_generated_at: Some(started_at),
-                notes: None,
-                persisted_new_count: 0,
-            },
-            ended_at,
-        );
-
-        assert_eq!(transcript.recording_sessions.len(), 1);
-        assert_eq!(transcript.duration_seconds, 10.0);
-        assert!(!transcript.summary_is_stale);
-    }
 
     #[test]
     fn build_meeting_on_segment_rolls_back_persisted_count_on_flush_failure() {

--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -78,14 +78,27 @@ fn build_meeting_on_segment(
                 let start = (meeting.existing_segments.len() + meeting.persisted_new_count) as i64;
                 let slice = meeting.new_segments[meeting.persisted_new_count..].to_vec();
                 meeting.persisted_new_count = meeting.new_segments.len();
-                Some((meeting.id.clone(), slice, start))
+                Some((meeting.id.clone(), slice, start, meeting.persisted_new_count))
             }
         };
 
-        if let Some((id, segments, start)) = batch
+        if let Some((id, segments, start, advanced_to)) = batch
             && let Err(e) = db.append_segments(&id, &segments, start)
         {
             warn!("Incremental meeting segment flush failed: {e}");
+            // Roll the counter back so this batch is retried on the next flush
+            // instead of being permanently skipped, which would otherwise widen
+            // the crash-loss window beyond one batch. This callback runs only on
+            // the single engine-actor thread, so nothing else advances
+            // persisted_new_count between the write above and this re-lock; the
+            // equality check below only guards against the accumulator having
+            // been taken (and possibly replaced) by a concurrent stop.
+            if let Ok(mut guard) = accumulator.lock()
+                && let Some(meeting) = guard.as_mut()
+                && meeting.persisted_new_count == advanced_to
+            {
+                meeting.persisted_new_count -= segments.len();
+            }
         }
     })
 }
@@ -136,6 +149,15 @@ async fn launch_meeting(
     if let Err(error) = res {
         if let Ok(mut acc) = acc.lock() {
             *acc = None;
+        }
+        // The header row upserted above is now orphaned (ended_at IS NULL) with
+        // no recording in progress: recovery is safe to run here immediately,
+        // rather than waiting for the next app restart, because clearing the
+        // accumulator above guarantees no meeting is mid-recording. This either
+        // deletes an empty new-meeting shell or finalizes a resumed meeting from
+        // its already-persisted segments.
+        if let Err(e) = state.db.recover_unfinished_meetings() {
+            warn!("Meeting recovery after failed start failed: {e}");
         }
         return Err(error);
     }
@@ -535,29 +557,45 @@ pub async fn stop_meeting_recording(state: State<'_, AppState>) -> Result<String
     tauri::async_runtime::spawn_blocking(move || {
         let state = app.state::<AppState>();
 
-        let pipeline_err =
-            stop_pipeline_blocking(&state.engine_actor, &state.audio_cmd_sender).err();
+        // Only the fallible drain+save is guarded: if it panics (e.g. an engine
+        // or DB driver bug), the transition and event emit below still must run
+        // so the machine never gets stuck in Stopping. Segments already flushed
+        // incrementally during the meeting are not lost even if this panics.
+        let drain_and_save = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let pipeline_err =
+                stop_pipeline_blocking(&state.engine_actor, &state.audio_cmd_sender).err();
 
-        // Authoritative full save from the in-memory accumulator (overwrites the
-        // incrementally-persisted rows with the complete, finalized transcript).
-        if let Ok(mut guard) = state.meeting_accumulator.lock()
-            && let Some(meeting) = guard.take()
-        {
-            let transcript = build_meeting_transcript(meeting, chrono::Utc::now());
-            if let Err(e) = state.db.save_meeting(&transcript) {
-                tracing::error!(id = %transcript.id, "Failed to save meeting: {e}");
-            } else {
-                info!(
-                    id = %transcript.id,
-                    duration = transcript.duration_seconds,
-                    sessions = transcript.recording_sessions.len(),
-                    "Meeting recording saved"
-                );
+            // Authoritative full save from the in-memory accumulator (overwrites the
+            // incrementally-persisted rows with the complete, finalized transcript).
+            if let Ok(mut guard) = state.meeting_accumulator.lock()
+                && let Some(meeting) = guard.take()
+            {
+                let transcript = build_meeting_transcript(meeting, chrono::Utc::now());
+                if let Err(e) = state.db.save_meeting(&transcript) {
+                    tracing::error!(id = %transcript.id, "Failed to save meeting: {e}");
+                } else {
+                    info!(
+                        id = %transcript.id,
+                        duration = transcript.duration_seconds,
+                        sessions = transcript.recording_sessions.len(),
+                        "Meeting recording saved"
+                    );
+                }
             }
-        }
 
-        // Always complete the transition, even if drain/save failed, so the
-        // machine never gets stuck in Stopping.
+            pipeline_err
+        }));
+
+        let pipeline_err = match drain_and_save {
+            Ok(pipeline_err) => pipeline_err,
+            Err(_) => {
+                tracing::error!("Meeting stop task panicked during drain/save");
+                None
+            }
+        };
+
+        // Always complete the transition, even if drain/save failed or panicked,
+        // so the machine never gets stuck in Stopping.
         if let Err(e) = state.apply_transition(StateAction::StopComplete) {
             warn!("Failed to complete stop transition: {e}");
         }
@@ -580,11 +618,14 @@ pub fn paste_text(text: String, delay_ms: u64) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
-    use super::build_meeting_transcript;
+    use super::{MEETING_FLUSH_THRESHOLD, build_meeting_on_segment, build_meeting_transcript};
     use crate::engine::{TranscriptionSegment, default_transcription_profile};
     use crate::state::MeetingAccumulator;
+    use crate::test_helpers::fixtures::test_db;
     use crate::transcript::MeetingRecordingSession;
     use chrono::{Duration, Utc};
+    use std::sync::{Arc, Mutex};
+    use tauri::ipc::Channel;
 
     #[test]
     fn build_meeting_transcript_appends_resumed_session_and_marks_summary_stale() {
@@ -672,5 +713,53 @@ mod tests {
         assert_eq!(transcript.recording_sessions.len(), 1);
         assert_eq!(transcript.duration_seconds, 10.0);
         assert!(!transcript.summary_is_stale);
+    }
+
+    #[test]
+    fn build_meeting_on_segment_rolls_back_persisted_count_on_flush_failure() {
+        // No upsert_meeting_header call for this id: the meetings row does not
+        // exist, so append_segments fails on the segments.meeting_id foreign
+        // key, exercising the same failure the fix guards against.
+        let (db, _dir) = test_db();
+        let db = Arc::new(db);
+
+        let accumulator = Arc::new(Mutex::new(Some(MeetingAccumulator {
+            id: "missing-meeting".to_string(),
+            title: "Ghost".to_string(),
+            existing_segments: Vec::new(),
+            new_segments: Vec::new(),
+            recording_sessions: Vec::new(),
+            session_started_at: Utc::now(),
+            transcription_profile: default_transcription_profile(),
+            summary: None,
+            summary_is_stale: false,
+            summary_model: None,
+            summary_generated_at: None,
+            notes: None,
+            persisted_new_count: 0,
+        })));
+
+        let channel: Channel<TranscriptionSegment> = Channel::new(|_| Ok(()));
+        let on_segment = build_meeting_on_segment(channel, Arc::clone(&accumulator), db);
+
+        for i in 0..MEETING_FLUSH_THRESHOLD {
+            on_segment(TranscriptionSegment {
+                text: format!("segment {i}"),
+                start_time: i as f64,
+                end_time: i as f64 + 1.0,
+                is_final: true,
+                language: None,
+                confidence: None,
+                speaker: None,
+            });
+        }
+
+        let guard = accumulator.lock().unwrap();
+        let meeting = guard.as_ref().unwrap();
+        assert_eq!(meeting.new_segments.len(), MEETING_FLUSH_THRESHOLD);
+        assert_eq!(
+            meeting.persisted_new_count, 0,
+            "flush failed (FK violation) so the batch must be retried, not lost"
+        );
     }
 }

--- a/src-tauri/src/db/meetings.rs
+++ b/src-tauri/src/db/meetings.rs
@@ -190,8 +190,10 @@ impl Database {
     /// Empty shells (a started meeting with no persisted segments) are deleted;
     /// the rest get `ended_at`/`duration`/`recording_sessions` synthesized from
     /// their persisted segments and are rewritten (which also rebuilds FTS).
-    /// Returns the number of meetings salvaged. Safe to call only at startup,
-    /// before any live recording can hold a legitimately-open meeting.
+    /// Returns the number of meetings salvaged. Safe to call whenever no
+    /// recording is live: at startup, and also from the failed-start path in
+    /// `launch_meeting`, since the accumulator guard there guarantees no other
+    /// meeting is mid-recording when it runs.
     pub fn recover_unfinished_meetings(&self) -> Result<usize, String> {
         let ids: Vec<String> = {
             let conn = self.conn.acquire()?;

--- a/src-tauri/src/ollama/mod.rs
+++ b/src-tauri/src/ollama/mod.rs
@@ -17,6 +17,20 @@ const MAP_NUM_CTX: u32 = 8192;
 /// the overlap carried between consecutive chunks to preserve boundary context.
 const CHUNK_WORDS: usize = 1400;
 const CHUNK_OVERLAP_WORDS: usize = 120;
+/// Map-stage concurrency cap: Ollama is a single local server backed by one
+/// GPU, so firing every chunk at once (a 2h meeting is ~13 chunks) queues
+/// requests behind each other anyway and thrashes VRAM. Two in flight keeps
+/// the queue short without serializing entirely.
+const MAP_CONCURRENCY: usize = 2;
+/// Lower bound on establishing a TCP connection to the local Ollama server;
+/// if it hasn't accepted the connection by then it's not coming up.
+const CONNECT_TIMEOUT_SECS: u64 = 5;
+/// Upper bound on the gap between received stream chunks, not on total
+/// request duration (long generations are legitimate). Every request below
+/// streams, so this is safe: a non-streaming response would otherwise
+/// deliver no bytes until generation finishes and could trip this timeout
+/// on a long generation.
+const READ_TIMEOUT_SECS: u64 = 120;
 
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 pub struct OllamaModelDescriptor {
@@ -290,44 +304,11 @@ fn build_reduce_prompt(part_summaries: &[String], notes: Option<&str>) -> String
     prompt
 }
 
-/// One non-streaming Ollama generation; returns the full response text.
-async fn generate_once(
-    client: &reqwest::Client,
-    url: &str,
-    model: &str,
-    system: &str,
-    prompt: String,
-    num_ctx: u32,
-    temperature: f32,
-) -> Result<String, String> {
-    let body = GenerateRequest {
-        model: model.to_string(),
-        prompt,
-        system: system.to_string(),
-        stream: false,
-        options: GenerateOptions {
-            temperature,
-            num_ctx,
-        },
-    };
-    let resp = client
-        .post(format!("{url}/api/generate"))
-        .json(&body)
-        .send()
-        .await
-        .map_err(|e| format!("Ollama request: {e}"))?;
-    if !resp.status().is_success() {
-        return Err(format!("Ollama error: {}", resp.status()));
-    }
-    let parsed = resp
-        .json::<GenerateChunk>()
-        .await
-        .map_err(|e| format!("Ollama response: {e}"))?;
-    Ok(parsed.response)
-}
-
 /// One streaming Ollama generation; forwards each token to `on_chunk` and
-/// returns the accumulated text.
+/// returns the accumulated text. Every generation streams, including the map
+/// stage (which passes a no-op `on_chunk`), so that `read_timeout` on the
+/// client only ever bounds the gap between chunks, never total generation
+/// time.
 #[allow(clippy::too_many_arguments)]
 async fn generate_stream(
     client: &reqwest::Client,
@@ -411,7 +392,11 @@ pub async fn summarize_stream(
     }
 
     let url = base_url.unwrap_or(OLLAMA_DEFAULT_URL);
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(CONNECT_TIMEOUT_SECS))
+        .read_timeout(std::time::Duration::from_secs(READ_TIMEOUT_SECS))
+        .build()
+        .map_err(|e| format!("Ollama client: {e}"))?;
 
     // Short enough to fit comfortably in one context — summarize directly.
     if estimate_tokens(transcript_text) <= STUFF_TOKEN_LIMIT {
@@ -429,27 +414,34 @@ pub async fn summarize_stream(
         return Ok(sanitize_summary(&full));
     }
 
-    // Map: summarize each chunk independently, concurrently.
+    // Map: summarize each chunk independently, bounded to MAP_CONCURRENCY at a
+    // time (see const doc) but with results collected in chunk order.
+    use futures_util::{StreamExt, TryStreamExt};
+    let no_op = |_: SummarizeProgress| {};
     let chunks = chunk_transcript(transcript_text);
     let n = chunks.len();
-    let maps = chunks.iter().enumerate().map(|(i, chunk)| {
-        let user = format!(
-            "Part {} of {}.\n\nTranscript excerpt:\n---\n{}\n---",
-            i + 1,
-            n,
-            chunk
-        );
-        generate_once(
-            &client,
-            url,
-            model,
-            OLLAMA_MAP_PROMPT,
-            user,
-            MAP_NUM_CTX,
-            0.2,
-        )
-    });
-    let part_summaries = futures_util::future::try_join_all(maps).await?;
+    let part_summaries: Vec<String> = futures_util::stream::iter(chunks.into_iter().enumerate())
+        .map(|(i, chunk)| {
+            let user = format!(
+                "Part {} of {}.\n\nTranscript excerpt:\n---\n{}\n---",
+                i + 1,
+                n,
+                chunk
+            );
+            generate_stream(
+                &client,
+                url,
+                model,
+                OLLAMA_MAP_PROMPT,
+                user,
+                MAP_NUM_CTX,
+                0.2,
+                &no_op,
+            )
+        })
+        .buffered(MAP_CONCURRENCY)
+        .try_collect()
+        .await?;
 
     // Reduce: merge the ordered part summaries into the final summary, streamed.
     let full = generate_stream(

--- a/src-tauri/src/ollama/mod.rs
+++ b/src-tauri/src/ollama/mod.rs
@@ -155,23 +155,23 @@ fn is_summary_capable_model(model: &str) -> bool {
     }
 
     let lower = model.to_ascii_lowercase();
-    let blocked_keywords = [
-        "whisper",
-        "stt",
-        "asr",
-        "speech",
-        "wav2vec",
-        "embed",
-        "embedding",
-        "minilm",
-        "bge",
-        "gte",
-        "e5",
-    ];
 
-    !blocked_keywords
+    // Long enough to be unambiguous as a substring anywhere in the name.
+    let blocked_substrings = ["whisper", "speech", "wav2vec", "embed", "minilm"];
+    if blocked_substrings
         .iter()
         .any(|keyword| lower.contains(keyword))
+    {
+        return false;
+    }
+
+    // Short keywords collide with unrelated model names as substrings (e.g.
+    // "e5" inside "faste5ish"), so only block them as whole tokens.
+    let blocked_tokens = ["stt", "asr", "e5", "bge", "gte"];
+    let tokens = lower.split(|c: char| !c.is_alphanumeric());
+    !tokens
+        .into_iter()
+        .any(|token| blocked_tokens.contains(&token))
 }
 
 fn summary_model_priority(model: &str) -> usize {
@@ -541,6 +541,19 @@ mod tests {
     fn rejects_speech_and_embedding_models_for_summary() {
         assert!(!is_summary_capable_model("karanchopda333/whisper:latest"));
         assert!(!is_summary_capable_model("nomic-embed-text:latest"));
+    }
+
+    #[test]
+    fn rejects_short_keyword_models_as_whole_tokens() {
+        assert!(!is_summary_capable_model("intfloat/e5-large"));
+        assert!(!is_summary_capable_model("kyutai-stt:1b"));
+    }
+
+    #[test]
+    fn accepts_models_where_short_keyword_is_only_a_substring() {
+        // "e5" and "gte" appear inside these names but not as a standalone token.
+        assert!(is_summary_capable_model("faste5ish:latest"));
+        assert!(is_summary_capable_model("vgte-model:latest"));
     }
 
     #[test]

--- a/src-tauri/src/permissions.rs
+++ b/src-tauri/src/permissions.rs
@@ -30,6 +30,15 @@ pub struct PermissionStatus {
     pub accessibility: PermState,
 }
 
+/// Which capability to probe or prompt for via `request`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionKind {
+    Microphone,
+    SystemAudio,
+    Accessibility,
+}
+
 /// Cheap, non-prompting snapshot for the initial onboarding render. Microphone
 /// and system audio are left `Unknown` (probing them would prompt); the user
 /// triggers those explicitly via `request_permission`.
@@ -139,14 +148,15 @@ pub fn probe_microphone() -> PermState {
         return PermState::Denied;
     }
 
-    // Wait up to ~800ms for a callback. On first launch the prompt is showing
-    // during this window; if the user grants quickly we see data, otherwise we
-    // report Denied and they re-trigger after granting.
-    for _ in 0..16 {
+    // Wait up to 15s for a callback. On first launch the macOS TCC dialog is
+    // still on screen when this probe starts, so the window must outlast the
+    // time it takes the user to read it and click Allow/Deny. When permission
+    // was already granted the early exit as soon as data arrives keeps this fast.
+    for _ in 0..150 {
         if got.load(Ordering::Relaxed) {
             break;
         }
-        std::thread::sleep(Duration::from_millis(50));
+        std::thread::sleep(Duration::from_millis(100));
     }
     drop(stream);
 
@@ -182,11 +192,11 @@ pub fn probe_system_audio() -> PermState {
 
 /// Trigger the native prompt (or open Settings) for one permission and return
 /// the resulting state.
-pub fn request(kind: &str) -> PermState {
+pub fn request(kind: PermissionKind) -> PermState {
     match kind {
-        "microphone" => probe_microphone(),
-        "system_audio" => probe_system_audio(),
-        "accessibility" => {
+        PermissionKind::Microphone => probe_microphone(),
+        PermissionKind::SystemAudio => probe_system_audio(),
+        PermissionKind::Accessibility => {
             open_accessibility_settings();
             if accessibility_granted() {
                 PermState::Granted
@@ -194,6 +204,5 @@ pub fn request(kind: &str) -> PermState {
                 PermState::Denied
             }
         }
-        _ => PermState::Unknown,
     }
 }

--- a/src-tauri/src/pipeline/actor.rs
+++ b/src-tauri/src/pipeline/actor.rs
@@ -18,7 +18,7 @@ use tauri_specta::Event;
 use tracing::{debug, error, info, warn};
 
 use crate::app_events::{PipelineError, PipelineErrorScope};
-use crate::audio::AudioMessage;
+use crate::audio::{AudioChunk, AudioMessage};
 use crate::engine::{
     AudioInputRequirements, Speaker, TranscriptionEngine, TranscriptionProfile,
     TranscriptionSegment,
@@ -345,11 +345,13 @@ impl EngineActor {
         info!("Engine actor shut down cleanly");
     }
 
-    /// A session died mid-recording: tell the audio thread to stop, surface
-    /// the error to the frontend, salvage any in-progress meeting, and fail
-    /// the state machine so the UI leaves the recording state. Without this,
-    /// the old pipeline died silently and the app looked like it "just
-    /// stopped transcribing".
+    /// A session died mid-recording: surface the error to the frontend, then
+    /// let `AppState` stop audio capture, salvage any in-progress meeting,
+    /// and fail the state machine so the UI leaves the recording state.
+    /// Without this, the old pipeline died silently and the app looked like
+    /// it "just stopped transcribing". The pipeline layer only owns emitting
+    /// the event here; the rest is app-level cleanup that doesn't belong on
+    /// this side of the actor/command boundary.
     fn handle_session_abort(&mut self, message: String) {
         if let Some(app) = &self.app {
             let _ = PipelineError {
@@ -358,38 +360,8 @@ impl EngineActor {
             }
             .emit(app);
 
-            let state = app.state::<crate::state::AppState>();
-            let _ = state
-                .audio_cmd_sender
-                .send(crate::state::AudioCommand::Stop);
-
-            // Salvage an in-progress meeting: stop_meeting_recording can no
-            // longer run once the machine is in Error, so the accumulated
-            // segments would otherwise be lost.
-            let accumulator = state
-                .meeting_accumulator
-                .lock()
-                .ok()
-                .and_then(|mut guard| guard.take());
-            if let Some(meeting) = accumulator {
-                let transcript = crate::commands::transcription::build_meeting_transcript(
-                    meeting,
-                    chrono::Utc::now(),
-                );
-                match state.db.save_meeting(&transcript) {
-                    Ok(()) => info!(
-                        id = %transcript.id,
-                        "Meeting salvaged to history after session abort"
-                    ),
-                    Err(e) => error!("Failed to salvage meeting after session abort: {e}"),
-                }
-            }
-
-            if let Err(e) =
-                state.apply_transition(crate::state_machine::StateAction::Fail { message })
-            {
-                warn!("Failed to apply Fail transition after session abort: {e}");
-            }
+            app.state::<crate::state::AppState>()
+                .abort_active_session(message);
         }
         // Drain whatever audio is still queued (including the EndOfStream the
         // audio thread sends on Stop) so nothing stale leaks into the next session.
@@ -478,38 +450,32 @@ impl EngineActor {
         let mut health = SessionHealth::start(session_id, Arc::clone(&self.dropped_counter));
         let engine = self.engine.as_mut().expect("engine present: checked above");
 
-        if diarize {
-            // Caller may now start audio capture.
-            let _ = reply.send(Ok(info));
-            // No Silero VAD in diarized mode: the two lanes must step together
-            // every frame to stay aligned in the batch, so we can't drop a
-            // silent frame from one side. Kyutai's own semantic VAD handles
-            // pauses.
-            active_diarized_loop(
-                &self.cmd_rx,
-                &self.audio_rx,
-                engine.as_mut(),
-                &on_segment,
-                session_id,
-                &text_filters,
-                &mut health,
-                self.app.as_ref(),
-            )
+        // No Silero VAD in diarized mode: the two lanes must step together
+        // every frame to stay aligned in the batch, so we can't drop a silent
+        // frame from one side. Kyutai's own semantic VAD handles pauses.
+        let mut mode: Box<dyn SessionMode> = if diarize {
+            Box::new(DiarizedMode::new())
         } else {
-            let mut audio_filters = build_audio_filters(&config.pipeline_config, sample_rate);
-            let _ = reply.send(Ok(info));
-            active_session_loop(
-                &self.cmd_rx,
-                &self.audio_rx,
-                engine.as_mut(),
-                &on_segment,
-                session_id,
-                &mut audio_filters,
-                &text_filters,
-                &mut health,
-                self.app.as_ref(),
-            )
-        }
+            Box::new(SingleMode::new(build_audio_filters(
+                &config.pipeline_config,
+                sample_rate,
+            )))
+        };
+
+        // Caller may now start audio capture.
+        let _ = reply.send(Ok(info));
+
+        run_session_loop(
+            &self.cmd_rx,
+            &self.audio_rx,
+            engine.as_mut(),
+            &on_segment,
+            session_id,
+            &text_filters,
+            &mut health,
+            self.app.as_ref(),
+            mode.as_mut(),
+        )
     }
 
     fn drain_audio_queue(&self) -> usize {
@@ -529,21 +495,242 @@ const EOS_WAIT: Duration = Duration::from_secs(5);
 /// (~2 seconds of audio at Kyutai's 80ms frames).
 const MAX_CONSECUTIVE_FRAME_ERRORS: u32 = 25;
 
-/// Process audio frames while the session is active.
+/// A session's audio buffering and engine-stepping strategy. The generic loop
+/// (`run_session_loop`) owns everything session-lifecycle-shaped (commands,
+/// stop sequencing, health, heartbeat, the error-streak abort); a mode only
+/// knows how to buffer chunks and turn a buffered frame into engine calls.
+trait SessionMode {
+    /// Buffer a chunk's samples (single buffer, or routed by `chunk.speaker`).
+    fn ingest(&mut self, chunk: AudioChunk);
+
+    /// True while a full engine frame can be drained from the buffer(s).
+    fn frame_ready(&self, chunk_size: usize) -> bool;
+
+    /// Drain one frame and run the engine on it. `Ok(None)` means the frame
+    /// was VAD-skipped (single mode only): frame/health counters still
+    /// advance, but the consecutive-error streak does not move. The caller
+    /// wraps this call in `catch_unwind`.
+    fn step(
+        &mut self,
+        engine: &mut dyn TranscriptionEngine,
+        chunk_size: usize,
+    ) -> Result<Option<Vec<TranscriptionSegment>>, String>;
+
+    /// Drain and transcribe one full frame unconditionally (no VAD gating):
+    /// used at session end, where every buffered frame must still reach the
+    /// engine even if VAD would otherwise have gated it.
+    fn finish_frame(
+        &mut self,
+        engine: &mut dyn TranscriptionEngine,
+        chunk_size: usize,
+    ) -> Result<Vec<TranscriptionSegment>, String>;
+
+    /// Feed whatever partial tail(s) remain (less than a full frame) through
+    /// the engine at session end.
+    fn finish_tail(
+        &mut self,
+        engine: &mut dyn TranscriptionEngine,
+    ) -> Result<Vec<TranscriptionSegment>, String>;
+
+    /// Emit the periodic heartbeat log line with mode-specific fields.
+    fn log_heartbeat(
+        &self,
+        session_id: u64,
+        frames_processed: u64,
+        segments_emitted: u64,
+        audio_backlog: usize,
+    );
+}
+
+/// Single mixed-stream session: one buffer gated by the configured audio
+/// filter chain (Silero VAD when enabled).
+struct SingleMode {
+    buffer: Vec<f32>,
+    audio_filters: AudioFilterChain,
+    vad_skipped: u64,
+}
+
+impl SingleMode {
+    fn new(audio_filters: AudioFilterChain) -> Self {
+        Self {
+            buffer: Vec::new(),
+            audio_filters,
+            vad_skipped: 0,
+        }
+    }
+}
+
+impl SessionMode for SingleMode {
+    fn ingest(&mut self, chunk: AudioChunk) {
+        self.buffer.extend_from_slice(&chunk.samples);
+    }
+
+    fn frame_ready(&self, chunk_size: usize) -> bool {
+        self.buffer.len() >= chunk_size
+    }
+
+    fn step(
+        &mut self,
+        engine: &mut dyn TranscriptionEngine,
+        chunk_size: usize,
+    ) -> Result<Option<Vec<TranscriptionSegment>>, String> {
+        let frame: Vec<f32> = self.buffer.drain(..chunk_size).collect();
+        if !self.audio_filters.process(&frame) {
+            self.vad_skipped += 1;
+            return Ok(None); // VAD says no speech — skip this frame
+        }
+        engine
+            .transcribe(&frame, None)
+            .map(Some)
+            .map_err(|e| e.to_string())
+    }
+
+    fn finish_frame(
+        &mut self,
+        engine: &mut dyn TranscriptionEngine,
+        chunk_size: usize,
+    ) -> Result<Vec<TranscriptionSegment>, String> {
+        let frame: Vec<f32> = self.buffer.drain(..chunk_size).collect();
+        catch_engine(|| engine.transcribe(&frame, None))
+    }
+
+    fn finish_tail(
+        &mut self,
+        engine: &mut dyn TranscriptionEngine,
+    ) -> Result<Vec<TranscriptionSegment>, String> {
+        if self.buffer.is_empty() {
+            return Ok(Vec::new());
+        }
+        let result = catch_engine(|| engine.transcribe(&self.buffer, None));
+        self.buffer.clear();
+        result
+    }
+
+    fn log_heartbeat(
+        &self,
+        session_id: u64,
+        frames_processed: u64,
+        segments_emitted: u64,
+        audio_backlog: usize,
+    ) {
+        info!(
+            session_id,
+            transcribed_frames = frames_processed,
+            vad_skipped = self.vad_skipped,
+            segments_emitted,
+            audio_backlog,
+            "Session heartbeat"
+        );
+    }
+}
+
+/// Diarized session: mic (Me) and system audio (Them) buffered separately and
+/// stepped together into one batched `transcribe_dual` call, so the two lanes
+/// stay frame-aligned. No Silero VAD: a silent frame can't be dropped from
+/// just one side without breaking that alignment (Kyutai's own semantic VAD
+/// handles pauses).
+struct DiarizedMode {
+    me_buf: Vec<f32>,
+    them_buf: Vec<f32>,
+}
+
+impl DiarizedMode {
+    fn new() -> Self {
+        Self {
+            me_buf: Vec::new(),
+            them_buf: Vec::new(),
+        }
+    }
+
+    /// Untagged audio (shouldn't happen in diarized mode) goes to the mic.
+    fn buf_for(&mut self, speaker: Option<Speaker>) -> &mut Vec<f32> {
+        match speaker {
+            Some(Speaker::Them) => &mut self.them_buf,
+            _ => &mut self.me_buf,
+        }
+    }
+}
+
+impl SessionMode for DiarizedMode {
+    fn ingest(&mut self, chunk: AudioChunk) {
+        self.buf_for(chunk.speaker)
+            .extend_from_slice(&chunk.samples);
+    }
+
+    fn frame_ready(&self, chunk_size: usize) -> bool {
+        self.me_buf.len() >= chunk_size && self.them_buf.len() >= chunk_size
+    }
+
+    fn step(
+        &mut self,
+        engine: &mut dyn TranscriptionEngine,
+        chunk_size: usize,
+    ) -> Result<Option<Vec<TranscriptionSegment>>, String> {
+        let me_frame: Vec<f32> = self.me_buf.drain(..chunk_size).collect();
+        let them_frame: Vec<f32> = self.them_buf.drain(..chunk_size).collect();
+        engine
+            .transcribe_dual(&me_frame, &them_frame)
+            .map(Some)
+            .map_err(|e| e.to_string())
+    }
+
+    fn finish_frame(
+        &mut self,
+        engine: &mut dyn TranscriptionEngine,
+        chunk_size: usize,
+    ) -> Result<Vec<TranscriptionSegment>, String> {
+        let me_frame: Vec<f32> = self.me_buf.drain(..chunk_size).collect();
+        let them_frame: Vec<f32> = self.them_buf.drain(..chunk_size).collect();
+        catch_engine(|| engine.transcribe_dual(&me_frame, &them_frame))
+    }
+
+    fn finish_tail(
+        &mut self,
+        engine: &mut dyn TranscriptionEngine,
+    ) -> Result<Vec<TranscriptionSegment>, String> {
+        if self.me_buf.is_empty() && self.them_buf.is_empty() {
+            return Ok(Vec::new());
+        }
+        // transcribe_dual zero-pads the shorter lane internally.
+        let me_tail = std::mem::take(&mut self.me_buf);
+        let them_tail = std::mem::take(&mut self.them_buf);
+        catch_engine(|| engine.transcribe_dual(&me_tail, &them_tail))
+    }
+
+    fn log_heartbeat(
+        &self,
+        session_id: u64,
+        frames_processed: u64,
+        segments_emitted: u64,
+        audio_backlog: usize,
+    ) {
+        info!(
+            session_id,
+            transcribed_frames = frames_processed,
+            segments_emitted,
+            audio_backlog,
+            "Diarized session heartbeat"
+        );
+    }
+}
+
+/// Process audio frames while the session is active. Owns command handling,
+/// health/heartbeat, the EOS-wait stop sequencing, and the consecutive-error
+/// abort logic; `mode` decides how audio is buffered and stepped through the
+/// engine (single stream + VAD, or paired diarized lanes).
 #[allow(clippy::too_many_arguments)]
-fn active_session_loop(
+fn run_session_loop(
     cmd_rx: &Receiver<EngineCommand>,
     audio_rx: &Receiver<AudioMessage>,
     engine: &mut dyn TranscriptionEngine,
     on_segment: &SegmentCallback,
     session_id: u64,
-    audio_filters: &mut AudioFilterChain,
     text_filters: &TextFilterChain,
     health: &mut SessionHealth,
     app: Option<&tauri::AppHandle>,
+    mode: &mut dyn SessionMode,
 ) -> SessionEnd {
     let chunk_size = engine.audio_requirements().chunk_size_samples as usize;
-    let mut audio_buffer: Vec<f32> = Vec::new();
     let mut summary = SessionSummary::default();
     let mut eos_received = false;
     let mut consecutive_errors: u32 = 0;
@@ -554,7 +741,6 @@ fn active_session_loop(
     // emits nothing, or VAD gates everything) looks identical to "still
     // recording" from the UI. This heartbeat makes the failure mode legible in
     // the log without the verbose debug setting.
-    let mut vad_skipped: u64 = 0;
     let mut segments_emitted: u64 = 0;
     let mut last_heartbeat = Instant::now();
     const HEARTBEAT: Duration = Duration::from_secs(30);
@@ -569,13 +755,11 @@ fn active_session_loop(
 
         if last_heartbeat.elapsed() >= HEARTBEAT {
             last_heartbeat = Instant::now();
-            info!(
+            mode.log_heartbeat(
                 session_id,
-                transcribed_frames = summary.frames_processed,
-                vad_skipped,
+                summary.frames_processed,
                 segments_emitted,
-                audio_backlog = audio_rx.len(),
-                "Session heartbeat"
+                audio_rx.len(),
             );
         }
 
@@ -594,7 +778,7 @@ fn active_session_loop(
                         on_segment,
                         session_id,
                         text_filters,
-                        &mut audio_buffer,
+                        mode,
                         &mut summary,
                     );
                     return SessionEnd::Stopped(reply, summary);
@@ -633,7 +817,7 @@ fn active_session_loop(
                 on_segment,
                 session_id,
                 text_filters,
-                &mut audio_buffer,
+                mode,
                 &mut summary,
             );
             return SessionEnd::Stopped(reply, summary);
@@ -654,7 +838,7 @@ fn active_session_loop(
                         on_segment,
                         session_id,
                         text_filters,
-                        &mut audio_buffer,
+                        mode,
                         &mut summary,
                     );
                     return SessionEnd::Stopped(reply, summary);
@@ -676,30 +860,29 @@ fn active_session_loop(
                 }
 
                 health.note_chunk(chunk.captured_at);
-                audio_buffer.extend_from_slice(&chunk.samples);
+                mode.ingest(chunk);
 
                 // Process complete engine-sized frames
-                while audio_buffer.len() >= chunk_size {
-                    let frame: Vec<f32> = audio_buffer.drain(..chunk_size).collect();
-                    if !audio_filters.process(&frame) {
-                        summary.frames_processed += 1;
-                        vad_skipped += 1;
-                        health.note_frame();
-                        continue; // VAD says no speech — skip this frame
-                    }
+                while mode.frame_ready(chunk_size) {
                     // A panic in the engine (candle/whisper/Metal) must not
                     // abort the whole app: catch it and treat it like a frame
                     // error so the streak logic below can recover or abort the
                     // session cleanly.
-                    let transcribe_result: Result<Vec<TranscriptionSegment>, String> =
+                    let step_result: Result<Option<Vec<TranscriptionSegment>>, String> =
                         match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                            engine.transcribe(&frame, None)
+                            mode.step(engine, chunk_size)
                         })) {
-                            Ok(inner) => inner.map_err(|e| e.to_string()),
+                            Ok(inner) => inner,
                             Err(_) => Err("engine panicked during transcribe".to_string()),
                         };
-                    match transcribe_result {
-                        Ok(segments) => {
+                    match step_result {
+                        Ok(None) => {
+                            // VAD-skipped frame (single mode only).
+                            summary.frames_processed += 1;
+                            health.note_frame();
+                            continue;
+                        }
+                        Ok(Some(segments)) => {
                             consecutive_errors = 0;
                             for seg in segments {
                                 if crate::debug::transcription_debug_enabled() {
@@ -757,14 +940,16 @@ fn active_session_loop(
     }
 }
 
-/// Drain remaining audio, run it through the engine, and flush.
+/// Drain remaining audio, run every buffered frame through the engine (no VAD
+/// gating: everything already captured must reach the engine), feed the
+/// tail(s), and flush. Every stage's segments go through `emit_filtered`.
 fn finish_session(
     audio_rx: &Receiver<AudioMessage>,
     engine: &mut dyn TranscriptionEngine,
     on_segment: &SegmentCallback,
     session_id: u64,
     text_filters: &TextFilterChain,
-    audio_buffer: &mut Vec<f32>,
+    mode: &mut dyn SessionMode,
     summary: &mut SessionSummary,
 ) {
     let chunk_size = engine.audio_requirements().chunk_size_samples as usize;
@@ -775,7 +960,7 @@ fn finish_session(
     while let Ok(msg) = audio_rx.try_recv() {
         match msg {
             AudioMessage::Chunk(chunk) if chunk.session_id == session_id => {
-                audio_buffer.extend_from_slice(&chunk.samples);
+                mode.ingest(chunk);
                 drained += 1;
             }
             AudioMessage::Chunk(_) => summary.skipped_chunks += 1,
@@ -786,10 +971,9 @@ fn finish_session(
         debug!("Drained {drained} remaining audio chunks on stop");
     }
 
-    // Process all buffered audio through the engine (frame by frame)
-    while audio_buffer.len() >= chunk_size {
-        let frame: Vec<f32> = audio_buffer.drain(..chunk_size).collect();
-        match catch_engine(|| engine.transcribe(&frame, None)) {
+    // Process all buffered audio through the engine (frame by frame).
+    while mode.frame_ready(chunk_size) {
+        match mode.finish_frame(engine, chunk_size) {
             Ok(segments) => {
                 for seg in segments {
                     if crate::debug::transcription_debug_enabled() {
@@ -805,17 +989,14 @@ fn finish_session(
         }
         summary.frames_processed += 1;
     }
-    // Process any remaining partial frame
-    if !audio_buffer.is_empty() {
-        match catch_engine(|| engine.transcribe(audio_buffer, None)) {
-            Ok(segments) => {
-                for seg in segments {
-                    emit_filtered(engine, text_filters, seg, on_segment);
-                }
+    // Process any remaining partial tail(s).
+    match mode.finish_tail(engine) {
+        Ok(segments) => {
+            for seg in segments {
+                emit_filtered(engine, text_filters, seg, on_segment);
             }
-            Err(e) => error!("Transcribe error on partial frame: {e}"),
         }
-        audio_buffer.clear();
+        Err(e) => error!("Transcribe error on partial frame: {e}"),
     }
 
     // Flush engine (e.g. feeds silence to extract remaining buffered tokens)
@@ -829,261 +1010,6 @@ fn finish_session(
             }
         }
         Err(e) => error!("Flush error: {e}"),
-    }
-}
-
-/// Append a chunk's samples to the buffer for its source (mic = Me, system =
-/// Them). Untagged audio (shouldn't happen in diarized mode) goes to the mic.
-fn route_chunk<'a>(
-    me_buf: &'a mut Vec<f32>,
-    them_buf: &'a mut Vec<f32>,
-    speaker: Option<Speaker>,
-) -> &'a mut Vec<f32> {
-    match speaker {
-        Some(Speaker::Them) => them_buf,
-        _ => me_buf,
-    }
-}
-
-/// Diarized session loop: one engine transcribes both sources as batch lanes
-/// (mic = Me, system audio = Them). Mirrors `active_session_loop`'s
-/// command/stop/health scaffolding, but pairs the two tagged streams frame by
-/// frame into `transcribe_dual`, which returns speaker-tagged segments. No
-/// Silero VAD: the lanes must step together to stay batch-aligned, so a silent
-/// frame can't be dropped from one side (Kyutai's own VAD handles pauses).
-#[allow(clippy::too_many_arguments)]
-fn active_diarized_loop(
-    cmd_rx: &Receiver<EngineCommand>,
-    audio_rx: &Receiver<AudioMessage>,
-    engine: &mut dyn TranscriptionEngine,
-    on_segment: &SegmentCallback,
-    session_id: u64,
-    text_filters: &TextFilterChain,
-    health: &mut SessionHealth,
-    app: Option<&tauri::AppHandle>,
-) -> SessionEnd {
-    let chunk_size = engine.audio_requirements().chunk_size_samples as usize;
-    let mut me_buf: Vec<f32> = Vec::new();
-    let mut them_buf: Vec<f32> = Vec::new();
-    let mut summary = SessionSummary::default();
-    let mut eos_received = false;
-    let mut consecutive_errors: u32 = 0;
-    let mut pending_stop: Option<(Sender<Result<SessionSummary, String>>, Instant)> = None;
-    let mut segments_emitted: u64 = 0;
-    let mut last_heartbeat = Instant::now();
-    const HEARTBEAT: Duration = Duration::from_secs(30);
-
-    loop {
-        if let Some(snapshot) = health.tick(audio_rx.len())
-            && let Some(app) = app
-        {
-            let _ = snapshot.emit(app);
-        }
-
-        if last_heartbeat.elapsed() >= HEARTBEAT {
-            last_heartbeat = Instant::now();
-            info!(
-                session_id,
-                transcribed_frames = summary.frames_processed,
-                segments_emitted,
-                audio_backlog = audio_rx.len(),
-                "Diarized session heartbeat"
-            );
-        }
-
-        match cmd_rx.try_recv() {
-            Ok(EngineCommand::AttachApp(_)) => {}
-            Ok(EngineCommand::StopSession { reply }) => {
-                if eos_received {
-                    summary.dropped_chunks = health.dropped_chunks();
-                    finish_diarized(
-                        audio_rx,
-                        engine,
-                        &mut me_buf,
-                        &mut them_buf,
-                        on_segment,
-                        session_id,
-                        text_filters,
-                        &mut summary,
-                    );
-                    return SessionEnd::Stopped(reply, summary);
-                }
-                pending_stop = Some((reply, Instant::now()));
-            }
-            Ok(EngineCommand::Shutdown) => return SessionEnd::Shutdown,
-            Ok(EngineCommand::LoadModel { reply, .. }) => {
-                let _ = reply.send(Err("Recording session active".into()));
-            }
-            Ok(EngineCommand::UnloadModel { reply }) => {
-                let _ = reply.send(Err("Recording session active".into()));
-            }
-            Ok(EngineCommand::StartSession { reply, .. }) => {
-                let _ = reply.send(Err("Recording session active".into()));
-            }
-            Ok(EngineCommand::DebugTranscribe { reply, .. }) => {
-                let _ = reply.send(Err("Recording session active".into()));
-            }
-            Err(_) => {}
-        }
-
-        if let Some((_, requested_at)) = &pending_stop
-            && requested_at.elapsed() > EOS_WAIT
-        {
-            warn!("End-of-stream marker never arrived; finishing diarized session anyway");
-            let (reply, _) = pending_stop.take().expect("pending_stop checked above");
-            summary.dropped_chunks = health.dropped_chunks();
-            finish_diarized(
-                audio_rx,
-                engine,
-                &mut me_buf,
-                &mut them_buf,
-                on_segment,
-                session_id,
-                text_filters,
-                &mut summary,
-            );
-            return SessionEnd::Stopped(reply, summary);
-        }
-
-        match audio_rx.recv_timeout(Duration::from_millis(50)) {
-            Ok(AudioMessage::EndOfStream { session_id: eos_id }) => {
-                if eos_id != session_id {
-                    continue;
-                }
-                eos_received = true;
-                if let Some((reply, _)) = pending_stop.take() {
-                    summary.dropped_chunks = health.dropped_chunks();
-                    finish_diarized(
-                        audio_rx,
-                        engine,
-                        &mut me_buf,
-                        &mut them_buf,
-                        on_segment,
-                        session_id,
-                        text_filters,
-                        &mut summary,
-                    );
-                    return SessionEnd::Stopped(reply, summary);
-                }
-            }
-            Ok(AudioMessage::Chunk(chunk)) => {
-                if chunk.session_id != session_id {
-                    summary.skipped_chunks += 1;
-                    continue;
-                }
-                health.note_chunk(chunk.captured_at);
-                route_chunk(&mut me_buf, &mut them_buf, chunk.speaker)
-                    .extend_from_slice(&chunk.samples);
-
-                // Step both lanes together while each has a full frame.
-                while me_buf.len() >= chunk_size && them_buf.len() >= chunk_size {
-                    let me_frame: Vec<f32> = me_buf.drain(..chunk_size).collect();
-                    let them_frame: Vec<f32> = them_buf.drain(..chunk_size).collect();
-                    let result: Result<Vec<TranscriptionSegment>, String> =
-                        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                            engine.transcribe_dual(&me_frame, &them_frame)
-                        })) {
-                            Ok(inner) => inner.map_err(|e| e.to_string()),
-                            Err(_) => Err("engine panicked during transcribe".to_string()),
-                        };
-                    match result {
-                        Ok(segments) => {
-                            consecutive_errors = 0;
-                            for seg in segments {
-                                segments_emitted += 1;
-                                emit_filtered(engine, text_filters, seg, on_segment);
-                            }
-                        }
-                        Err(e) => {
-                            consecutive_errors += 1;
-                            error!("Diarized transcribe error (frame skipped): {e}");
-                            if consecutive_errors == 1
-                                && let Some(app) = app
-                            {
-                                let _ = PipelineError {
-                                    scope: PipelineErrorScope::Frame,
-                                    message: e.clone(),
-                                }
-                                .emit(app);
-                            }
-                            if consecutive_errors >= MAX_CONSECUTIVE_FRAME_ERRORS {
-                                if let Some((reply, _)) = pending_stop.take() {
-                                    let _ = reply.send(Err(format!("Session aborted: {e}")));
-                                }
-                                return SessionEnd::Aborted(format!(
-                                    "Transcription failed {MAX_CONSECUTIVE_FRAME_ERRORS} frames in a row: {e}"
-                                ));
-                            }
-                        }
-                    }
-                    summary.frames_processed += 1;
-                    health.note_frame();
-                }
-            }
-            Err(crossbeam_channel::RecvTimeoutError::Timeout) => {}
-            Err(crossbeam_channel::RecvTimeoutError::Disconnected) => {
-                return SessionEnd::AudioGone;
-            }
-        }
-    }
-}
-
-/// Drain remaining audio, transcribe the paired tails, and flush the engine.
-#[allow(clippy::too_many_arguments)]
-fn finish_diarized(
-    audio_rx: &Receiver<AudioMessage>,
-    engine: &mut dyn TranscriptionEngine,
-    me_buf: &mut Vec<f32>,
-    them_buf: &mut Vec<f32>,
-    on_segment: &SegmentCallback,
-    session_id: u64,
-    text_filters: &TextFilterChain,
-    summary: &mut SessionSummary,
-) {
-    let chunk_size = engine.audio_requirements().chunk_size_samples as usize;
-
-    while let Ok(msg) = audio_rx.try_recv() {
-        match msg {
-            AudioMessage::Chunk(chunk) if chunk.session_id == session_id => {
-                route_chunk(me_buf, them_buf, chunk.speaker).extend_from_slice(&chunk.samples);
-            }
-            AudioMessage::Chunk(_) => summary.skipped_chunks += 1,
-            AudioMessage::EndOfStream { .. } => {}
-        }
-    }
-
-    let emit_all = |engine: &mut dyn TranscriptionEngine, segments: Vec<TranscriptionSegment>| {
-        for seg in segments {
-            emit_filtered(engine, text_filters, seg, on_segment);
-        }
-    };
-
-    // Step the paired frames both lanes still hold.
-    while me_buf.len() >= chunk_size && them_buf.len() >= chunk_size {
-        let me_frame: Vec<f32> = me_buf.drain(..chunk_size).collect();
-        let them_frame: Vec<f32> = them_buf.drain(..chunk_size).collect();
-        match catch_engine(|| engine.transcribe_dual(&me_frame, &them_frame)) {
-            Ok(segments) => emit_all(engine, segments),
-            Err(e) => {
-                error!("Diarized transcribe error during drain: {e}");
-                break;
-            }
-        }
-        summary.frames_processed += 1;
-    }
-    // Any uneven tail: transcribe_dual zero-pads the shorter lane internally.
-    if !me_buf.is_empty() || !them_buf.is_empty() {
-        let me_tail = std::mem::take(me_buf);
-        let them_tail = std::mem::take(them_buf);
-        match catch_engine(|| engine.transcribe_dual(&me_tail, &them_tail)) {
-            Ok(segments) => emit_all(engine, segments),
-            Err(e) => error!("Diarized transcribe error on partial frame: {e}"),
-        }
-    }
-    // Flush returns batched, speaker-tagged segments in diarized mode.
-    match catch_engine(|| engine.flush()) {
-        Ok(segments) => emit_all(engine, segments),
-        Err(e) => error!("Diarized flush error: {e}"),
     }
 }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use crossbeam_channel::Sender;
 use tauri::AppHandle;
 use tauri_specta::Event;
-use tracing::debug;
+use tracing::{debug, error, info, warn};
 
 use crate::app_events::StateChanged;
 use crate::db::Database;
@@ -12,7 +12,7 @@ use crate::engine::{TranscriptionProfile, TranscriptionSegment};
 use crate::lock_ext::MutexExt;
 use crate::pipeline::EngineActorHandle;
 use crate::state_machine::{AppStateMachine, StateAction};
-use crate::transcript::MeetingRecordingSession;
+use crate::transcript::{MeetingRecordingSession, MeetingTranscript};
 
 /// Commands sent to the audio thread
 pub enum AudioCommand {
@@ -54,6 +54,57 @@ pub struct MeetingAccumulator {
     /// incremental persistence path. Lets a crash mid-meeting lose at most the
     /// last unflushed batch instead of the whole session.
     pub persisted_new_count: usize,
+}
+
+impl MeetingAccumulator {
+    /// Build the persisted transcript for this accumulator, appending one
+    /// completed recording session ending at `ended_at`. Also used by the
+    /// engine actor (via `AppState::abort_active_session`) to salvage a
+    /// meeting when its recording session aborts mid-way.
+    pub fn into_transcript(self, ended_at: chrono::DateTime<chrono::Utc>) -> MeetingTranscript {
+        let mut segments = self.existing_segments;
+        let start_segment_index = segments.len() as u64;
+        let had_new_segments = !self.new_segments.is_empty();
+        let has_summary = self.summary.is_some();
+        segments.extend(self.new_segments);
+        let end_segment_index = segments.len() as u64;
+
+        let mut recording_sessions = self.recording_sessions;
+        recording_sessions.push(MeetingRecordingSession::completed(
+            uuid::Uuid::new_v4().to_string(),
+            self.session_started_at,
+            ended_at,
+            start_segment_index,
+            end_segment_index,
+        ));
+
+        let started_at = recording_sessions
+            .first()
+            .map(|session| session.started_at)
+            .unwrap_or(self.session_started_at);
+        let ended_at = recording_sessions.last().map(|session| session.ended_at);
+        let duration_seconds = recording_sessions
+            .iter()
+            .map(|session| session.duration_seconds)
+            .sum();
+
+        MeetingTranscript {
+            id: self.id,
+            title: self.title,
+            started_at,
+            ended_at,
+            duration_seconds,
+            transcription_profile: self.transcription_profile,
+            recording_sessions,
+            segments,
+            summary: self.summary,
+            summary_is_stale: self.summary_is_stale || (has_summary && had_new_segments),
+            summary_model: self.summary_model,
+            summary_generated_at: self.summary_generated_at,
+            edited_transcript: None,
+            notes: self.notes,
+        }
+    }
 }
 
 /// Shared application state, managed by Tauri.
@@ -132,5 +183,131 @@ impl AppState {
             .as_ref()
             .cloned()
             .ok_or_else(|| "App handle not set".to_string())
+    }
+
+    /// A session died mid-recording: stop audio capture, salvage any
+    /// in-progress meeting to the DB, and fail the state machine so the UI
+    /// leaves the recording state. Called by the engine actor after it emits
+    /// the PipelineError event (the pipeline layer owns that event; this is
+    /// the app-level cleanup that follows it).
+    pub fn abort_active_session(&self, message: String) {
+        let _ = self.audio_cmd_sender.send(AudioCommand::Stop);
+
+        // Salvage an in-progress meeting: stop_meeting_recording can no
+        // longer run once the machine is in Error, so the accumulated
+        // segments would otherwise be lost.
+        let accumulator = self
+            .meeting_accumulator
+            .lock()
+            .ok()
+            .and_then(|mut guard| guard.take());
+        if let Some(meeting) = accumulator {
+            let transcript = meeting.into_transcript(chrono::Utc::now());
+            match self.db.save_meeting(&transcript) {
+                Ok(()) => info!(
+                    id = %transcript.id,
+                    "Meeting salvaged to history after session abort"
+                ),
+                Err(e) => error!("Failed to salvage meeting after session abort: {e}"),
+            }
+        }
+
+        if let Err(e) = self.apply_transition(StateAction::Fail { message }) {
+            warn!("Failed to apply Fail transition after session abort: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::default_transcription_profile;
+    use crate::transcript::MeetingRecordingSession;
+    use chrono::Duration;
+
+    #[test]
+    fn into_transcript_appends_resumed_session_and_marks_summary_stale() {
+        let first_start = chrono::Utc::now();
+        let first_end = first_start + Duration::seconds(30);
+        let second_start = first_end + Duration::minutes(5);
+        let second_end = second_start + Duration::seconds(45);
+
+        let accumulator = MeetingAccumulator {
+            id: "meeting-1".to_string(),
+            title: "Roadmap".to_string(),
+            existing_segments: vec![TranscriptionSegment {
+                text: "Existing".to_string(),
+                start_time: 0.0,
+                end_time: 1.0,
+                is_final: true,
+                language: None,
+                confidence: None,
+                speaker: None,
+            }],
+            new_segments: vec![TranscriptionSegment {
+                text: "Appended".to_string(),
+                start_time: 1.0,
+                end_time: 2.0,
+                is_final: true,
+                language: None,
+                confidence: None,
+                speaker: None,
+            }],
+            recording_sessions: vec![MeetingRecordingSession::completed(
+                "session-1".to_string(),
+                first_start,
+                first_end,
+                0,
+                1,
+            )],
+            session_started_at: second_start,
+            transcription_profile: default_transcription_profile(),
+            summary: Some("Old summary".to_string()),
+            summary_is_stale: false,
+            summary_model: Some("qwen".to_string()),
+            summary_generated_at: Some(first_end),
+            notes: None,
+            persisted_new_count: 0,
+        };
+
+        let transcript = accumulator.into_transcript(second_end);
+
+        assert_eq!(transcript.id, "meeting-1");
+        assert_eq!(transcript.recording_sessions.len(), 2);
+        assert_eq!(transcript.recording_sessions[1].start_segment_index, 1);
+        assert_eq!(transcript.recording_sessions[1].end_segment_index, 2);
+        assert_eq!(transcript.segments.len(), 2);
+        assert!(transcript.summary_is_stale);
+        assert_eq!(transcript.started_at, first_start);
+        assert_eq!(transcript.ended_at, Some(second_end));
+        assert_eq!(transcript.duration_seconds, 75.0);
+    }
+
+    #[test]
+    fn into_transcript_preserves_fresh_summary_when_no_new_segments_arrive() {
+        let started_at = chrono::Utc::now();
+        let ended_at = started_at + Duration::seconds(10);
+
+        let accumulator = MeetingAccumulator {
+            id: "meeting-2".to_string(),
+            title: "Silent Resume".to_string(),
+            existing_segments: Vec::new(),
+            new_segments: Vec::new(),
+            recording_sessions: Vec::new(),
+            session_started_at: started_at,
+            transcription_profile: default_transcription_profile(),
+            summary: Some("Still current".to_string()),
+            summary_is_stale: false,
+            summary_model: Some("qwen".to_string()),
+            summary_generated_at: Some(started_at),
+            notes: None,
+            persisted_new_count: 0,
+        };
+
+        let transcript = accumulator.into_transcript(ended_at);
+
+        assert_eq!(transcript.recording_sessions.len(), 1);
+        assert_eq!(transcript.duration_seconds, 10.0);
+        assert!(!transcript.summary_is_stale);
     }
 }

--- a/src/lib/api/permissions.ts
+++ b/src/lib/api/permissions.ts
@@ -1,11 +1,11 @@
 import { commands, unwrap } from "./generated";
-import type { PermissionStatus, PermState } from "../types";
+import type { PermissionKind, PermissionStatus, PermState } from "../types";
+
+export type { PermissionKind };
 
 export async function getPermissionStatus(): Promise<PermissionStatus> {
   return unwrap(commands.getPermissionStatus());
 }
-
-export type PermissionKind = "microphone" | "system_audio" | "accessibility";
 
 export async function requestPermission(kind: PermissionKind): Promise<PermState> {
   return unwrap(commands.requestPermission(kind));

--- a/src/lib/api/settings.test.ts
+++ b/src/lib/api/settings.test.ts
@@ -38,7 +38,7 @@ describe('settings API', () => {
 
   it('saveSettings passes settings object', async () => {
     mockInvoke.mockResolvedValue(null);
-    const settings = { theme: 'light' as const, locale: '', auto_paste: true, paste_delay_ms: 200, ollama_url: 'http://localhost:11434', ollama_model: 'llama3', debug_transcription: false, audio_device: null, transcription_engine_id: 'kyutai', transcription_model_id: 'stt-1b', transcription_backend_id: 'candle', vad_enabled: true, filler_removal: true, stutter_collapse: false, dictionary_correction: true };
+    const settings = { theme: 'light' as const, locale: '', auto_paste: true, paste_delay_ms: 200, ollama_url: 'http://localhost:11434', ollama_model: 'llama3', debug_transcription: false, audio_device: null, transcription_engine_id: 'kyutai', transcription_model_id: 'stt-1b', transcription_backend_id: 'candle', vad_enabled: true, filler_removal: true, stutter_collapse: false, dictionary_correction: true, capture_system_audio: true };
 
     await saveSettings(settings);
 

--- a/src/lib/features/meeting/controller.svelte.test.ts
+++ b/src/lib/features/meeting/controller.svelte.test.ts
@@ -57,7 +57,6 @@ vi.mock("../../api/transcription", () => ({
 
 function createMockAppState() {
   return {
-    currentView: "meeting" as string,
     currentMeetingId: null as string | null,
     machineState: { state: "idle" } as import("../../types").AppStateMachine,
     isRecording: false,
@@ -65,6 +64,7 @@ function createMockAppState() {
     transcriptionRuntimePhase: "ready" as string,
     settings: {
       theme: "dark" as const,
+      locale: "",
       auto_paste: false,
       paste_delay_ms: 100,
       ollama_url: "http://localhost:11434",
@@ -74,6 +74,11 @@ function createMockAppState() {
       transcription_engine_id: "kyutai",
       transcription_model_id: "stt-1b-en_fr",
       transcription_backend_id: "candle",
+      vad_enabled: true,
+      filler_removal: true,
+      stutter_collapse: false,
+      dictionary_correction: true,
+      capture_system_audio: true,
     },
     selectedDevice: "",
     openMeeting: vi.fn(),
@@ -124,6 +129,7 @@ function makeMeeting(overrides: Partial<MeetingTranscript> = {}): MeetingTranscr
     summary_model: null,
     summary_generated_at: null,
     edited_transcript: null,
+    notes: null,
     ...overrides,
   };
 }

--- a/src/lib/features/meeting/controller.svelte.ts
+++ b/src/lib/features/meeting/controller.svelte.ts
@@ -190,6 +190,7 @@ function createMeetingControllerInstance() {
         summary_model: null,
         summary_generated_at: null,
         edited_transcript: null,
+        notes: null,
       };
     } catch (e) {
       statusMessage = errorMessage(e);

--- a/src/lib/features/settings/controller.svelte.test.ts
+++ b/src/lib/features/settings/controller.svelte.test.ts
@@ -61,6 +61,7 @@ const defaultSettings: AppSettings = {
   filler_removal: true,
   stutter_collapse: false,
   dictionary_correction: true,
+  capture_system_audio: true,
 };
 
 const fakeDevices: AudioDeviceInfo[] = [
@@ -203,7 +204,6 @@ describe("settings controller", () => {
     mockListen.mockResolvedValue(vi.fn());
 
     const app = getAppState();
-    app.currentView = "transcription";
     app.currentMeetingId = null;
     app.selectedDevice = "";
     app.machineState = { state: "idle" };

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -154,7 +154,6 @@ describe("transcription controller", () => {
 
     // Reset shared singleton app state between tests
     const app = getAppState();
-    app.currentView = "transcription";
     app.currentMeetingId = null;
     app.machineState = { state: "idle" };
     app.transcriptionRuntimePhase = "download_required";
@@ -178,6 +177,7 @@ describe("transcription controller", () => {
       filler_removal: true,
       stutter_collapse: false,
       dictionary_correction: true,
+      capture_system_audio: true,
     };
 
     Object.assign(navigator, {

--- a/src/lib/pill/PillApp.svelte
+++ b/src/lib/pill/PillApp.svelte
@@ -2,7 +2,8 @@
   import { Square } from "@lucide/svelte";
   import { onMount } from "svelte";
   import { t } from "svelte-i18n";
-  import { commands, events } from "../api/generated";
+  import { events } from "../api/generated";
+  import { getMachineState } from "../api/transcription";
   import Waveform from "../components/Waveform.svelte";
   import type { AppStateMachine } from "../types";
 
@@ -33,7 +34,7 @@
   onMount(() => {
     document.body.classList.add("pill-body");
 
-    void commands.getMachineState().then((state) => {
+    void getMachineState().then((state) => {
       machineState = state;
     });
     void events.stateChanged.listen((event) => {

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -51,6 +51,7 @@ describe('app store', () => {
       filler_removal: true,
       stutter_collapse: false,
       dictionary_correction: true,
+      capture_system_audio: true,
     };
     state.settings = newSettings;
     expect(state.settings.theme).toBe('light');

--- a/src/lib/test-helpers/fixtures.ts
+++ b/src/lib/test-helpers/fixtures.ts
@@ -148,6 +148,7 @@ export const mockMeeting: MeetingTranscript = {
   summary_model: null,
   summary_generated_at: null,
   edited_transcript: null,
+  notes: null,
 };
 
 export const mockMeetingList: MeetingListItem[] = [
@@ -189,6 +190,7 @@ export const mockSettings: AppSettings = {
   filler_removal: true,
   stutter_collapse: false,
   dictionary_correction: true,
+  capture_system_audio: true,
 };
 
 export const mockShortcuts: ShortcutSettings = {

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -468,10 +468,9 @@ async getPermissionStatus() : Promise<Result<PermissionStatus, string>> {
 },
 /**
  * Trigger the native prompt (or open System Settings) for one permission.
- * `kind` is "microphone" | "system_audio" | "accessibility". The probe opens
- * a device, so it runs off the command thread.
+ * The probe opens a device, so it runs off the command thread.
  */
-async requestPermission(kind: string) : Promise<Result<PermState, string>> {
+async requestPermission(kind: PermissionKind) : Promise<Result<PermState, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("request_permission", { kind }) };
 } catch (e) {
@@ -594,6 +593,10 @@ export type PermState = "granted" | "denied" |
  * The OS doesn't support this capability (e.g. taps need macOS 14.4+).
  */
 "unsupported"
+/**
+ * Which capability to probe or prompt for via `request`.
+ */
+export type PermissionKind = "microphone" | "system_audio" | "accessibility"
 export type PermissionStatus = { microphone: PermState; system_audio: PermState; accessibility: PermState }
 /**
  * Pipeline failure surfaced to the frontend instead of dying silently in logs.

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -16,6 +16,7 @@ export type {
   OllamaModelDescriptor,
   OllamaStatus,
   PermState,
+  PermissionKind,
   PermissionStatus,
   RecordingKind,
   ShortcutSettings,


### PR DESCRIPTION
## Summary

Five focused sets of fixes coming out of a review of the recent recording, diarization, and summarization work.

- **Type gate repaired**: test fixtures were missing the newer \`capture_system_audio\` and \`notes\` fields and two tests referenced the removed \`currentView\` store property, so \`npm run check\` had been failing silently. Also fixes two real production issues the gate exposed: the optimistic post-stop meeting object lacked \`notes\`, and the floating pill assigned the raw command Result instead of the unwrapped state machine, breaking its dictation/meeting mode detection.
- **Ollama summarization no longer hangs forever**: 5s connect timeout, 120s read timeout (gap between stream chunks, so long generations still complete), every request streams including the map stage, and map concurrency is bounded to 2 with chunk order preserved.
- **Meeting failure paths hardened**: a failed session launch no longer leaves a ghost empty meeting in the list; a panic during the background drain+save can no longer wedge the state machine in Stopping; a failed incremental segment flush now rolls back its counter so the batch is retried instead of silently dropped (covered by a test driving a real FK failure).
- **Engine actor deduplicated**: the single-stream and diarized session loops shared ~250 lines of stop/command/heartbeat/error-streak scaffolding; there is now one loop driven by a \`SessionMode\` trait (net -74 lines). Meeting salvage moved from the pipeline layer into \`AppState\`, removing the pipeline dependency on the commands layer.
- **Smaller correctness fixes**: permission kind is now a typed enum end to end instead of a string with a silent fallback; the first-run microphone probe waits out the TCC dialog instead of reporting Denied after 800ms; Ollama model filtering no longer blocks names that merely contain short keywords like "e5" as substrings.

## Test plan

- \`cargo test --lib\`: 216 passed (3 new tests: flush-failure rollback, token-based model filtering both directions).
- \`cargo clippy --all-targets\` and \`cargo fmt --check\`: clean.
- \`npm run check\`: 0 errors (was 11 before this branch).
- \`npm test\`: 128 passed.
- Manual pass worth doing before merge: one dictation and one diarized meeting (start, stop, resume), one long-transcript summary against a live Ollama, and the first-run permissions flow on a clean TCC state.