### PR TITLE
Gate meeting echo cancellation on output mute and volume

### DIFF
--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -60,7 +60,7 @@ struct MeetingState {
     /// physical device, so output-device changes don't require a rebuild.
     #[cfg(target_os = "macos")]
     tap: Option<super::system_tap::TapHandle>,
-    /// Whether echo cancellation is currently engaged (speakers route).
+    /// Whether echo cancellation is currently engaged (speakers audible).
     aec_active: bool,
     /// Emit mic (Me) and system audio (Them) as two source-tagged streams
     /// instead of one mixed stream.
@@ -69,22 +69,23 @@ struct MeetingState {
 }
 
 impl MeetingState {
-    /// Engage/disengage echo cancellation when the default output switches
-    /// between built-in speakers and anything else (headphones, Bluetooth…).
+    /// Engage/disengage echo cancellation when whether speaker output can
+    /// leak into the mic changes: built-in speakers versus anything else
+    /// (headphones, Bluetooth), and muted or silent versus audible.
     #[cfg(target_os = "macos")]
     fn check_output_route(&mut self, _app: Option<&tauri::AppHandle>) {
         use super::{aec, mixer, output_route};
 
-        let speakers = self.tap.is_some() && output_route::output_is_builtin_speakers();
-        if speakers != self.aec_active {
-            if speakers {
-                info!("Output switched to built-in speakers — echo cancellation engaged");
+        let can_leak = self.tap.is_some() && output_route::output_can_leak_into_mic();
+        if can_leak != self.aec_active {
+            if can_leak {
+                info!("Speakers audible, echo cancellation engaged");
                 self.mixer.set_aec(Some(aec::Aec::new(mixer::MIX_RATE)));
             } else {
-                info!("Output no longer on speakers — echo cancellation disengaged");
+                info!("Output muted or off speakers, echo cancellation disengaged");
                 self.mixer.set_aec(None);
             }
-            self.aec_active = speakers;
+            self.aec_active = can_leak;
         }
     }
 
@@ -537,16 +538,16 @@ impl AudioCapture {
         );
 
         // Echo cancellation only matters when system audio can leak from
-        // the speakers back into the mic — and only if we actually have the
+        // the speakers back into the mic, and only if we actually have the
         // system-audio reference signal to cancel against.
         #[cfg(target_os = "macos")]
         let aec_active = {
-            let speakers = tap.is_some() && super::output_route::output_is_builtin_speakers();
-            if speakers {
-                info!("Built-in speakers detected — echo cancellation engaged");
+            let can_leak = tap.is_some() && super::output_route::output_can_leak_into_mic();
+            if can_leak {
+                info!("Speakers audible, echo cancellation engaged");
                 mixer.set_aec(Some(super::aec::Aec::new(super::mixer::MIX_RATE)));
             }
-            speakers
+            can_leak
         };
         #[cfg(not(target_os = "macos"))]
         let aec_active = false;

--- a/src-tauri/src/audio/output_route.rs
+++ b/src-tauri/src/audio/output_route.rs
@@ -1,8 +1,12 @@
 //! Default-output-device introspection for system-audio capture.
 //!
 //! The system tap's aggregate device must reference the current default
-//! output device, and echo cancellation is only useful when that output is
-//! the built-in speakers (headphones physically can't leak into the mic).
+//! output device, and echo cancellation is only useful when that output can
+//! actually leak into the microphone: built-in speakers, not muted, and at
+//! an audible volume. The tap delivers audio pre-volume, so a muted or
+//! silenced speaker output still hands the canceller a full-level signal it
+//! will never hear echoed back, which makes an unconverged canceller
+//! suppress the mic instead.
 
 #![cfg(target_os = "macos")]
 
@@ -11,10 +15,11 @@ use std::ptr::NonNull;
 
 use objc2_core_audio::{
     AudioObjectGetPropertyData, AudioObjectID, AudioObjectPropertyAddress,
-    kAudioDevicePropertyDataSource, kAudioDevicePropertyDeviceUID,
-    kAudioDevicePropertyTransportType, kAudioDeviceTransportTypeBuiltIn,
-    kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyElementMain,
-    kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyScopeOutput, kAudioObjectSystemObject,
+    kAudioDevicePropertyDataSource, kAudioDevicePropertyDeviceUID, kAudioDevicePropertyMute,
+    kAudioDevicePropertyTransportType, kAudioDevicePropertyVolumeScalar,
+    kAudioDeviceTransportTypeBuiltIn, kAudioHardwarePropertyDefaultOutputDevice,
+    kAudioObjectPropertyElementMain, kAudioObjectPropertyScopeGlobal,
+    kAudioObjectPropertyScopeOutput, kAudioObjectSystemObject,
 };
 use objc2_core_foundation::{CFRetained, CFString};
 
@@ -82,14 +87,19 @@ pub fn device_uid(device: AudioObjectID) -> Result<String, String> {
     Ok(uid.to_string())
 }
 
-/// Whether the default output routes to the built-in speakers — the only
-/// case where system audio can acoustically leak back into the microphone
-/// and echo cancellation is worth running.
-pub fn output_is_builtin_speakers() -> bool {
-    let Ok(device) = default_output_device() else {
-        return false;
-    };
+fn output_address(selector: u32) -> AudioObjectPropertyAddress {
+    AudioObjectPropertyAddress {
+        mSelector: selector,
+        mScope: kAudioObjectPropertyScopeOutput,
+        mElement: kAudioObjectPropertyElementMain,
+    }
+}
 
+/// Whether the default output device routes to the built-in speakers rather
+/// than headphones or an external device. Built-in transport covers both
+/// the speakers and the headphone jack; the data source ('ispk' vs 'hdpn')
+/// tells them apart. If the device doesn't report one, assume speakers.
+fn output_is_builtin_speakers(device: AudioObjectID) -> bool {
     let mut transport: u32 = 0;
     if get_property(
         device,
@@ -102,17 +112,103 @@ pub fn output_is_builtin_speakers() -> bool {
         return false;
     }
 
-    // Built-in transport covers both the speakers and the headphone jack;
-    // the data source ('ispk' vs 'hdpn') tells them apart. If the device
-    // doesn't report one, assume speakers.
     let mut source: u32 = 0;
-    let address = AudioObjectPropertyAddress {
-        mSelector: kAudioDevicePropertyDataSource,
-        mScope: kAudioObjectPropertyScopeOutput,
-        mElement: kAudioObjectPropertyElementMain,
-    };
-    match get_property(device, address, &mut source) {
+    match get_property(
+        device,
+        output_address(kAudioDevicePropertyDataSource),
+        &mut source,
+    ) {
         Ok(()) => source == DATA_SOURCE_INTERNAL_SPEAKER,
         Err(_) => true,
+    }
+}
+
+/// Whether the default output device is muted. Treated as not muted if the
+/// property can't be read (not every device implements it).
+fn output_is_muted(device: AudioObjectID) -> bool {
+    let mut muted: u32 = 0;
+    match get_property(device, output_address(kAudioDevicePropertyMute), &mut muted) {
+        Ok(()) => muted != 0,
+        Err(_) => false,
+    }
+}
+
+/// The default output device's scalar volume (0.0 to 1.0). Falls back from
+/// the main element to channel 1, then assumes audible if neither can be
+/// read (some devices only expose per-channel volume, others none at all).
+fn output_volume(device: AudioObjectID) -> f32 {
+    let mut volume: f32 = 0.0;
+    if get_property(
+        device,
+        output_address(kAudioDevicePropertyVolumeScalar),
+        &mut volume,
+    )
+    .is_ok()
+    {
+        return volume;
+    }
+
+    let channel_one = AudioObjectPropertyAddress {
+        mSelector: kAudioDevicePropertyVolumeScalar,
+        mScope: kAudioObjectPropertyScopeOutput,
+        mElement: 1,
+    };
+    match get_property(device, channel_one, &mut volume) {
+        Ok(()) => volume,
+        Err(_) => 1.0,
+    }
+}
+
+/// Minimum scalar volume treated as audible. Below this, the render signal
+/// reaching the speakers is effectively silence.
+const AUDIBLE_VOLUME_THRESHOLD: f32 = 0.01;
+
+/// Pure decision: can output audio acoustically leak back into the mic?
+/// Only true for unmuted, audible built-in speakers, headphones and
+/// external devices can't leak regardless of volume or mute state.
+fn can_leak(is_speakers: bool, muted: bool, volume: f32) -> bool {
+    is_speakers && !muted && volume > AUDIBLE_VOLUME_THRESHOLD
+}
+
+/// Whether the default output can acoustically leak into the microphone
+/// right now: built-in speakers, unmuted, and at an audible volume. This is
+/// the only case where echo cancellation does useful work; running it
+/// against a muted or silenced output starves the canceller of any real
+/// echo to converge on and it ends up suppressing the mic instead.
+pub fn output_can_leak_into_mic() -> bool {
+    let Ok(device) = default_output_device() else {
+        return false;
+    };
+
+    let is_speakers = output_is_builtin_speakers(device);
+    if !is_speakers {
+        return false;
+    }
+
+    can_leak(is_speakers, output_is_muted(device), output_volume(device))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::can_leak;
+
+    #[test]
+    fn speakers_unmuted_audible_can_leak() {
+        assert!(can_leak(true, false, 1.0));
+    }
+
+    #[test]
+    fn muted_speakers_cannot_leak() {
+        assert!(!can_leak(true, true, 1.0));
+    }
+
+    #[test]
+    fn zero_volume_speakers_cannot_leak() {
+        assert!(!can_leak(true, false, 0.0));
+    }
+
+    #[test]
+    fn headphones_cannot_leak() {
+        assert!(!can_leak(false, false, 1.0));
     }
 }


### PR DESCRIPTION
## Problem

In meeting mode, playing system audio (e.g. a YouTube video) with the speakers muted or at volume 0 erased the user's voice from the transcript: the system-audio leg transcribed fine, but the mic leg went silent whenever audio was playing.

## Cause

Echo cancellation engaged whenever the default output was the built-in speakers, regardless of volume or mute. The Core Audio tap delivers audio pre-volume, so the canceller received a full-level render signal but no echo ever reached the mic. An unconverged canceller aggressively suppresses the capture signal during far-end activity, killing the user's voice.

## Fix

- New predicate `output_can_leak_into_mic()`: built-in speakers AND not muted (`kAudioDevicePropertyMute`) AND volume above 0.01 (`kAudioDevicePropertyVolumeScalar`, channel-1 fallback, fail-open when unreadable).
- Both AEC engage points in `capture.rs` use it; the existing ~2s route poll picks up mute/volume changes mid-session.
- The decision is factored into a pure `can_leak()` helper with unit tests.

## Validation

Full Rust suite passes (220 tests), clippy clean with `-D warnings`.