### PR TITLE
Add release pipeline, MIT license, and README refresh

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -3,7 +3,7 @@ name: Contracts
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,111 @@
+name: Release
+
+# Builds the macOS installer on every version tag and attaches it to a GitHub Release.
+#   git tag v0.1.0 && git push origin v0.1.0
+#
+# macOS Apple Silicon only, single leg (aarch64-apple-darwin). Souffle has no
+# other target: Metal inference (candle, whisper.cpp) and Core Audio process
+# taps are Apple Silicon only, and the bundled resources/libonnxruntime.dylib
+# is an arm64 build. There is no Intel mac, Windows, Linux, or mobile leg.
+#
+# Signing + notarization are optional: the six APPLE_* secrets listed below
+# already exist in this repo. Without them the build still works, it just
+# ships unsigned.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Create the draft release exactly once, up front, and let the build job
+  # upload into it by id. This avoids a race where the job creates its own
+  # release draft on top of a concurrent one.
+  # ---------------------------------------------------------------------------
+  create-release:
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.create.outputs.result }}
+    steps:
+      - name: Create draft release
+        id: create
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const tag = process.env.GITHUB_REF_NAME;
+            const { data } = await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tag,
+              name: `Soufflé ${tag}`,
+              body: [
+                'Download the .dmg below for Apple Silicon Macs.',
+                '',
+                'Requires macOS 13 or newer on Apple Silicon (M1 or newer).',
+              ].join('\n'),
+              draft: true,
+              prerelease: false,
+            });
+            return data.id;
+
+  # ---------------------------------------------------------------------------
+  # macOS (Apple Silicon): builds the signed/notarized .dmg and uploads it
+  # into the draft release created above.
+  # ---------------------------------------------------------------------------
+  desktop:
+    needs: create-release
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+
+      # cmake builds the sentencepiece tokenizer; it's preinstalled on
+      # GitHub's macOS runner images, so no separate setup step is needed.
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: "./src-tauri -> target"
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Set app version from tag
+        shell: bash
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          export VERSION="${TAG#v}"
+          node -e "const fs=require('fs');const p='src-tauri/tauri.conf.json';const c=JSON.parse(fs.readFileSync(p));c.version=process.env.VERSION;fs.writeFileSync(p,JSON.stringify(c,null,2)+'\n');"
+          echo "Built version set to $VERSION"
+        # The installer version comes from tauri.conf.json. We overwrite it from
+        # the tag here so the tag is the single source of truth for the release.
+
+      - name: Build and release
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # macOS signing + notarization (optional, leave unset to ship unsigned)
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        with:
+          releaseId: ${{ needs.create-release.outputs.release_id }}
+          args: --target aarch64-apple-darwin

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Damien Goehrig
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,84 +1,59 @@
-# Souffle
+# Soufflé
 
