### PR TITLE
Dictionary phonetics, meeting-scoped transcription hints, live Me/Them labels

### DIFF
--- a/src-tauri/src/calendar/mod.rs
+++ b/src-tauri/src/calendar/mod.rs
@@ -70,11 +70,12 @@ fn local_day_bounds(now: DateTime<Local>) -> (i64, i64) {
         chrono::LocalResult::Single(dt) => dt,
         chrono::LocalResult::Ambiguous(a, _) => a,
         // Skipped by a DST jump: shift forward an hour.
-        chrono::LocalResult::None => {
-            Local.from_utc_datetime(&(naive - ChronoDuration::hours(1)))
-        }
+        chrono::LocalResult::None => Local.from_utc_datetime(&(naive - ChronoDuration::hours(1))),
     };
-    (resolve(start_naive).timestamp(), resolve(end_naive).timestamp())
+    (
+        resolve(start_naive).timestamp(),
+        resolve(end_naive).timestamp(),
+    )
 }
 
 /// Strip a `mailto:` scheme from a participant URL, keeping only plausible
@@ -236,9 +237,9 @@ mod macos {
                 .map(|s| s.to_string())
                 .unwrap_or_default();
             let organizer_email = email_from_participant_url(&organizer_url);
-            let matched = participants.iter_mut().find(|p| {
-                p.email.is_some() && p.email == organizer_email
-            });
+            let matched = participants
+                .iter_mut()
+                .find(|p| p.email.is_some() && p.email == organizer_email);
             match matched {
                 Some(p) => p.is_organizer = true,
                 None => participants.insert(0, convert_participant(&organizer, true)),
@@ -258,8 +259,7 @@ mod macos {
             location: unsafe { event.location() }
                 .map(|l| l.to_string())
                 .filter(|l| !l.trim().is_empty()),
-            url: unsafe { event.URL() }
-                .and_then(|u| u.absoluteString().map(|s| s.to_string())),
+            url: unsafe { event.URL() }.and_then(|u| u.absoluteString().map(|s| s.to_string())),
             description: unsafe { event.notes() }
                 .map(|n| n.to_string())
                 .filter(|n| !n.trim().is_empty()),

--- a/src-tauri/src/calendar/mod.rs
+++ b/src-tauri/src/calendar/mod.rs
@@ -43,6 +43,9 @@ pub struct CalendarEvent {
     pub location: Option<String>,
     /// The event URL — for video meetings this is usually the conference link.
     pub url: Option<String>,
+    /// The invitation body (EKCalendarItem notes). Mined for session-scoped
+    /// transcription hints when a meeting starts from this event.
+    pub description: Option<String>,
 }
 
 /// Today's events plus the permission state, so the UI can render the
@@ -257,6 +260,9 @@ mod macos {
                 .filter(|l| !l.trim().is_empty()),
             url: unsafe { event.URL() }
                 .and_then(|u| u.absoluteString().map(|s| s.to_string())),
+            description: unsafe { event.notes() }
+                .map(|n| n.to_string())
+                .filter(|n| !n.trim().is_empty()),
         })
     }
 

--- a/src-tauri/src/calendar/scheduler.rs
+++ b/src-tauri/src/calendar/scheduler.rs
@@ -157,6 +157,7 @@ mod tests {
             participants: Vec::<MeetingParticipant>::new(),
             location: None,
             url: None,
+            description: None,
         }
     }
 

