### PR TITLE
Incremental live transcript grouping with bounded rendering

### DIFF
--- a/src/lib/features/home/LiveSessionCard.svelte
+++ b/src/lib/features/home/LiveSessionCard.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
   import { ClipboardCheck, Square } from "@lucide/svelte";
-  import { onMount } from "svelte";
+  import { onDestroy, onMount } from "svelte";
   import { t } from "svelte-i18n";
   import Waveform from "../../components/Waveform.svelte";
   import Spinner from "../../components/ui/Spinner.svelte";
-  import { groupIntoParagraphs } from "../../utils/paragraphs";
   import MeetingNotesSection from "../meeting/components/MeetingNotesSection.svelte";
   import type { createMeetingController } from "../meeting/controller.svelte";
   import type { createTranscriptionController } from "../transcription/controller.svelte";
@@ -19,6 +18,12 @@
     meeting: ReturnType<typeof createMeetingController>;
   } = $props();
 
+  /** Only the most recent paragraphs stay in the DOM; older ones are still in
+   * `meeting.liveTranscript.committed` but are never rendered live. */
+  const LIVE_PARAGRAPH_WINDOW = 30;
+  /** Auto-scroll only kicks in when already within this many px of the bottom. */
+  const NEAR_BOTTOM_PX = 40;
+
   let elapsedSeconds = $state(0);
   let transcriptEl: HTMLDivElement | undefined = $state();
 
@@ -27,11 +32,20 @@
   // Meetings render through the same paragraph grouping as the finished
   // transcript, so diarized sessions show Me/Them live: segments are ordered
   // by time and split on speaker changes instead of one undifferentiated blob.
+  // `committed` only grows by push and can hold hours of history, so slice it
+  // to the window first: slicing the last N elements is O(N), not O(meeting
+  // length), which keeps this derived cheap on every incoming segment.
   const liveParagraphs = $derived(
-    mode === "meeting" ? groupIntoParagraphs(meeting.liveMeetingSegments, 1.5) : [],
+    mode === "meeting"
+      ? [...meeting.liveTranscript.committed.slice(-LIVE_PARAGRAPH_WINDOW), ...meeting.liveTranscript.tail]
+        .slice(-LIVE_PARAGRAPH_WINDOW)
+      : [],
   );
+  const liveTentative = $derived(mode === "meeting" ? meeting.liveTranscript.tentative : "");
 
-  const hasLiveContent = $derived(mode === "dictation" ? Boolean(liveText) : liveParagraphs.length > 0);
+  const hasLiveContent = $derived(
+    mode === "dictation" ? Boolean(liveText) : liveParagraphs.length > 0 || Boolean(liveTentative),
+  );
 
   const elapsed = $derived(
     `${Math.floor(elapsedSeconds / 60)}:${`${elapsedSeconds % 60}`.padStart(2, "0")}`,
@@ -52,11 +66,33 @@
     }
   }
 
-  // Keep the latest words in view as they stream in.
+  // Track whether the user is (still) parked near the bottom, independent of
+  // content changes, so a burst of new segments never fights a manual scroll
+  // up to read earlier text.
+  let isNearBottom = true;
+  let scrollRafId: number | null = null;
+
+  function handleScroll() {
+    const el = transcriptEl;
+    if (!el) return;
+    isNearBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= NEAR_BOTTOM_PX;
+  }
+
+  function scheduleAutoscroll() {
+    if (!isNearBottom || scrollRafId !== null) return;
+    scrollRafId = requestAnimationFrame(() => {
+      scrollRafId = null;
+      if (transcriptEl) transcriptEl.scrollTop = transcriptEl.scrollHeight;
+    });
+  }
+
+  // Keep the latest words in view as they stream in, coalesced to one scroll
+  // per frame instead of one per segment.
   $effect(() => {
     void liveText;
     void liveParagraphs;
-    if (transcriptEl) transcriptEl.scrollTop = transcriptEl.scrollHeight;
+    void liveTentative;
+    scheduleAutoscroll();
   });
 
   onMount(() => {
@@ -64,6 +100,10 @@
       elapsedSeconds += 1;
     }, 1000);
     return () => clearInterval(timer);
+  });
+
+  onDestroy(() => {
+    if (scrollRafId !== null) cancelAnimationFrame(scrollRafId);
   });
 </script>
 