-A private, local speech-to-text desktop app for macOS. Everything runs on your machine — no cloud, no API keys, no data leaves your computer.
+![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
+![Tauri 2](https://img.shields.io/badge/Tauri-2-24C8DB?logo=tauri&logoColor=white)
+![Svelte 5](https://img.shields.io/badge/Svelte-5-FF3E00?logo=svelte&logoColor=white)
+![TypeScript](https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white)
+![macOS Apple Silicon](https://img.shields.io/badge/platform-macOS%20Apple%20Silicon-lightgrey)
+
+A private, local speech-to-text app for macOS. Everything runs on-device: no cloud, no API keys, nothing leaves your machine.
 
 ## What it does
 
-- **Dictation** — Press a button or a global shortcut, speak, and get text. Optionally auto-pastes into whatever app you were using.
-- **Meeting transcription** — Record a meeting with a live transcript that streams word by word.
-- **Meeting summaries** — Generate summaries from your transcripts using a local Ollama model.
-- **Full-text search** — All transcripts and dictation entries are indexed and searchable.
+- **Dictation**, with auto-paste into whatever app you were using and a global shortcut to start it from anywhere.
+- **Meeting transcription**, with a live transcript and system-audio capture that separates Me from Them.
+- **Meeting summaries**, generated from your transcripts by a local Ollama model.
+- **Full-text search** across every transcript and dictation entry.
 
 ## Speech models
 
 All models run locally and are downloaded on first use from HuggingFace:
 
-- [Kyutai STT 1B](https://huggingface.co/kyutai/stt-1b-en_fr-candle) (default) — French + English streaming transcription, ~2.4 GB, Metal GPU via Candle
-- [Kyutai STT 2.6B](https://huggingface.co/kyutai/stt-2.6b-en-candle) — English, higher quality, ~5.6 GB
-- [Whisper Large V3 Turbo](https://huggingface.co/ggerganov/whisper.cpp) — multilingual, ~1.6 GB, Metal via whisper.cpp
-- [Parakeet TDT 0.6B v3](https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx) — 25 languages with punctuation and capitalization, ~670 MB int8, fast CPU inference via ONNX Runtime
+- [Kyutai STT 1B](https://huggingface.co/kyutai/stt-1b-en_fr-candle) (default): French + English streaming transcription, ~2.4 GB, Metal GPU via Candle
+- [Kyutai STT 2.6B](https://huggingface.co/kyutai/stt-2.6b-en-candle): English, higher quality, ~5.6 GB
+- [Whisper Large V3 Turbo](https://huggingface.co/ggerganov/whisper.cpp): multilingual, ~1.6 GB, Metal via whisper.cpp
+- [Parakeet TDT 0.6B v3](https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx): 25 languages with punctuation and capitalization, ~670 MB int8, fast CPU inference via ONNX Runtime
 
-## Prerequisites
+## Download
 
-- macOS with Apple Silicon (M1/M2/M3/M4,M5)
-- [Rust](https://rustup.rs/) toolchain
-- [Node.js](https://nodejs.org/) (v18+)
-- [cmake](https://cmake.org/) (`brew install cmake`) — required to build the tokenizer
-- [Ollama](https://ollama.com/) (optional) — for meeting summaries
+Prebuilt installers are on the [**Releases**](https://github.com/damione1/souffle/releases/latest) page: a `.dmg` for Apple Silicon Macs, requiring macOS 13 or newer.
 
 ## Getting started
 
-```bash
-# Install frontend dependencies
-npm install
+### Prerequisites
 
-# Run in development mode
+- An Apple Silicon Mac
+- [Rust](https://rustup.rs/) toolchain
+- [Node.js](https://nodejs.org/) 18+
+- [cmake](https://cmake.org/) (`brew install cmake`), required to build the tokenizer
+- [Ollama](https://ollama.com/) (optional), for meeting summaries
+
+### Develop
+
+```bash
+npm install
 npm run tauri dev
 ```
 
-On first launch, the app will prompt you to download and load the speech model (~2.4 GB). This is a one-time step.
-
-## Building for production
+### Build
 
 ```bash
 npm run tauri build
 ```
 
-The `.dmg` installer is output to `src-tauri/target/release/bundle/dmg/`.
+Tagged releases (`git tag vX.Y.Z && git push origin vX.Y.Z`) are built, signed, and notarized by CI.
 
-Without a signing identity the bundle is only ad-hoc signed: it runs on the
-build machine, but any other Mac will quarantine it on arrival (AirDrop,
-download…) and Gatekeeper reports it as *"damaged and can't be opened"*.
-Recipients can bypass that with `xattr -cr /Applications/Soufflé.app`, but the
-real fix is signing + notarization.
-
-### Signing & notarization (distribution)
-
-Requires an [Apple Developer Program](https://developer.apple.com/programs/)
-membership and a **Developer ID Application** certificate installed in the
-keychain (Xcode → Settings → Accounts → Manage Certificates, or
-developer.apple.com → Certificates). Check it with:
-
-```bash
-security find-identity -v -p codesigning
-```
-
-Then build with the signing/notarization environment set — Tauri picks these
-up automatically and staples the notarization ticket to the DMG:
-
-```bash
-export APPLE_SIGNING_IDENTITY="Developer ID Application: Your Name (TEAMID)"
-export APPLE_ID="you@example.com"            # Apple ID of the developer account
-export APPLE_PASSWORD="app-specific-pwd"      # appleid.apple.com → App-Specific Passwords
-export APPLE_TEAM_ID="TEAMID"
-npm run tauri build
-```
-
-The hardened runtime is enabled with the entitlements in
-`src-tauri/entitlements.plist` (JIT/unsigned-memory exceptions required by the
-Metal inference runtimes).
-
-## Running tests
+### Tests
 
 ```bash
 # Rust tests
@@ -88,6 +63,10 @@ cargo test --manifest-path src-tauri/Cargo.toml
 npm test
 ```
 
+## Tech stack
+
+[Tauri 2](https://tauri.app/) (Rust core) · [SvelteKit](https://kit.svelte.dev/) + [Svelte 5](https://svelte.dev/) · TypeScript. Inference runs via [Candle](https://github.com/huggingface/candle) (Metal), whisper.cpp, and ONNX Runtime.
+
 ## License
 
-Private project.
+Released under the MIT License.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "souffle",
   "private": true,
   "version": "0.1.0",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,6 +3,7 @@ name = "souffle"
 version = "0.1.0"
 description = "Local speech-to-text desktop application"
 authors = ["Damien Goehrig"]
+license = "MIT"
 edition = "2024"
 
 [lib]


### PR DESCRIPTION
## Changes

- **`release.yml`**: builds, signs, and notarizes the Apple Silicon `.dmg` on every `v*` tag and attaches it to a draft GitHub Release. Draft is created once up front, the build uploads into it by id. Uses the existing `APPLE_*` repo secrets; ships unsigned if they're absent. Single `aarch64-apple-darwin` leg: Metal inference (candle, whisper.cpp), Core Audio process taps, and the bundled arm64 `libonnxruntime.dylib` rule out other targets.
- **`contracts.yml`**: push trigger fixed from `main` to `master` (it never fired).
- **`LICENSE.md`**: MIT, plus `license` fields in `package.json` and `Cargo.toml`.
- **`README.md`**: rewritten with badge pills, short pitch, features, speech models, download and getting-started sections. Manual signing walkthrough replaced by a one-liner since CI handles it.

## Release flow

```
git tag v0.1.0 && git push origin v0.1.0
```