### PR TITLE
Auto-stop recordings when the meeting seems over

### DIFF
--- a/src-tauri/src/app_events.rs
+++ b/src-tauri/src/app_events.rs
@@ -108,3 +108,23 @@ pub struct UpcomingMeeting {
     pub event: crate::calendar::CalendarEvent,
     pub starts_in_seconds: u32,
 }
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum MeetingIdleReason {
+    /// No transcript segment with text for the configured silence threshold.
+    Silence,
+    /// The session has run past the configured max-duration failsafe.
+    MaxDuration,
+}
+
+/// A meeting recording session looks like it has ended: either speech has
+/// stopped for a while, or the session hit the max-duration failsafe. Drives
+/// the live-card banner; a system notification is also sent on the first
+/// occurrence (see `pipeline::idle::MeetingIdleSignal::first`).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, Event)]
+pub struct MeetingIdle {
+    pub reason: MeetingIdleReason,
+    pub idle_seconds: u64,
+    pub threshold_seconds: u64,
+}

--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -239,11 +239,27 @@ fn start_pipeline_blocking(
     let diarize =
         capture_system_audio && settings.transcription_engine_id == crate::engine::KYUTAI_ENGINE_ID;
 
+    // Auto-stop detection only applies to meetings: dictation sessions are
+    // short and user-driven, so "meeting is over" doesn't apply. This is a
+    // session-start snapshot; a setting changed mid-meeting only takes effect
+    // on the next meeting.
+    let idle_config = (mode == PipelineMode::Meeting && settings.meeting_autostop_enabled).then(
+        || crate::pipeline::MeetingIdleConfig {
+            silence_threshold: Some(Duration::from_secs(u64::from(
+                settings.meeting_autostop_minutes * 60,
+            ))),
+            max_duration: Some(Duration::from_secs(u64::from(
+                settings.meeting_max_duration_minutes * 60,
+            ))),
+        },
+    );
+
     let config = SessionConfig {
         pipeline_config: settings.pipeline_config(),
         dictionary_entries: db.list_dictionary_entries()?,
         session_terms,
         diarize,
+        idle_config,
     };
 
     // The actor replies once the engine is reset and ready for audio.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -163,6 +163,7 @@ fn specta_builder() -> Builder<tauri::Wry> {
             app_events::MeetingStopRequested,
             app_events::MeetingFinalized,
             app_events::UpcomingMeeting,
+            app_events::MeetingIdle,
         ])
 }
 

--- a/src-tauri/src/pipeline/actor.rs
+++ b/src-tauri/src/pipeline/actor.rs
@@ -14,10 +14,11 @@ use std::time::{Duration, Instant};
 
 use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
 use tauri::Manager;
+use tauri_plugin_notification::NotificationExt;
 use tauri_specta::Event;
 use tracing::{debug, error, info, warn};
 
-use crate::app_events::{PipelineError, PipelineErrorScope};
+use crate::app_events::{MeetingIdle, MeetingIdleReason, PipelineError, PipelineErrorScope};
 use crate::audio::{AudioChunk, AudioMessage};
 use crate::engine::{
     AudioInputRequirements, Speaker, TranscriptionEngine, TranscriptionProfile,
@@ -31,6 +32,7 @@ use crate::platform::with_autorelease_pool;
 
 use super::SegmentCallback;
 use super::health::SessionHealth;
+use super::idle::{MeetingIdleConfig, MeetingIdleMonitor};
 
 /// Creates engines ON the actor thread. Production uses `crate::engine::create_engine`;
 /// tests inject factories that produce mock engines.
@@ -64,6 +66,9 @@ pub struct SessionConfig {
     /// Diarized meeting: run a second engine so the mic (Me) and system audio
     /// (Them) legs are transcribed separately and segments are speaker-tagged.
     pub diarize: bool,
+    /// Meeting-only auto-stop detection (silence + max duration). `None` for
+    /// dictation sessions, where "meeting is over" doesn't apply.
+    pub idle_config: Option<MeetingIdleConfig>,
 }
 
 pub enum EngineCommand {
@@ -557,6 +562,9 @@ impl EngineActor {
         );
 
         let mut health = SessionHealth::start(session_id, Arc::clone(&self.dropped_counter));
+        let idle_monitor = config
+            .idle_config
+            .map(|idle_config| MeetingIdleMonitor::new(idle_config, Instant::now()));
         let engine = self.engine.as_mut().expect("engine present: checked above");
 
         // No Silero VAD in diarized mode: the two lanes must step together
@@ -585,6 +593,7 @@ impl EngineActor {
             self.app.as_ref(),
             mode.as_mut(),
             pending_unload_timeout,
+            idle_monitor,
         )
     }
 
@@ -840,6 +849,7 @@ fn run_session_loop(
     app: Option<&tauri::AppHandle>,
     mode: &mut dyn SessionMode,
     pending_unload_timeout: &mut Option<Option<Duration>>,
+    mut idle_monitor: Option<MeetingIdleMonitor>,
 ) -> SessionEnd {
     let chunk_size = engine.audio_requirements().chunk_size_samples as usize;
     let mut summary = SessionSummary::default();
@@ -862,6 +872,22 @@ fn run_session_loop(
             && let Some(app) = app
         {
             let _ = snapshot.emit(app);
+        }
+
+        // Meeting-only: has the meeting probably ended (silence / max duration)?
+        if let Some(monitor) = idle_monitor.as_mut()
+            && let Some(signal) = monitor.tick(Instant::now())
+            && let Some(app) = app
+        {
+            let _ = MeetingIdle {
+                reason: signal.reason,
+                idle_seconds: signal.idle_seconds,
+                threshold_seconds: signal.threshold_seconds,
+            }
+            .emit(app);
+            if signal.first {
+                notify_meeting_idle(app, signal.reason);
+            }
         }
 
         if last_heartbeat.elapsed() >= HEARTBEAT {
@@ -1006,7 +1032,11 @@ fn run_session_loop(
                                     debug!("Segment: {:?} final={}", seg.text, seg.is_final);
                                 }
                                 segments_emitted += 1;
-                                emit_filtered(engine, text_filters, seg, on_segment);
+                                if emit_filtered(engine, text_filters, seg, on_segment)
+                                    && let Some(monitor) = idle_monitor.as_mut()
+                                {
+                                    monitor.note_segment(Instant::now());
+                                }
                             }
                         }
                         Err(e) => {
@@ -1142,19 +1172,59 @@ fn catch_engine<T, E: std::string::ToString>(
     }
 }
 
-/// Normalize engine-specific tokens, then apply text filter chain before emitting.
+/// Normalize engine-specific tokens, then apply text filter chain before
+/// emitting. Returns whether the filtered text was non-empty (i.e. an actual
+/// segment reached `on_segment`), which the meeting idle monitor uses as its
+/// speech-activity signal.
 fn emit_filtered(
     engine: &dyn TranscriptionEngine,
     text_filters: &TextFilterChain,
     mut segment: TranscriptionSegment,
     on_segment: &SegmentCallback,
-) {
+) -> bool {
     // Step 1: engine-specific normalization (strip [_TT_], ▁, etc.)
     segment.text = engine.normalize_text(&segment.text);
     // Step 2: shared text filter chain (filler, stutter, dictionary, whitespace)
     segment.text = text_filters.apply(&segment.text);
-    if !segment.text.is_empty() {
-        on_segment(segment);
+    if segment.text.is_empty() {
+        return false;
+    }
+    on_segment(segment);
+    true
+}
+
+/// System notification for the first crossing of an idle signal only;
+/// re-signals (throttled webview convergence) must not spam the OS.
+/// Informational only: no action buttons, matching the calendar reminder's
+/// notification (action buttons/click callbacks are unreliable on macOS).
+fn notify_meeting_idle(app: &tauri::AppHandle, reason: MeetingIdleReason) {
+    let db = &app.state::<crate::state::AppState>().db;
+    let locale = crate::settings::AppSettings::load(db)
+        .map(|settings| settings.locale)
+        .unwrap_or_default();
+    let french = locale.starts_with("fr");
+
+    let (title, body) = match reason {
+        MeetingIdleReason::Silence => (
+            if french { "Réunion probablement terminée" } else { "Meeting seems to be over" },
+            if french {
+                "Aucune parole détectée depuis un moment. L'enregistrement va bientôt s'arrêter."
+            } else {
+                "No speech detected for a while. Recording will stop soon."
+            },
+        ),
+        MeetingIdleReason::MaxDuration => (
+            if french { "Durée maximale atteinte" } else { "Maximum duration reached" },
+            if french {
+                "L'enregistrement de la réunion a atteint la durée maximale et va s'arrêter."
+            } else {
+                "The meeting recording hit its maximum duration and is stopping."
+            },
+        ),
+    };
+
+    if let Err(e) = app.notification().builder().title(title).body(body).show() {
+        warn!("Meeting idle notification failed: {e}");
     }
 }
 
@@ -1192,6 +1262,7 @@ mod tests {
             dictionary_entries: vec![],
             session_terms: vec![],
             diarize: false,
+            idle_config: None,
         }
     }
 
@@ -1286,6 +1357,7 @@ mod tests {
             dictionary_entries: vec![],
             session_terms: vec![],
             diarize: true,
+            idle_config: None,
         };
         actor.start_session(1, cfg, cb).expect("start diarized");
 
@@ -1636,5 +1708,73 @@ mod tests {
             0,
             "a disabled (0 minute) timeout must never unload the model"
         );
+    }
+
+    // Idle-monitor wiring: the monitor's own behavior (signal cadence, re-arm,
+    // max duration) is covered exhaustively in `pipeline::idle`'s unit tests,
+    // which run on bare `Instant`s with no thread involved. These tests only
+    // verify the actor accepts `idle_config` and runs a session to completion
+    // without panicking. There is no `AppHandle` in these tests (`AttachApp`
+    // is never sent), so the event-emission path can't be observed here.
+    #[test]
+    fn session_with_idle_config_runs_to_completion() {
+        let mock = MockEngine::new().with_transcribe_response(Ok(vec![seg("hello")]), 3);
+        let (actor, audio_tx) = spawn_with_mock(mock);
+
+        let cfg = SessionConfig {
+            idle_config: Some(super::MeetingIdleConfig {
+                silence_threshold: Some(Duration::from_millis(50)),
+                max_duration: None,
+            }),
+            ..session_config()
+        };
+        let (collected, cb) = collecting_callback();
+        actor.start_session(1, cfg, cb).expect("start with idle config");
+
+        // Give the actor loop a few ticks past the silence threshold with no
+        // segments arriving, then confirm it is still alive and stops cleanly.
+        std::thread::sleep(Duration::from_millis(120));
+        for _ in 0..3 {
+            audio_tx.send(audio_chunk(1)).unwrap();
+        }
+        audio_tx.send(end_of_stream(1)).unwrap();
+
+        actor
+            .stop_session(Duration::from_secs(2))
+            .expect("stop session with idle config");
+        assert!(
+            collected.lock().unwrap().iter().any(|s| s.text == "hello"),
+            "session should keep transcribing normally alongside idle tracking"
+        );
+    }
+
+    #[test]
+    fn session_with_idle_config_and_active_speech_never_stalls() {
+        // A tiny max_duration alongside a segment stream: the actor must keep
+        // draining audio and stop normally even once max-duration has crossed.
+        let mock = MockEngine::new().with_transcribe_response(Ok(vec![seg("hi")]), 5);
+        let (actor, audio_tx) = spawn_with_mock(mock);
+
+        let cfg = SessionConfig {
+            idle_config: Some(super::MeetingIdleConfig {
+                silence_threshold: None,
+                max_duration: Some(Duration::from_millis(10)),
+            }),
+            ..session_config()
+        };
+        let (collected, cb) = collecting_callback();
+        actor.start_session(1, cfg, cb).expect("start with idle config");
+
+        std::thread::sleep(Duration::from_millis(50));
+        for _ in 0..5 {
+            audio_tx.send(audio_chunk(1)).unwrap();
+        }
+        audio_tx.send(end_of_stream(1)).unwrap();
+
+        let summary = actor
+            .stop_session(Duration::from_secs(2))
+            .expect("stop session with max-duration idle config");
+        assert_eq!(summary.frames_processed, 5);
+        assert!(collected.lock().unwrap().iter().any(|s| s.text == "hi"));
     }
 }

