### PR TITLE
Ship the ONNX Runtime dylib in Frameworks so it gets signed

### DIFF
--- a/src-tauri/src/ort_runtime.rs
+++ b/src-tauri/src/ort_runtime.rs
@@ -13,12 +13,16 @@ const ORT_DYLIB_FILENAME: &str = "libonnxruntime.dylib";
 
 /// Search for a bundled resource file in standard locations
 /// (next to the binary in dev, in the .app bundle when packaged).
+/// The ONNX Runtime dylib ships in Contents/Frameworks rather than
+/// Resources so the bundler code-signs it; notarization rejects unsigned
+/// Mach-O files anywhere in the bundle.
 pub fn resolve_resource(filename: &str) -> Option<PathBuf> {
     let candidates: Vec<PathBuf> = std::env::current_exe()
         .ok()
         .and_then(|exe| exe.parent().map(|dir| dir.to_path_buf()))
         .map(|bin_dir| {
             vec![
+                bin_dir.join("../Frameworks").join(filename),
                 bin_dir.join("resources").join(filename),
                 bin_dir.join("../Resources/resources").join(filename),
                 PathBuf::from("resources").join(filename),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -59,8 +59,7 @@
     "active": true,
     "targets": "all",
     "resources": {
-      "resources/silero_vad_v4.onnx": "resources/silero_vad_v4.onnx",
-      "resources/libonnxruntime.dylib": "resources/libonnxruntime.dylib"
+      "resources/silero_vad_v4.onnx": "resources/silero_vad_v4.onnx"
     },
     "icon": [
       "icons/32x32.png",
@@ -72,7 +71,10 @@
     "macOS": {
       "entitlements": "./entitlements.plist",
       "minimumSystemVersion": "13.0",
-      "hardenedRuntime": true
+      "hardenedRuntime": true,
+      "frameworks": [
+        "resources/libonnxruntime.dylib"
+      ]
     }
   },
   "plugins": {}


### PR DESCRIPTION
The v0.1.0 notarization failed with "The binary is not signed with a valid Developer ID certificate" / "The signature does not include a secure timestamp" for `Contents/Resources/resources/libonnxruntime.dylib`. Files shipped via `bundle.resources` are treated as plain data and never code-signed, but Apple scans every Mach-O in the archive.

- Move the dylib from `bundle.resources` to `bundle.macOS.frameworks`: the bundler copies it to `Contents/Frameworks` and the codesign step signs it with the Developer ID identity and a secure timestamp.
- `resolve_resource` now checks `Contents/Frameworks` first; dev-mode lookups are unchanged.

Verified with a local `npm run tauri build`: the dylib lands in `Contents/Frameworks/`, `Contents/Resources/resources/` only carries the VAD model (plain data).