@@ -125,12 +165,13 @@
       </div>
       <div
         bind:this={transcriptEl}
+        onscroll={handleScroll}
         class="flex max-h-[250px] flex-1 flex-col gap-4 overflow-y-auto pr-1.5"
       >
         {#if !hasLiveContent}
           <span class="text-sm text-text-muted">{$t("home.listening")}</span>
         {:else}
-          {#each liveParagraphs as paragraph}
+          {#each liveParagraphs as paragraph, i (paragraph.id)}
             <div class="flex flex-col gap-[3px]" style="animation: rise-in 240ms ease;">
               <div class="flex items-center gap-2">
                 {#if paragraph.speaker}
@@ -142,9 +183,17 @@
                 {/if}
                 <span class="font-mono text-[10.5px] text-text-faint">{paragraph.timestamp}</span>
               </div>
-              <p class="m-0 text-[15px] leading-[1.75] text-text-secondary">{paragraph.text}</p>
+              <p class="m-0 text-[15px] leading-[1.75] text-text-secondary">
+                {paragraph.text}
+                {#if i === liveParagraphs.length - 1 && liveTentative}
+                  <span class="opacity-50">{paragraph.text ? " " : ""}{liveTentative}</span>
+                {/if}
+              </p>
             </div>
           {/each}
+          {#if liveParagraphs.length === 0 && liveTentative}
+            <p class="m-0 text-[15px] leading-[1.75] text-text-secondary opacity-50">{liveTentative}</p>
+          {/if}
         {/if}
       </div>
     </div>

--- a/src/lib/features/meeting/controller.svelte.ts
+++ b/src/lib/features/meeting/controller.svelte.ts
@@ -15,6 +15,7 @@ import { getAppState } from "../../stores/app.svelte";
 import type { MeetingCalendarContext, MeetingTranscript, OllamaModelDescriptor, SummarizeProgress, TranscriptionCatalog, TranscriptionSegment } from "../../types";
 import { errorMessage } from "../../utils";
 import { toSelectedTranscriptionProfile } from "../transcription/catalog";
+import { createLiveTranscript } from "./live-transcript.svelte";
 
 function defaultMeetingTitle(): string {
   return `Meeting ${new Date().toLocaleDateString()}`;
@@ -44,6 +45,12 @@ function createMeetingControllerInstance() {
     || (app.machineState.state === "stopping"
         && typeof app.machineState.data?.was_recording === "object"),
   );
+  // Incremental grouper for the compact live view (LiveSessionCard): bounded
+  // work per segment instead of re-grouping the whole meeting each time.
+  const liveTranscript = createLiveTranscript(1.5);
+  // Raw finalized segments, still needed by the meeting detail view's full
+  // transcript section (buildMeetingTranscriptBlocks operates on segments,
+  // not paragraphs). Mutated via push, not clone-per-segment.
   let liveMeetingSegments = $state<TranscriptionSegment[]>([]);
 
   let meeting = $state<MeetingTranscript | null>(null);
@@ -162,6 +169,7 @@ function createMeetingControllerInstance() {
     try {
       const title = options?.title?.trim() || defaultMeetingTitle();
       const calendar = options?.calendar ?? null;
+      liveTranscript.reset();
       liveMeetingSegments = [];
       statusMessage = "";
       summaryStream = "";
@@ -176,8 +184,11 @@ function createMeetingControllerInstance() {
       );
 
       await startMeetingRecording(title, calendar, (segment) => {
-        if (!segment.is_final || !segment.text) return;
-        liveMeetingSegments = [...liveMeetingSegments, segment];
+        // Only skip empty finals; non-final (tentative) segments still flow
+        // through so the live view can show them as a faded suffix.
+        if (segment.is_final && !segment.text) return;
+        liveTranscript.append(segment);
+        if (segment.is_final && segment.text) liveMeetingSegments.push(segment);
       });
 
       meeting = {
@@ -200,6 +211,7 @@ function createMeetingControllerInstance() {
       };
     } catch (e) {
       statusMessage = errorMessage(e);
+      liveTranscript.reset();
       liveMeetingSegments = [];
     }
   }
@@ -208,16 +220,19 @@ function createMeetingControllerInstance() {
     if (!meeting || !meeting.id) return;
 
     try {
+      liveTranscript.reset();
       liveMeetingSegments = [];
       statusMessage = "";
       summaryStream = "";
 
       await resumeMeetingRecording(meeting.id, (segment) => {
-        if (!segment.is_final || !segment.text) return;
-        liveMeetingSegments = [...liveMeetingSegments, segment];
+        if (segment.is_final && !segment.text) return;
+        liveTranscript.append(segment);
+        if (segment.is_final && segment.text) liveMeetingSegments.push(segment);
       });
     } catch (e) {
       statusMessage = errorMessage(e);
+      liveTranscript.reset();
       liveMeetingSegments = [];
     }
   }
@@ -256,6 +271,7 @@ function createMeetingControllerInstance() {
    * buffer. No-op if the user already navigated elsewhere. */
   function handleMeetingFinalized(id: string) {
     if (app.currentMeetingId !== id && meeting?.id !== id) return;
+    liveTranscript.reset();
     liveMeetingSegments = [];
     void loadMeeting(id);
   }
@@ -263,6 +279,7 @@ function createMeetingControllerInstance() {
   /** The backend aborted the recording session (machine went to Error).
    * The backend salvages the accumulated meeting to history before failing. */
   function handleRecordingAborted() {
+    liveTranscript.reset();
     liveMeetingSegments = [];
     meeting = null;
     app.currentMeetingId = null;
@@ -274,6 +291,7 @@ function createMeetingControllerInstance() {
   function closeMeeting() {
     void flushNotes();
     meeting = null;
+    liveTranscript.reset();
     liveMeetingSegments = [];
     statusMessage = "";
     summaryStream = "";
@@ -387,6 +405,7 @@ function createMeetingControllerInstance() {
     get isSummarizing() { return isSummarizing; },
     get summaryStream() { return summaryStream; },
     get isRecordingMeeting() { return isRecordingMeeting; },
+    get liveTranscript() { return liveTranscript; },
     get liveMeetingSegments() { return liveMeetingSegments; },
     get meeting() { return meeting; },
     get isLoadingMeeting() { return isLoadingMeeting; },

--- a/src/lib/features/meeting/live-transcript.svelte.test.ts
+++ b/src/lib/features/meeting/live-transcript.svelte.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import { createLiveTranscript } from "./live-transcript.svelte";
+import { groupIntoParagraphs } from "../../utils/paragraphs";
+import type { Speaker, TranscriptionSegment } from "../../types";
+
+function seg(
+  text: string,
+  start: number,
+  overrides: Partial<TranscriptionSegment> = {},
+): TranscriptionSegment {
+  return {
+    text,
+    start_time: start,
+    end_time: start + 0.5,
+    is_final: true,
+    language: null,
+    confidence: null,
+    ...overrides,
+  };
+}
+
+function dseg(text: string, start: number, speaker: Speaker): TranscriptionSegment {
+  return seg(text, start, { speaker });
+}
+
+const PAUSE_THRESHOLD = 1.5;
+
+/** Feed segments one-by-one into a fresh grouper and return the final
+ * flattened committed+tail paragraphs (stripped of the live-only `id`). */
+function runStream(segments: TranscriptionSegment[]) {
+  const live = createLiveTranscript(PAUSE_THRESHOLD);
+  for (const s of segments) live.append(s);
+  const all = [...live.committed, ...live.tail].map(({ id: _id, ...rest }) => rest);
+  return { live, all };
+}
+
+describe("createLiveTranscript equivalence", () => {
+  it("matches batch grouping for a plain in-order stream", () => {
+    const segments = [
+      seg("Hello world.", 0),
+      seg("New paragraph after a pause.", 2.0),
+      seg("And more.", 2.5),
+      seg("Yet another sentence.", 3.0),
+    ];
+    const { all } = runStream(segments);
+    expect(all).toEqual(groupIntoParagraphs(segments, PAUSE_THRESHOLD));
+  });
+
+  it("matches batch grouping for a heavily punctuated stream that spans many paragraphs", () => {
+    const segments = Array.from({ length: 20 }, (_, i) =>
+      seg(`Sentence number ${i + 1}.`, i * 2.0), // 2s gaps: pause break every sentence
+    );
+    const { all } = runStream(segments);
+    expect(all).toEqual(groupIntoParagraphs(segments, PAUSE_THRESHOLD));
+  });
+
+  it("matches batch grouping for diarized alternating speakers with slight interleave", () => {
+    // Mic and system audio lanes arrive close together but not perfectly
+    // ordered; the grouper still sorts by start_time before grouping.
+    const segments = [
+      dseg("hi there", 0, "me"),
+      dseg("hello back", 2.1, "them"),
+      dseg("how are you", 4.3, "me"),
+      dseg("great thanks", 4.35, "them"), // arrives right after, slightly interleaved
+      dseg("good to hear", 6.5, "me"),
+    ];
+    const { all } = runStream(segments);
+    expect(all).toEqual(groupIntoParagraphs(segments, PAUSE_THRESHOLD));
+  });
+
+  it("matches batch grouping for a long unpunctuated stream (hard length cap)", () => {
+    const segments = Array.from({ length: 300 }, (_, i) => seg(`word${i}`, i * 0.1));
+    const { all } = runStream(segments);
+    expect(all).toEqual(groupIntoParagraphs(segments, PAUSE_THRESHOLD));
+  });
+
+  it("commits paragraphs to `committed` once more than 2 paragraphs are open", () => {
+    const segments = [
+      seg("First paragraph.", 0),
+      seg("Second paragraph.", 2.0),
+      seg("Third paragraph.", 4.0),
+      seg("Fourth paragraph.", 6.0),
+    ];
+    const live = createLiveTranscript(PAUSE_THRESHOLD);
+    for (const s of segments) live.append(s);
+
+    expect(live.tail.length).toBeLessThanOrEqual(2);
+    expect(live.committed.length + live.tail.length).toBe(4);
+    expect(live.committed.length).toBeGreaterThan(0);
+  });
+});
+
+describe("createLiveTranscript committed immutability", () => {
+  it("never mutates a committed paragraph after it is committed", () => {
+    const segments = [
+      seg("First paragraph.", 0),
+      seg("Second paragraph.", 2.0),
+      seg("Third paragraph.", 4.0),
+      seg("Fourth paragraph.", 6.0),
+      seg("Fifth paragraph.", 8.0),
+    ];
+    const live = createLiveTranscript(PAUSE_THRESHOLD);
+    for (const s of segments) live.append(s);
+
+    expect(live.committed.length).toBeGreaterThan(0);
+    const snapshot = live.committed.map((p) => ({ ref: p, copy: { ...p } }));
+
+    // Append more segments; already-committed paragraphs must stay identical.
+    live.append(seg("Sixth paragraph.", 10.0));
+    live.append(seg("Seventh paragraph.", 12.0));
+
+    for (const { ref, copy } of snapshot) {
+      expect(ref).toEqual(copy);
+    }
+  });
+});
+
+describe("createLiveTranscript tentative text", () => {
+  it("sets tentative on a non-final segment and clears it on the next final", () => {
+    const live = createLiveTranscript(PAUSE_THRESHOLD);
+    live.append(seg("Hello wor", 0, { is_final: false }));
+    expect(live.tentative).toBe("Hello wor");
+    expect(live.committed).toEqual([]);
+    expect(live.tail).toEqual([]);
+
+    live.append(seg("Hello world.", 0));
+    expect(live.tentative).toBe("");
+    expect(live.tail).toHaveLength(1);
+    expect(live.tail[0].text).toBe("Hello world.");
+  });
+
+  it("does not increment segmentCount for non-final segments", () => {
+    const live = createLiveTranscript(PAUSE_THRESHOLD);
+    live.append(seg("partial", 0, { is_final: false }));
+    expect(live.segmentCount).toBe(0);
+    live.append(seg("partial done.", 0));
+    expect(live.segmentCount).toBe(1);
+  });
+});
+
+describe("createLiveTranscript reset", () => {
+  it("clears committed, tail, tentative, and segmentCount", () => {
+    const live = createLiveTranscript(PAUSE_THRESHOLD);
+    live.append(seg("First paragraph.", 0));
+    live.append(seg("Second paragraph.", 2.0));
+    live.append(seg("Third paragraph.", 4.0));
+    live.append(seg("Fourth paragraph.", 6.0));
+    live.append(seg("partial", 8.0, { is_final: false }));
+
+    expect(live.committed.length + live.tail.length).toBeGreaterThan(0);
+    expect(live.tentative).toBe("partial");
+
+    live.reset();
+
+    expect(live.committed).toEqual([]);
+    expect(live.tail).toEqual([]);
+    expect(live.tentative).toBe("");
+    expect(live.segmentCount).toBe(0);
+
+    // Grouper is fully usable again after reset.
+    live.append(seg("Fresh start.", 0));
+    expect(live.tail).toHaveLength(1);
+    expect(live.tail[0].text).toBe("Fresh start.");
+  });
+});
+
+describe("createLiveTranscript paragraph ids", () => {
+  it("assigns strictly increasing ids across committed and tail paragraphs", () => {
+    const segments = Array.from({ length: 10 }, (_, i) => seg(`Sentence ${i}.`, i * 2.0));
+    const live = createLiveTranscript(PAUSE_THRESHOLD);
+    for (const s of segments) live.append(s);
+
+    const ids = [...live.committed, ...live.tail].map((p) => p.id);
+    expect(ids.length).toBeGreaterThan(1);
+    for (let i = 1; i < ids.length; i++) {
+      expect(ids[i]).toBeGreaterThan(ids[i - 1]);
+    }
+  });
+
+  it("keeps the same id for a growing tail paragraph across appends", () => {
+    const live = createLiveTranscript(PAUSE_THRESHOLD);
+    live.append(seg("Hello", 0));
+    expect(live.tail).toHaveLength(1);
+    const firstId = live.tail[0].id;
+
+    // No pause, no sentence end yet: still the same open paragraph.
+    live.append(seg("world", 0.5));
+    expect(live.tail).toHaveLength(1);
+    expect(live.tail[0].id).toBe(firstId);
+    expect(live.tail[0].text).toBe("Hello world");
+  });
+});

--- a/src/lib/features/meeting/live-transcript.svelte.ts
+++ b/src/lib/features/meeting/live-transcript.svelte.ts
@@ -1,0 +1,125 @@
+import type { Paragraph } from "../../utils/paragraphs";
+import { groupIntoParagraphsWithRanges } from "../../utils/paragraphs";
+import type { TranscriptionSegment } from "../../types";
+
+/** A grouped paragraph with a stable id for keyed rendering. Ids are assigned
+ * once, when a paragraph first comes into existence (either at commit time,
+ * or the first time it appears in the tail), and never reassigned while the
+ * paragraph keeps growing. */
+export type LiveParagraph = Paragraph & { id: number };
+
+/**
+ * Incremental paragraph grouper for a live transcript stream.
+ *
+ * Batch grouping (`groupIntoParagraphs`) re-scans every segment on every
+ * call, which is O(n) per call and O(n^2) over a whole meeting. This grouper
+ * instead freezes paragraphs as soon as a later segment proves they are
+ * closed (a new paragraph started after them) and only re-groups the small
+ * "tail" of still-open paragraphs on each `append`.
+ *
+ * Correctness: paragraph state (sentence count, char count, pause gap) only
+ * ever depends on segments at or after the paragraph's own start, so once a
+ * later paragraph has started, earlier paragraphs can never change. For an
+ * in-order stream this makes `[...committed, ...tail]` byte-identical to
+ * `groupIntoParagraphs(allSegments, pauseThreshold)`.
+ *
+ * The one caveat is diarization: mic and system audio are transcribed on
+ * independent lanes and merged by timestamp, so a final segment can arrive
+ * slightly out of order relative to a lane that's already been committed. In
+ * that rare case the late segment is simply inserted at the tail (bounded
+ * staleness) rather than reopening an already-frozen paragraph. This is
+ * acceptable for the live view; the post-stop transcript regroups everything
+ * from the database, so nothing is lost.
+ */
+export function createLiveTranscript(pauseThreshold: number) {
+  /** At most this many trailing paragraphs are kept open (not yet frozen). */
+  const MAX_TAIL_PARAGRAPHS = 2;
+
+  let committed = $state<LiveParagraph[]>([]);
+  let tail = $state<LiveParagraph[]>([]);
+  let tentative = $state("");
+  let segmentCount = $state(0);
+
+  // Not reactive state on purpose: only the derived paragraphs need to drive
+  // rendering, and re-sorting/regrouping this buffer never touches anything
+  // outside the (bounded) tail.
+  let tailSegments: TranscriptionSegment[] = [];
+  let nextParagraphId = 0;
+
+  function insertByStartTime(seg: TranscriptionSegment) {
+    // Fast path: in-order arrival, the overwhelming common case.
+    if (tailSegments.length === 0 || seg.start_time >= tailSegments[tailSegments.length - 1].start_time) {
+      tailSegments.push(seg);
+      return;
+    }
+    let lo = 0;
+    let hi = tailSegments.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1;
+      if (tailSegments[mid].start_time <= seg.start_time) lo = mid + 1;
+      else hi = mid;
+    }
+    tailSegments.splice(lo, 0, seg);
+  }
+
+  function regroupTail() {
+    const { paragraphs, ranges, ordered } = groupIntoParagraphsWithRanges(tailSegments, pauseThreshold);
+    const prevTail = tail;
+    const numToCommit = Math.max(0, paragraphs.length - MAX_TAIL_PARAGRAPHS);
+
+    // A committed paragraph is always a prefix of the previous tail (new
+    // paragraphs only ever appear at the end), so it keeps the id it was
+    // already assigned while still open rather than getting a new one now.
+    let cutIndex = 0;
+    for (let i = 0; i < numToCommit; i++) {
+      const id = i < prevTail.length ? prevTail[i].id : nextParagraphId++;
+      committed.push({ ...paragraphs[i], id });
+      cutIndex = ranges[i].end;
+    }
+    if (numToCommit > 0) tailSegments = ordered.slice(cutIndex);
+
+    // Reassign ids: a paragraph that already existed in the previous tail
+    // keeps its id (so keyed rendering treats it as the same, growing node);
+    // only a genuinely new trailing paragraph gets a fresh id.
+    const remaining = paragraphs.slice(numToCommit);
+    const survivingOldCount = Math.max(0, prevTail.length - numToCommit);
+    tail = remaining.map((paragraph, i) =>
+      i < survivingOldCount
+        ? { ...paragraph, id: prevTail[numToCommit + i].id }
+        : { ...paragraph, id: nextParagraphId++ },
+    );
+  }
+
+  function append(segment: TranscriptionSegment) {
+    if (!segment.is_final) {
+      tentative = segment.text;
+      return;
+    }
+    tentative = "";
+    segmentCount++;
+
+    const diarizedSoFar = segment.speaker != null || tailSegments.some((s) => s.speaker != null);
+    if (diarizedSoFar) insertByStartTime(segment);
+    else tailSegments.push(segment);
+
+    regroupTail();
+  }
+
+  function reset() {
+    tailSegments = [];
+    committed = [];
+    tail = [];
+    tentative = "";
+    segmentCount = 0;
+    nextParagraphId = 0;
+  }
+
+  return {
+    append,
+    reset,
+    get committed() { return committed; },
+    get tail() { return tail; },
+    get tentative() { return tentative; },
+    get segmentCount() { return segmentCount; },
+  };
+}

--- a/src/lib/utils/paragraphs.test.ts
+++ b/src/lib/utils/paragraphs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildMeetingTranscriptBlocks, groupIntoParagraphs } from './paragraphs';
+import { buildMeetingTranscriptBlocks, groupIntoParagraphs, groupIntoParagraphsWithRanges } from './paragraphs';
 import type { MeetingRecordingSession, TranscriptionSegment } from '../types';
 
 function seg(text: string, start: number, end?: number): TranscriptionSegment {
@@ -161,6 +161,75 @@ describe('groupIntoParagraphs', () => {
     ];
     const result = groupIntoParagraphs(segments, 1.5);
     expect(result).toHaveLength(1);
+  });
+});
+
+describe('groupIntoParagraphsWithRanges', () => {
+  function checkRangesReconstructParagraphs(segments: TranscriptionSegment[], pauseThreshold: number) {
+    const { paragraphs, ranges, ordered } = groupIntoParagraphsWithRanges(segments, pauseThreshold);
+    const batch = groupIntoParagraphs(segments, pauseThreshold);
+    expect(paragraphs).toEqual(batch);
+    expect(ranges).toHaveLength(paragraphs.length);
+
+    // Ranges form a contiguous, non-overlapping, ascending partition.
+    let expectedStart = 0;
+    for (const range of ranges) {
+      expect(range.start).toBe(expectedStart);
+      expect(range.end).toBeGreaterThan(range.start);
+      expectedStart = range.end;
+    }
+
+    // Reconstructing each paragraph's text from its range (skipping empty
+    // segments, same as the grouping rules) must reproduce the paragraph.
+    for (let i = 0; i < ranges.length; i++) {
+      const { start, end } = ranges[i];
+      const reconstructedText = ordered
+        .slice(start, end)
+        .map((s) => s.text.trim())
+        .filter((t) => t.length > 0)
+        .join(' ');
+      expect(reconstructedText).toBe(paragraphs[i].text);
+    }
+  }
+
+  it('covers a plain in-order stream with contiguous ranges', () => {
+    const segments = [
+      seg('Hello world.', 0),
+      seg('New paragraph after a pause.', 2.0),
+      seg('And more.', 2.5),
+    ];
+    checkRangesReconstructParagraphs(segments, 1.5);
+  });
+
+  it('covers a diarized, interleaved stream with contiguous ranges', () => {
+    const segments = [
+      dseg('second', 3, 'them'),
+      dseg('first', 1, 'me'),
+      dseg('third', 5, 'them'),
+    ];
+    checkRangesReconstructParagraphs(segments, 1.5);
+  });
+
+  it('keeps an empty-text segment inside the range of the paragraph being built', () => {
+    const segments = [
+      seg('Hello', 0),
+      seg('', 0.3), // empty text, mid-paragraph
+      seg('world.', 0.6),
+    ];
+    const { paragraphs, ranges, ordered } = groupIntoParagraphsWithRanges(segments, 1.5);
+    expect(paragraphs).toHaveLength(1);
+    expect(paragraphs[0].text).toBe('Hello world.');
+    expect(ranges).toEqual([{ start: 0, end: 3 }]);
+    expect(ordered).toHaveLength(3);
+  });
+
+  it('returns empty ranges for empty input', () => {
+    expect(groupIntoParagraphsWithRanges([], 1.5)).toEqual({ paragraphs: [], ranges: [], ordered: [] });
+  });
+
+  it('matches groupIntoParagraphs output for a long unpunctuated stream', () => {
+    const segments = Array.from({ length: 300 }, (_, i) => seg(`word${i}`, i * 0.1));
+    checkRangesReconstructParagraphs(segments, 1.5);
   });
 });
 

--- a/src/lib/utils/paragraphs.ts
+++ b/src/lib/utils/paragraphs.ts
@@ -24,8 +24,16 @@ function countSentenceEnds(text: string): number {
   return (text.match(/[.!?…]+(?=["»”')\]]*(\s|$))/g) ?? []).length;
 }
 
+/** Half-open index range `[start, end)` into the ordered segment array that a
+ * paragraph was built from. */
+export type ParagraphRange = { start: number; end: number };
+
 /**
- * Group segments into flowing paragraphs with a leading timestamp.
+ * Group segments into flowing paragraphs with a leading timestamp, also
+ * returning the source index range (into the returned `ordered` array) each
+ * paragraph consumed. Callers that need incremental/streaming regrouping use
+ * the ranges to know which segments a completed paragraph consumed, without
+ * duplicating the break rules below.
  *
  * Paragraphs only break at sentence boundaries, triggered by any of:
  * - a pause ≥ `pauseThreshold` seconds before the next segment
@@ -38,11 +46,11 @@ function countSentenceEnds(text: string): number {
  * Parakeet emit sentence/window segments. Negative gaps (legacy data with
  * window-relative timestamps) never trigger a pause break.
  */
-export function groupIntoParagraphs(
+export function groupIntoParagraphsWithRanges(
   segments: TranscriptionSegment[],
   pauseThreshold: number,
-): Paragraph[] {
-  if (segments.length === 0) return [];
+): { paragraphs: Paragraph[]; ranges: ParagraphRange[]; ordered: TranscriptionSegment[] } {
+  if (segments.length === 0) return { paragraphs: [], ranges: [], ordered: segments };
 
   // Diarized meetings tag each segment with a speaker. Mic (Me) and system
   // audio (Them) are transcribed independently, so order by time to read as a
@@ -55,6 +63,8 @@ export function groupIntoParagraphs(
     : segments;
 
   const paragraphs: Paragraph[] = [];
+  const ranges: ParagraphRange[] = [];
+  let rangeStart = 0;
   let currentTimestamp = formatTimestamp(ordered[0].start_time);
   let currentSpeaker: Speaker | null = ordered[0].speaker ?? null;
   let currentWords: string[] = [];
@@ -63,12 +73,14 @@ export function groupIntoParagraphs(
   let endsSentence = false;
   let lastEnd = ordered[0].start_time;
 
-  const flush = (nextStart: number, nextSpeaker: Speaker | null) => {
+  const flush = (boundaryIndex: number, nextStart: number, nextSpeaker: Speaker | null) => {
     paragraphs.push({
       timestamp: currentTimestamp,
       text: currentWords.join(" "),
       speaker: currentSpeaker,
     });
+    ranges.push({ start: rangeStart, end: boundaryIndex });
+    rangeStart = boundaryIndex;
     currentTimestamp = formatTimestamp(nextStart);
     currentSpeaker = nextSpeaker;
     currentWords = [];
@@ -77,15 +89,19 @@ export function groupIntoParagraphs(
     endsSentence = false;
   };
 
-  for (const seg of ordered) {
+  for (let i = 0; i < ordered.length; i++) {
+    const seg = ordered[i];
     const text = seg.text.trim();
+    // An empty segment carries no text but still occupies an index; it stays
+    // part of whichever paragraph range is currently open (or the next one,
+    // if none has started yet), since ranges are tracked by index, not text.
     if (!text) continue;
     const speaker = seg.speaker ?? null;
 
     if (currentWords.length > 0) {
       // A speaker change always starts a new paragraph (even mid-sentence).
       if (diarized && speaker !== currentSpeaker) {
-        flush(seg.start_time, speaker);
+        flush(i, seg.start_time, speaker);
       } else {
         const gap = seg.start_time - lastEnd;
         const breakAtSentence =
@@ -96,7 +112,7 @@ export function groupIntoParagraphs(
         const breakHard = currentChars >= HARD_MAX_CHARS;
 
         if (breakAtSentence || breakHard) {
-          flush(seg.start_time, speaker);
+          flush(i, seg.start_time, speaker);
         }
       }
     } else {
@@ -116,9 +132,22 @@ export function groupIntoParagraphs(
       text: currentWords.join(" "),
       speaker: currentSpeaker,
     });
+    ranges.push({ start: rangeStart, end: ordered.length });
   }
 
-  return paragraphs;
+  return { paragraphs, ranges, ordered };
+}
+
+/**
+ * Group segments into flowing paragraphs with a leading timestamp. See
+ * `groupIntoParagraphsWithRanges` for the break rules; this is a thin
+ * wrapper that drops the ranges for callers that only need the paragraphs.
+ */
+export function groupIntoParagraphs(
+  segments: TranscriptionSegment[],
+  pauseThreshold: number,
+): Paragraph[] {
+  return groupIntoParagraphsWithRanges(segments, pauseThreshold).paragraphs;
 }
 
 function toParagraphBlocks(paragraphs: Paragraph[]): TranscriptParagraphBlock[] {


### PR DESCRIPTION
The live meeting view regrouped every segment ever received on each new segment and re-rendered the full unkeyed list: O(n) per segment, O(n²) over a meeting, plus a forced-layout autoscroll per segment. This PR makes live-transcript work bounded per segment regardless of meeting length.

- New incremental grouper (`live-transcript.svelte.ts`): committed paragraphs are append-only; only the open tail (max 2 paragraphs) regroups per segment. Byte-identical output to batch grouping for in-order streams (equivalence-tested).
- Break rules stay single-source: `groupIntoParagraphsWithRanges` extends the existing util; `groupIntoParagraphs` is now a wrapper over it.
- Live card renders a keyed `{#each}` windowed to the last 30 paragraphs; entry animation no longer replays on old nodes.
- Autoscroll only engages near the bottom and coalesces via rAF.
- Non-final segments render as a faded tentative suffix (engines emit only finals today; forward wiring).

Tests: equivalence vs batch grouping (plain/punctuated/diarized-interleaved/unpunctuated), commit immutability, tentative set/clear, reset, id stability, range coverage. 153 frontend tests green, check and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuuJ8cV2dsbwNnc7Y8gm2b