--- a/src-tauri/src/pipeline/idle.rs
+++ b/src-tauri/src/pipeline/idle.rs
@@ -1,0 +1,258 @@
+//! Detects a meeting that has probably ended: either no speech for a
+//! configured silence threshold, or a hard max-duration failsafe.
+//!
+//! Pure and unit-testable: all time math runs on `Instant`s passed in by the
+//! caller, so tests never sleep for real.
+
+use std::time::{Duration, Instant};
+
+use crate::app_events::MeetingIdleReason;
+
+/// How often a persisting silence (or max-duration) condition re-signals, so
+/// a throttled/backgrounded webview still converges on the current state
+/// instead of missing the one-shot signal.
+const SILENCE_RESIGNAL_INTERVAL: Duration = Duration::from_secs(30);
+const MAX_DURATION_RESIGNAL_INTERVAL: Duration = Duration::from_secs(60);
+
+/// Session-start snapshot of the auto-stop settings. `None` on either field
+/// disables that signal; a dictation session passes `None` for the whole
+/// monitor since idle detection only makes sense for meetings.
+#[derive(Debug, Clone, Copy)]
+pub struct MeetingIdleConfig {
+    pub silence_threshold: Option<Duration>,
+    pub max_duration: Option<Duration>,
+}
+
+/// A detected idle condition, ready to be turned into an app event / OS
+/// notification by the caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MeetingIdleSignal {
+    pub reason: MeetingIdleReason,
+    pub idle_seconds: u64,
+    pub threshold_seconds: u64,
+    /// True only on the first signal for this idle episode: the caller should
+    /// send an OS notification on `first == true` and skip it on re-signals.
+    pub first: bool,
+}
+
+/// Tracks silence and total-duration to detect a meeting that is probably
+/// over. Lives on the actor thread alongside `SessionHealth`; call
+/// `note_segment` for every emitted segment with non-empty text and `tick`
+/// on the same cadence as the health snapshot.
+pub struct MeetingIdleMonitor {
+    config: MeetingIdleConfig,
+    started_at: Instant,
+    last_activity: Instant,
+    /// `Some` once silence has crossed the threshold for the current episode;
+    /// cleared by `note_segment`. Tracks when the silence signal was last
+    /// emitted, for the re-signal cadence.
+    silence_signaled_at: Option<Instant>,
+    /// Same idea for max-duration, which only ever fires once per session
+    /// (there's no "re-arm": duration only grows).
+    max_duration_signaled_at: Option<Instant>,
+}
+
+impl MeetingIdleMonitor {
+    pub fn new(config: MeetingIdleConfig, started_at: Instant) -> Self {
+        Self {
+            config,
+            started_at,
+            last_activity: started_at,
+            silence_signaled_at: None,
+            max_duration_signaled_at: None,
+        }
+    }
+
+    /// Record a segment with non-empty text: resets the silence clock and
+    /// re-arms silence notifications for the next episode of silence.
+    pub fn note_segment(&mut self, now: Instant) {
+        self.last_activity = now;
+        self.silence_signaled_at = None;
+    }
+
+    /// Check both conditions against `now`. Max-duration takes priority when
+    /// both would fire in the same tick, since it stops immediately, but in
+    /// practice a max-duration session will have long since been silent-idle
+    /// too: the caller only needs one signal per tick.
+    pub fn tick(&mut self, now: Instant) -> Option<MeetingIdleSignal> {
+        if let Some(signal) = self.check_max_duration(now) {
+            return Some(signal);
+        }
+        self.check_silence(now)
+    }
+
+    fn check_max_duration(&mut self, now: Instant) -> Option<MeetingIdleSignal> {
+        let max_duration = self.config.max_duration?;
+        let elapsed = now.saturating_duration_since(self.started_at);
+        if elapsed < max_duration {
+            return None;
+        }
+
+        let first = self.max_duration_signaled_at.is_none();
+        let due = match self.max_duration_signaled_at {
+            None => true,
+            Some(last) => now.saturating_duration_since(last) >= MAX_DURATION_RESIGNAL_INTERVAL,
+        };
+        if !due {
+            return None;
+        }
+        self.max_duration_signaled_at = Some(now);
+
+        Some(MeetingIdleSignal {
+            reason: MeetingIdleReason::MaxDuration,
+            idle_seconds: elapsed.as_secs(),
+            threshold_seconds: max_duration.as_secs(),
+            first,
+        })
+    }
+
+    fn check_silence(&mut self, now: Instant) -> Option<MeetingIdleSignal> {
+        let threshold = self.config.silence_threshold?;
+        let idle = now.saturating_duration_since(self.last_activity);
+        if idle < threshold {
+            return None;
+        }
+
+        let first = self.silence_signaled_at.is_none();
+        let due = match self.silence_signaled_at {
+            None => true,
+            Some(last) => now.saturating_duration_since(last) >= SILENCE_RESIGNAL_INTERVAL,
+        };
+        if !due {
+            return None;
+        }
+        self.silence_signaled_at = Some(now);
+
+        Some(MeetingIdleSignal {
+            reason: MeetingIdleReason::Silence,
+            idle_seconds: idle.as_secs(),
+            threshold_seconds: threshold.as_secs(),
+            first,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn monitor(silence: Option<Duration>, max_duration: Option<Duration>) -> (MeetingIdleMonitor, Instant) {
+        let start = Instant::now();
+        let config = MeetingIdleConfig {
+            silence_threshold: silence,
+            max_duration,
+        };
+        (MeetingIdleMonitor::new(config, start), start)
+    }
+
+    #[test]
+    fn no_signal_before_threshold() {
+        let (mut m, start) = monitor(Some(Duration::from_secs(60)), None);
+        assert_eq!(m.tick(start + Duration::from_secs(30)), None);
+    }
+
+    #[test]
+    fn first_silence_crossing_signals_with_first_true() {
+        let (mut m, start) = monitor(Some(Duration::from_secs(60)), None);
+        let now = start + Duration::from_secs(61);
+        let signal = m.tick(now).expect("should signal");
+        assert_eq!(signal.reason, MeetingIdleReason::Silence);
+        assert_eq!(signal.idle_seconds, 61);
+        assert_eq!(signal.threshold_seconds, 60);
+        assert!(signal.first);
+    }
+
+    #[test]
+    fn resignals_every_30s_while_silence_persists() {
+        let (mut m, start) = monitor(Some(Duration::from_secs(60)), None);
+        let first_signal_at = start + Duration::from_secs(61);
+        let first = m.tick(first_signal_at).expect("first signal");
+        assert!(first.first);
+
+        // Too soon: no re-signal yet.
+        assert_eq!(m.tick(first_signal_at + Duration::from_secs(10)), None);
+
+        // 30s after the first signal: re-signals, but first == false.
+        let second = m
+            .tick(first_signal_at + Duration::from_secs(30))
+            .expect("resignal at 30s");
+        assert!(!second.first);
+        assert_eq!(second.reason, MeetingIdleReason::Silence);
+
+        // Another 30s later: signals again.
+        assert!(
+            m.tick(first_signal_at + Duration::from_secs(60))
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn segment_rearms_silence_detection() {
+        let (mut m, start) = monitor(Some(Duration::from_secs(60)), None);
+        let now = start + Duration::from_secs(61);
+        assert!(m.tick(now).is_some());
+
+        // Activity resumes: silence clock resets and re-arms.
+        m.note_segment(now + Duration::from_secs(1));
+
+        // Not enough new silence yet.
+        assert_eq!(m.tick(now + Duration::from_secs(30)), None);
+
+        // Crosses threshold again from the new baseline; first == true again.
+        let signal = m
+            .tick(now + Duration::from_secs(1) + Duration::from_secs(61))
+            .expect("should re-signal after new silence");
+        assert!(signal.first);
+    }
+
+    #[test]
+    fn max_duration_crossing_signals() {
+        let (mut m, start) = monitor(None, Some(Duration::from_secs(3600)));
+        assert_eq!(m.tick(start + Duration::from_secs(3599)), None);
+
+        let signal = m
+            .tick(start + Duration::from_secs(3601))
+            .expect("should signal max duration");
+        assert_eq!(signal.reason, MeetingIdleReason::MaxDuration);
+        assert_eq!(signal.idle_seconds, 3601);
+        assert_eq!(signal.threshold_seconds, 3600);
+        assert!(signal.first);
+    }
+
+    #[test]
+    fn max_duration_resignals_every_60s() {
+        let (mut m, start) = monitor(None, Some(Duration::from_secs(3600)));
+        let first_at = start + Duration::from_secs(3601);
+        let first = m.tick(first_at).expect("first signal");
+        assert!(first.first);
+
+        assert_eq!(m.tick(first_at + Duration::from_secs(30)), None);
+
+        let second = m
+            .tick(first_at + Duration::from_secs(60))
+            .expect("resignal at 60s");
+        assert!(!second.first);
+    }
+
+    #[test]
+    fn both_disabled_never_signals() {
+        let (mut m, start) = monitor(None, None);
+        assert_eq!(m.tick(start + Duration::from_secs(999_999)), None);
+    }
+
+    #[test]
+    fn max_duration_takes_priority_over_silence_in_same_tick() {
+        let (mut m, start) = monitor(Some(Duration::from_secs(60)), Some(Duration::from_secs(120)));
+        let now = start + Duration::from_secs(121);
+        let signal = m.tick(now).expect("should signal");
+        assert_eq!(signal.reason, MeetingIdleReason::MaxDuration);
+    }
+
+    #[test]
+    fn note_segment_before_any_silence_is_a_noop_for_threshold_math() {
+        let (mut m, start) = monitor(Some(Duration::from_secs(60)), None);
+        m.note_segment(start + Duration::from_secs(10));
+        assert_eq!(m.tick(start + Duration::from_secs(40)), None);
+        assert!(m.tick(start + Duration::from_secs(71)).is_some());
+    }
+}

--- a/src-tauri/src/pipeline/mod.rs
+++ b/src-tauri/src/pipeline/mod.rs
@@ -2,10 +2,12 @@
 
 mod actor;
 mod health;
+mod idle;
 
 pub use actor::{
     EngineActorHandle, EngineCommand, EngineFactory, EngineInfo, SessionConfig, SessionSummary,
 };
+pub use idle::MeetingIdleConfig;
 
 use crate::engine::TranscriptionSegment;
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -26,6 +26,9 @@ const CALENDAR_INTEGRATION_ENABLED_KEY: &str = "calendar_integration_enabled";
 const CALENDAR_SELECTED_IDS_KEY: &str = "calendar_selected_ids";
 const CALENDAR_REMINDER_MINUTES_KEY: &str = "calendar_reminder_minutes";
 const MODEL_UNLOAD_TIMEOUT_MINUTES_KEY: &str = "model_unload_timeout_minutes";
+const MEETING_AUTOSTOP_ENABLED_KEY: &str = "meeting_autostop_enabled";
+const MEETING_AUTOSTOP_MINUTES_KEY: &str = "meeting_autostop_minutes";
+const MEETING_MAX_DURATION_MINUTES_KEY: &str = "meeting_max_duration_minutes";
 const LOCALE_KEY: &str = "locale";
 const SHORTCUT_TOGGLE_KEY: &str = "shortcut_toggle";
 const SHORTCUT_PUSH_TO_TALK_KEY: &str = "shortcut_push_to_talk";
@@ -70,11 +73,23 @@ pub struct AppSettings {
     /// reclaim RAM; 0 means never unload. The next recording reloads it
     /// through the normal load flow.
     pub model_unload_timeout_minutes: u32,
+    /// Detect a meeting that has probably ended (no speech for a while, or
+    /// the max-duration failsafe) and offer/auto-stop. A session snapshots
+    /// these settings at start; changes apply from the next meeting.
+    pub meeting_autostop_enabled: bool,
+    /// Silence duration (minutes) before the meeting is considered idle.
+    pub meeting_autostop_minutes: u32,
+    /// Hard failsafe: stop the meeting after this many minutes regardless of
+    /// speech activity.
+    pub meeting_max_duration_minutes: u32,
 }
 
 /// Allowed values for `model_unload_timeout_minutes`: 0 (never) plus the
 /// options offered in the settings UI.
 const ALLOWED_UNLOAD_TIMEOUT_MINUTES: [u32; 4] = [0, 5, 15, 60];
+
+const MEETING_AUTOSTOP_MINUTES_RANGE: std::ops::RangeInclusive<u32> = 3..=60;
+const MEETING_MAX_DURATION_MINUTES_RANGE: std::ops::RangeInclusive<u32> = 60..=720;
 
 impl Default for AppSettings {
     fn default() -> Self {
@@ -99,6 +114,9 @@ impl Default for AppSettings {
             calendar_selected_ids: Vec::new(),
             calendar_reminder_minutes: 2,
             model_unload_timeout_minutes: 0,
+            meeting_autostop_enabled: true,
+            meeting_autostop_minutes: 10,
+            meeting_max_duration_minutes: 240,
         }
     }
 }
@@ -202,6 +220,21 @@ impl AppSettings {
         {
             settings.model_unload_timeout_minutes = model_unload_timeout_minutes;
         }
+        if let Some(meeting_autostop_enabled) =
+            read_json_setting::<bool>(db, MEETING_AUTOSTOP_ENABLED_KEY)?
+        {
+            settings.meeting_autostop_enabled = meeting_autostop_enabled;
+        }
+        if let Some(meeting_autostop_minutes) =
+            read_json_setting::<u32>(db, MEETING_AUTOSTOP_MINUTES_KEY)?
+        {
+            settings.meeting_autostop_minutes = meeting_autostop_minutes;
+        }
+        if let Some(meeting_max_duration_minutes) =
+            read_json_setting::<u32>(db, MEETING_MAX_DURATION_MINUTES_KEY)?
+        {
+            settings.meeting_max_duration_minutes = meeting_max_duration_minutes;
+        }
 
         Ok(settings.sanitized())
     }
@@ -295,6 +328,13 @@ impl AppSettings {
             normalized.model_unload_timeout_minutes = Self::default().model_unload_timeout_minutes;
         }
 
+        if !MEETING_AUTOSTOP_MINUTES_RANGE.contains(&normalized.meeting_autostop_minutes) {
+            normalized.meeting_autostop_minutes = Self::default().meeting_autostop_minutes;
+        }
+        if !MEETING_MAX_DURATION_MINUTES_RANGE.contains(&normalized.meeting_max_duration_minutes) {
+            normalized.meeting_max_duration_minutes = Self::default().meeting_max_duration_minutes;
+        }
+
         normalized
     }
 
@@ -355,6 +395,21 @@ impl AppSettings {
             db,
             MODEL_UNLOAD_TIMEOUT_MINUTES_KEY,
             &normalized.model_unload_timeout_minutes,
+        )?;
+        write_json_setting(
+            db,
+            MEETING_AUTOSTOP_ENABLED_KEY,
+            &normalized.meeting_autostop_enabled,
+        )?;
+        write_json_setting(
+            db,
+            MEETING_AUTOSTOP_MINUTES_KEY,
+            &normalized.meeting_autostop_minutes,
+        )?;
+        write_json_setting(
+            db,
+            MEETING_MAX_DURATION_MINUTES_KEY,
+            &normalized.meeting_max_duration_minutes,
         )?;
 
         if let Some(audio_device) = normalized.audio_device.as_ref() {
@@ -481,6 +536,9 @@ mod tests {
             calendar_selected_ids: vec!["cal-1".into(), "cal-2".into()],
             calendar_reminder_minutes: 5,
             model_unload_timeout_minutes: 15,
+            meeting_autostop_enabled: false,
+            meeting_autostop_minutes: 15,
+            meeting_max_duration_minutes: 120,
         };
 
         settings.save(&db).expect("save settings");
@@ -612,6 +670,57 @@ mod tests {
             let clean = s.sanitize_for_save().unwrap();
             assert_eq!(clean.model_unload_timeout_minutes, minutes);
         }
+    }
+
+    #[test]
+    fn meeting_autostop_minutes_out_of_range_falls_back_to_default() {
+        let (db, _dir) = test_db();
+        db.set_setting("meeting_autostop_minutes", "2")
+            .expect("save minutes");
+        let settings = AppSettings::load(&db).expect("load settings");
+        assert_eq!(settings.meeting_autostop_minutes, 10);
+
+        db.set_setting("meeting_autostop_minutes", "61")
+            .expect("save minutes");
+        let settings = AppSettings::load(&db).expect("load settings");
+        assert_eq!(settings.meeting_autostop_minutes, 10);
+
+        for minutes in [3, 30, 60] {
+            let s = AppSettings {
+                meeting_autostop_minutes: minutes,
+                ..AppSettings::default()
+            };
+            let clean = s.sanitize_for_save().unwrap();
+            assert_eq!(clean.meeting_autostop_minutes, minutes);
+        }
+    }
+
+    #[test]
+    fn meeting_max_duration_minutes_out_of_range_falls_back_to_default() {
+        let (db, _dir) = test_db();
+        db.set_setting("meeting_max_duration_minutes", "59")
+            .expect("save minutes");
+        let settings = AppSettings::load(&db).expect("load settings");
+        assert_eq!(settings.meeting_max_duration_minutes, 240);
+
+        db.set_setting("meeting_max_duration_minutes", "721")
+            .expect("save minutes");
+        let settings = AppSettings::load(&db).expect("load settings");
+        assert_eq!(settings.meeting_max_duration_minutes, 240);
+
+        for minutes in [60, 240, 480, 720] {
+            let s = AppSettings {
+                meeting_max_duration_minutes: minutes,
+                ..AppSettings::default()
+            };
+            let clean = s.sanitize_for_save().unwrap();
+            assert_eq!(clean.meeting_max_duration_minutes, minutes);
+        }
+    }
+
+    #[test]
+    fn meeting_autostop_enabled_defaults_true() {
+        assert!(AppSettings::default().meeting_autostop_enabled);
     }
 
     #[test]

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -15,6 +15,7 @@
   import {
     notifyMeetingAborted,
     notifyMeetingFinalized,
+    notifyMeetingIdle,
     notifyMeetingStopRequested,
   } from "./lib/features/meeting/controller.svelte";
   import {
@@ -38,6 +39,7 @@
   let unlistenMeetingStop: (() => void) | null = null;
   let unlistenMeetingFinalized: (() => void) | null = null;
   let unlistenUpcomingMeeting: (() => void) | null = null;
+  let unlistenMeetingIdle: (() => void) | null = null;
 
   const healthDegraded = $derived(
     app.transcriptionHealth !== null && app.transcriptionHealth.status !== "healthy",
@@ -176,6 +178,12 @@
       unlistenUpcomingMeeting = fn;
     });
 
+    events.meetingIdle.listen((event) => {
+      notifyMeetingIdle(event.payload);
+    }).then((fn) => {
+      unlistenMeetingIdle = fn;
+    });
+
     return () => {
       cleanupTranscription();
       unlistenNav?.();
@@ -186,6 +194,7 @@
       unlistenMeetingStop?.();
       unlistenMeetingFinalized?.();
       unlistenUpcomingMeeting?.();
+      unlistenMeetingIdle?.();
     };
   });
 </script>

--- a/src/lib/api/settings.test.ts
+++ b/src/lib/api/settings.test.ts
@@ -38,7 +38,7 @@ describe('settings API', () => {
 
   it('saveSettings passes settings object', async () => {
     mockInvoke.mockResolvedValue(null);
-    const settings = { theme: 'light' as const, locale: '', auto_paste: true, paste_delay_ms: 200, ollama_url: 'http://localhost:11434', ollama_model: 'llama3', debug_transcription: false, audio_device: null, transcription_engine_id: 'kyutai', transcription_model_id: 'stt-1b', transcription_backend_id: 'candle', vad_enabled: true, filler_removal: true, stutter_collapse: false, dictionary_correction: true, capture_system_audio: true, calendar_integration_enabled: false, calendar_selected_ids: [], calendar_reminder_minutes: 2, model_unload_timeout_minutes: 0 };
+    const settings = { theme: 'light' as const, locale: '', auto_paste: true, paste_delay_ms: 200, ollama_url: 'http://localhost:11434', ollama_model: 'llama3', debug_transcription: false, audio_device: null, transcription_engine_id: 'kyutai', transcription_model_id: 'stt-1b', transcription_backend_id: 'candle', vad_enabled: true, filler_removal: true, stutter_collapse: false, dictionary_correction: true, capture_system_audio: true, calendar_integration_enabled: false, calendar_selected_ids: [], calendar_reminder_minutes: 2, model_unload_timeout_minutes: 0, meeting_autostop_enabled: true, meeting_autostop_minutes: 10, meeting_max_duration_minutes: 240 };
 
     await saveSettings(settings);
 

--- a/src/lib/components/SettingsView.svelte
+++ b/src/lib/components/SettingsView.svelte
@@ -111,6 +111,9 @@
       fillerRemoval={controller.app.settings.filler_removal}
       stutterCollapse={controller.app.settings.stutter_collapse}
       dictionaryCorrection={controller.app.settings.dictionary_correction}
+      meetingAutostopEnabled={controller.app.settings.meeting_autostop_enabled}
+      meetingAutostopMinutes={controller.app.settings.meeting_autostop_minutes}
+      meetingMaxDurationMinutes={controller.app.settings.meeting_max_duration_minutes}
       onDeviceChange={controller.onDeviceChange}
       onRefreshDevices={controller.refreshDevices}
       onCaptureSystemAudioChange={controller.onCaptureSystemAudioChange}
@@ -118,6 +121,9 @@
       onFillerRemovalChange={controller.onFillerRemovalChange}
       onStutterCollapseChange={controller.onStutterCollapseChange}
       onDictionaryCorrectionChange={controller.onDictionaryCorrectionChange}
+      onMeetingAutostopEnabledChange={controller.onMeetingAutostopEnabledChange}
+      onMeetingAutostopMinutesChange={controller.onMeetingAutostopMinutesChange}
+      onMeetingMaxDurationMinutesChange={controller.onMeetingMaxDurationMinutesChange}
     />
 
     <IntelligenceSettingsSection

--- a/src/lib/features/home/LiveSessionCard.svelte
+++ b/src/lib/features/home/LiveSessionCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ClipboardCheck, Square } from "@lucide/svelte";
+  import { AlarmClockOff, ClipboardCheck, Square } from "@lucide/svelte";
   import { onDestroy, onMount } from "svelte";
   import { t } from "svelte-i18n";
   import Waveform from "../../components/Waveform.svelte";
@@ -56,6 +56,10 @@
   );
 
   const systemAudioActive = $derived(Boolean(meeting.app.systemAudioStatus?.active));
+
+  const idleSilenceMinutes = $derived(
+    meeting.idleSignal ? Math.max(1, Math.round(meeting.idleSignal.idle_seconds / 60)) : 0,
+  );
 
   function stop() {
     if (stopping) return;
@@ -152,6 +156,21 @@
       {/if}
     </div>
   {:else}
+    {#if mode === "meeting" && meeting.idleSignal}
+      <div class="flex items-center gap-3 rounded-default bg-warning/10 px-4 py-3 outline-1 outline-warning/30">
+        <AlarmClockOff size={16} class="shrink-0 text-warning" aria-hidden="true" />
+        <p class="m-0 min-w-0 flex-1 text-sm text-warning">
+          {$t("home.idle_silence_banner", { values: { minutes: idleSilenceMinutes } })}
+        </p>
+        <button onclick={stop} class="btn btn-danger btn-sm shrink-0" disabled={stopping}>
+          {$t("home.idle_stop_now")}
+        </button>
+        <button onclick={() => meeting.dismissIdle()} class="btn btn-sm shrink-0">
+          {$t("home.idle_keep_recording")}
+        </button>
+      </div>
+    {/if}
+
     <!-- Meeting hero: live transcript front and center. -->
     <div class="flex min-h-[300px] flex-col gap-[18px] rounded-[18px] bg-surface-1 px-6 py-[22px] outline-1 outline-ghost-border">
       <div class="flex items-center justify-between">

--- a/src/lib/features/meeting/controller.svelte.test.ts
+++ b/src/lib/features/meeting/controller.svelte.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type {
   MeetingCalendarContext,
+  MeetingIdle,
   MeetingTranscript,
   OllamaStatus,
   SummarizeProgress,
@@ -110,7 +111,9 @@ vi.mock("../transcription/catalog", () => ({
   }),
 }));
 
-const { createMeetingController, resetMeetingControllerForTest } = await import("./controller.svelte");
+const { createMeetingController, resetMeetingControllerForTest, notifyMeetingIdle } = await import(
+  "./controller.svelte"
+);
 
 // ── Fixtures ─────────────────────────────────────────────────────────
 
@@ -427,5 +430,132 @@ describe("MeetingController", () => {
     mockApp.settings.ollama_model = "llama3";
     await ctrl.checkOllama();
     expect(ctrl.selectedModel).toBe("llama3");
+  });
+
+  describe("notifyMeetingIdle", () => {
+    function setRecordingMeeting() {
+      mockApp.machineState = {
+        state: "recording_meeting",
+        data: {
+          profile: makeMeeting().transcription_profile,
+          session_id: 1,
+          meeting_id: "live-1",
+        },
+      } as import("../../types").AppStateMachine;
+    }
+
+    function idle(overrides: Partial<MeetingIdle> = {}): MeetingIdle {
+      return { reason: "silence", idle_seconds: 60, threshold_seconds: 600, ...overrides };
+    }
+
+    async function mountedController() {
+      mockGetOllamaStatus.mockResolvedValue(makeOllamaStatus());
+      mockGetTranscriptionCatalog.mockResolvedValue(makeCatalog());
+      const ctrl = createMeetingController();
+      await ctrl.mount();
+      return ctrl;
+    }
+
+    it("is ignored entirely when not recording a meeting", async () => {
+      const ctrl = await mountedController();
+      notifyMeetingIdle(idle());
+      expect(ctrl.idleSignal).toBeNull();
+      expect(mockStopMeetingRecording).not.toHaveBeenCalled();
+    });
+
+    it("max_duration sets a status message and stops immediately", async () => {
+      mockStopMeetingRecording.mockResolvedValue("meet-1");
+      mockGetMeeting.mockResolvedValue(makeMeeting());
+      const ctrl = await mountedController();
+      setRecordingMeeting();
+
+      notifyMeetingIdle(idle({ reason: "max_duration", idle_seconds: 14400, threshold_seconds: 14400 }));
+      await vi.waitFor(() => expect(mockStopMeetingRecording).toHaveBeenCalledOnce());
+
+      expect(ctrl.statusMessage).toMatch(/maximum meeting duration/i);
+    });
+
+    it("max_duration does not double-stop while already stopping", async () => {
+      mockStopMeetingRecording.mockImplementation(() => new Promise(() => {})); // never resolves
+      const ctrl = await mountedController();
+      setRecordingMeeting();
+
+      notifyMeetingIdle(idle({ reason: "max_duration" }));
+      notifyMeetingIdle(idle({ reason: "max_duration" }));
+      await Promise.resolve();
+
+      expect(mockStopMeetingRecording).toHaveBeenCalledOnce();
+    });
+
+    it("silence sets idleSignal without stopping before the grace period", async () => {
+      const ctrl = await mountedController();
+      setRecordingMeeting();
+
+      notifyMeetingIdle(idle({ reason: "silence", idle_seconds: 601, threshold_seconds: 600 }));
+
+      expect(ctrl.idleSignal).toEqual(idle({ reason: "silence", idle_seconds: 601, threshold_seconds: 600 }));
+      expect(mockStopMeetingRecording).not.toHaveBeenCalled();
+    });
+
+    it("silence auto-stops once idle_seconds reaches threshold + 120s grace", async () => {
+      mockStopMeetingRecording.mockResolvedValue("meet-1");
+      mockGetMeeting.mockResolvedValue(makeMeeting());
+      const ctrl = await mountedController();
+      setRecordingMeeting();
+
+      // Still under the grace window: banner shows, no stop yet.
+      notifyMeetingIdle(idle({ reason: "silence", idle_seconds: 719, threshold_seconds: 600 }));
+      expect(mockStopMeetingRecording).not.toHaveBeenCalled();
+      expect(ctrl.idleSignal).not.toBeNull();
+
+      // Crosses threshold + 120s: auto-stop fires.
+      notifyMeetingIdle(idle({ reason: "silence", idle_seconds: 720, threshold_seconds: 600 }));
+      await vi.waitFor(() => expect(mockStopMeetingRecording).toHaveBeenCalledOnce());
+    });
+
+    it("dismissIdle suppresses further silence banners until a segment re-arms it", async () => {
+      const ctrl = await mountedController();
+      setRecordingMeeting();
+
+      notifyMeetingIdle(idle({ reason: "silence", idle_seconds: 601, threshold_seconds: 600 }));
+      expect(ctrl.idleSignal).not.toBeNull();
+
+      ctrl.dismissIdle();
+      expect(ctrl.idleSignal).toBeNull();
+
+      // Still silent: dismissed state suppresses the banner from reappearing.
+      notifyMeetingIdle(idle({ reason: "silence", idle_seconds: 631, threshold_seconds: 600 }));
+      expect(ctrl.idleSignal).toBeNull();
+      expect(mockStopMeetingRecording).not.toHaveBeenCalled();
+    });
+
+    it("a new transcript segment clears idleSignal and re-arms after dismissal", async () => {
+      let onSegmentCallback: ((segment: TranscriptionSegment) => void) | undefined;
+      mockStartMeetingRecording.mockImplementation(async (_title, _calendar, onSegment) => {
+        onSegmentCallback = onSegment;
+      });
+
+      const ctrl = await mountedController();
+      await ctrl.startRecording();
+      setRecordingMeeting();
+
+      notifyMeetingIdle(idle({ reason: "silence", idle_seconds: 601, threshold_seconds: 600 }));
+      expect(ctrl.idleSignal).not.toBeNull();
+      ctrl.dismissIdle();
+
+      // Speech resumes: a final segment with text clears the banner and re-arms.
+      onSegmentCallback?.({
+        text: "we're back",
+        start_time: 0,
+        end_time: 1,
+        is_final: true,
+        language: null,
+        confidence: null,
+        speaker: null,
+      });
+
+      notifyMeetingIdle(idle({ reason: "silence", idle_seconds: 601, threshold_seconds: 600 }));
+      expect(ctrl.idleSignal).not.toBeNull();
+    });
   });
 });

--- a/src/lib/features/meeting/controller.svelte.ts
+++ b/src/lib/features/meeting/controller.svelte.ts
@@ -12,7 +12,7 @@ import {
 import { getOllamaStatus } from "../../api/ollama";
 import { getTranscriptionCatalog } from "../../api/transcription";
 import { getAppState } from "../../stores/app.svelte";
-import type { MeetingCalendarContext, MeetingTranscript, OllamaModelDescriptor, SummarizeProgress, TranscriptionCatalog, TranscriptionSegment } from "../../types";
+import type { MeetingCalendarContext, MeetingIdle, MeetingTranscript, OllamaModelDescriptor, SummarizeProgress, TranscriptionCatalog, TranscriptionSegment } from "../../types";
 import { errorMessage } from "../../utils";
 import { toSelectedTranscriptionProfile } from "../transcription/catalog";
 import { ensureModelLoaded } from "../transcription/runtime";
@@ -21,6 +21,10 @@ import { createLiveTranscript } from "./live-transcript.svelte";
 function defaultMeetingTitle(): string {
   return `Meeting ${new Date().toLocaleDateString()}`;
 }
+
+/** Extra silence tolerated after the banner first appears before auto-stop
+ * kicks in, on top of the configured silence threshold. */
+const SILENCE_AUTOSTOP_GRACE_SECONDS = 120;
 
 function createMeetingControllerInstance() {
   const app = getAppState();
@@ -40,6 +44,12 @@ function createMeetingControllerInstance() {
   let notesDraft = $state("");
   let notesSaveState = $state<"idle" | "pending" | "saved">("idle");
   let notesTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // Meeting-idle ("meeting seems to be over") banner state.
+  let idleSignal = $state<MeetingIdle | null>(null);
+  // True once the user dismissed the current silence episode ("keep
+  // recording"); suppresses further banners until a segment re-arms it.
+  let idleDismissed = $state(false);
 
   let isRecordingMeeting = $derived(
     app.machineState.state === "recording_meeting"
@@ -154,6 +164,13 @@ function createMeetingControllerInstance() {
     }
   }
 
+  /** Speech activity (a new segment) or a fresh recording resets the idle
+   * banner and re-arms it for the next episode of silence. */
+  function clearIdleState() {
+    idleSignal = null;
+    idleDismissed = false;
+  }
+
   async function checkOllama() {
     try {
       const status = await getOllamaStatus();
@@ -190,6 +207,7 @@ function createMeetingControllerInstance() {
       meeting = null;
       notesDraft = "";
       notesSaveState = "idle";
+      clearIdleState();
       const transcriptionProfile = toSelectedTranscriptionProfile(
         transcriptionCatalog,
         app.settings.transcription_engine_id,
@@ -203,6 +221,7 @@ function createMeetingControllerInstance() {
         if (segment.is_final && !segment.text) return;
         liveTranscript.append(segment);
         if (segment.is_final && segment.text) liveMeetingSegments.push(segment);
+        clearIdleState();
       });
 
       meeting = {
@@ -240,11 +259,13 @@ function createMeetingControllerInstance() {
       liveMeetingSegments = [];
       statusMessage = "";
       summaryStream = "";
+      clearIdleState();
 
       await resumeMeetingRecording(meeting.id, (segment) => {
         if (segment.is_final && !segment.text) return;
         liveTranscript.append(segment);
         if (segment.is_final && segment.text) liveMeetingSegments.push(segment);
+        clearIdleState();
       });
     } catch (e) {
       statusMessage = errorMessage(e);
@@ -256,6 +277,7 @@ function createMeetingControllerInstance() {
   async function stopRecording() {
     if (isStopping) return; // guard against double-stop
     stopRequested = true;
+    clearIdleState();
     try {
       // Unsaved notes must reach the accumulator before it is persisted.
       await flushNotes();
@@ -289,6 +311,7 @@ function createMeetingControllerInstance() {
     if (app.currentMeetingId !== id && meeting?.id !== id) return;
     liveTranscript.reset();
     liveMeetingSegments = [];
+    clearIdleState();
     void loadMeeting(id);
   }
 
@@ -299,8 +322,36 @@ function createMeetingControllerInstance() {
     liveMeetingSegments = [];
     meeting = null;
     app.currentMeetingId = null;
+    clearIdleState();
     statusMessage =
       "Recording was interrupted — the meeting recorded so far was saved to history.";
+  }
+
+  /** The backend detected the meeting has probably ended (silence or the
+   * max-duration failsafe). Ignored outside an active meeting recording. */
+  function handleMeetingIdle(payload: MeetingIdle) {
+    if (!isRecordingMeeting) return;
+
+    if (payload.reason === "max_duration") {
+      if (isStopping) return;
+      statusMessage = "Maximum meeting duration reached. Stopping the recording.";
+      void stopRecording();
+      return;
+    }
+
+    // Silence: suppressed once the user chose to keep recording, until
+    // speech resumes and re-arms it.
+    if (idleDismissed) return;
+    idleSignal = payload;
+    if (payload.idle_seconds >= payload.threshold_seconds + SILENCE_AUTOSTOP_GRACE_SECONDS) {
+      void stopRecording();
+    }
+  }
+
+  /** "Keep recording": suppress the banner until speech resumes. */
+  function dismissIdle() {
+    idleDismissed = true;
+    idleSignal = null;
   }
 
   /** Leave the detail view: clear the open meeting and return to the list. */
@@ -432,6 +483,8 @@ function createMeetingControllerInstance() {
     set editedTranscriptDraft(value: string) { editedTranscriptDraft = value; },
     get notesDraft() { return notesDraft; },
     get notesSaveState() { return notesSaveState; },
+    get idleSignal() { return idleSignal; },
+    get idleDismissed() { return idleDismissed; },
     onNotesChange,
     flushNotes,
     mount,
@@ -451,6 +504,8 @@ function createMeetingControllerInstance() {
     resetEditedTranscript,
     handleRecordingAborted,
     handleMeetingFinalized,
+    handleMeetingIdle,
+    dismissIdle,
   };
 }
 
@@ -472,6 +527,12 @@ export function notifyMeetingStopRequested() {
   if (instance?.isRecordingMeeting) {
     void instance.stopRecording();
   }
+}
+
+/** Called from the global MeetingIdle listener when the backend detects the
+ * meeting has probably ended (silence or the max-duration failsafe). */
+export function notifyMeetingIdle(payload: MeetingIdle) {
+  instance?.handleMeetingIdle(payload);
 }
 
 // Singleton: survives view mount/unmount cycles so liveMeetingSegments

--- a/src/lib/features/settings/components/AudioSettingsSection.svelte
+++ b/src/lib/features/settings/components/AudioSettingsSection.svelte
@@ -4,6 +4,21 @@
   import SettingsField from "../../../components/ui/SettingsField.svelte";
   import type { AudioDeviceInfo } from "../../../types";
 
+  const autostopMinutesOptions = [5, 10, 15, 30] as const;
+  const autostopMinutesKeys: Record<(typeof autostopMinutesOptions)[number], string> = {
+    5: "settings_audio.meeting_autostop_5min",
+    10: "settings_audio.meeting_autostop_10min",
+    15: "settings_audio.meeting_autostop_15min",
+    30: "settings_audio.meeting_autostop_30min",
+  };
+
+  const maxDurationMinutesOptions = [120, 240, 480] as const;
+  const maxDurationMinutesKeys: Record<(typeof maxDurationMinutesOptions)[number], string> = {
+    120: "settings_audio.meeting_max_duration_2h",
+    240: "settings_audio.meeting_max_duration_4h",
+    480: "settings_audio.meeting_max_duration_8h",
+  };
+
   let {
     audioDevices,
     selectedDevice,
@@ -13,6 +28,9 @@
     fillerRemoval,
     stutterCollapse,
     dictionaryCorrection,
+    meetingAutostopEnabled,
+    meetingAutostopMinutes,
+    meetingMaxDurationMinutes,
     onDeviceChange,
     onRefreshDevices,
     onCaptureSystemAudioChange,
@@ -20,6 +38,9 @@
     onFillerRemovalChange,
     onStutterCollapseChange,
     onDictionaryCorrectionChange,
+    onMeetingAutostopEnabledChange,
+    onMeetingAutostopMinutesChange,
+    onMeetingMaxDurationMinutesChange,
   }: {
     audioDevices: AudioDeviceInfo[];
     selectedDevice: string;
@@ -29,6 +50,9 @@
     fillerRemoval: boolean;
     stutterCollapse: boolean;
     dictionaryCorrection: boolean;
+    meetingAutostopEnabled: boolean;
+    meetingAutostopMinutes: number;
+    meetingMaxDurationMinutes: number;
     onDeviceChange: (event: Event) => void | Promise<void>;
     onRefreshDevices: () => void | Promise<void>;
     onCaptureSystemAudioChange: (event: Event) => void | Promise<void>;
@@ -36,6 +60,9 @@
     onFillerRemovalChange: (event: Event) => void | Promise<void>;
     onStutterCollapseChange: (event: Event) => void | Promise<void>;
     onDictionaryCorrectionChange: (event: Event) => void | Promise<void>;
+    onMeetingAutostopEnabledChange: (event: Event) => void | Promise<void>;
+    onMeetingAutostopMinutesChange: (event: Event) => void | Promise<void>;
+    onMeetingMaxDurationMinutesChange: (event: Event) => void | Promise<void>;
   } = $props();
 </script>
 
@@ -68,6 +95,53 @@
     >
       {#snippet control()}
         <input type="checkbox" checked={captureSystemAudio} onchange={onCaptureSystemAudioChange} class="switch" aria-label={$t("settings_audio.capture_system_audio")} />
+      {/snippet}
+    </SettingsField>
+  {/if}
+
+  <SettingsField
+    label={$t("settings_audio.meeting_autostop")}
+    description={$t("settings_audio.meeting_autostop_desc")}
+  >
+    {#snippet control()}
+      <input type="checkbox" checked={meetingAutostopEnabled} onchange={onMeetingAutostopEnabledChange} class="switch" aria-label={$t("settings_audio.meeting_autostop")} />
+    {/snippet}
+  </SettingsField>
+
+  {#if meetingAutostopEnabled}
+    <SettingsField
+      label={$t("settings_audio.meeting_autostop_minutes_label")}
+      htmlFor="meeting-autostop-minutes"
+    >
+      {#snippet control()}
+        <select
+          id="meeting-autostop-minutes"
+          value={meetingAutostopMinutes}
+          onchange={onMeetingAutostopMinutesChange}
+          class="field-select max-w-48"
+        >
+          {#each autostopMinutesOptions as minutes}
+            <option value={minutes}>{$t(autostopMinutesKeys[minutes])}</option>
+          {/each}
+        </select>
+      {/snippet}
+    </SettingsField>
+
+    <SettingsField
+      label={$t("settings_audio.meeting_max_duration_label")}
+      htmlFor="meeting-max-duration-minutes"
+    >
+      {#snippet control()}
+        <select
+          id="meeting-max-duration-minutes"
+          value={meetingMaxDurationMinutes}
+          onchange={onMeetingMaxDurationMinutesChange}
+          class="field-select max-w-48"
+        >
+          {#each maxDurationMinutesOptions as minutes}
+            <option value={minutes}>{$t(maxDurationMinutesKeys[minutes])}</option>
+          {/each}
+        </select>
       {/snippet}
     </SettingsField>
   {/if}

--- a/src/lib/features/settings/controller.svelte.test.ts
+++ b/src/lib/features/settings/controller.svelte.test.ts
@@ -66,6 +66,9 @@ const defaultSettings: AppSettings = {
   calendar_selected_ids: [],
   calendar_reminder_minutes: 2,
   model_unload_timeout_minutes: 0,
+  meeting_autostop_enabled: true,
+  meeting_autostop_minutes: 10,
+  meeting_max_duration_minutes: 240,
 }
 
 const fakeDevices: AudioDeviceInfo[] = [

--- a/src/lib/features/settings/controller.svelte.ts
+++ b/src/lib/features/settings/controller.svelte.ts
@@ -384,6 +384,29 @@ export function createSettingsController() {
     });
   }
 
+  function onMeetingAutostopEnabledChange(event: Event) {
+    const checked = (event.target as HTMLInputElement).checked;
+    void persistSettings((settings) => {
+      settings.meeting_autostop_enabled = checked;
+    });
+  }
+
+  function onMeetingAutostopMinutesChange(event: Event) {
+    const value = parseInt((event.target as HTMLSelectElement).value, 10);
+    if (!Number.isFinite(value)) return;
+    void persistSettings((settings) => {
+      settings.meeting_autostop_minutes = value;
+    });
+  }
+
+  function onMeetingMaxDurationMinutesChange(event: Event) {
+    const value = parseInt((event.target as HTMLSelectElement).value, 10);
+    if (!Number.isFinite(value)) return;
+    void persistSettings((settings) => {
+      settings.meeting_max_duration_minutes = value;
+    });
+  }
+
   /** Populate the calendar picker without prompting: only fetch calendars
    * when the integration is on (which implies access was granted). */
   async function loadCalendars() {
@@ -596,6 +619,9 @@ export function createSettingsController() {
     get systemAudioSupported() { return systemAudioSupported; },
     onCaptureSystemAudioChange,
     onModelUnloadTimeoutChange,
+    onMeetingAutostopEnabledChange,
+    onMeetingAutostopMinutesChange,
+    onMeetingMaxDurationMinutesChange,
     onVadEnabledChange,
     onFillerRemovalChange,
     onStutterCollapseChange,

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -182,6 +182,9 @@ describe("transcription controller", () => {
       calendar_selected_ids: [],
       calendar_reminder_minutes: 2,
       model_unload_timeout_minutes: 0,
+      meeting_autostop_enabled: true,
+      meeting_autostop_minutes: 10,
+      meeting_max_duration_minutes: 240,
     };
 
     Object.assign(navigator, {

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -19,7 +19,18 @@
     "dictionary_correction": "Dictionary Correction",
     "dictionary_correction_desc": "Correct misrecognized words using your custom dictionary.",
     "capture_system_audio": "System Audio Capture",
-    "capture_system_audio_desc": "During meetings, capture the computer's audio output (Teams, Zoom…) alongside the microphone. No configuration needed."
+    "capture_system_audio_desc": "During meetings, capture the computer's audio output (Teams, Zoom…) alongside the microphone. No configuration needed.",
+    "meeting_autostop": "Detect meeting end",
+    "meeting_autostop_desc": "Stop recording automatically when no one has spoken for a while.",
+    "meeting_autostop_minutes_label": "Stop after",
+    "meeting_autostop_5min": "5 minutes of silence",
+    "meeting_autostop_10min": "10 minutes of silence",
+    "meeting_autostop_15min": "15 minutes of silence",
+    "meeting_autostop_30min": "30 minutes of silence",
+    "meeting_max_duration_label": "Maximum meeting length",
+    "meeting_max_duration_2h": "2 hours",
+    "meeting_max_duration_4h": "4 hours",
+    "meeting_max_duration_8h": "8 hours"
   },
   "settings_dictionary": {
     "title": "Custom Dictionary",
@@ -224,7 +235,10 @@
     "press": "Press",
     "autopaste_hint": "Auto-pastes into your last app when you stop",
     "live_transcript": "Live transcript",
-    "system_audio_active": "System audio active"
+    "system_audio_active": "System audio active",
+    "idle_silence_banner": "No speech detected for {minutes} min. Recording will stop soon.",
+    "idle_stop_now": "Stop now",
+    "idle_keep_recording": "Keep recording"
   },
   "permissions": {
     "title": "Grant permissions",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -19,7 +19,18 @@
     "dictionary_correction": "Correction par dictionnaire",
     "dictionary_correction_desc": "Corrige les mots mal reconnus à l'aide de votre dictionnaire personnalisé.",
     "capture_system_audio": "Capture de l'audio système",
-    "capture_system_audio_desc": "Pendant les meetings, capture la sortie audio de l'ordinateur (Teams, Zoom…) en plus du micro. Aucune configuration requise."
+    "capture_system_audio_desc": "Pendant les meetings, capture la sortie audio de l'ordinateur (Teams, Zoom…) en plus du micro. Aucune configuration requise.",
+    "meeting_autostop": "Détecter la fin de réunion",
+    "meeting_autostop_desc": "Arrête l'enregistrement automatiquement quand personne n'a parlé depuis un moment.",
+    "meeting_autostop_minutes_label": "Arrêter après",
+    "meeting_autostop_5min": "5 minutes de silence",
+    "meeting_autostop_10min": "10 minutes de silence",
+    "meeting_autostop_15min": "15 minutes de silence",
+    "meeting_autostop_30min": "30 minutes de silence",
+    "meeting_max_duration_label": "Durée maximale de la réunion",
+    "meeting_max_duration_2h": "2 heures",
+    "meeting_max_duration_4h": "4 heures",
+    "meeting_max_duration_8h": "8 heures"
   },
   "settings_dictionary": {
     "title": "Dictionnaire personnalisé",
@@ -224,7 +235,10 @@
     "press": "Appuyez sur",
     "autopaste_hint": "Collé automatiquement dans votre dernière app à l’arrêt",
     "live_transcript": "Transcription en direct",
-    "system_audio_active": "Audio système actif"
+    "system_audio_active": "Audio système actif",
+    "idle_silence_banner": "Aucune parole détectée depuis {minutes} min. L'enregistrement va bientôt s'arrêter.",
+    "idle_stop_now": "Arrêter maintenant",
+    "idle_keep_recording": "Continuer l'enregistrement"
   },
   "permissions": {
     "title": "Autoriser les permissions",

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -56,6 +56,9 @@ describe('app store', () => {
       calendar_selected_ids: [],
       calendar_reminder_minutes: 2,
       model_unload_timeout_minutes: 0,
+      meeting_autostop_enabled: true,
+      meeting_autostop_minutes: 10,
+      meeting_max_duration_minutes: 240,
     };
     state.settings = newSettings;
     expect(state.settings.theme).toBe('light');

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -71,6 +71,9 @@ let settings = $state<AppSettings>({
   calendar_selected_ids: [],
   calendar_reminder_minutes: 2,
   model_unload_timeout_minutes: 0,
+  meeting_autostop_enabled: true,
+  meeting_autostop_minutes: 10,
+  meeting_max_duration_minutes: 240,
 });
 
 function deriveRecordingMode(state: AppStateMachine): "idle" | "dictation" | "meeting" {

--- a/src/lib/test-helpers/fixtures.ts
+++ b/src/lib/test-helpers/fixtures.ts
@@ -197,6 +197,9 @@ export const mockSettings: AppSettings = {
   calendar_selected_ids: [],
   calendar_reminder_minutes: 2,
   model_unload_timeout_minutes: 0,
+  meeting_autostop_enabled: true,
+  meeting_autostop_minutes: 10,
+  meeting_max_duration_minutes: 240,
 }
 
 export const mockShortcuts: ShortcutSettings = {

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -499,6 +499,7 @@ async listTodaysCalendarEvents() : Promise<Result<TodayCalendar, string>> {
 export const events = __makeEvents__<{
 audioLevel: AudioLevel,
 meetingFinalized: MeetingFinalized,
+meetingIdle: MeetingIdle,
 meetingStopRequested: MeetingStopRequested,
 navigate: Navigate,
 pipelineError: PipelineError,
@@ -512,6 +513,7 @@ upcomingMeeting: UpcomingMeeting
 }>({
 audioLevel: "audio-level",
 meetingFinalized: "meeting-finalized",
+meetingIdle: "meeting-idle",
 meetingStopRequested: "meeting-stop-requested",
 navigate: "navigate",
 pipelineError: "pipeline-error",
@@ -554,7 +556,22 @@ calendar_reminder_minutes: number;
  * reclaim RAM; 0 means never unload. The next recording reloads it
  * through the normal load flow.
  */
-model_unload_timeout_minutes: number }
+model_unload_timeout_minutes: number; 
+/**
+ * Detect a meeting that has probably ended (no speech for a while, or
+ * the max-duration failsafe) and offer/auto-stop. A session snapshots
+ * these settings at start; changes apply from the next meeting.
+ */
+meeting_autostop_enabled: boolean; 
+/**
+ * Silence duration (minutes) before the meeting is considered idle.
+ */
+meeting_autostop_minutes: number; 
+/**
+ * Hard failsafe: stop the meeting after this many minutes regardless of
+ * speech activity.
+ */
+meeting_max_duration_minutes: number }
 /**
  * Unified application state machine.
  * Replaces scattered `is_recording`, `model_loaded`, `recording_mode`, `active_profile` booleans
@@ -643,6 +660,22 @@ description?: string | null }
  * when this arrives.
  */
 export type MeetingFinalized = { id: string }
+/**
+ * A meeting recording session looks like it has ended: either speech has
+ * stopped for a while, or the session hit the max-duration failsafe. Drives
+ * the live-card banner; a system notification is also sent on the first
+ * occurrence (see `pipeline::idle::MeetingIdleSignal::first`).
+ */
+export type MeetingIdle = { reason: MeetingIdleReason; idle_seconds: number; threshold_seconds: number }
+export type MeetingIdleReason = 
+/**
+ * No transcript segment with text for the configured silence threshold.
+ */
+"silence" | 
+/**
+ * The session has run past the configured max-duration failsafe.
+ */
+"max_duration"
 /**
  * Lightweight item for listing meetings
  */

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -12,6 +12,8 @@ export type {
   DownloadStatus,
   ErrorRecovery,
   MeetingCalendarContext,
+  MeetingIdle,
+  MeetingIdleReason,
   MeetingListItem,
   MeetingParticipant,
   MeetingRecordingSession,


### PR DESCRIPTION
Adds meeting-end detection: a silence signal (no post-filter transcript text for 3-60 min, default 10) raises a banner + one OS notification and auto-stops after a 2-minute grace; a max-duration failsafe (default 4h) notifies and stops immediately. Keep recording suppresses the current episode until speech resumes. Dictation sessions are unaffected.

Design: pure MeetingIdleMonitor driven by injected Instants (deterministic tests, no sleeps), re-signals every 30s/60s so a backgrounded webview converges, first-crossing flag gates the OS notification, config is a session-start snapshot. Settings live next to the other meeting options.

Gates: 299 Rust tests, 160 frontend tests, clippy/check/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuuJ8cV2dsbwNnc7Y8gm2b