### PR TITLE
Unload the transcription model when idle

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -25,6 +25,9 @@ pub fn save_settings(
     let settings = settings.sanitize_for_save()?;
     settings.save(&state.db)?;
     crate::debug::set_transcription_debug(settings.debug_transcription);
+    state
+        .engine_actor
+        .set_unload_timeout(settings.model_unload_timeout_minutes);
     // A locale change must relabel the tray menu immediately.
     if let Ok(machine) = state.current_machine_state() {
         crate::tray::sync(&app, &machine);

--- a/src-tauri/src/engine/mock.rs
+++ b/src-tauri/src/engine/mock.rs
@@ -6,6 +6,8 @@ use super::{
 };
 use std::collections::VecDeque;
 use std::path::Path;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// A configurable mock engine for testing.
 /// Push responses into `transcribe_responses` and `flush_responses` queues;
@@ -14,6 +16,10 @@ pub struct MockEngine {
     loaded: bool,
     pub transcribe_responses: VecDeque<Result<Vec<TranscriptionSegment>, EngineError>>,
     pub flush_responses: VecDeque<Result<Vec<TranscriptionSegment>, EngineError>>,
+    /// Shared with tests via `unload_count_handle()` (clone it before handing
+    /// the mock to the actor's factory, since the mock itself is moved), so
+    /// idle-unload behavior can be observed from outside the actor thread.
+    unload_count: Arc<AtomicUsize>,
 }
 
 impl Default for MockEngine {
@@ -28,7 +34,14 @@ impl MockEngine {
             loaded: false,
             transcribe_responses: VecDeque::new(),
             flush_responses: VecDeque::new(),
+            unload_count: Arc::new(AtomicUsize::new(0)),
         }
+    }
+
+    /// Clone of the unload counter; call before the mock is moved into the
+    /// actor's factory closure.
+    pub fn unload_count_handle(&self) -> Arc<AtomicUsize> {
+        Arc::clone(&self.unload_count)
     }
 
     /// Convenience: pre-load N identical transcribe responses.
@@ -73,6 +86,7 @@ impl TranscriptionEngine for MockEngine {
 
     fn unload_model(&mut self) -> Result<(), EngineError> {
         self.loaded = false;
+        self.unload_count.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -277,6 +277,17 @@ pub fn run() {
                 tracing::warn!("Failed to register shortcuts on startup: {e}");
             }
 
+            match settings::AppSettings::load(&state.db) {
+                Ok(app_settings) => {
+                    state
+                        .engine_actor
+                        .set_unload_timeout(app_settings.model_unload_timeout_minutes);
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to load settings on startup: {e}");
+                }
+            }
+
             tray::setup_tray(app.handle())?;
             calendar::scheduler::spawn(app.handle().clone());
             info!("Souffle started");

--- a/src-tauri/src/pipeline/actor.rs
+++ b/src-tauri/src/pipeline/actor.rs
@@ -12,7 +12,7 @@ use std::sync::Mutex;
 use std::sync::atomic::AtomicU64;
 use std::time::{Duration, Instant};
 
-use crossbeam_channel::{Receiver, Sender};
+use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
 use tauri::Manager;
 use tauri_specta::Event;
 use tracing::{debug, error, info, warn};
@@ -91,6 +91,8 @@ pub enum EngineCommand {
         samples: Vec<f32>,
         reply: Sender<Result<Vec<TranscriptionSegment>, String>>,
     },
+    /// Reconfigure the idle-unload timeout. `None` disables it. Fire-and-forget.
+    SetUnloadTimeout(Option<Duration>),
     Shutdown,
 }
 
@@ -122,6 +124,8 @@ impl EngineActorHandle {
                     engine: None,
                     app: None,
                     dropped_counter,
+                    unload_timeout: None,
+                    idle_since: None,
                 }
                 .run();
             })
@@ -176,6 +180,22 @@ impl EngineActorHandle {
 
     pub fn unload_model(&self) -> Result<(), String> {
         self.request(|reply| EngineCommand::UnloadModel { reply }, None)
+    }
+
+    /// Reconfigure the idle-unload timeout; `0` disables it. Fire-and-forget:
+    /// the actor picks it up on its next loop iteration.
+    pub fn set_unload_timeout(&self, minutes: u32) {
+        let duration = (minutes > 0).then(|| Duration::from_secs(u64::from(minutes) * 60));
+        let _ = self.cmd_tx.send(EngineCommand::SetUnloadTimeout(duration));
+    }
+
+    /// Test-only: set the idle-unload timeout directly as a `Duration`, so
+    /// tests don't have to wait out real minutes.
+    #[cfg(test)]
+    pub fn set_unload_timeout_for_test(&self, duration: Duration) {
+        let _ = self
+            .cmd_tx
+            .send(EngineCommand::SetUnloadTimeout(Some(duration)));
     }
 
     /// Start a transcription session. Replies once the engine state is reset
@@ -248,6 +268,12 @@ struct EngineActor {
     engine: Option<Box<dyn TranscriptionEngine>>,
     app: Option<tauri::AppHandle>,
     dropped_counter: Arc<AtomicU64>,
+    /// Idle-unload timeout; `None` means "never unload". Reconfigured via
+    /// `EngineCommand::SetUnloadTimeout`.
+    unload_timeout: Option<Duration>,
+    /// When the engine last became idle (loaded, no session active). `None`
+    /// while a session is running or no engine is loaded.
+    idle_since: Option<Instant>,
 }
 
 /// Outcome of an active session loop.
@@ -270,9 +296,32 @@ impl EngineActor {
         let mut session_count: u32 = 0;
 
         loop {
-            let Ok(cmd) = self.cmd_rx.recv() else {
-                warn!("Engine actor command channel disconnected, exiting");
-                break;
+            // While the engine is loaded, idle, and an unload timeout is
+            // configured, wait only until the deadline instead of blocking
+            // forever. Everything else (an active session, no engine, no
+            // timeout) keeps the original plain `recv()`.
+            let cmd = if let Some(deadline) = self.idle_deadline() {
+                let now = Instant::now();
+                if now >= deadline {
+                    self.handle_idle_timeout();
+                    continue;
+                }
+                match self.cmd_rx.recv_timeout(deadline - now) {
+                    Ok(cmd) => cmd,
+                    Err(RecvTimeoutError::Timeout) => continue,
+                    Err(RecvTimeoutError::Disconnected) => {
+                        warn!("Engine actor command channel disconnected, exiting");
+                        break;
+                    }
+                }
+            } else {
+                match self.cmd_rx.recv() {
+                    Ok(cmd) => cmd,
+                    Err(_) => {
+                        warn!("Engine actor command channel disconnected, exiting");
+                        break;
+                    }
+                }
             };
 
             match cmd {
@@ -301,9 +350,23 @@ impl EngineActor {
                     info!(
                         "Inference session {session_count} starting (audio session {session_id})"
                     );
+                    self.idle_since = None;
+                    let mut pending_unload_timeout: Option<Option<Duration>> = None;
                     let end = with_autorelease_pool(|| {
-                        self.handle_session(session_id, config, on_segment, reply)
+                        self.handle_session(
+                            session_id,
+                            config,
+                            on_segment,
+                            reply,
+                            &mut pending_unload_timeout,
+                        )
                     });
+                    // A SetUnloadTimeout received mid-session was consumed by
+                    // the session loop's command drain; apply it now instead
+                    // of losing it.
+                    if let Some(duration) = pending_unload_timeout {
+                        self.unload_timeout = duration;
+                    }
                     match end {
                         SessionEnd::Stopped(done, summary) => {
                             let _ = done.send(Ok(summary));
@@ -329,6 +392,9 @@ impl EngineActor {
                             );
                         }
                     }
+                    if self.engine.is_some() {
+                        self.idle_since = Some(Instant::now());
+                    }
                 }
                 EngineCommand::StopSession { reply } => {
                     // Already idle — stop is idempotent.
@@ -337,6 +403,12 @@ impl EngineActor {
                 EngineCommand::DebugTranscribe { samples, reply } => {
                     let result = with_autorelease_pool(|| self.handle_debug_transcribe(&samples));
                     let _ = reply.send(result);
+                    if self.engine.is_some() {
+                        self.idle_since = Some(Instant::now());
+                    }
+                }
+                EngineCommand::SetUnloadTimeout(duration) => {
+                    self.unload_timeout = duration;
                 }
                 EngineCommand::Shutdown => break,
             }
@@ -379,6 +451,32 @@ impl EngineActor {
             }
             drop(engine);
         }
+        self.idle_since = None;
+    }
+
+    /// Deadline at which the currently loaded, idle model should be
+    /// unloaded, or `None` if no unload is scheduled: no engine loaded, no
+    /// timeout configured, or a session is active (which clears `idle_since`).
+    fn idle_deadline(&self) -> Option<Instant> {
+        self.engine.as_ref()?;
+        let timeout = self.unload_timeout?;
+        let idle_since = self.idle_since?;
+        Some(idle_since + timeout)
+    }
+
+    /// Unload the model after it has sat idle past the configured timeout,
+    /// and tell `AppState` so the state machine (and therefore the frontend)
+    /// reflects reality: the next recording start must reload through the
+    /// normal load flow instead of finding a silently-vanished engine.
+    fn handle_idle_timeout(&mut self) {
+        info!(
+            timeout = ?self.unload_timeout,
+            "Unloading idle transcription model to reclaim memory"
+        );
+        with_autorelease_pool(|| self.drop_engine());
+        if let Some(app) = &self.app {
+            app.state::<crate::state::AppState>().unload_idle_model();
+        }
     }
 
     fn handle_load(
@@ -397,6 +495,8 @@ impl EngineActor {
             mic_gain: engine.mic_gain(),
         };
         self.engine = Some(engine);
+        // No session is active right after a load: start the idle clock.
+        self.idle_since = Some(Instant::now());
         Ok(info)
     }
 
@@ -417,6 +517,7 @@ impl EngineActor {
         config: SessionConfig,
         on_segment: SegmentCallback,
         reply: Sender<Result<EngineInfo, String>>,
+        pending_unload_timeout: &mut Option<Option<Duration>>,
     ) -> SessionEnd {
         // Clear stale audio left over from previous sessions before resetting.
         let drained = self.drain_audio_queue();
@@ -483,6 +584,7 @@ impl EngineActor {
             &mut health,
             self.app.as_ref(),
             mode.as_mut(),
+            pending_unload_timeout,
         )
     }
 
@@ -737,6 +839,7 @@ fn run_session_loop(
     health: &mut SessionHealth,
     app: Option<&tauri::AppHandle>,
     mode: &mut dyn SessionMode,
+    pending_unload_timeout: &mut Option<Option<Duration>>,
 ) -> SessionEnd {
     let chunk_size = engine.audio_requirements().chunk_size_samples as usize;
     let mut summary = SessionSummary::default();
@@ -807,6 +910,12 @@ fn run_session_loop(
             }
             Ok(EngineCommand::DebugTranscribe { reply, .. }) => {
                 let _ = reply.send(Err("Recording session active".into()));
+            }
+            // No reply channel to report "busy" on; remember the latest
+            // value and let the caller apply it once the session ends,
+            // rather than silently dropping the setting change.
+            Ok(EngineCommand::SetUnloadTimeout(duration)) => {
+                *pending_unload_timeout = Some(duration);
             }
             Err(_) => {}
         }
@@ -1052,8 +1161,9 @@ fn emit_filtered(
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use std::sync::atomic::Ordering;
     use std::sync::{Arc, Mutex};
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use crossbeam_channel::{Sender, unbounded};
 
@@ -1458,5 +1568,73 @@ mod tests {
         actor
             .stop_session(Duration::from_secs(2))
             .expect("stop while idle should be idempotent");
+    }
+
+    /// Poll `cond` until it's true or `timeout` elapses, so idle-unload tests
+    /// don't rely on a single fixed sleep racing the actor thread.
+    fn wait_for(cond: impl Fn() -> bool, timeout: Duration) -> bool {
+        let start = Instant::now();
+        loop {
+            if cond() {
+                return true;
+            }
+            if start.elapsed() >= timeout {
+                return cond();
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[test]
+    fn idle_timeout_unloads_engine_after_inactivity() {
+        let mock = MockEngine::new();
+        let unload_count = mock.unload_count_handle();
+        // spawn_with_mock's initial load_model call already starts the idle
+        // clock, so configuring a tiny timeout is enough to trigger unload.
+        let (actor, _audio_tx) = spawn_with_mock(mock);
+
+        actor.set_unload_timeout_for_test(Duration::from_millis(50));
+
+        assert!(
+            wait_for(|| unload_count.load(Ordering::SeqCst) >= 1, Duration::from_secs(2)),
+            "engine should unload once the idle timeout elapses"
+        );
+    }
+
+    #[test]
+    fn idle_timeout_set_during_session_applies_after_it_ends() {
+        let mock = MockEngine::new();
+        let unload_count = mock.unload_count_handle();
+        let (actor, audio_tx) = spawn_with_mock(mock);
+
+        actor
+            .start_session(1, session_config(), Box::new(|_| {}))
+            .expect("start");
+        // Sent while a session is active: must not be dropped, only deferred.
+        actor.set_unload_timeout_for_test(Duration::from_millis(50));
+        audio_tx.send(end_of_stream(1)).unwrap();
+        actor.stop_session(Duration::from_secs(2)).expect("stop");
+
+        assert!(
+            wait_for(|| unload_count.load(Ordering::SeqCst) >= 1, Duration::from_secs(2)),
+            "timeout set mid-session must still apply once the session ends"
+        );
+    }
+
+    #[test]
+    fn unload_timeout_disabled_by_default_never_unloads() {
+        let mock = MockEngine::new();
+        let unload_count = mock.unload_count_handle();
+        let (actor, _audio_tx) = spawn_with_mock(mock);
+
+        // 0 minutes == disabled; explicit, matching the default setting.
+        actor.set_unload_timeout(0);
+
+        std::thread::sleep(Duration::from_millis(150));
+        assert_eq!(
+            unload_count.load(Ordering::SeqCst),
+            0,
+            "a disabled (0 minute) timeout must never unload the model"
+        );
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -25,6 +25,7 @@ const CAPTURE_SYSTEM_AUDIO_KEY: &str = "capture_system_audio";
 const CALENDAR_INTEGRATION_ENABLED_KEY: &str = "calendar_integration_enabled";
 const CALENDAR_SELECTED_IDS_KEY: &str = "calendar_selected_ids";
 const CALENDAR_REMINDER_MINUTES_KEY: &str = "calendar_reminder_minutes";
+const MODEL_UNLOAD_TIMEOUT_MINUTES_KEY: &str = "model_unload_timeout_minutes";
 const LOCALE_KEY: &str = "locale";
 const SHORTCUT_TOGGLE_KEY: &str = "shortcut_toggle";
 const SHORTCUT_PUSH_TO_TALK_KEY: &str = "shortcut_push_to_talk";
@@ -65,7 +66,15 @@ pub struct AppSettings {
     pub calendar_selected_ids: Vec<String>,
     /// How long before an event the "start transcription?" reminder fires.
     pub calendar_reminder_minutes: u32,
+    /// Unload the transcription model after this many idle minutes to
+    /// reclaim RAM; 0 means never unload. The next recording reloads it
+    /// through the normal load flow.
+    pub model_unload_timeout_minutes: u32,
 }
+
+/// Allowed values for `model_unload_timeout_minutes`: 0 (never) plus the
+/// options offered in the settings UI.
+const ALLOWED_UNLOAD_TIMEOUT_MINUTES: [u32; 4] = [0, 5, 15, 60];
 
 impl Default for AppSettings {
     fn default() -> Self {
@@ -89,6 +98,7 @@ impl Default for AppSettings {
             calendar_integration_enabled: false,
             calendar_selected_ids: Vec::new(),
             calendar_reminder_minutes: 2,
+            model_unload_timeout_minutes: 0,
         }
     }
 }
@@ -187,6 +197,11 @@ impl AppSettings {
         {
             settings.calendar_reminder_minutes = calendar_reminder_minutes;
         }
+        if let Some(model_unload_timeout_minutes) =
+            read_json_setting::<u32>(db, MODEL_UNLOAD_TIMEOUT_MINUTES_KEY)?
+        {
+            settings.model_unload_timeout_minutes = model_unload_timeout_minutes;
+        }
 
         Ok(settings.sanitized())
     }
@@ -276,6 +291,10 @@ impl AppSettings {
             normalized.calendar_reminder_minutes = Self::default().calendar_reminder_minutes;
         }
 
+        if !ALLOWED_UNLOAD_TIMEOUT_MINUTES.contains(&normalized.model_unload_timeout_minutes) {
+            normalized.model_unload_timeout_minutes = Self::default().model_unload_timeout_minutes;
+        }
+
         normalized
     }
 
@@ -331,6 +350,11 @@ impl AppSettings {
             db,
             CALENDAR_REMINDER_MINUTES_KEY,
             &normalized.calendar_reminder_minutes,
+        )?;
+        write_json_setting(
+            db,
+            MODEL_UNLOAD_TIMEOUT_MINUTES_KEY,
+            &normalized.model_unload_timeout_minutes,
         )?;
 
         if let Some(audio_device) = normalized.audio_device.as_ref() {
@@ -456,6 +480,7 @@ mod tests {
             calendar_integration_enabled: true,
             calendar_selected_ids: vec!["cal-1".into(), "cal-2".into()],
             calendar_reminder_minutes: 5,
+            model_unload_timeout_minutes: 15,
         };
 
         settings.save(&db).expect("save settings");
@@ -569,6 +594,24 @@ mod tests {
             .expect("save minutes");
         let settings = AppSettings::load(&db).expect("load settings");
         assert_eq!(settings.calendar_reminder_minutes, 2);
+    }
+
+    #[test]
+    fn model_unload_timeout_minutes_rejects_unlisted_values() {
+        let (db, _dir) = test_db();
+        db.set_setting("model_unload_timeout_minutes", "7")
+            .expect("save minutes");
+        let settings = AppSettings::load(&db).expect("load settings");
+        assert_eq!(settings.model_unload_timeout_minutes, 0);
+
+        for minutes in [0, 5, 15, 60] {
+            let s = AppSettings {
+                model_unload_timeout_minutes: minutes,
+                ..AppSettings::default()
+            };
+            let clean = s.sanitize_for_save().unwrap();
+            assert_eq!(clean.model_unload_timeout_minutes, minutes);
+        }
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -191,6 +191,21 @@ impl AppState {
             .ok_or_else(|| "App handle not set".to_string())
     }
 
+    /// The engine actor unloaded an idle model to reclaim memory. Mirrors the
+    /// Unload/UnloadComplete pair already used when swapping models, so the
+    /// state machine (and therefore the frontend) never disagrees with the
+    /// actor about whether a model is actually loaded. A no-op (logged) if
+    /// the machine isn't in `Ready` (e.g. a recording start raced the timer).
+    pub fn unload_idle_model(&self) {
+        if let Err(e) = self.apply_transition(StateAction::Unload { next_profile: None }) {
+            warn!("Idle model unload: failed to start transition: {e}");
+            return;
+        }
+        if let Err(e) = self.apply_transition(StateAction::UnloadComplete) {
+            warn!("Idle model unload: failed to complete transition: {e}");
+        }
+    }
+
     /// A session died mid-recording: stop audio capture, salvage any
     /// in-progress meeting to the DB, and fail the state machine so the UI
     /// leaves the recording state. Called by the engine actor after it emits

--- a/src/lib/api/settings.test.ts
+++ b/src/lib/api/settings.test.ts
@@ -38,7 +38,7 @@ describe('settings API', () => {
 
   it('saveSettings passes settings object', async () => {
     mockInvoke.mockResolvedValue(null);
-    const settings = { theme: 'light' as const, locale: '', auto_paste: true, paste_delay_ms: 200, ollama_url: 'http://localhost:11434', ollama_model: 'llama3', debug_transcription: false, audio_device: null, transcription_engine_id: 'kyutai', transcription_model_id: 'stt-1b', transcription_backend_id: 'candle', vad_enabled: true, filler_removal: true, stutter_collapse: false, dictionary_correction: true, capture_system_audio: true, calendar_integration_enabled: false, calendar_selected_ids: [], calendar_reminder_minutes: 2 };
+    const settings = { theme: 'light' as const, locale: '', auto_paste: true, paste_delay_ms: 200, ollama_url: 'http://localhost:11434', ollama_model: 'llama3', debug_transcription: false, audio_device: null, transcription_engine_id: 'kyutai', transcription_model_id: 'stt-1b', transcription_backend_id: 'candle', vad_enabled: true, filler_removal: true, stutter_collapse: false, dictionary_correction: true, capture_system_audio: true, calendar_integration_enabled: false, calendar_selected_ids: [], calendar_reminder_minutes: 2, model_unload_timeout_minutes: 0 };
 
     await saveSettings(settings);
 

--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -31,7 +31,10 @@
     recordingMode === "idle"
       && (Boolean(meeting.meeting) || meeting.isLoadingMeeting || Boolean(app.currentMeetingId)),
   );
-  const modelReady = $derived(app.transcriptionRuntimePhase === "ready");
+  // "load_required" (e.g. after the idle-unload timeout freed the model)
+  // still allows starting: the start flow reloads it on demand. Only
+  // "download_required" (nothing on disk yet) truly blocks starting.
+  const modelReady = $derived(app.transcriptionRuntimePhase !== "download_required");
 
   onMount(() => {
     void timeline.refresh();

--- a/src/lib/components/SettingsView.svelte
+++ b/src/lib/components/SettingsView.svelte
@@ -61,7 +61,9 @@
     downloadedBytes={controller.downloadedBytes}
     downloadTotalBytes={controller.downloadTotalBytes}
     downloadFile={controller.downloadFile}
+    unloadTimeoutMinutes={controller.app.settings.model_unload_timeout_minutes}
     onSelectModel={controller.selectModelOption}
+    onUnloadTimeoutChange={controller.onModelUnloadTimeoutChange}
   />
 
   <InterfaceSettingsSection

--- a/src/lib/features/meeting/controller.svelte.ts
+++ b/src/lib/features/meeting/controller.svelte.ts
@@ -15,6 +15,7 @@ import { getAppState } from "../../stores/app.svelte";
 import type { MeetingCalendarContext, MeetingTranscript, OllamaModelDescriptor, SummarizeProgress, TranscriptionCatalog, TranscriptionSegment } from "../../types";
 import { errorMessage } from "../../utils";
 import { toSelectedTranscriptionProfile } from "../transcription/catalog";
+import { ensureModelLoaded } from "../transcription/runtime";
 import { createLiveTranscript } from "./live-transcript.svelte";
 
 function defaultMeetingTitle(): string {
@@ -61,12 +62,15 @@ function createMeetingControllerInstance() {
   // machine reports "stopping".
   let stopRequested = $state(false);
   let isStopping = $derived(stopRequested || app.machineState.state === "stopping");
+  // "load_required" stays resumable: resumeRecording reloads the model on
+  // demand, same as a fresh start after an idle unload.
   let canResumeRecording = $derived(
     Boolean(meeting?.id)
     && !isRecordingMeeting
     && !isLoadingMeeting
     && !isSummarizing
-    && app.transcriptionRuntimePhase === "ready",
+    && (app.transcriptionRuntimePhase === "ready"
+      || app.transcriptionRuntimePhase === "load_required"),
   );
 
   async function mount() {
@@ -166,6 +170,16 @@ function createMeetingControllerInstance() {
     title?: string;
     calendar?: MeetingCalendarContext;
   }) {
+    if (app.transcriptionRuntimePhase !== "ready") {
+      // Model may have been unloaded by the idle timeout; reload through the
+      // normal load flow before recording rather than failing on start.
+      statusMessage = "";
+      const ready = await ensureModelLoaded(app, transcriptionCatalog, (message) => { statusMessage = message; });
+      if (!ready) {
+        if (!statusMessage) statusMessage = "Load the model before starting a meeting.";
+        return;
+      }
+    }
     try {
       const title = options?.title?.trim() || defaultMeetingTitle();
       const calendar = options?.calendar ?? null;
@@ -220,6 +234,8 @@ function createMeetingControllerInstance() {
     if (!meeting || !meeting.id) return;
 
     try {
+      const ready = await ensureModelLoaded(app, transcriptionCatalog, (message) => { statusMessage = message; });
+      if (!ready) return;
       liveTranscript.reset();
       liveMeetingSegments = [];
       statusMessage = "";

--- a/src/lib/features/settings/components/ModelSettingsSection.svelte
+++ b/src/lib/features/settings/components/ModelSettingsSection.svelte
@@ -1,10 +1,19 @@
 <script lang="ts">
   import { t } from "svelte-i18n";
   import ProgressBar from "../../../components/ui/ProgressBar.svelte";
+  import SettingsField from "../../../components/ui/SettingsField.svelte";
   import StatusChip from "../../../components/ui/StatusChip.svelte";
   import { listAvailableModelOptions } from "../../transcription/catalog";
   import type { TranscriptionModelOperationState } from "../../transcription/state";
   import type { TranscriptionCatalog, TranscriptionRuntimePhase } from "../../../types";
+
+  const unloadTimeoutOptions = [0, 5, 15, 60] as const;
+  const unloadTimeoutKeys: Record<(typeof unloadTimeoutOptions)[number], string> = {
+    0: "settings_model.unload_timeout_never",
+    5: "settings_model.unload_timeout_5min",
+    15: "settings_model.unload_timeout_15min",
+    60: "settings_model.unload_timeout_1hour",
+  };
 
   let {
     catalog,
@@ -15,7 +24,9 @@
     downloadedBytes,
     downloadTotalBytes,
     downloadFile,
+    unloadTimeoutMinutes,
     onSelectModel,
+    onUnloadTimeoutChange,
   }: {
     catalog: TranscriptionCatalog | null;
     selectedEngineId: string;
@@ -25,7 +36,9 @@
     downloadedBytes: number;
     downloadTotalBytes: number | null;
     downloadFile: string;
+    unloadTimeoutMinutes: number;
     onSelectModel: (key: string) => void | Promise<void>;
+    onUnloadTimeoutChange: (event: Event) => void;
   } = $props();
 
   const options = $derived(listAvailableModelOptions(catalog));
@@ -72,5 +85,24 @@
         />
       </div>
     {/if}
+
+    <SettingsField
+      label={$t("settings_model.unload_timeout_label")}
+      description={$t("settings_model.unload_timeout_desc")}
+      htmlFor="model-unload-timeout"
+    >
+      {#snippet control()}
+        <select
+          id="model-unload-timeout"
+          value={unloadTimeoutMinutes}
+          onchange={onUnloadTimeoutChange}
+          class="field-select max-w-48"
+        >
+          {#each unloadTimeoutOptions as minutes}
+            <option value={minutes}>{$t(unloadTimeoutKeys[minutes])}</option>
+          {/each}
+        </select>
+      {/snippet}
+    </SettingsField>
   </div>
 </section>

--- a/src/lib/features/settings/controller.svelte.test.ts
+++ b/src/lib/features/settings/controller.svelte.test.ts
@@ -65,6 +65,7 @@ const defaultSettings: AppSettings = {
   calendar_integration_enabled: false,
   calendar_selected_ids: [],
   calendar_reminder_minutes: 2,
+  model_unload_timeout_minutes: 0,
 }
 
 const fakeDevices: AudioDeviceInfo[] = [

--- a/src/lib/features/settings/controller.svelte.ts
+++ b/src/lib/features/settings/controller.svelte.ts
@@ -376,6 +376,14 @@ export function createSettingsController() {
     });
   }
 
+  function onModelUnloadTimeoutChange(event: Event) {
+    const value = parseInt((event.target as HTMLSelectElement).value, 10);
+    if (!Number.isFinite(value)) return;
+    void persistSettings((settings) => {
+      settings.model_unload_timeout_minutes = value;
+    });
+  }
+
   /** Populate the calendar picker without prompting: only fetch calendars
    * when the integration is on (which implies access was granted). */
   async function loadCalendars() {
@@ -587,6 +595,7 @@ export function createSettingsController() {
     onOllamaModelChange,
     get systemAudioSupported() { return systemAudioSupported; },
     onCaptureSystemAudioChange,
+    onModelUnloadTimeoutChange,
     onVadEnabledChange,
     onFillerRemovalChange,
     onStutterCollapseChange,

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -181,6 +181,7 @@ describe("transcription controller", () => {
       calendar_integration_enabled: false,
       calendar_selected_ids: [],
       calendar_reminder_minutes: 2,
+      model_unload_timeout_minutes: 0,
     };
 
     Object.assign(navigator, {

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -11,7 +11,7 @@ import { createTimelineController } from "../timeline/controller.svelte";
 import type { TranscriptionCatalog, TranscriptionSegment } from "../../types";
 import { errorMessage } from "../../utils";
 import { formatSelectedTranscriptionLabel } from "./catalog";
-import { refreshTranscriptionRuntimeStatus } from "./runtime";
+import { ensureModelLoaded, refreshTranscriptionRuntimeStatus } from "./runtime";
 
 /** Persist a finished dictation and surface it in the timeline. */
 async function saveToHistory(text: string) {
@@ -123,11 +123,20 @@ function createTranscriptionControllerInstance() {
       return;
     }
 
-    if (app.transcriptionRuntimePhase !== "ready") {
-      statusMessage = app.transcriptionRuntimePhase === "download_required"
-        ? "Download and load the model before starting dictation."
-        : "Load the model before starting dictation.";
+    if (app.transcriptionRuntimePhase === "download_required") {
+      statusMessage = "Download and load the model before starting dictation.";
       return;
+    }
+    if (app.transcriptionRuntimePhase !== "ready") {
+      // Model was unloaded (e.g. the idle timeout freed it); reload through
+      // the normal load flow before recording instead of leaving the user
+      // stuck with a disabled button.
+      statusMessage = "";
+      const ready = await ensureModelLoaded(app, catalog, (message) => { statusMessage = message; });
+      if (!ready) {
+        if (!statusMessage) statusMessage = "Load the model before starting dictation.";
+        return;
+      }
     }
 
     transcript = "";

--- a/src/lib/features/transcription/runtime.ts
+++ b/src/lib/features/transcription/runtime.ts
@@ -153,6 +153,27 @@ export async function runStartupModelFlow(app: AppState): Promise<void> {
   }
 }
 
+// Indirection so TypeScript re-reads the getter after the `await` below
+// instead of reusing the "load_required" narrowing from the earlier check.
+function currentPhase(app: AppState): AppState["transcriptionRuntimePhase"] {
+  return app.transcriptionRuntimePhase;
+}
+
+/** Load the model on demand if it's sitting in "load_required" (e.g. after
+ * an idle-timeout unload), then report whether it's ready to record. A
+ * no-op success when already ready, and a no-op failure when nothing is
+ * downloaded yet (the caller should send the user to onboarding instead). */
+export async function ensureModelLoaded(
+  app: AppState,
+  catalog: TranscriptionCatalog | null,
+  setStatusMessage: (message: string) => void,
+): Promise<boolean> {
+  if (currentPhase(app) === "ready") return true;
+  if (currentPhase(app) !== "load_required") return false;
+  await startTranscriptionModelLoad(app, catalog, setStatusMessage);
+  return currentPhase(app) === "ready";
+}
+
 export async function startTranscriptionModelLoad(
   app: AppState,
   catalog: TranscriptionCatalog | null,

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -188,7 +188,13 @@
   "settings_model": {
     "title": "Transcription model",
     "description": "Pick a model — it downloads and loads automatically. Everything runs on this Mac.",
-    "downloading": "Downloading…"
+    "downloading": "Downloading…",
+    "unload_timeout_label": "Unload model when idle",
+    "unload_timeout_desc": "Frees memory after a period of no transcription activity. Reloads automatically the next time you start recording.",
+    "unload_timeout_never": "Never",
+    "unload_timeout_5min": "After 5 minutes",
+    "unload_timeout_15min": "After 15 minutes",
+    "unload_timeout_1hour": "After 1 hour"
   },
   "settings_advanced": {
     "title": "Advanced",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -188,7 +188,13 @@
   "settings_model": {
     "title": "Modèle de transcription",
     "description": "Choisissez un modèle — il se télécharge et se charge automatiquement. Tout tourne sur ce Mac.",
-    "downloading": "Téléchargement…"
+    "downloading": "Téléchargement…",
+    "unload_timeout_label": "Décharger le modèle en cas d'inactivité",
+    "unload_timeout_desc": "Libère de la mémoire après une période sans transcription. Se recharge automatiquement au prochain enregistrement.",
+    "unload_timeout_never": "Jamais",
+    "unload_timeout_5min": "Après 5 minutes",
+    "unload_timeout_15min": "Après 15 minutes",
+    "unload_timeout_1hour": "Après 1 heure"
   },
   "settings_advanced": {
     "title": "Avancé",

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -55,6 +55,7 @@ describe('app store', () => {
       calendar_integration_enabled: false,
       calendar_selected_ids: [],
       calendar_reminder_minutes: 2,
+      model_unload_timeout_minutes: 0,
     };
     state.settings = newSettings;
     expect(state.settings.theme).toBe('light');

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -70,6 +70,7 @@ let settings = $state<AppSettings>({
   calendar_integration_enabled: false,
   calendar_selected_ids: [],
   calendar_reminder_minutes: 2,
+  model_unload_timeout_minutes: 0,
 });
 
 function deriveRecordingMode(state: AppStateMachine): "idle" | "dictation" | "meeting" {

--- a/src/lib/test-helpers/fixtures.ts
+++ b/src/lib/test-helpers/fixtures.ts
@@ -196,6 +196,7 @@ export const mockSettings: AppSettings = {
   calendar_integration_enabled: false,
   calendar_selected_ids: [],
   calendar_reminder_minutes: 2,
+  model_unload_timeout_minutes: 0,
 }
 
 export const mockShortcuts: ShortcutSettings = {

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -548,7 +548,13 @@ calendar_selected_ids: string[];
 /**
  * How long before an event the "start transcription?" reminder fires.
  */
-calendar_reminder_minutes: number }
+calendar_reminder_minutes: number; 
+/**
+ * Unload the transcription model after this many idle minutes to
+ * reclaim RAM; 0 means never unload. The next recording reloads it
+ * through the normal load flow.
+ */
+model_unload_timeout_minutes: number }
 /**
  * Unified application state machine.
  * Replaces scattered `is_recording`, `model_loaded`, `recording_mode`, `active_profile` booleans


### PR DESCRIPTION
Adds an idle unload timeout (Never/5/15/60 min) for the loaded STT model. The engine actor waits with a deadline only when loaded, idle, and configured; expiry drops the engine and replays the Unload/UnloadComplete transitions so runtime phase, tray and pill all follow. Dictation start, meeting start and meeting resume now reload the model on demand, which also revives the previously dead Downloaded state.

Notable: a timeout change sent mid-recording is captured by the session loop and applied after the session ends (tested); deterministic actor tests inject a 50ms duration instead of sleeping minutes.

Gates: 285 Rust tests, 153 frontend tests, clippy/check/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuuJ8cV2dsbwNnc7Y8gm2b