--- a/src-tauri/src/calendar/scheduler.rs
+++ b/src-tauri/src/calendar/scheduler.rs
@@ -166,7 +166,10 @@ mod tests {
         let now = Utc::now();
         let fired = HashSet::new();
         let at_boundary = event("a", now + chrono::Duration::minutes(2));
-        let beyond = event("b", now + chrono::Duration::minutes(2) + chrono::Duration::seconds(1));
+        let beyond = event(
+            "b",
+            now + chrono::Duration::minutes(2) + chrono::Duration::seconds(1),
+        );
         let due = due_reminders(now, &[at_boundary, beyond], 2, &fired);
         assert_eq!(due.len(), 1);
         assert_eq!(due[0].id, "a");
@@ -197,8 +200,14 @@ mod tests {
     fn prune_drops_only_stale_keys() {
         let now = Utc::now();
         let mut fired = HashSet::new();
-        fired.insert(("old".to_string(), (now - chrono::Duration::days(2)).timestamp()));
-        fired.insert(("recent".to_string(), (now - chrono::Duration::hours(1)).timestamp()));
+        fired.insert((
+            "old".to_string(),
+            (now - chrono::Duration::days(2)).timestamp(),
+        ));
+        fired.insert((
+            "recent".to_string(),
+            (now - chrono::Duration::hours(1)).timestamp(),
+        ));
         prune_fired(&mut fired, now);
         assert_eq!(fired.len(), 1);
         assert!(fired.iter().any(|(id, _)| id == "recent"));

--- a/src-tauri/src/commands/dictionary.rs
+++ b/src-tauri/src/commands/dictionary.rs
@@ -14,7 +14,7 @@ pub fn list_dictionary(state: State<'_, AppState>) -> Result<Vec<DictionaryEntry
 pub fn add_dictionary_entry(
     state: State<'_, AppState>,
     term: String,
-    phonetic_code: Option<String>,
+    pronunciation: Option<String>,
     category: Option<String>,
 ) -> Result<DictionaryEntry, String> {
     let term = term.trim();
@@ -23,7 +23,7 @@ pub fn add_dictionary_entry(
     }
     state
         .db
-        .add_dictionary_entry(term, phonetic_code.as_deref(), category.as_deref())
+        .add_dictionary_entry(term, pronunciation.as_deref(), category.as_deref())
 }
 
 #[tauri::command]
@@ -32,7 +32,7 @@ pub fn update_dictionary_entry(
     state: State<'_, AppState>,
     id: i64,
     term: String,
-    phonetic_code: Option<String>,
+    pronunciation: Option<String>,
     category: Option<String>,
 ) -> Result<(), String> {
     let term = term.trim();
@@ -41,7 +41,7 @@ pub fn update_dictionary_entry(
     }
     state
         .db
-        .update_dictionary_entry(id, term, phonetic_code.as_deref(), category.as_deref())
+        .update_dictionary_entry(id, term, pronunciation.as_deref(), category.as_deref())
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -115,9 +115,25 @@ fn build_meeting_on_segment(
 async fn launch_meeting(
     state: &AppState,
     accumulator: MeetingAccumulator,
+    event_description: Option<String>,
     channel: Channel<TranscriptionSegment>,
 ) -> Result<u64, String> {
     let session_id = next_audio_session_id(state)?;
+
+    // Session-scoped transcription hints: participant names plus distinctive
+    // jargon from the event title/description. Never persisted.
+    let participant_names: Vec<String> = accumulator
+        .participants
+        .iter()
+        .map(|p| p.name.clone())
+        .collect();
+    let session_terms = crate::filter::session_terms::derive_session_terms(
+        &participant_names,
+        &[
+            accumulator.title.as_str(),
+            event_description.as_deref().unwrap_or(""),
+        ],
+    );
 
     // Persist the header before any segments so a crash leaves a recoverable
     // row (ended_at IS NULL) and segment FK targets exist.
@@ -147,6 +163,7 @@ async fn launch_meeting(
             &db,
             session_id,
             PipelineMode::Meeting,
+            session_terms,
             on_segment,
         )
     })
@@ -202,6 +219,7 @@ fn start_pipeline_blocking(
     db: &Database,
     session_id: u64,
     mode: PipelineMode,
+    session_terms: Vec<String>,
     on_segment: SegmentCallback,
 ) -> Result<(), String> {
     // Snapshot settings and dictionary; the actor builds filter chains on its
@@ -224,6 +242,7 @@ fn start_pipeline_blocking(
     let config = SessionConfig {
         pipeline_config: settings.pipeline_config(),
         dictionary_entries: db.list_dictionary_entries()?,
+        session_terms,
         diarize,
     };
 
@@ -310,6 +329,7 @@ pub async fn start_transcription(
             &db,
             session_id,
             PipelineMode::Dictation,
+            Vec::new(),
             on_segment,
         )
     })
@@ -384,9 +404,13 @@ pub async fn start_meeting_recording(
     }
 
     let meeting_id = Uuid::new_v4().to_string();
-    let (calendar_event_id, participants) = match calendar {
-        Some(context) => (Some(context.event_id), context.participants),
-        None => (None, Vec::new()),
+    let (calendar_event_id, participants, event_description) = match calendar {
+        Some(context) => (
+            Some(context.event_id),
+            context.participants,
+            context.description,
+        ),
+        None => (None, Vec::new(), None),
     };
     let accumulator = MeetingAccumulator {
         id: meeting_id.clone(),
@@ -406,7 +430,7 @@ pub async fn start_meeting_recording(
         persisted_new_count: 0,
     };
 
-    let session_id = launch_meeting(&state, accumulator, channel).await?;
+    let session_id = launch_meeting(&state, accumulator, event_description, channel).await?;
 
     state.apply_transition(StateAction::StartMeeting {
         session_id,
@@ -470,7 +494,7 @@ pub async fn resume_meeting_recording(
         persisted_new_count: 0,
     };
 
-    let session_id = launch_meeting(&state, accumulator, channel).await?;
+    let session_id = launch_meeting(&state, accumulator, None, channel).await?;
 
     state.apply_transition(StateAction::StartMeeting {
         session_id,

--- a/src-tauri/src/db/dictionary.rs
+++ b/src-tauri/src/db/dictionary.rs
@@ -1,7 +1,6 @@
 use rusqlite::params;
 
 use crate::filter::DictionaryEntry;
-use crate::filter::soundex::soundex;
 use crate::lock_ext::MutexExt;
 
 use super::Database;
@@ -17,7 +16,7 @@ impl Database {
                 Ok(DictionaryEntry {
                     id: row.get(0)?,
                     term: row.get(1)?,
-                    phonetic_code: row.get(2)?,
+                    pronunciation: row.get(2)?,
                     category: row.get(3)?,
                     created_at: row.get(4)?,
                 })
@@ -28,19 +27,22 @@ impl Database {
         Ok(entries)
     }
 
+    /// The `phonetic_code` column stores the user's pronunciation spelling
+    /// (e.g. "vésix" for "V6") since schema v9; the Soundex code is derived
+    /// at filter-build time, never persisted.
     pub fn add_dictionary_entry(
         &self,
         term: &str,
-        phonetic_code: Option<&str>,
+        pronunciation: Option<&str>,
         category: Option<&str>,
     ) -> Result<DictionaryEntry, String> {
         let conn = self.conn.acquire()?;
         let now = chrono::Utc::now().to_rfc3339();
-        let effective_phonetic = phonetic_code.map(String::from).or_else(|| soundex(term));
+        let pronunciation = pronunciation.map(str::trim).filter(|p| !p.is_empty());
 
         conn.execute(
             "INSERT INTO dictionary (term, phonetic_code, category, created_at) VALUES (?1, ?2, ?3, ?4)",
-            params![term, effective_phonetic, category, now],
+            params![term, pronunciation, category, now],
         )
         .map_err(|e| format!("Insert dictionary entry: {e}"))?;
 
@@ -48,7 +50,7 @@ impl Database {
         Ok(DictionaryEntry {
             id,
             term: term.to_string(),
-            phonetic_code: effective_phonetic,
+            pronunciation: pronunciation.map(String::from),
             category: category.map(String::from),
             created_at: now,
         })
@@ -58,16 +60,16 @@ impl Database {
         &self,
         id: i64,
         term: &str,
-        phonetic_code: Option<&str>,
+        pronunciation: Option<&str>,
         category: Option<&str>,
     ) -> Result<(), String> {
         let conn = self.conn.acquire()?;
-        let effective_phonetic = phonetic_code.map(String::from).or_else(|| soundex(term));
+        let pronunciation = pronunciation.map(str::trim).filter(|p| !p.is_empty());
 
         let updated = conn
             .execute(
                 "UPDATE dictionary SET term = ?1, phonetic_code = ?2, category = ?3 WHERE id = ?4",
-                params![term, effective_phonetic, category, id],
+                params![term, pronunciation, category, id],
             )
             .map_err(|e| format!("Update dictionary entry: {e}"))?;
 
@@ -110,7 +112,7 @@ mod tests {
             .add_dictionary_entry("Kubernetes", None, Some("tech"))
             .unwrap();
         assert_eq!(entry.term, "Kubernetes");
-        assert!(entry.phonetic_code.is_some());
+        assert_eq!(entry.pronunciation, None);
         assert_eq!(entry.category.as_deref(), Some("tech"));
 
         // List
@@ -149,18 +151,21 @@ mod tests {
     }
 
     #[test]
-    fn dictionary_auto_soundex() {
+    fn dictionary_stores_no_pronunciation_by_default() {
         let (db, _dir) = test_db();
         let entry = db.add_dictionary_entry("Robert", None, None).unwrap();
-        assert_eq!(entry.phonetic_code.as_deref(), Some("R163"));
+        assert_eq!(entry.pronunciation, None);
     }
 
     #[test]
-    fn dictionary_explicit_phonetic_preserved() {
+    fn dictionary_pronunciation_stored_verbatim_and_blank_dropped() {
         let (db, _dir) = test_db();
         let entry = db
-            .add_dictionary_entry("Souffle", Some("CUSTOM"), None)
+            .add_dictionary_entry("V6", Some("vésix"), None)
             .unwrap();
-        assert_eq!(entry.phonetic_code.as_deref(), Some("CUSTOM"));
+        assert_eq!(entry.pronunciation.as_deref(), Some("vésix"));
+
+        let blank = db.add_dictionary_entry("K8s", Some("   "), None).unwrap();
+        assert_eq!(blank.pronunciation, None);
     }
 }

--- a/src-tauri/src/db/dictionary.rs
+++ b/src-tauri/src/db/dictionary.rs
@@ -160,9 +160,7 @@ mod tests {
     #[test]
     fn dictionary_pronunciation_stored_verbatim_and_blank_dropped() {
         let (db, _dir) = test_db();
-        let entry = db
-            .add_dictionary_entry("V6", Some("vésix"), None)
-            .unwrap();
+        let entry = db.add_dictionary_entry("V6", Some("vésix"), None).unwrap();
         assert_eq!(entry.pronunciation.as_deref(), Some("vésix"));
 
         let blank = db.add_dictionary_entry("K8s", Some("   "), None).unwrap();

--- a/src-tauri/src/db/meetings.rs
+++ b/src-tauri/src/db/meetings.rs
@@ -530,8 +530,9 @@ impl MeetingRow {
     /// NULL (pre-v8 rows) means no participants.
     fn participants(&self) -> Result<Vec<MeetingParticipant>, String> {
         match self.participants.as_deref() {
-            Some(raw) => serde_json::from_str(raw)
-                .map_err(|e| format!("Deserialize participants: {e}")),
+            Some(raw) => {
+                serde_json::from_str(raw).map_err(|e| format!("Deserialize participants: {e}"))
+            }
             None => Ok(Vec::new()),
         }
     }
@@ -543,7 +544,9 @@ fn serialize_participants(participants: &[MeetingParticipant]) -> Result<Option<
     if participants.is_empty() {
         return Ok(None);
     }
-    serde_json::to_string(participants).map(Some).map_err(|e| format!("Serialize participants: {e}"))
+    serde_json::to_string(participants)
+        .map(Some)
+        .map_err(|e| format!("Serialize participants: {e}"))
 }
 
 fn parse_datetime(value: &str) -> Result<DateTime<Utc>, String> {

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -160,6 +160,12 @@ impl Database {
                     .map_err(|e| format!("Update schema version v8: {e}"))?;
             }
 
+            if current_version < 9 {
+                schema::migrate_dictionary_phonetics_to_v9(&conn)?;
+                conn.execute("UPDATE schema_version SET version = 9", [])
+                    .map_err(|e| format!("Update schema version v9: {e}"))?;
+            }
+
             info!("Schema migration complete");
         }
 

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -355,7 +355,9 @@ pub fn migrate_text_search_to_v4(conn: &mut Connection) -> Result<(), String> {
 pub fn migrate_dictionary_phonetics_to_v9(conn: &Connection) -> Result<(), String> {
     let auto_derived: Vec<i64> = {
         let mut stmt = conn
-            .prepare("SELECT id, term, phonetic_code FROM dictionary WHERE phonetic_code IS NOT NULL")
+            .prepare(
+                "SELECT id, term, phonetic_code FROM dictionary WHERE phonetic_code IS NOT NULL",
+            )
             .map_err(|e| format!("Prepare v9 dictionary scan: {e}"))?;
         let rows = stmt
             .query_map([], |row| {
@@ -369,7 +371,9 @@ pub fn migrate_dictionary_phonetics_to_v9(conn: &Connection) -> Result<(), Strin
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| format!("Collect v9 dictionary scan: {e}"))?;
         rows.into_iter()
-            .filter(|(_, term, code)| crate::filter::soundex::soundex(term).as_deref() == Some(code))
+            .filter(|(_, term, code)| {
+                crate::filter::soundex::soundex(term).as_deref() == Some(code)
+            })
             .map(|(id, _, _)| id)
             .collect()
     };

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -4,8 +4,9 @@ use rusqlite::{Connection, params};
 use crate::engine::TranscriptionProfile;
 use crate::transcript::{legacy_recording_session, resolve_legacy_transcription_profile};
 
-/// Schema version 8: calendar_event_id + participants columns on meetings
-pub const SCHEMA_VERSION: i64 = 8;
+/// Schema version 9: dictionary.phonetic_code holds a pronunciation spelling;
+/// legacy auto-derived Soundex codes are cleared.
+pub const SCHEMA_VERSION: i64 = 9;
 
 pub const CREATE_SCHEMA_VERSION: &str = "
     CREATE TABLE IF NOT EXISTS schema_version (
@@ -344,6 +345,41 @@ pub fn migrate_text_search_to_v4(conn: &mut Connection) -> Result<(), String> {
     tx.commit()
         .map_err(|e| format!("Commit v4 migration: {e}"))?;
 
+    Ok(())
+}
+
+/// v9: `dictionary.phonetic_code` becomes a user-facing pronunciation
+/// spelling. Until now the app auto-filled it with the term's Soundex code;
+/// those derived values are cleared (kept only if a caller stored something
+/// other than the auto value). The Soundex is recomputed at filter build.
+pub fn migrate_dictionary_phonetics_to_v9(conn: &Connection) -> Result<(), String> {
+    let auto_derived: Vec<i64> = {
+        let mut stmt = conn
+            .prepare("SELECT id, term, phonetic_code FROM dictionary WHERE phonetic_code IS NOT NULL")
+            .map_err(|e| format!("Prepare v9 dictionary scan: {e}"))?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, i64>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            })
+            .map_err(|e| format!("Query v9 dictionary scan: {e}"))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("Collect v9 dictionary scan: {e}"))?;
+        rows.into_iter()
+            .filter(|(_, term, code)| crate::filter::soundex::soundex(term).as_deref() == Some(code))
+            .map(|(id, _, _)| id)
+            .collect()
+    };
+    for id in auto_derived {
+        conn.execute(
+            "UPDATE dictionary SET phonetic_code = NULL WHERE id = ?1",
+            params![id],
+        )
+        .map_err(|e| format!("Clear auto phonetic code (id {id}): {e}"))?;
+    }
     Ok(())
 }
 

--- a/src-tauri/src/filter/mod.rs
+++ b/src-tauri/src/filter/mod.rs
@@ -1,4 +1,5 @@
 mod audio_vad;
+pub mod session_terms;
 pub mod soundex;
 mod text_dictionary;
 mod text_filler;
@@ -150,6 +151,7 @@ pub fn build_audio_filters(config: &PipelineConfig, source_sample_rate: u32) -> 
 pub fn build_text_filters(
     config: &PipelineConfig,
     dictionary: Vec<DictionaryEntry>,
+    session_terms: &[String],
 ) -> TextFilterChain {
     let mut filters: Vec<Box<dyn TextFilter>> = Vec::new();
     if config.filler_removal_enabled {
@@ -158,8 +160,12 @@ pub fn build_text_filters(
     if config.stutter_collapse_enabled {
         filters.push(Box::new(text_stutter::StutterCollapseFilter::new()));
     }
-    if config.dictionary_correction_enabled && !dictionary.is_empty() {
-        filters.push(Box::new(text_dictionary::DictionaryFilter::new(dictionary)));
+    if config.dictionary_correction_enabled && (!dictionary.is_empty() || !session_terms.is_empty())
+    {
+        filters.push(Box::new(text_dictionary::DictionaryFilter::with_session_terms(
+            dictionary,
+            session_terms,
+        )));
     }
     // Whitespace normalization always runs last to clean up artifacts from previous filters
     filters.push(Box::new(text_whitespace::WhitespaceNormFilter));
@@ -232,7 +238,7 @@ mod tests {
             stutter_collapse_enabled: false,
             dictionary_correction_enabled: false,
         };
-        let chain = build_text_filters(&config, vec![]);
+        let chain = build_text_filters(&config, vec![], &[]);
         // Whitespace normalization should still clean up
         assert_eq!(chain.apply("  hello   world  "), "hello world");
     }

--- a/src-tauri/src/filter/mod.rs
+++ b/src-tauri/src/filter/mod.rs
@@ -104,7 +104,10 @@ pub struct PipelineConfig {
 pub struct DictionaryEntry {
     pub id: i64,
     pub term: String,
-    pub phonetic_code: Option<String>,
+    /// How the term sounds when spoken, spelled out (e.g. "vésix" for "V6").
+    /// Drives phonetic matching; when absent, the term's own Soundex is used
+    /// (except for digit-bearing terms, whose Soundex is meaningless).
+    pub pronunciation: Option<String>,
     pub category: Option<String>,
     pub created_at: String,
 }

--- a/src-tauri/src/filter/mod.rs
+++ b/src-tauri/src/filter/mod.rs
@@ -162,10 +162,9 @@ pub fn build_text_filters(
     }
     if config.dictionary_correction_enabled && (!dictionary.is_empty() || !session_terms.is_empty())
     {
-        filters.push(Box::new(text_dictionary::DictionaryFilter::with_session_terms(
-            dictionary,
-            session_terms,
-        )));
+        filters.push(Box::new(
+            text_dictionary::DictionaryFilter::with_session_terms(dictionary, session_terms),
+        ));
     }
     // Whitespace normalization always runs last to clean up artifacts from previous filters
     filters.push(Box::new(text_whitespace::WhitespaceNormFilter));

--- a/src-tauri/src/filter/session_terms.rs
+++ b/src-tauri/src/filter/session_terms.rs
@@ -1,0 +1,116 @@
+//! Session-scoped transcription hints derived from meeting context
+//! (calendar participants, event title and description). These terms feed
+//! the dictionary filter for one recording session only and are never
+//! persisted to the user's dictionary.
+
+use std::collections::HashSet;
+
+/// Upper bound on derived terms: invitation bodies can be huge
+/// (videoconference boilerplate), and every term costs a comparison per
+/// transcribed word.
+const MAX_SESSION_TERMS: usize = 50;
+
+/// Minimum token length; shorter tokens collide with function words.
+const MIN_TOKEN_LEN: usize = 3;
+
+/// Derive session terms from participant names plus free text (event title,
+/// invitation body). Names contribute every name token; free text only
+/// contributes visually distinctive tokens (CamelCase, acronyms), because
+/// injecting ordinary words would invite corrections toward them.
+pub fn derive_session_terms(names: &[String], free_texts: &[&str]) -> Vec<String> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut terms = Vec::new();
+    let mut push = |token: &str| {
+        if terms.len() < MAX_SESSION_TERMS && seen.insert(token.to_lowercase()) {
+            terms.push(token.to_string());
+        }
+    };
+
+    for token in names.iter().flat_map(|name| name.split_whitespace()) {
+        let token = token.trim_matches(|c: char| !c.is_alphanumeric());
+        if is_name_token(token) {
+            push(token);
+        }
+    }
+
+    for token in free_texts.iter().flat_map(|text| text.split_whitespace()) {
+        let token = token.trim_matches(|c: char| !c.is_alphanumeric());
+        if is_distinctive_token(token) {
+            push(token);
+        }
+    }
+
+    terms
+}
+
+fn is_name_token(token: &str) -> bool {
+    token.chars().count() >= MIN_TOKEN_LEN
+        && token.chars().all(|c| c.is_alphabetic() || c == '-' || c == '\'')
+}
+
+/// Jargon detector for free text: CamelCase ("FluidNC") and acronyms
+/// ("API"). Ordinary capitalized words (sentence starts, title case) don't
+/// qualify. Digit-bearing tokens are skipped: session terms match through
+/// Soundex only, and digits carry no phonetic signal.
+fn is_distinctive_token(token: &str) -> bool {
+    if token.chars().count() < MIN_TOKEN_LEN || !token.chars().all(char::is_alphanumeric) {
+        return false;
+    }
+    if token.chars().any(|c| c.is_ascii_digit()) {
+        return false;
+    }
+    token.chars().skip(1).any(char::is_uppercase)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strs(terms: &[String]) -> Vec<&str> {
+        terms.iter().map(String::as_str).collect()
+    }
+
+    #[test]
+    fn name_tokens_are_split_and_deduped() {
+        let names = vec!["Alice Martin".to_string(), "alice Dupont".to_string()];
+        let terms = derive_session_terms(&names, &[]);
+        assert_eq!(strs(&terms), vec!["Alice", "Martin", "Dupont"]);
+    }
+
+    #[test]
+    fn short_name_tokens_are_dropped() {
+        let names = vec!["Al Pacino".to_string()];
+        assert_eq!(strs(&derive_session_terms(&names, &[])), vec!["Pacino"]);
+    }
+
+    #[test]
+    fn free_text_keeps_only_distinctive_tokens() {
+        let terms = derive_session_terms(
+            &[],
+            &["Sprint planning for FluidNC and the API, V6 rollout tomorrow"],
+        );
+        assert_eq!(strs(&terms), vec!["FluidNC", "API"]);
+    }
+
+    #[test]
+    fn punctuation_is_trimmed() {
+        let terms = derive_session_terms(&[], &["(FluidNC), API."]);
+        assert_eq!(strs(&terms), vec!["FluidNC", "API"]);
+    }
+
+    #[test]
+    fn capped_at_max_terms() {
+        let text = (0..70u8)
+            .map(|i| {
+                format!(
+                    "term{}{}X",
+                    char::from(b'a' + i / 26),
+                    char::from(b'a' + i % 26)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(" ");
+        let terms = derive_session_terms(&[], &[text.as_str()]);
+        assert_eq!(terms.len(), MAX_SESSION_TERMS);
+    }
+}

--- a/src-tauri/src/filter/session_terms.rs
+++ b/src-tauri/src/filter/session_terms.rs
@@ -45,7 +45,9 @@ pub fn derive_session_terms(names: &[String], free_texts: &[&str]) -> Vec<String
 
 fn is_name_token(token: &str) -> bool {
     token.chars().count() >= MIN_TOKEN_LEN
-        && token.chars().all(|c| c.is_alphabetic() || c == '-' || c == '\'')
+        && token
+            .chars()
+            .all(|c| c.is_alphabetic() || c == '-' || c == '\'')
 }
 
 /// Jargon detector for free text: CamelCase ("FluidNC") and acronyms

--- a/src-tauri/src/filter/soundex.rs
+++ b/src-tauri/src/filter/soundex.rs
@@ -1,12 +1,10 @@
 /// Standard American Soundex encoding.
 /// Returns a 4-character code: first letter + 3 digits.
 /// H and W are transparent — they don't separate identical codes.
+/// Accented Latin letters fold to their base letter (the app transcribes
+/// French) instead of being silently dropped.
 pub fn soundex(word: &str) -> Option<String> {
-    let chars: Vec<char> = word
-        .chars()
-        .filter(|c| c.is_ascii_alphabetic())
-        .map(|c| c.to_ascii_uppercase())
-        .collect();
+    let chars: Vec<char> = word.chars().filter_map(fold_to_ascii_upper).collect();
 
     let first = *chars.first()?;
     let mut code = String::with_capacity(4);
@@ -37,6 +35,20 @@ pub fn soundex(word: &str) -> Option<String> {
         code.push('0');
     }
     Some(code)
+}
+
+fn fold_to_ascii_upper(c: char) -> Option<char> {
+    let folded = match c {
+        'à' | 'â' | 'ä' | 'á' | 'À' | 'Â' | 'Ä' | 'Á' => 'A',
+        'é' | 'è' | 'ê' | 'ë' | 'É' | 'È' | 'Ê' | 'Ë' => 'E',
+        'î' | 'ï' | 'í' | 'Î' | 'Ï' | 'Í' => 'I',
+        'ô' | 'ö' | 'ó' | 'Ô' | 'Ö' | 'Ó' => 'O',
+        'ù' | 'û' | 'ü' | 'ú' | 'Ù' | 'Û' | 'Ü' | 'Ú' => 'U',
+        'ç' | 'Ç' => 'C',
+        c if c.is_ascii_alphabetic() => c.to_ascii_uppercase(),
+        _ => return None,
+    };
+    Some(folded)
 }
 
 fn letter_to_digit(ch: char) -> char {
@@ -79,5 +91,12 @@ mod tests {
     fn case_insensitive() {
         assert_eq!(soundex("smith"), soundex("SMITH"));
         assert_eq!(soundex("smith"), soundex("Smith"));
+    }
+
+    #[test]
+    fn accented_letters_fold_to_base() {
+        assert_eq!(soundex("vésix"), soundex("vesix"));
+        assert_eq!(soundex("François"), soundex("Francois"));
+        assert_eq!(soundex("Éric"), soundex("Eric"));
     }
 }

--- a/src-tauri/src/filter/text_dictionary.rs
+++ b/src-tauri/src/filter/text_dictionary.rs
@@ -45,10 +45,6 @@ fn derive_phonetic_code(term: &str, pronunciation: Option<&str>) -> Option<Strin
 }
 
 impl DictionaryFilter {
-    pub fn new(entries: Vec<DictionaryEntry>) -> Self {
-        Self::with_session_terms(entries, &[])
-    }
-
     /// `session_terms` are ephemeral additions for one recording session
     /// (participant names, meeting jargon); they match phonetically only.
     pub fn with_session_terms(entries: Vec<DictionaryEntry>, session_terms: &[String]) -> Self {
@@ -191,38 +187,38 @@ mod tests {
 
     #[test]
     fn corrects_close_misspelling() {
-        let f = DictionaryFilter::new(vec![entry("Kubernetes")]);
+        let f = DictionaryFilter::with_session_terms(vec![entry("Kubernetes")], &[]);
         assert_eq!(f.apply("Kubernetis"), "Kubernetes");
     }
 
     #[test]
     fn preserves_exact_match() {
-        let f = DictionaryFilter::new(vec![entry("Docker")]);
+        let f = DictionaryFilter::with_session_terms(vec![entry("Docker")], &[]);
         assert_eq!(f.apply("Docker is great"), "Docker is great");
     }
 
     #[test]
     fn soundex_match_for_proper_nouns() {
-        let f = DictionaryFilter::new(vec![entry("Damien")]);
+        let f = DictionaryFilter::with_session_terms(vec![entry("Damien")], &[]);
         // "Damian" has the same Soundex as "Damien" (D550)
         assert_eq!(f.apply("Hello Damian"), "Hello Damien");
     }
 
     #[test]
     fn preserves_unrelated_words() {
-        let f = DictionaryFilter::new(vec![entry("Kubernetes")]);
+        let f = DictionaryFilter::with_session_terms(vec![entry("Kubernetes")], &[]);
         assert_eq!(f.apply("the quick brown fox"), "the quick brown fox");
     }
 
     #[test]
     fn empty_dictionary_passthrough() {
-        let f = DictionaryFilter::new(vec![]);
+        let f = DictionaryFilter::with_session_terms(vec![], &[]);
         assert_eq!(f.apply("hello world"), "hello world");
     }
 
     #[test]
     fn empty_input() {
-        let f = DictionaryFilter::new(vec![entry("Test")]);
+        let f = DictionaryFilter::with_session_terms(vec![entry("Test")], &[]);
         assert_eq!(f.apply(""), "");
     }
 
@@ -230,23 +226,26 @@ mod tests {
     fn short_words_are_never_corrected() {
         // "va" collides with "V6" through alphabetic Soundex ("V000" both);
         // the 2-char guard must keep function words untouched.
-        let f = DictionaryFilter::new(vec![entry("V6")]);
+        let f = DictionaryFilter::with_session_terms(vec![entry("V6")], &[]);
         assert_eq!(f.apply("il va faire"), "il va faire");
 
-        let names = DictionaryFilter::new(vec![entry("Damien")]);
+        let names = DictionaryFilter::with_session_terms(vec![entry("Damien")], &[]);
         assert_eq!(names.apply("de la part"), "de la part");
     }
 
     #[test]
     fn digit_terms_get_no_auto_phonetic_matching() {
-        let f = DictionaryFilter::new(vec![entry("V6")]);
+        let f = DictionaryFilter::with_session_terms(vec![entry("V6")], &[]);
         // "vas" (3 chars, Soundex V000 too) must not become V6 either.
         assert_eq!(f.apply("tu vas bien"), "tu vas bien");
     }
 
     #[test]
     fn pronunciation_drives_phonetic_matching() {
-        let f = DictionaryFilter::new(vec![entry_with_pronunciation("V6", "vésix")]);
+        let f = DictionaryFilter::with_session_terms(
+            vec![entry_with_pronunciation("V6", "vésix")],
+            &[],
+        );
         assert_eq!(f.apply("le vésix arrive"), "le V6 arrive");
         assert_eq!(f.apply("le vesix arrive"), "le V6 arrive");
         // Unrelated words with a different Soundex stay untouched.
@@ -256,7 +255,10 @@ mod tests {
 
     #[test]
     fn blank_pronunciation_falls_back_to_term_soundex() {
-        let f = DictionaryFilter::new(vec![entry_with_pronunciation("Damien", "  ")]);
+        let f = DictionaryFilter::with_session_terms(
+            vec![entry_with_pronunciation("Damien", "  ")],
+            &[],
+        );
         assert_eq!(f.apply("Hello Damian"), "Hello Damien");
     }
 
@@ -276,7 +278,7 @@ mod tests {
         let f = DictionaryFilter::with_session_terms(vec![], &["Martin".to_string()]);
         assert_eq!(f.apply("le matin venu"), "le matin venu");
 
-        let user = DictionaryFilter::new(vec![entry("Martin")]);
+        let user = DictionaryFilter::with_session_terms(vec![entry("Martin")], &[]);
         assert_eq!(user.apply("le matin venu"), "le Martin venu");
     }
 

--- a/src-tauri/src/filter/text_dictionary.rs
+++ b/src-tauri/src/filter/text_dictionary.rs
@@ -6,6 +6,11 @@ use super::{DictionaryEntry, TextFilter, TextFilterKind};
 /// Maximum normalized Levenshtein distance for a fuzzy match.
 const LEVENSHTEIN_THRESHOLD: f64 = 0.82; // similarity > 0.82 means distance < 0.18
 
+/// Words shorter than this are never corrected: short function words ("va",
+/// "de", "on") collide with almost anything phonetically and correcting them
+/// does far more harm than good.
+const MIN_WORD_LEN: usize = 3;
+
 pub struct DictionaryFilter {
     entries: Vec<DictionaryMatch>,
 }
@@ -16,13 +21,26 @@ struct DictionaryMatch {
     phonetic_code: Option<String>,
 }
 
+/// Phonetic code used for matching: the user-provided pronunciation wins;
+/// otherwise the term's own Soundex, except for digit-bearing terms ("V6",
+/// "K8s") whose alphabetic Soundex would collide with unrelated short words.
+fn derive_phonetic_code(term: &str, pronunciation: Option<&str>) -> Option<String> {
+    if let Some(p) = pronunciation.map(str::trim).filter(|p| !p.is_empty()) {
+        return soundex(p);
+    }
+    if term.chars().any(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    soundex(term)
+}
+
 impl DictionaryFilter {
     pub fn new(entries: Vec<DictionaryEntry>) -> Self {
         let entries = entries
             .into_iter()
             .map(|e| {
                 let term_lower = e.term.to_lowercase();
-                let phonetic_code = e.phonetic_code.or_else(|| soundex(&e.term));
+                let phonetic_code = derive_phonetic_code(&e.term, e.pronunciation.as_deref());
                 DictionaryMatch {
                     term: e.term,
                     term_lower,
@@ -34,6 +52,9 @@ impl DictionaryFilter {
     }
 
     fn find_replacement(&self, word: &str) -> Option<&str> {
+        if word.chars().count() < MIN_WORD_LEN {
+            return None;
+        }
         let word_lower = word.to_lowercase();
         let word_soundex = soundex(word);
 
@@ -120,9 +141,16 @@ mod tests {
         DictionaryEntry {
             id: 0,
             term: term.to_string(),
-            phonetic_code: None,
+            pronunciation: None,
             category: None,
             created_at: String::new(),
+        }
+    }
+
+    fn entry_with_pronunciation(term: &str, pronunciation: &str) -> DictionaryEntry {
+        DictionaryEntry {
+            pronunciation: Some(pronunciation.to_string()),
+            ..entry(term)
         }
     }
 
@@ -161,5 +189,39 @@ mod tests {
     fn empty_input() {
         let f = DictionaryFilter::new(vec![entry("Test")]);
         assert_eq!(f.apply(""), "");
+    }
+
+    #[test]
+    fn short_words_are_never_corrected() {
+        // "va" collides with "V6" through alphabetic Soundex ("V000" both);
+        // the 2-char guard must keep function words untouched.
+        let f = DictionaryFilter::new(vec![entry("V6")]);
+        assert_eq!(f.apply("il va faire"), "il va faire");
+
+        let names = DictionaryFilter::new(vec![entry("Damien")]);
+        assert_eq!(names.apply("de la part"), "de la part");
+    }
+
+    #[test]
+    fn digit_terms_get_no_auto_phonetic_matching() {
+        let f = DictionaryFilter::new(vec![entry("V6")]);
+        // "vas" (3 chars, Soundex V000 too) must not become V6 either.
+        assert_eq!(f.apply("tu vas bien"), "tu vas bien");
+    }
+
+    #[test]
+    fn pronunciation_drives_phonetic_matching() {
+        let f = DictionaryFilter::new(vec![entry_with_pronunciation("V6", "vésix")]);
+        assert_eq!(f.apply("le vésix arrive"), "le V6 arrive");
+        assert_eq!(f.apply("le vesix arrive"), "le V6 arrive");
+        // Unrelated words with a different Soundex stay untouched.
+        assert_eq!(f.apply("il va faire"), "il va faire");
+        assert_eq!(f.apply("tu vas bien"), "tu vas bien");
+    }
+
+    #[test]
+    fn blank_pronunciation_falls_back_to_term_soundex() {
+        let f = DictionaryFilter::new(vec![entry_with_pronunciation("Damien", "  ")]);
+        assert_eq!(f.apply("Hello Damian"), "Hello Damien");
     }
 }

--- a/src-tauri/src/filter/text_dictionary.rs
+++ b/src-tauri/src/filter/text_dictionary.rs
@@ -11,6 +11,10 @@ const LEVENSHTEIN_THRESHOLD: f64 = 0.82; // similarity > 0.82 means distance < 0
 /// does far more harm than good.
 const MIN_WORD_LEN: usize = 3;
 
+/// Minimum similarity for a phonetic-only (session term) match, on top of
+/// Soundex equality.
+const SESSION_SIMILARITY_FLOOR: f64 = 0.5;
+
 pub struct DictionaryFilter {
     entries: Vec<DictionaryMatch>,
 }
@@ -19,6 +23,12 @@ struct DictionaryMatch {
     term: String,
     term_lower: String,
     phonetic_code: Option<String>,
+    /// Session-scoped terms (participant names, meeting jargon) were not
+    /// chosen by the user, so they only match through Soundex plus a
+    /// similarity floor — never through Levenshtein alone. This keeps
+    /// injected names like "Martin" from rewriting ordinary words such as
+    /// "matin" (similarity 0.83, above the fuzzy threshold).
+    phonetic_only: bool,
 }
 
 /// Phonetic code used for matching: the user-provided pronunciation wins;
@@ -36,7 +46,13 @@ fn derive_phonetic_code(term: &str, pronunciation: Option<&str>) -> Option<Strin
 
 impl DictionaryFilter {
     pub fn new(entries: Vec<DictionaryEntry>) -> Self {
-        let entries = entries
+        Self::with_session_terms(entries, &[])
+    }
+
+    /// `session_terms` are ephemeral additions for one recording session
+    /// (participant names, meeting jargon); they match phonetically only.
+    pub fn with_session_terms(entries: Vec<DictionaryEntry>, session_terms: &[String]) -> Self {
+        let mut matches: Vec<DictionaryMatch> = entries
             .into_iter()
             .map(|e| {
                 let term_lower = e.term.to_lowercase();
@@ -45,10 +61,24 @@ impl DictionaryFilter {
                     term: e.term,
                     term_lower,
                     phonetic_code,
+                    phonetic_only: false,
                 }
             })
             .collect();
-        Self { entries }
+        for term in session_terms {
+            let term_lower = term.to_lowercase();
+            // A user entry for the same term wins over the session variant.
+            if matches.iter().any(|m| m.term_lower == term_lower) {
+                continue;
+            }
+            matches.push(DictionaryMatch {
+                term: term.clone(),
+                term_lower,
+                phonetic_code: soundex(term),
+                phonetic_only: true,
+            });
+        }
+        Self { entries: matches }
     }
 
     fn find_replacement(&self, word: &str) -> Option<&str> {
@@ -75,8 +105,13 @@ impl DictionaryFilter {
                 _ => false,
             };
 
-            // Accept if either condition is met
-            if similarity >= LEVENSHTEIN_THRESHOLD || soundex_match {
+            let accepted = if entry.phonetic_only {
+                soundex_match && similarity >= SESSION_SIMILARITY_FLOOR
+            } else {
+                // Accept if either condition is met
+                similarity >= LEVENSHTEIN_THRESHOLD || soundex_match
+            };
+            if accepted {
                 let score = if soundex_match {
                     similarity + 0.1 // Boost soundex matches slightly
                 } else {
@@ -223,5 +258,34 @@ mod tests {
     fn blank_pronunciation_falls_back_to_term_soundex() {
         let f = DictionaryFilter::new(vec![entry_with_pronunciation("Damien", "  ")]);
         assert_eq!(f.apply("Hello Damian"), "Hello Damien");
+    }
+
+    #[test]
+    fn session_terms_correct_phonetic_misses_only() {
+        let f = DictionaryFilter::with_session_terms(vec![], &["Alice".to_string()]);
+        // Same Soundex (A420), similar spelling: corrected.
+        assert_eq!(f.apply("bonjour Alyce"), "bonjour Alice");
+        assert_eq!(f.apply("bonjour Alice"), "bonjour Alice");
+    }
+
+    #[test]
+    fn session_terms_never_match_through_levenshtein_alone() {
+        // "matin" vs "Martin": similarity 0.83 (above the fuzzy threshold)
+        // but different Soundex — a user entry would rewrite it, a session
+        // term must not.
+        let f = DictionaryFilter::with_session_terms(vec![], &["Martin".to_string()]);
+        assert_eq!(f.apply("le matin venu"), "le matin venu");
+
+        let user = DictionaryFilter::new(vec![entry("Martin")]);
+        assert_eq!(user.apply("le matin venu"), "le Martin venu");
+    }
+
+    #[test]
+    fn user_entry_wins_over_session_duplicate() {
+        let f = DictionaryFilter::with_session_terms(
+            vec![entry_with_pronunciation("V6", "vésix")],
+            &["v6".to_string()],
+        );
+        assert_eq!(f.apply("le vésix arrive"), "le V6 arrive");
     }
 }

--- a/src-tauri/src/pipeline/actor.rs
+++ b/src-tauri/src/pipeline/actor.rs
@@ -58,6 +58,9 @@ pub struct SessionSummary {
 pub struct SessionConfig {
     pub pipeline_config: PipelineConfig,
     pub dictionary_entries: Vec<DictionaryEntry>,
+    /// Ephemeral correction terms for this session only (participant names,
+    /// meeting jargon); never persisted to the user's dictionary.
+    pub session_terms: Vec<String>,
     /// Diarized meeting: run a second engine so the mic (Me) and system audio
     /// (Them) legs are transcribed separately and segments are speaker-tagged.
     pub diarize: bool,
@@ -445,7 +448,11 @@ impl EngineActor {
 
         // Filter chains are built on this thread so ONNX Runtime (Silero VAD)
         // initialization shares the thread with engine Metal work.
-        let text_filters = build_text_filters(&config.pipeline_config, config.dictionary_entries);
+        let text_filters = build_text_filters(
+            &config.pipeline_config,
+            config.dictionary_entries,
+            &config.session_terms,
+        );
 
         let mut health = SessionHealth::start(session_id, Arc::clone(&self.dropped_counter));
         let engine = self.engine.as_mut().expect("engine present: checked above");
@@ -1072,6 +1079,7 @@ mod tests {
         SessionConfig {
             pipeline_config: noop_filter_config(),
             dictionary_entries: vec![],
+            session_terms: vec![],
             diarize: false,
         }
     }
@@ -1165,6 +1173,7 @@ mod tests {
         let cfg = SessionConfig {
             pipeline_config: noop_filter_config(),
             dictionary_entries: vec![],
+            session_terms: vec![],
             diarize: true,
         };
         actor.start_session(1, cfg, cb).expect("start diarized");

--- a/src-tauri/src/transcript.rs
+++ b/src-tauri/src/transcript.rs
@@ -79,6 +79,10 @@ pub struct MeetingTranscript {
 pub struct MeetingCalendarContext {
     pub event_id: String,
     pub participants: Vec<MeetingParticipant>,
+    /// Invitation body; mined for session-scoped transcription hints at
+    /// start, not persisted.
+    #[serde(default)]
+    pub description: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/src/lib/api/dictionary.ts
+++ b/src/lib/api/dictionary.ts
@@ -7,19 +7,19 @@ export async function listDictionary(): Promise<DictionaryEntry[]> {
 
 export async function addDictionaryEntry(
   term: string,
-  phoneticCode: string | null,
+  pronunciation: string | null,
   category: string | null,
 ): Promise<DictionaryEntry> {
-  return unwrap(commands.addDictionaryEntry(term, phoneticCode, category));
+  return unwrap(commands.addDictionaryEntry(term, pronunciation, category));
 }
 
 export async function updateDictionaryEntry(
   id: number,
   term: string,
-  phoneticCode: string | null,
+  pronunciation: string | null,
   category: string | null,
 ): Promise<void> {
-  await unwrap(commands.updateDictionaryEntry(id, term, phoneticCode, category));
+  await unwrap(commands.updateDictionaryEntry(id, term, pronunciation, category));
 }
 
 export async function deleteDictionaryEntry(id: number): Promise<void> {

--- a/src/lib/features/calendar/controller.svelte.test.ts
+++ b/src/lib/features/calendar/controller.svelte.test.ts
@@ -39,6 +39,7 @@ function makeEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
     ],
     location: null,
     url: null,
+    description: null,
     ...overrides,
   };
 }
@@ -97,7 +98,7 @@ describe("calendar controller", () => {
 
     expect(mockStartRecording).toHaveBeenCalledWith({
       title: "Sprint Planning",
-      calendar: { event_id: "evt-1", participants: event.participants },
+      calendar: { event_id: "evt-1", participants: event.participants, description: null },
     });
   });
 

--- a/src/lib/features/calendar/controller.svelte.ts
+++ b/src/lib/features/calendar/controller.svelte.ts
@@ -34,7 +34,11 @@ function createCalendarControllerInstance() {
     const meeting = createMeetingController();
     await meeting.startRecording({
       title: event.title,
-      calendar: { event_id: event.id, participants: event.participants },
+      calendar: {
+        event_id: event.id,
+        participants: event.participants,
+        description: event.description,
+      },
     });
   }
 

--- a/src/lib/features/home/LiveSessionCard.svelte
+++ b/src/lib/features/home/LiveSessionCard.svelte
@@ -4,6 +4,7 @@
   import { t } from "svelte-i18n";
   import Waveform from "../../components/Waveform.svelte";
   import Spinner from "../../components/ui/Spinner.svelte";
+  import { groupIntoParagraphs } from "../../utils/paragraphs";
   import MeetingNotesSection from "../meeting/components/MeetingNotesSection.svelte";
   import type { createMeetingController } from "../meeting/controller.svelte";
   import type { createTranscriptionController } from "../transcription/controller.svelte";
@@ -21,11 +22,16 @@
   let elapsedSeconds = $state(0);
   let transcriptEl: HTMLDivElement | undefined = $state();
 
-  const liveText = $derived(
-    mode === "dictation"
-      ? transcription.transcript
-      : meeting.liveMeetingSegments.map((segment) => segment.text).join(" "),
+  const liveText = $derived(mode === "dictation" ? transcription.transcript : "");
+
+  // Meetings render through the same paragraph grouping as the finished
+  // transcript, so diarized sessions show Me/Them live: segments are ordered
+  // by time and split on speaker changes instead of one undifferentiated blob.
+  const liveParagraphs = $derived(
+    mode === "meeting" ? groupIntoParagraphs(meeting.liveMeetingSegments, 1.5) : [],
   );
+
+  const hasLiveContent = $derived(mode === "dictation" ? Boolean(liveText) : liveParagraphs.length > 0);
 
   const elapsed = $derived(
     `${Math.floor(elapsedSeconds / 60)}:${`${elapsedSeconds % 60}`.padStart(2, "0")}`,
@@ -47,6 +53,7 @@
   // Keep the latest words in view as they stream in.
   $effect(() => {
     void liveText;
+    void liveParagraphs;
     if (transcriptEl) transcriptEl.scrollTop = transcriptEl.scrollHeight;
   });
 
@@ -91,10 +98,23 @@
       bind:this={transcriptEl}
       class="max-h-44 min-h-24 overflow-y-auto rounded-lg bg-surface-1/70 p-3 text-sm leading-relaxed text-text-secondary"
     >
-      {#if liveText}
+      {#if !hasLiveContent}
+        <span class="text-text-muted">{$t("home.listening")}</span>
+      {:else if mode === "dictation"}
         {liveText}
       {:else}
-        <span class="text-text-muted">{$t("home.listening")}</span>
+        {#each liveParagraphs as paragraph}
+          <p class="mb-2 last:mb-0">
+            {#if paragraph.speaker}
+              <span
+                class="mr-1 text-xs font-semibold"
+                class:text-accent={paragraph.speaker === "me"}
+                class:text-text-primary={paragraph.speaker === "them"}
+              >{paragraph.speaker === "me" ? $t("transcript.me") : $t("transcript.them")}</span>
+            {/if}
+            {paragraph.text}
+          </p>
+        {/each}
       {/if}
     </div>
 

--- a/src/lib/features/meeting/controller.svelte.test.ts
+++ b/src/lib/features/meeting/controller.svelte.test.ts
@@ -255,6 +255,7 @@ describe("MeetingController", () => {
       participants: [
         { name: "Alice", email: "alice@corp.com", is_organizer: true, is_current_user: false },
       ],
+      description: null,
     };
 
     const ctrl = createMeetingController();

--- a/src/lib/features/settings/components/DictionarySettingsSection.svelte
+++ b/src/lib/features/settings/components/DictionarySettingsSection.svelte
@@ -9,11 +9,12 @@
     onDelete,
   }: {
     entries: DictionaryEntry[];
-    onAdd: (term: string, phoneticCode: string | null, category: string | null) => void | Promise<void>;
+    onAdd: (term: string, pronunciation: string | null, category: string | null) => void | Promise<void>;
     onDelete: (id: number) => void | Promise<void>;
   } = $props();
 
   let newTerm = $state("");
+  let newPronunciation = $state("");
   let newCategory = $state("");
   let addError = $state("");
 
@@ -22,8 +23,9 @@
     if (!term) return;
     addError = "";
     try {
-      await onAdd(term, null, newCategory.trim() || null);
+      await onAdd(term, newPronunciation.trim() || null, newCategory.trim() || null);
       newTerm = "";
+      newPronunciation = "";
       newCategory = "";
     } catch (e) {
       addError = e instanceof Error ? e.message : String(e);
@@ -54,6 +56,18 @@
       />
     </div>
     <div class="flex flex-col gap-1">
+      <label for="dict-pronunciation" class="field-label">{$t("settings_dictionary.pronunciation")}</label>
+      <input
+        id="dict-pronunciation"
+        type="text"
+        bind:value={newPronunciation}
+        onkeydown={handleKeyDown}
+        placeholder={$t("settings_dictionary.pronunciation_placeholder")}
+        title={$t("settings_dictionary.pronunciation_desc")}
+        class="field-input w-32"
+      />
+    </div>
+    <div class="flex flex-col gap-1">
       <label for="dict-category" class="field-label">{$t("settings_dictionary.category")}</label>
       <input
         id="dict-category"
@@ -76,7 +90,9 @@
     <div class="flex flex-col gap-1 mt-1">
       {#each entries as entry (entry.id)}
         <div class="flex items-center gap-2 py-1.5 px-2 rounded-lg bg-surface-secondary/50 text-sm">
-          <span class="flex-1 font-medium">{entry.term}</span>
+          <span class="flex-1 font-medium">
+            {entry.term}{#if entry.pronunciation}<span class="text-text-muted font-normal"> · {entry.pronunciation}</span>{/if}
+          </span>
           {#if entry.category}
             <span class="text-text-tertiary text-xs">{entry.category}</span>
           {/if}

--- a/src/lib/features/settings/controller.svelte.ts
+++ b/src/lib/features/settings/controller.svelte.ts
@@ -449,8 +449,8 @@ export function createSettingsController() {
     }
   }
 
-  async function handleAddDictionaryEntry(term: string, phoneticCode: string | null, category: string | null) {
-    const entry = await apiAddDictionaryEntry(term, phoneticCode, category);
+  async function handleAddDictionaryEntry(term: string, pronunciation: string | null, category: string | null) {
+    const entry = await apiAddDictionaryEntry(term, pronunciation, category);
     dictionaryEntries = [...dictionaryEntries, entry].sort((a, b) => a.term.localeCompare(b.term));
   }
 

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -29,7 +29,10 @@
     "category_placeholder": "e.g. tech",
     "add_entry": "Add entry",
     "delete": "Delete",
-    "empty": "No custom dictionary entries yet."
+    "empty": "No custom dictionary entries yet.",
+    "pronunciation": "Pronunciation",
+    "pronunciation_placeholder": "e.g. vaysix",
+    "pronunciation_desc": "How the term sounds when spoken, spelled out. Helps match terms like V6 said \"vaysix\"."
   },
   "settings_calendar": {
     "title": "Calendar",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -29,7 +29,10 @@
     "category_placeholder": "ex. tech",
     "add_entry": "Ajouter une entrée",
     "delete": "Supprimer",
-    "empty": "Aucune entrée dans le dictionnaire personnalisé."
+    "empty": "Aucune entrée dans le dictionnaire personnalisé.",
+    "pronunciation": "Prononciation",
+    "pronunciation_placeholder": "ex. vésix",
+    "pronunciation_desc": "Comment le terme se prononce, écrit en toutes lettres. Aide à reconnaître des termes comme V6 dit « vésix »."
   },
   "settings_calendar": {
     "title": "Calendrier",

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -582,7 +582,12 @@ id: string; title: string; start: string; end: string; calendar_id: string; cale
 /**
  * The event URL — for video meetings this is usually the conference link.
  */
-url: string | null }
+url: string | null; 
+/**
+ * The invitation body (EKCalendarItem notes). Mined for session-scoped
+ * transcription hints when a meeting starts from this event.
+ */
+description: string | null }
 /**
  * One calendar as shown in the settings picker.
  */
@@ -621,7 +626,12 @@ export type HealthStatus = "healthy" |
  * Calendar context passed by the frontend when starting a meeting from a
  * calendar event.
  */
-export type MeetingCalendarContext = { event_id: string; participants: MeetingParticipant[] }
+export type MeetingCalendarContext = { event_id: string; participants: MeetingParticipant[]; 
+/**
+ * Invitation body; mined for session-scoped transcription hints at
+ * start, not persisted.
+ */
+description?: string | null }
 /**
  * Emitted once a stopped meeting has been fully drained and saved in the
  * background, so the detail view can refresh from the now-complete record.

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -423,17 +423,17 @@ async listDictionary() : Promise<Result<DictionaryEntry[], string>> {
     else return { status: "error", error: e  as any };
 }
 },
-async addDictionaryEntry(term: string, phoneticCode: string | null, category: string | null) : Promise<Result<DictionaryEntry, string>> {
+async addDictionaryEntry(term: string, pronunciation: string | null, category: string | null) : Promise<Result<DictionaryEntry, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("add_dictionary_entry", { term, phoneticCode, category }) };
+    return { status: "ok", data: await TAURI_INVOKE("add_dictionary_entry", { term, pronunciation, category }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
 },
-async updateDictionaryEntry(id: number, term: string, phoneticCode: string | null, category: string | null) : Promise<Result<null, string>> {
+async updateDictionaryEntry(id: number, term: string, pronunciation: string | null, category: string | null) : Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("update_dictionary_entry", { id, term, phoneticCode, category }) };
+    return { status: "ok", data: await TAURI_INVOKE("update_dictionary_entry", { id, term, pronunciation, category }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -595,7 +595,13 @@ source_title: string | null }
  * A dictation history entry
  */
 export type DictationEntry = { id: string; text: string; timestamp: string }
-export type DictionaryEntry = { id: number; term: string; phonetic_code: string | null; category: string | null; created_at: string }
+export type DictionaryEntry = { id: number; term: string; 
+/**
+ * How the term sounds when spoken, spelled out (e.g. "vésix" for "V6").
+ * Drives phonetic matching; when absent, the term's own Soundex is used
+ * (except for digit-bearing terms, whose Soundex is meaningless).
+ */
+pronunciation: string | null; category: string | null; created_at: string }
 /**
  * Download status reported to the frontend
  */


### PR DESCRIPTION
Three fixes from live-meeting feedback.

## Dictionary correction: fix the "va" → "V6" class of false positives

Soundex strips digits, so soundex("V6") == soundex("va") == "V000", and the Soundex branch bypassed the Levenshtein threshold entirely: every spoken "va" became "V6". Fixes:

- Words shorter than 3 characters are never corrected (function words collide with everything).
- Digit-bearing terms get no auto-derived Soundex (the code is meaningless).
- Accented letters fold to their base letter in Soundex instead of being dropped (French app).
- The `phonetic_code` column becomes a user-facing **pronunciation spelling** (schema v9 clears legacy auto-derived codes; anything a caller stored explicitly is preserved). Typing "vésix" for V6 makes the spoken form match while "va"/"vas" stay untouched. The dictionary settings form gains the pronunciation field, shown next to each entry.

## Meeting-scoped transcription hints (nothing persisted)

When a meeting starts from a calendar event, the session's dictionary filter receives ephemeral terms: participant name tokens, plus distinctive jargon (CamelCase, acronyms) mined from the event title and invitation body (`CalendarEvent.description`, new). Capped at 50 terms, deduplicated, never written to the user's dictionary.

Session terms match under a stricter rule than user entries: Soundex equality plus a similarity floor, never Levenshtein alone, so an injected "Martin" cannot rewrite "matin" (similarity 0.83 would have passed the fuzzy threshold).

## Live Me/Them speaker labels

Diarized segments already carry their speaker tag live; the live session card was flattening them into one text blob. It now renders through the same `groupIntoParagraphs` as the finished transcript: time-ordered, paragraph break per speaker change, colored Me/Them labels. Dictation keeps the plain-text path.

## Verification

`cargo test` (244), `cargo clippy --all-targets -- -D warnings`, `npm test -- --run` (137), `npm run check`, `npm run build`: all green. New unit tests cover the va/V6 case, pronunciation matching, session-term guards (matin/Martin), term derivation, and the v9 migration path.