### PR TITLE
Stall recovery ladder and mic-loss surfacing

### DIFF
--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -45,6 +45,108 @@ const MIC_CHECK_INTERVAL: Duration = Duration::from_secs(2);
 /// interval so both modes stream levels at ~15Hz.
 const LEVEL_EMIT_INTERVAL: Duration = Duration::from_millis(66);
 
+/// Consecutive rebuild failures after which a dictation session (mic is the
+/// only source) gives up and ends itself, rather than retrying forever
+/// while the UI still claims to be recording. ~10s at the `MIC_CHECK_INTERVAL`
+/// cadence.
+const DICTATION_ABORT_AFTER_FAILURES: u32 = 5;
+
+/// Decision for one mic-loss episode in `check_mic_health`, given how many
+/// rebuilds have failed in a row, whether the session has another audio
+/// source to fall back on, and whether this episode already warned once.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MicLossAction {
+    /// Nothing to surface yet; keep retrying at the normal cadence.
+    KeepRetrying,
+    /// Surface a one-time, non-fatal warning: the mic is gone but another
+    /// source (system audio) is still capturing.
+    WarnOnce,
+    /// No other source exists; give up and end the session.
+    Abort,
+}
+
+/// Pure decision function backing `check_mic_health`'s mic-loss ladder, kept
+/// free of any capture state so it can be unit-tested directly.
+fn decide_mic_loss(
+    consecutive_failures: u32,
+    has_other_source: bool,
+    already_warned_this_episode: bool,
+) -> MicLossAction {
+    if consecutive_failures == 0 {
+        return MicLossAction::KeepRetrying;
+    }
+    if has_other_source {
+        if already_warned_this_episode {
+            MicLossAction::KeepRetrying
+        } else {
+            MicLossAction::WarnOnce
+        }
+    } else if consecutive_failures >= DICTATION_ABORT_AFTER_FAILURES {
+        MicLossAction::Abort
+    } else {
+        MicLossAction::KeepRetrying
+    }
+}
+
+#[cfg(test)]
+mod mic_loss_tests {
+    use super::*;
+
+    #[test]
+    fn keeps_retrying_with_no_failures_yet() {
+        assert_eq!(
+            decide_mic_loss(0, false, false),
+            MicLossAction::KeepRetrying
+        );
+        assert_eq!(decide_mic_loss(0, true, false), MicLossAction::KeepRetrying);
+    }
+
+    #[test]
+    fn dictation_keeps_retrying_below_threshold() {
+        for n in 1..DICTATION_ABORT_AFTER_FAILURES {
+            assert_eq!(
+                decide_mic_loss(n, false, false),
+                MicLossAction::KeepRetrying,
+                "failure {n} should not abort yet"
+            );
+        }
+    }
+
+    #[test]
+    fn dictation_aborts_at_threshold() {
+        assert_eq!(
+            decide_mic_loss(DICTATION_ABORT_AFTER_FAILURES, false, false),
+            MicLossAction::Abort
+        );
+        assert_eq!(
+            decide_mic_loss(DICTATION_ABORT_AFTER_FAILURES + 3, false, false),
+            MicLossAction::Abort
+        );
+    }
+
+    #[test]
+    fn meeting_never_aborts_even_well_past_threshold() {
+        assert_eq!(
+            decide_mic_loss(DICTATION_ABORT_AFTER_FAILURES + 50, true, true),
+            MicLossAction::KeepRetrying
+        );
+    }
+
+    #[test]
+    fn meeting_warns_once_then_keeps_retrying_quietly() {
+        assert_eq!(decide_mic_loss(1, true, false), MicLossAction::WarnOnce);
+        assert_eq!(decide_mic_loss(2, true, true), MicLossAction::KeepRetrying);
+        assert_eq!(decide_mic_loss(9, true, true), MicLossAction::KeepRetrying);
+    }
+
+    #[test]
+    fn meeting_rearms_after_episode_flag_clears() {
+        // A caller resets `already_warned_this_episode` to false once a
+        // rebuild succeeds; the next loss episode should warn again.
+        assert_eq!(decide_mic_loss(1, true, false), MicLossAction::WarnOnce);
+    }
+}
+
 /// Gates AudioLevel emission to at most once per `LEVEL_EMIT_INTERVAL`.
 struct AudioLevelThrottle {
     last_emit: Option<Instant>,
@@ -251,15 +353,31 @@ pub struct AudioCapture {
     last_mic_check: Instant,
     /// Throttles pushed AudioLevel events while a session is active.
     level_throttle: AudioLevelThrottle,
+    /// Consecutive failed capture rebuilds since the last success (reset to
+    /// 0 on success). Drives the mic-loss ladder in `check_mic_health`.
+    mic_rebuild_failures: u32,
+    /// Whether the current mic-loss episode already surfaced its one-time
+    /// warning (meeting mode only); re-armed on the next successful rebuild.
+    mic_loss_warned: bool,
+    /// Shared with the engine actor. Set right before this thread exits
+    /// after giving up on an unrecoverable microphone, so the actor's
+    /// AudioGone handler can surface a mic-specific message instead of its
+    /// generic fallback.
+    audio_gone_reason: Arc<Mutex<Option<String>>>,
 }
 
 impl AudioCapture {
     /// Spawn the audio thread. Returns channels for commanding it and receiving audio.
     /// `dropped_counter` is incremented for every chunk lost to a full channel;
     /// the engine actor resets and reads it for health reporting.
+    /// `audio_gone_reason` is shared with the engine actor: this thread sets
+    /// it right before an unrecoverable failure ends the whole capture
+    /// thread, so the actor's `AudioGone` handler can surface a specific
+    /// message instead of its generic fallback.
     pub fn spawn(
         audio_rms: Arc<AtomicU32>,
         dropped_counter: Arc<AtomicU64>,
+        audio_gone_reason: Arc<Mutex<Option<String>>>,
     ) -> Result<(Sender<AudioCommand>, Receiver<AudioMessage>), String> {
         let (cmd_tx, cmd_rx) = crossbeam_channel::unbounded::<AudioCommand>();
         // Bounded channel: many small chunks per second from cpal; inference (Kyutai/Metal)
@@ -287,6 +405,9 @@ impl AudioCapture {
                     stream_failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
                     last_mic_check: Instant::now(),
                     level_throttle: AudioLevelThrottle::new(),
+                    mic_rebuild_failures: 0,
+                    mic_loss_warned: false,
+                    audio_gone_reason,
                 };
 
                 // Block on commands while idle; during sessions, wake
@@ -321,7 +442,12 @@ impl AudioCapture {
                                 }
                                 if capture.last_mic_check.elapsed() >= MIC_CHECK_INTERVAL {
                                     capture.last_mic_check = Instant::now();
-                                    capture.check_mic_health();
+                                    if capture.check_mic_health() {
+                                        tracing::error!(
+                                            "Microphone unrecoverable; ending session to keep the app alive"
+                                        );
+                                        break;
+                                    }
                                 }
                                 capture.emit_throttled_audio_level();
                                 continue;
@@ -683,9 +809,16 @@ impl AudioCapture {
     /// device changed (lid closed, headset plugged in…). The session keeps
     /// its id, so the engine actor sees one continuous stream; at most a
     /// couple of seconds of audio are lost.
-    fn check_mic_health(&mut self) {
+    ///
+    /// Returns `true` if the microphone is unrecoverable and has no other
+    /// audio source to fall back on (dictation): the session has already
+    /// been ended and the caller must break its run loop so the whole
+    /// thread exits. Returns `false` in every other case, including a
+    /// meeting session that lost its mic but keeps retrying while the
+    /// system-audio leg still captures the other participants.
+    fn check_mic_health(&mut self) -> bool {
         let Some(params) = self.active_params.clone() else {
-            return;
+            return false;
         };
 
         let failed = self
@@ -705,21 +838,54 @@ impl AudioCapture {
             && self.find_device().ok().and_then(|d| d.name().ok()) != self.mic_device_name;
 
         if !failed && !default_changed {
-            return;
+            return false;
         }
 
         info!(
             "Input device {} — rebuilding audio capture",
             if failed { "failed" } else { "changed" }
         );
-        if let Err(e) = self.start(
+        match self.start(
             params.session_id,
             params.target_sample_rate,
             params.mic_gain,
             params.capture_system_audio,
             params.diarize,
         ) {
-            warn!("Capture rebuild failed (will retry): {e}");
+            Ok(()) => {
+                self.mic_rebuild_failures = 0;
+                self.mic_loss_warned = false;
+                false
+            }
+            Err(e) => {
+                self.mic_rebuild_failures += 1;
+                warn!(
+                    "Capture rebuild failed ({} in a row): {e}",
+                    self.mic_rebuild_failures
+                );
+                match decide_mic_loss(
+                    self.mic_rebuild_failures,
+                    params.capture_system_audio,
+                    self.mic_loss_warned,
+                ) {
+                    MicLossAction::KeepRetrying => false,
+                    MicLossAction::WarnOnce => {
+                        self.mic_loss_warned = true;
+                        self.emit_pipeline_warning(
+                            "Microphone lost; still recording system audio.".to_string(),
+                        );
+                        false
+                    }
+                    MicLossAction::Abort => {
+                        warn!(
+                            "Microphone unrecoverable after {} attempts; ending session",
+                            self.mic_rebuild_failures
+                        );
+                        self.abort_after_mic_loss();
+                        true
+                    }
+                }
+            }
         }
     }
 
@@ -776,6 +942,21 @@ impl AudioCapture {
         }
     }
 
+    /// Surface a non-fatal pipeline problem: the session keeps running.
+    /// Reuses the `Frame` scope (a transient, non-fatal problem the user
+    /// should see) rather than adding a dedicated warning scope — the
+    /// frontend only ever displays `message` and doesn't branch on `scope`.
+    fn emit_pipeline_warning(&self, message: String) {
+        use tauri_specta::Event;
+        if let Some(app) = &self.app {
+            let _ = crate::app_events::PipelineError {
+                scope: crate::app_events::PipelineErrorScope::Frame,
+                message,
+            }
+            .emit(app);
+        }
+    }
+
     /// Update the shared RMS level (waveform) from one or two legs combined.
     fn store_meeting_rms(&self, a: &[f32], b: &[f32]) {
         let n = a.len() + b.len();
@@ -817,12 +998,15 @@ impl AudioCapture {
         }
     }
 
-    /// Tear down the current session after a panic in the tick path, without
-    /// running any of the (possibly corrupt) flush paths. The audio thread then
-    /// exits; the engine actor observes the closed audio channel (AudioGone) and
-    /// recovers — salvaging the meeting accumulated so far and surfacing a
-    /// recoverable error — instead of the whole app aborting.
-    fn abort_after_panic(&mut self) {
+    /// Tear down all session state after a fatal, unrecoverable capture
+    /// failure, without running any of the (possibly corrupt) flush paths.
+    /// Shared by the panic recovery path and the terminal mic-loss path:
+    /// both end with the caller breaking the audio thread's run loop, so
+    /// the thread exits and the engine actor observes the closed audio
+    /// channel (AudioGone) and recovers — salvaging the meeting accumulated
+    /// so far and surfacing a recoverable error — instead of the whole app
+    /// aborting.
+    fn teardown_session_state(&mut self) {
         self.active_session_id.store(0, Ordering::Release);
         self.audio_rms.store(0f32.to_bits(), Ordering::Relaxed);
         self.active_params = None;
@@ -839,6 +1023,27 @@ impl AudioCapture {
         }
         self.emit_audio_level(0.0);
         self.level_throttle.reset();
+    }
+
+    fn abort_after_panic(&mut self) {
+        self.teardown_session_state();
+    }
+
+    /// Ends a dictation session whose microphone could not be rebuilt after
+    /// repeated attempts and has no other audio source to fall back on.
+    /// Records the reason for the engine actor's `AudioGone` handler before
+    /// tearing down — see `teardown_session_state` for why exiting this
+    /// thread is what lets the actor salvage and fail the session, exactly
+    /// like a panic abort.
+    fn abort_after_mic_loss(&mut self) {
+        if let Ok(mut reason) = self.audio_gone_reason.lock() {
+            *reason = Some(
+                "The microphone was lost and could not be reconnected; \
+                 the recording so far was saved."
+                    .to_string(),
+            );
+        }
+        self.teardown_session_state();
     }
 
     fn stop(&mut self) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -181,22 +181,30 @@ pub fn run() {
     let audio_rms = Arc::new(std::sync::atomic::AtomicU32::new(0f32.to_bits()));
     // Chunks dropped by the capture callback — read by the actor for health reporting
     let dropped_counter = Arc::new(std::sync::atomic::AtomicU64::new(0));
+    // Reason the capture thread sets right before it exits after an
+    // unrecoverable failure (e.g. mic loss with no other source); read by
+    // the actor's AudioGone handler.
+    let audio_gone_reason = Arc::new(std::sync::Mutex::new(None));
 
     // Spawn the audio thread before Tauri starts (cpal Stream is !Send on macOS)
-    let (cmd_tx, audio_rx) =
-        match AudioCapture::spawn(Arc::clone(&audio_rms), Arc::clone(&dropped_counter)) {
-            Ok(channels) => channels,
-            Err(e) => {
-                tracing::error!("Fatal: {e}");
-                std::process::exit(1);
-            }
-        };
+    let (cmd_tx, audio_rx) = match AudioCapture::spawn(
+        Arc::clone(&audio_rms),
+        Arc::clone(&dropped_counter),
+        Arc::clone(&audio_gone_reason),
+    ) {
+        Ok(channels) => channels,
+        Err(e) => {
+            tracing::error!("Fatal: {e}");
+            std::process::exit(1);
+        }
+    };
 
     // Spawn the engine actor — the single thread that owns the transcription
     // engine and consumes captured audio.
     let engine_actor = match pipeline::EngineActorHandle::spawn(
         audio_rx,
         dropped_counter,
+        audio_gone_reason,
         Box::new(engine::create_engine),
     ) {
         Ok(actor) => Arc::new(actor),

--- a/src-tauri/src/pipeline/actor.rs
+++ b/src-tauri/src/pipeline/actor.rs
@@ -31,7 +31,7 @@ use crate::filter::{
 use crate::platform::with_autorelease_pool;
 
 use super::SegmentCallback;
-use super::health::SessionHealth;
+use super::health::{SessionHealth, StallAction, StallRecovery};
 use super::idle::{MeetingIdleConfig, MeetingIdleMonitor};
 
 /// Creates engines ON the actor thread. Production uses `crate::engine::create_engine`;
@@ -111,9 +111,14 @@ pub struct EngineActorHandle {
 impl EngineActorHandle {
     /// Spawn the actor thread. It owns the audio receiver and (eventually) the engine.
     /// `dropped_counter` is shared with the audio capture callback for health reporting.
+    /// `audio_gone_reason` is shared with the audio capture thread: when the
+    /// audio channel disconnects, the actor takes whatever reason capture
+    /// left there (e.g. an unrecoverable mic loss) instead of assuming a
+    /// generic failure.
     pub fn spawn(
         audio_rx: Receiver<AudioMessage>,
         dropped_counter: Arc<AtomicU64>,
+        audio_gone_reason: Arc<Mutex<Option<String>>>,
         factory: EngineFactory,
     ) -> Result<Self, String> {
         let (cmd_tx, cmd_rx) = crossbeam_channel::unbounded::<EngineCommand>();
@@ -129,6 +134,7 @@ impl EngineActorHandle {
                     engine: None,
                     app: None,
                     dropped_counter,
+                    audio_gone_reason,
                     unload_timeout: None,
                     idle_since: None,
                 }
@@ -273,6 +279,12 @@ struct EngineActor {
     engine: Option<Box<dyn TranscriptionEngine>>,
     app: Option<tauri::AppHandle>,
     dropped_counter: Arc<AtomicU64>,
+    /// Reason the audio capture thread set right before it exits after an
+    /// unrecoverable failure (e.g. mic loss with no other source). Read
+    /// (and cleared) when the audio channel disconnects; falls back to a
+    /// generic message when empty (audio thread panicked or exited for some
+    /// other reason).
+    audio_gone_reason: Arc<Mutex<Option<String>>>,
     /// Idle-unload timeout; `None` means "never unload". Reconfigured via
     /// `EngineCommand::SetUnloadTimeout`.
     unload_timeout: Option<Duration>,
@@ -392,9 +404,19 @@ impl EngineActor {
                             // recoverable error so the user can retry — same path
                             // as a session abort. The actor stays alive.
                             error!("Audio channel disconnected mid-session; recovering");
-                            self.handle_session_abort(
-                                "Audio capture stopped unexpectedly".to_string(),
-                            );
+                            // The capture thread leaves a specific reason here
+                            // before it exits deliberately (e.g. unrecoverable
+                            // mic loss); fall back to a generic message when
+                            // it's empty (a genuine panic or unexpected exit).
+                            let reason = self
+                                .audio_gone_reason
+                                .lock()
+                                .ok()
+                                .and_then(|mut guard| guard.take())
+                                .unwrap_or_else(|| {
+                                    "Audio capture stopped unexpectedly".to_string()
+                                });
+                            self.handle_session_abort(reason);
                         }
                     }
                     if self.engine.is_some() {
@@ -855,6 +877,11 @@ fn run_session_loop(
     let mut summary = SessionSummary::default();
     let mut eos_received = false;
     let mut consecutive_errors: u32 = 0;
+    // Drives the stall recovery ladder (in-place reset, then give up) from
+    // continuous stalled health snapshots. See `StallRecovery` for the
+    // known limitation: an engine call that blocks forever never returns
+    // control here, so this only covers "loop alive, no frames" stalls.
+    let mut stall_recovery = StallRecovery::new();
     // Stop request waiting for this session's EndOfStream marker.
     let mut pending_stop: Option<(Sender<Result<SessionSummary, String>>, Instant)> = None;
 
@@ -867,11 +894,41 @@ fn run_session_loop(
     const HEARTBEAT: Duration = Duration::from_secs(30);
 
     loop {
-        // Periodic health snapshot to the frontend
-        if let Some(snapshot) = health.tick(audio_rx.len())
-            && let Some(app) = app
-        {
-            let _ = snapshot.emit(app);
+        // Periodic health snapshot to the frontend, and to the stall
+        // recovery ladder.
+        if let Some(snapshot) = health.tick(audio_rx.len()) {
+            let action = stall_recovery.on_snapshot(snapshot.status, Instant::now());
+            if let Some(app) = app {
+                let _ = snapshot.emit(app);
+            }
+            match action {
+                Some(StallAction::Reset) => {
+                    warn!(
+                        "Session {session_id} stalled for 30s with no frames processed; \
+                         attempting in-place engine reset"
+                    );
+                    // Match the panic protection already used for engine
+                    // calls in this loop (mode.step / catch_engine below): a
+                    // broken engine must not take the actor thread down
+                    // while we try to recover it.
+                    match catch_engine(|| engine.reset_state()) {
+                        Ok(()) => info!("Session {session_id}: stall recovery reset succeeded"),
+                        Err(e) => {
+                            warn!("Session {session_id}: stall recovery reset failed: {e}")
+                        }
+                    }
+                }
+                Some(StallAction::Abort) => {
+                    let message = "The transcription engine stopped responding; \
+                                    the recording so far was saved."
+                        .to_string();
+                    if let Some((reply, _)) = pending_stop.take() {
+                        let _ = reply.send(Err(message.clone()));
+                    }
+                    return SessionEnd::Aborted(message);
+                }
+                None => {}
+            }
         }
 
         // Meeting-only: has the meeting probably ended (silence / max duration)?
@@ -1301,6 +1358,7 @@ mod tests {
         let actor = EngineActorHandle::spawn(
             audio_rx,
             Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            Arc::new(Mutex::new(None)),
             Box::new(move |_profile| {
                 cell.lock()
                     .unwrap()
@@ -1587,6 +1645,7 @@ mod tests {
         let actor = EngineActorHandle::spawn(
             audio_rx,
             Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            Arc::new(Mutex::new(None)),
             Box::new(|_| Err("no engine in this test".into())),
         )
         .expect("spawn");

--- a/src-tauri/src/pipeline/health.rs
+++ b/src-tauri/src/pipeline/health.rs
@@ -91,6 +91,82 @@ impl SessionHealth {
     }
 }
 
+/// How long a session must be continuously stalled before the recovery
+/// ladder attempts an in-place engine reset.
+const RESET_AFTER: Duration = Duration::from_secs(30);
+/// How much additional continuous stall time, after the reset attempt, the
+/// ladder gives the engine before ending the session.
+const ABORT_AFTER: Duration = Duration::from_secs(30);
+
+/// Action for `run_session_loop` to take in response to a stall episode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StallAction {
+    /// First rung: try to unstick the engine in place.
+    Reset,
+    /// Second rung: the reset didn't help (or was never reached because the
+    /// stall persisted); end the session.
+    Abort,
+}
+
+/// Tracks continuous stall duration across health snapshots and decides
+/// when to attempt recovery versus give up. Pure decision logic (no I/O, no
+/// engine access), so it can be driven and unit-tested independently of
+/// `run_session_loop`.
+///
+/// Known limitation: this only detects a session loop that is alive but not
+/// producing frames (queue building up, `note_frame()` not being called). A
+/// stall where the engine blocks forever *inside* a single `transcribe`
+/// call never returns control to the loop that drives this struct, so the
+/// ladder cannot see or recover from that case. Covering it would need a
+/// cross-thread watchdog, which is out of scope here.
+pub struct StallRecovery {
+    stalled_since: Option<Instant>,
+    reset_attempted: bool,
+}
+
+impl StallRecovery {
+    pub fn new() -> Self {
+        Self {
+            stalled_since: None,
+            reset_attempted: false,
+        }
+    }
+
+    /// Feed one health snapshot's status and the time it was taken. Returns
+    /// the action to take, if any. Any non-stalled status clears the
+    /// episode: frames are flowing again, so the next stall starts a fresh
+    /// count.
+    pub fn on_snapshot(&mut self, status: HealthStatus, now: Instant) -> Option<StallAction> {
+        if status != HealthStatus::Stalled {
+            self.stalled_since = None;
+            self.reset_attempted = false;
+            return None;
+        }
+
+        let stalled_since = *self.stalled_since.get_or_insert(now);
+        let elapsed = now.saturating_duration_since(stalled_since);
+
+        if !self.reset_attempted {
+            if elapsed >= RESET_AFTER {
+                self.reset_attempted = true;
+                return Some(StallAction::Reset);
+            }
+            return None;
+        }
+
+        if elapsed >= RESET_AFTER + ABORT_AFTER {
+            return Some(StallAction::Abort);
+        }
+        None
+    }
+}
+
+impl Default for StallRecovery {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -148,5 +224,84 @@ mod tests {
         h.last_emit = Instant::now() - Duration::from_secs(2);
         let snap = h.tick(0).expect("snapshot due");
         assert_eq!(snap.status, crate::app_events::HealthStatus::Healthy);
+    }
+
+    #[test]
+    fn stall_recovery_no_action_while_not_stalled() {
+        let mut r = StallRecovery::new();
+        let t0 = Instant::now();
+        assert_eq!(r.on_snapshot(HealthStatus::Healthy, t0), None);
+        assert_eq!(r.on_snapshot(HealthStatus::Lagging, t0), None);
+    }
+
+    #[test]
+    fn stall_recovery_no_action_before_reset_threshold() {
+        let mut r = StallRecovery::new();
+        let t0 = Instant::now();
+        assert_eq!(r.on_snapshot(HealthStatus::Stalled, t0), None);
+        assert_eq!(
+            r.on_snapshot(HealthStatus::Stalled, t0 + Duration::from_secs(29)),
+            None
+        );
+    }
+
+    #[test]
+    fn stall_recovery_resets_at_30s() {
+        let mut r = StallRecovery::new();
+        let t0 = Instant::now();
+        r.on_snapshot(HealthStatus::Stalled, t0);
+        assert_eq!(
+            r.on_snapshot(HealthStatus::Stalled, t0 + Duration::from_secs(30)),
+            Some(StallAction::Reset)
+        );
+    }
+
+    #[test]
+    fn stall_recovery_does_not_reset_twice_in_one_episode() {
+        let mut r = StallRecovery::new();
+        let t0 = Instant::now();
+        r.on_snapshot(HealthStatus::Stalled, t0);
+        r.on_snapshot(HealthStatus::Stalled, t0 + Duration::from_secs(30));
+        assert_eq!(
+            r.on_snapshot(HealthStatus::Stalled, t0 + Duration::from_secs(45)),
+            None
+        );
+    }
+
+    #[test]
+    fn stall_recovery_aborts_60s_after_initial_stall() {
+        let mut r = StallRecovery::new();
+        let t0 = Instant::now();
+        r.on_snapshot(HealthStatus::Stalled, t0);
+        r.on_snapshot(HealthStatus::Stalled, t0 + Duration::from_secs(30));
+        assert_eq!(
+            r.on_snapshot(HealthStatus::Stalled, t0 + Duration::from_secs(59)),
+            None
+        );
+        assert_eq!(
+            r.on_snapshot(HealthStatus::Stalled, t0 + Duration::from_secs(60)),
+            Some(StallAction::Abort)
+        );
+    }
+
+    #[test]
+    fn stall_recovery_rearms_after_healthy_snapshot() {
+        let mut r = StallRecovery::new();
+        let t0 = Instant::now();
+        r.on_snapshot(HealthStatus::Stalled, t0);
+        assert_eq!(
+            r.on_snapshot(HealthStatus::Stalled, t0 + Duration::from_secs(30)),
+            Some(StallAction::Reset)
+        );
+        // Frames resume: the episode is cleared entirely.
+        let t1 = t0 + Duration::from_secs(31);
+        assert_eq!(r.on_snapshot(HealthStatus::Healthy, t1), None);
+
+        // A fresh stall needs its own full 30s before resetting again.
+        assert_eq!(r.on_snapshot(HealthStatus::Stalled, t1), None);
+        assert_eq!(
+            r.on_snapshot(HealthStatus::Stalled, t1 + Duration::from_secs(30)),
+            Some(StallAction::Reset)
+        );
     }
 }


### PR DESCRIPTION
Two reliability gaps closed:

- Stalled sessions (loop alive, no frames, e.g. a starved lane) get one in-place engine reset at 30s of continuous stall and a salvage-abort at 60s, reusing the existing panic-abort path (PipelineError + meeting saved to history). Pure StallRecovery ladder, unit-tested with synthetic Instants; known limitation documented: an engine blocked inside a transcribe call never returns to the loop.
- Mic loss: dictation aborts after 5 consecutive rebuild failures with a specific mic-loss message (shared audio-gone-reason slot between capture thread and actor); meetings with system audio warn once per episode and keep retrying at the 2s cadence while the system lane keeps recording.

Gates: 323 Rust tests, clippy clean, frontend check/build clean (no frontend changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuuJ8cV2dsbwNnc7Y8gm2b