### PR TITLE
Per-meeting export: Markdown, JSON, SRT, VTT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,10 @@
     "": {
       "name": "souffle",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@lucide/svelte": "^1.7.0",
+        "@tauri-apps/plugin-dialog": "^2.7.1",
         "svelte-i18n": "^4.0.1"
       },
       "devDependencies": {
@@ -1508,10 +1510,9 @@
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
-      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
-      "dev": true,
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.1.tgz",
+      "integrity": "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -1733,6 +1734,15 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-dialog": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.1.tgz",
+      "integrity": "sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.11.0"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@lucide/svelte": "^1.7.0",
+    "@tauri-apps/plugin-dialog": "^2.7.1",
     "svelte-i18n": "^4.0.1"
   }
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5475,6 +5475,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2 0.6.2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6300,6 +6324,7 @@ dependencies = [
  "strsim",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-log",
@@ -6778,6 +6803,24 @@ dependencies = [
  "tauri-utils",
  "toml 0.9.12+spec-1.1.0",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9204b425d9be8d12aa60c2a83a289cf7d1caae40f57f336ed1155b3a5c0e359b"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ tauri = { version = "2", features = ["tray-icon", "macos-private-api", "image-pn
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-fs = "2"
+tauri-plugin-dialog = "2"
 tauri-plugin-log = "2"
 tauri-plugin-single-instance = "2"
 specta = { version = "=2.0.0-rc.22", features = ["derive", "chrono"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -14,6 +14,7 @@
     "global-shortcut:allow-is-registered",
     "notification:default",
     "fs:default",
+    "dialog:allow-save",
     "log:default"
   ]
 }

--- a/src-tauri/src/commands/meetings.rs
+++ b/src-tauri/src/commands/meetings.rs
@@ -2,6 +2,7 @@ use tauri::State;
 use tauri::ipc::Channel;
 
 use crate::db::search::SearchResult;
+use crate::export::{self, ExportFormat};
 use crate::settings::AppSettings;
 use crate::state::AppState;
 
@@ -94,6 +95,47 @@ pub fn save_edited_transcript(
     state
         .db
         .save_edited_transcript(&id, edited_transcript.as_deref())
+}
+
+/// Render a meeting export without writing to disk. Used by tests and, if
+/// ever needed, a clipboard-copy affordance.
+#[tauri::command]
+#[specta::specta]
+pub fn export_meeting_preview(
+    state: State<'_, AppState>,
+    id: String,
+    format: ExportFormat,
+) -> Result<String, String> {
+    let meeting = state.db.load_meeting(&id)?;
+    export::render_meeting(&meeting, format)
+}
+
+/// Suggested filename for a meeting export (e.g. `2026-07-09-weekly-sync.md`),
+/// used as the save dialog's default path.
+#[tauri::command]
+#[specta::specta]
+pub fn export_meeting_filename(
+    state: State<'_, AppState>,
+    id: String,
+    format: ExportFormat,
+) -> Result<String, String> {
+    let meeting = state.db.load_meeting(&id)?;
+    Ok(export::export_default_filename(&meeting, format))
+}
+
+/// Render a meeting export and write it to `path`. The save dialog itself
+/// (picking `path`) runs frontend-side via the dialog plugin.
+#[tauri::command]
+#[specta::specta]
+pub fn export_meeting_to_file(
+    state: State<'_, AppState>,
+    id: String,
+    format: ExportFormat,
+    path: String,
+) -> Result<(), String> {
+    let meeting = state.db.load_meeting(&id)?;
+    let rendered = export::render_meeting(&meeting, format)?;
+    std::fs::write(&path, rendered).map_err(|e| format!("Write export file: {e}"))
 }
 
 /// Check if Ollama is available and list models

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -1,0 +1,850 @@
+//! Renders a `MeetingTranscript` into Markdown, JSON, SRT, or VTT text for
+//! the single-meeting export feature. Pure string rendering: no I/O here,
+//! `commands::meetings` handles the file dialog / filesystem write.
+
+use crate::engine::{Speaker, TranscriptionSegment};
+use crate::transcript::MeetingTranscript;
+
+/// Minimum on-screen duration given to a subtitle cue whose segment has a
+/// zero or inverted end time, so SRT/VTT players never render a cue with
+/// zero (or negative) length.
+const MIN_CUE_DURATION_SECONDS: f64 = 0.5;
+
+/// Paragraph pause threshold used for Markdown transcript rendering; mirrors
+/// the `pauseThreshold` the live transcript view passes to
+/// `groupIntoParagraphs` (src/lib/utils/paragraphs.ts).
+const PARAGRAPH_PAUSE_THRESHOLD_SECONDS: f64 = 1.5;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "snake_case")]
+pub enum ExportFormat {
+    Markdown,
+    Json,
+    Srt,
+    Vtt,
+}
+
+/// File extension (without the dot) for a given export format.
+pub fn export_extension(format: ExportFormat) -> &'static str {
+    match format {
+        ExportFormat::Markdown => "md",
+        ExportFormat::Json => "json",
+        ExportFormat::Srt => "srt",
+        ExportFormat::Vtt => "vtt",
+    }
+}
+
+/// Lowercase, alphanumeric-only slug: everything else collapses to a single
+/// hyphen, and leading/trailing hyphens are trimmed. Falls back to
+/// `"meeting"` when nothing alphanumeric survives (empty title, emoji-only
+/// title, etc).
+fn slugify(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    let mut last_was_separator = false;
+    for ch in input.to_lowercase().chars() {
+        if ch.is_ascii_alphanumeric() {
+            result.push(ch);
+            last_was_separator = false;
+        } else if !last_was_separator {
+            result.push('-');
+            last_was_separator = true;
+        }
+    }
+    let trimmed = result.trim_matches('-');
+    if trimmed.is_empty() {
+        "meeting".to_string()
+    } else {
+        trimmed.to_string()
+    }
+}
+
+/// Suggested filename for a meeting export, e.g. `2026-07-09-weekly-sync.md`.
+pub fn export_default_filename(meeting: &MeetingTranscript, format: ExportFormat) -> String {
+    let date = meeting.started_at.format("%Y-%m-%d");
+    let slug = slugify(&meeting.title);
+    format!("{date}-{slug}.{}", export_extension(format))
+}
+
+/// Render a meeting into the requested export format.
+pub fn render_meeting(meeting: &MeetingTranscript, format: ExportFormat) -> Result<String, String> {
+    match format {
+        ExportFormat::Markdown => Ok(render_markdown(meeting)),
+        ExportFormat::Json => render_json(meeting),
+        ExportFormat::Srt => Ok(render_srt(meeting)),
+        ExportFormat::Vtt => Ok(render_vtt(meeting)),
+    }
+}
+
+fn humanize_duration(total_seconds: f64) -> String {
+    let total = total_seconds.max(0.0).round() as i64;
+    let hours = total / 3600;
+    let minutes = (total % 3600) / 60;
+    let seconds = total % 60;
+
+    let mut parts = Vec::new();
+    if hours > 0 {
+        parts.push(format!("{hours}h"));
+    }
+    if hours > 0 || minutes > 0 {
+        parts.push(format!("{minutes}m"));
+    }
+    parts.push(format!("{seconds}s"));
+    parts.join(" ")
+}
+
+fn render_markdown(meeting: &MeetingTranscript) -> String {
+    let mut out = String::new();
+
+    out.push_str(&format!("# {}\n\n", meeting.title));
+
+    out.push_str(&format!(
+        "- **Date:** {}\n",
+        meeting.started_at.format("%Y-%m-%d %H:%M UTC")
+    ));
+    out.push_str(&format!(
+        "- **Duration:** {}\n",
+        humanize_duration(meeting.duration_seconds)
+    ));
+    if !meeting.participants.is_empty() {
+        let names = meeting
+            .participants
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        out.push_str(&format!("- **Participants:** {names}\n"));
+    }
+    out.push_str(&format!(
+        "- **Engine:** {}\n",
+        meeting.transcription_profile.engine_label
+    ));
+
+    if let Some(notes) = non_empty(meeting.notes.as_deref()) {
+        out.push_str("\n## Notes\n\n");
+        out.push_str(notes);
+        out.push('\n');
+    }
+
+    if let Some(summary) = non_empty(meeting.summary.as_deref()) {
+        out.push_str("\n## Summary\n\n");
+        out.push_str(summary);
+        out.push('\n');
+    }
+
+    out.push_str("\n## Transcript\n\n");
+    match non_empty(meeting.edited_transcript.as_deref()) {
+        Some(edited) => out.push_str(edited),
+        None => {
+            let grouped = paragraphs::group_into_paragraphs(
+                &meeting.segments,
+                PARAGRAPH_PAUSE_THRESHOLD_SECONDS,
+            );
+            let rendered = grouped
+                .iter()
+                .map(render_paragraph_markdown)
+                .collect::<Vec<_>>()
+                .join("\n\n");
+            out.push_str(&rendered);
+        }
+    }
+    out.push('\n');
+
+    out
+}
+
+fn non_empty(text: Option<&str>) -> Option<&str> {
+    text.map(str::trim).filter(|t| !t.is_empty())
+}
+
+fn render_paragraph_markdown(p: &paragraphs::Paragraph) -> String {
+    match p.speaker {
+        Some(Speaker::Me) => format!("**Me** [{}] {}", p.timestamp, p.text),
+        Some(Speaker::Them) => format!("**Them** [{}] {}", p.timestamp, p.text),
+        None => format!("[{}] {}", p.timestamp, p.text),
+    }
+}
+
+fn render_json(meeting: &MeetingTranscript) -> Result<String, String> {
+    serde_json::to_string_pretty(meeting).map_err(|e| format!("Serialize meeting: {e}"))
+}
+
+/// Diarized meetings interleave Me (mic) and Them (system audio) segments in
+/// storage order per processing frame, not strictly by time, so every export
+/// renderer must sort a copy by start time to read as a conversation and
+/// keep cue timestamps monotonic. Non-diarized streams keep storage order:
+/// legacy window-relative timestamps must not be reordered. Same rule as the
+/// TS `groupIntoParagraphs` (src/lib/utils/paragraphs.ts); the sort is stable
+/// on both sides, so equal start times preserve storage order too.
+fn time_ordered_segments(segments: &[TranscriptionSegment]) -> Vec<&TranscriptionSegment> {
+    let diarized = segments.iter().any(|s| s.speaker.is_some());
+    let mut ordered: Vec<&TranscriptionSegment> = segments.iter().collect();
+    if diarized {
+        ordered.sort_by(|a, b| {
+            a.start_time
+                .partial_cmp(&b.start_time)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+    }
+    ordered
+}
+
+fn speaker_prefix(speaker: Option<Speaker>, text: &str) -> String {
+    match speaker {
+        Some(Speaker::Me) => format!("Me: {text}"),
+        Some(Speaker::Them) => format!("Them: {text}"),
+        None => text.to_string(),
+    }
+}
+
+/// `start_time`/`end_time` clamped to a valid, non-zero-length cue window.
+fn cue_window(start_time: f64, end_time: f64) -> (f64, f64) {
+    let start = start_time.max(0.0);
+    let end = if end_time > start {
+        end_time
+    } else {
+        start + MIN_CUE_DURATION_SECONDS
+    };
+    (start, end)
+}
+
+fn srt_timestamp(seconds: f64) -> String {
+    let total_millis = (seconds.max(0.0) * 1000.0).round() as i64;
+    let hours = total_millis / 3_600_000;
+    let minutes = (total_millis % 3_600_000) / 60_000;
+    let secs = (total_millis % 60_000) / 1000;
+    let millis = total_millis % 1000;
+    format!("{hours:02}:{minutes:02}:{secs:02},{millis:03}")
+}
+
+fn vtt_timestamp(seconds: f64) -> String {
+    srt_timestamp(seconds).replace(',', ".")
+}
+
+fn render_srt(meeting: &MeetingTranscript) -> String {
+    let mut out = String::new();
+    let mut index = 1u32;
+    for seg in time_ordered_segments(&meeting.segments) {
+        let text = seg.text.trim();
+        if text.is_empty() {
+            continue;
+        }
+        let (start, end) = cue_window(seg.start_time, seg.end_time);
+        out.push_str(&format!(
+            "{index}\n{} --> {}\n{}\n\n",
+            srt_timestamp(start),
+            srt_timestamp(end),
+            speaker_prefix(seg.speaker, text),
+        ));
+        index += 1;
+    }
+    finish_cue_block(out)
+}
+
+fn render_vtt(meeting: &MeetingTranscript) -> String {
+    let mut out = String::from("WEBVTT\n\n");
+    for seg in time_ordered_segments(&meeting.segments) {
+        let text = seg.text.trim();
+        if text.is_empty() {
+            continue;
+        }
+        let (start, end) = cue_window(seg.start_time, seg.end_time);
+        out.push_str(&format!(
+            "{} --> {}\n{}\n\n",
+            vtt_timestamp(start),
+            vtt_timestamp(end),
+            speaker_prefix(seg.speaker, text),
+        ));
+    }
+    finish_cue_block(out)
+}
+
+/// Trailing blank line between cues is a separator, not part of the file;
+/// trim it and end with exactly one newline.
+fn finish_cue_block(out: String) -> String {
+    format!("{}\n", out.trim_end())
+}
+
+/// Rust port of `groupIntoParagraphs` from `src/lib/utils/paragraphs.ts`,
+/// used only for the Markdown export's `## Transcript` section. Kept as a
+/// private submodule (not re-exported) since nothing outside export
+/// rendering needs paragraph grouping on the backend. See
+/// `src-tauri/tests/fixtures/paragraph_grouping.json` for the cross-language
+/// fixture that pins this port against the TS original.
+mod paragraphs {
+    use crate::engine::{Speaker, TranscriptionSegment};
+
+    /// Paragraph break after this many sentences, even with no pause.
+    pub const MAX_SENTENCES_PER_PARAGRAPH: usize = 4;
+    /// Once a paragraph reaches this length, break at the next sentence end.
+    pub const SOFT_MAX_CHARS: usize = 480;
+    /// Absolute ceiling for streams with no punctuation at all.
+    pub const HARD_MAX_CHARS: usize = 700;
+
+    /// Closing quote/bracket characters allowed between sentence-ending
+    /// punctuation and the sentence boundary itself, mirroring the TS
+    /// `["»”')\]]` character class.
+    const CLOSING_CHARS: [char; 6] = ['"', '»', '\u{201d}', '\'', ')', ']'];
+    const SENTENCE_END_CHARS: [char; 4] = ['.', '!', '?', '\u{2026}'];
+
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Paragraph {
+        pub timestamp: String,
+        pub text: String,
+        pub speaker: Option<Speaker>,
+    }
+
+    fn format_timestamp(seconds: f64) -> String {
+        let mins = (seconds / 60.0).floor() as i64;
+        let secs = (seconds % 60.0).floor() as i64;
+        format!("{mins}:{secs:02}")
+    }
+
+    /// Does `text` end with sentence-ending punctuation, optionally followed
+    /// by closing quotes/brackets? Port of the TS `SENTENCE_END` regex
+    /// (`/[.!?…]["»”')\]]*\s*$/`); `text` is expected pre-trimmed of
+    /// whitespace like the TS caller, but trailing whitespace is stripped
+    /// defensively to match the regex's `\s*$` exactly.
+    fn ends_sentence(text: &str) -> bool {
+        let mut chars: Vec<char> = text.chars().collect();
+        while matches!(chars.last(), Some(c) if c.is_whitespace()) {
+            chars.pop();
+        }
+        while matches!(chars.last(), Some(c) if CLOSING_CHARS.contains(c)) {
+            chars.pop();
+        }
+        matches!(chars.last(), Some(c) if SENTENCE_END_CHARS.contains(c))
+    }
+
+    /// Count sentence-ending punctuation runs in `text` that are followed by
+    /// whitespace or end-of-string (after skipping closing quotes/brackets).
+    /// Port of the TS `countSentenceEnds`, which uses a lookahead the `regex`
+    /// crate doesn't support, so this walks the string manually instead.
+    fn count_sentence_ends(text: &str) -> usize {
+        let chars: Vec<char> = text.chars().collect();
+        let n = chars.len();
+        let mut count = 0;
+        let mut i = 0;
+        while i < n {
+            if SENTENCE_END_CHARS.contains(&chars[i]) {
+                let mut j = i + 1;
+                while j < n && SENTENCE_END_CHARS.contains(&chars[j]) {
+                    j += 1;
+                }
+                let mut k = j;
+                while k < n && CLOSING_CHARS.contains(&chars[k]) {
+                    k += 1;
+                }
+                if k == n || chars[k].is_whitespace() {
+                    count += 1;
+                }
+                i = j;
+            } else {
+                i += 1;
+            }
+        }
+        count
+    }
+
+    fn flush_paragraph(
+        paragraphs: &mut Vec<Paragraph>,
+        timestamp: &str,
+        speaker: Option<Speaker>,
+        words: &mut Vec<String>,
+    ) {
+        paragraphs.push(Paragraph {
+            timestamp: timestamp.to_string(),
+            text: words.join(" "),
+            speaker,
+        });
+        words.clear();
+    }
+
+    /// Group segments into flowing paragraphs with a leading timestamp. See
+    /// `groupIntoParagraphs` in `src/lib/utils/paragraphs.ts` for the
+    /// authoritative rule set (pause threshold, sentence/char caps, diarized
+    /// sort-and-break-on-speaker-change): this is a line-for-line port,
+    /// including its quirk of seeding the first paragraph's timestamp from
+    /// `ordered[0]` even if that segment's text turns out to be empty.
+    pub fn group_into_paragraphs(
+        segments: &[TranscriptionSegment],
+        pause_threshold: f64,
+    ) -> Vec<Paragraph> {
+        if segments.is_empty() {
+            return Vec::new();
+        }
+
+        let diarized = segments.iter().any(|s| s.speaker.is_some());
+        let ordered = super::time_ordered_segments(segments);
+
+        let mut paragraphs: Vec<Paragraph> = Vec::new();
+        let mut current_timestamp = format_timestamp(ordered[0].start_time);
+        let mut current_speaker: Option<Speaker> = ordered[0].speaker;
+        let mut current_words: Vec<String> = Vec::new();
+        let mut current_chars: usize = 0;
+        let mut sentence_count: usize = 0;
+        let mut ends_sentence_flag = false;
+        let mut last_end = ordered[0].start_time;
+
+        for seg in &ordered {
+            let text = seg.text.trim();
+            if text.is_empty() {
+                continue;
+            }
+            let speaker = seg.speaker;
+
+            if !current_words.is_empty() {
+                let mut broke = false;
+                if diarized && speaker != current_speaker {
+                    flush_paragraph(
+                        &mut paragraphs,
+                        &current_timestamp,
+                        current_speaker,
+                        &mut current_words,
+                    );
+                    broke = true;
+                } else {
+                    let gap = seg.start_time - last_end;
+                    let break_at_sentence = ends_sentence_flag
+                        && (gap >= pause_threshold
+                            || sentence_count >= MAX_SENTENCES_PER_PARAGRAPH
+                            || current_chars >= SOFT_MAX_CHARS);
+                    let break_hard = current_chars >= HARD_MAX_CHARS;
+
+                    if break_at_sentence || break_hard {
+                        flush_paragraph(
+                            &mut paragraphs,
+                            &current_timestamp,
+                            current_speaker,
+                            &mut current_words,
+                        );
+                        broke = true;
+                    }
+                }
+
+                if broke {
+                    current_timestamp = format_timestamp(seg.start_time);
+                    current_speaker = speaker;
+                    current_chars = 0;
+                    sentence_count = 0;
+                    // ends_sentence_flag is unconditionally recomputed below
+                    // from this segment's text, so no reset needed here.
+                }
+            } else {
+                current_speaker = speaker;
+            }
+
+            current_words.push(text.to_string());
+            current_chars += text.chars().count() + 1;
+            sentence_count += count_sentence_ends(text);
+            ends_sentence_flag = ends_sentence(text);
+            let end = if seg.end_time != 0.0 {
+                seg.end_time
+            } else {
+                seg.start_time
+            };
+            last_end = last_end.max(end);
+        }
+
+        if !current_words.is_empty() {
+            paragraphs.push(Paragraph {
+                timestamp: current_timestamp,
+                text: current_words.join(" "),
+                speaker: current_speaker,
+            });
+        }
+
+        paragraphs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::fixtures::{sample_meeting, sample_segment};
+
+    fn diarized_segment(
+        text: &str,
+        start: f64,
+        end: f64,
+        speaker: Speaker,
+    ) -> crate::engine::TranscriptionSegment {
+        let mut seg = sample_segment(text, start, end);
+        seg.speaker = Some(speaker);
+        seg
+    }
+
+    // ── slugify / filename ──────────────────────────────────────────────
+
+    #[test]
+    fn slugify_basic_title() {
+        let mut meeting = sample_meeting("m1");
+        meeting.title = "Weekly Sync".to_string();
+        meeting.started_at = "2026-07-09T10:00:00Z".parse().unwrap();
+        assert_eq!(
+            export_default_filename(&meeting, ExportFormat::Markdown),
+            "2026-07-09-weekly-sync.md"
+        );
+    }
+
+    #[test]
+    fn slugify_collapses_punctuation_and_spaces() {
+        let mut meeting = sample_meeting("m1");
+        meeting.title = "Q3   Planning -- Budget & Roadmap!!".to_string();
+        let filename = export_default_filename(&meeting, ExportFormat::Json);
+        assert!(filename.ends_with(".json"));
+        assert!(!filename.contains("--"));
+        assert!(!filename.contains(' '));
+    }
+
+    #[test]
+    fn slugify_strips_accents_to_ascii_only() {
+        let mut meeting = sample_meeting("m1");
+        meeting.title = "Café Meeting".to_string();
+        let filename = export_default_filename(&meeting, ExportFormat::Srt);
+        // Accented chars are not ASCII alphanumeric, so they collapse into
+        // the hyphen separator rather than surviving into the slug.
+        assert!(filename.contains("caf-meeting") || filename.contains("caf-meeting-"));
+        assert!(filename.is_ascii());
+    }
+
+    #[test]
+    fn slugify_emoji_only_title_falls_back() {
+        let mut meeting = sample_meeting("m1");
+        meeting.title = "🎉🎉🎉".to_string();
+        let filename = export_default_filename(&meeting, ExportFormat::Vtt);
+        assert!(filename.ends_with("-meeting.vtt"));
+    }
+
+    #[test]
+    fn slugify_empty_title_falls_back() {
+        let mut meeting = sample_meeting("m1");
+        meeting.title = "".to_string();
+        let filename = export_default_filename(&meeting, ExportFormat::Markdown);
+        assert!(filename.ends_with("-meeting.md"));
+    }
+
+    #[test]
+    fn export_extension_matches_format() {
+        assert_eq!(export_extension(ExportFormat::Markdown), "md");
+        assert_eq!(export_extension(ExportFormat::Json), "json");
+        assert_eq!(export_extension(ExportFormat::Srt), "srt");
+        assert_eq!(export_extension(ExportFormat::Vtt), "vtt");
+    }
+
+    // ── markdown ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn markdown_includes_metadata_block() {
+        let mut meeting = sample_meeting("m1");
+        meeting.title = "Weekly Sync".to_string();
+        meeting.participants = vec![crate::transcript::MeetingParticipant {
+            name: "Alice".to_string(),
+            email: None,
+            is_organizer: true,
+            is_current_user: false,
+        }];
+        let rendered = render_meeting(&meeting, ExportFormat::Markdown).unwrap();
+        assert!(rendered.starts_with("# Weekly Sync\n\n"));
+        assert!(rendered.contains("**Date:**"));
+        assert!(rendered.contains("**Duration:**"));
+        assert!(rendered.contains("**Participants:** Alice"));
+        assert!(rendered.contains("**Engine:**"));
+        assert!(rendered.contains(&meeting.transcription_profile.engine_label));
+    }
+
+    #[test]
+    fn markdown_omits_participants_line_when_empty() {
+        let meeting = sample_meeting("m1");
+        let rendered = render_meeting(&meeting, ExportFormat::Markdown).unwrap();
+        assert!(!rendered.contains("**Participants:**"));
+    }
+
+    #[test]
+    fn markdown_includes_notes_and_summary_sections_when_present() {
+        let mut meeting = sample_meeting("m1");
+        meeting.notes = Some("Remember the budget question".to_string());
+        meeting.summary = Some("- Point one\n- Point two".to_string());
+        let rendered = render_meeting(&meeting, ExportFormat::Markdown).unwrap();
+        assert!(rendered.contains("## Notes\n\nRemember the budget question"));
+        assert!(rendered.contains("## Summary\n\n- Point one\n- Point two"));
+    }
+
+    #[test]
+    fn markdown_omits_notes_and_summary_sections_when_absent() {
+        let meeting = sample_meeting("m1");
+        let rendered = render_meeting(&meeting, ExportFormat::Markdown).unwrap();
+        assert!(!rendered.contains("## Notes"));
+        assert!(!rendered.contains("## Summary"));
+    }
+
+    #[test]
+    fn markdown_edited_transcript_takes_precedence_over_segments() {
+        let mut meeting = sample_meeting("m1");
+        meeting.edited_transcript = Some("This is the cleaned-up transcript.".to_string());
+        let rendered = render_meeting(&meeting, ExportFormat::Markdown).unwrap();
+        assert!(rendered.contains("## Transcript\n\nThis is the cleaned-up transcript."));
+        // The raw segment text ("Hello world") must not also appear as a
+        // paragraph; only the edited text represents the transcript.
+        assert!(!rendered.contains("[0:00] Hello world"));
+    }
+
+    #[test]
+    fn markdown_falls_back_to_paragraphs_when_edited_transcript_is_blank() {
+        let mut meeting = sample_meeting("m1");
+        meeting.edited_transcript = Some("   ".to_string());
+        let rendered = render_meeting(&meeting, ExportFormat::Markdown).unwrap();
+        assert!(rendered.contains("[0:00] Hello world"));
+    }
+
+    #[test]
+    fn markdown_paragraphs_use_speaker_prefix_when_diarized() {
+        let mut meeting = sample_meeting("m1");
+        meeting.segments = vec![
+            diarized_segment("Hi there", 0.0, 1.0, Speaker::Me),
+            diarized_segment("Hello back", 2.0, 3.0, Speaker::Them),
+        ];
+        let rendered = render_meeting(&meeting, ExportFormat::Markdown).unwrap();
+        assert!(rendered.contains("**Me** [0:00] Hi there"));
+        assert!(rendered.contains("**Them** [0:02] Hello back"));
+    }
+
+    #[test]
+    fn markdown_paragraphs_have_no_speaker_prefix_when_not_diarized() {
+        let meeting = sample_meeting("m1");
+        let rendered = render_meeting(&meeting, ExportFormat::Markdown).unwrap();
+        assert!(rendered.contains("[0:00] Hello world"));
+        assert!(!rendered.contains("**Me**"));
+        assert!(!rendered.contains("**Them**"));
+    }
+
+    // ── json ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn json_round_trips_the_full_meeting() {
+        let meeting = sample_meeting("m1");
+        let rendered = render_meeting(&meeting, ExportFormat::Json).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&rendered).unwrap();
+        assert_eq!(parsed["id"], "m1");
+        assert_eq!(parsed["segments"][0]["text"], "Hello world");
+        // Pretty-printed: multi-line, not a single compact line.
+        assert!(rendered.contains('\n'));
+    }
+
+    // ── srt ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn srt_renders_standard_blocks() {
+        let mut meeting = sample_meeting("m1");
+        meeting.segments = vec![sample_segment("Hello world", 0.0, 1.5)];
+        let rendered = render_meeting(&meeting, ExportFormat::Srt).unwrap();
+        assert_eq!(rendered, "1\n00:00:00,000 --> 00:00:01,500\nHello world\n");
+    }
+
+    #[test]
+    fn srt_skips_empty_text_segments_and_renumbers() {
+        let mut meeting = sample_meeting("m1");
+        meeting.segments = vec![
+            sample_segment("First", 0.0, 1.0),
+            sample_segment("   ", 1.0, 2.0),
+            sample_segment("Second", 2.0, 3.0),
+        ];
+        let rendered = render_meeting(&meeting, ExportFormat::Srt).unwrap();
+        assert!(rendered.starts_with("1\n"));
+        assert!(rendered.contains("\n2\n"));
+        assert!(!rendered.contains("3\n"));
+    }
+
+    #[test]
+    fn srt_uses_speaker_prefix_when_diarized() {
+        let mut meeting = sample_meeting("m1");
+        meeting.segments = vec![
+            diarized_segment("Hi there", 0.0, 1.0, Speaker::Me),
+            diarized_segment("Hello back", 1.0, 2.0, Speaker::Them),
+        ];
+        let rendered = render_meeting(&meeting, ExportFormat::Srt).unwrap();
+        assert!(rendered.contains("Me: Hi there"));
+        assert!(rendered.contains("Them: Hello back"));
+    }
+
+    #[test]
+    fn srt_formats_timestamps_past_one_hour() {
+        let mut meeting = sample_meeting("m1");
+        meeting.segments = vec![sample_segment("Late in the meeting", 3_661.25, 3_662.5)];
+        let rendered = render_meeting(&meeting, ExportFormat::Srt).unwrap();
+        assert!(rendered.contains("01:01:01,250 --> 01:01:02,500"));
+    }
+
+    #[test]
+    fn srt_clamps_zero_or_inverted_duration_to_minimum() {
+        let mut meeting = sample_meeting("m1");
+        // end_time == start_time
+        meeting.segments = vec![sample_segment("Instant", 10.0, 10.0)];
+        let rendered = render_meeting(&meeting, ExportFormat::Srt).unwrap();
+        assert!(rendered.contains("00:00:10,000 --> 00:00:10,500"));
+    }
+
+    #[test]
+    fn srt_clamps_inverted_end_before_start() {
+        let mut meeting = sample_meeting("m1");
+        meeting.segments = vec![sample_segment("Bad data", 10.0, 5.0)];
+        let rendered = render_meeting(&meeting, ExportFormat::Srt).unwrap();
+        assert!(rendered.contains("00:00:10,000 --> 00:00:10,500"));
+    }
+
+    #[test]
+    fn srt_sorts_diarized_interleaved_segments_by_start_time() {
+        let mut meeting = sample_meeting("m1");
+        // Storage order interleaves Me/Them per frame, not by time.
+        meeting.segments = vec![
+            diarized_segment("Second line", 5.0, 6.0, Speaker::Them),
+            diarized_segment("First line", 1.0, 2.0, Speaker::Me),
+            diarized_segment("Third line", 8.0, 9.0, Speaker::Me),
+        ];
+        let rendered = render_meeting(&meeting, ExportFormat::Srt).unwrap();
+        let expected = "1\n\
+             00:00:01,000 --> 00:00:02,000\n\
+             Me: First line\n\
+             \n\
+             2\n\
+             00:00:05,000 --> 00:00:06,000\n\
+             Them: Second line\n\
+             \n\
+             3\n\
+             00:00:08,000 --> 00:00:09,000\n\
+             Me: Third line\n";
+        assert_eq!(rendered, expected);
+    }
+
+    #[test]
+    fn srt_keeps_storage_order_for_non_diarized_segments() {
+        let mut meeting = sample_meeting("m1");
+        // Legacy window-relative timestamps: storage order is authoritative
+        // and must not be reordered even though start times go backwards.
+        meeting.segments = vec![
+            sample_segment("Window one", 4.0, 4.5),
+            sample_segment("Window two", 0.2, 0.7),
+        ];
+        let rendered = render_meeting(&meeting, ExportFormat::Srt).unwrap();
+        let one = rendered.find("Window one").unwrap();
+        let two = rendered.find("Window two").unwrap();
+        assert!(one < two);
+    }
+
+    // ── vtt ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn vtt_starts_with_webvtt_header() {
+        let meeting = sample_meeting("m1");
+        let rendered = render_meeting(&meeting, ExportFormat::Vtt).unwrap();
+        assert!(rendered.starts_with("WEBVTT\n\n"));
+    }
+
+    #[test]
+    fn vtt_uses_dot_decimal_separator() {
+        let mut meeting = sample_meeting("m1");
+        meeting.segments = vec![sample_segment("Hello world", 0.0, 1.5)];
+        let rendered = render_meeting(&meeting, ExportFormat::Vtt).unwrap();
+        assert!(rendered.contains("00:00:00.000 --> 00:00:01.500"));
+        assert!(!rendered.contains(','));
+    }
+
+    #[test]
+    fn vtt_sorts_diarized_interleaved_segments_by_start_time() {
+        let mut meeting = sample_meeting("m1");
+        meeting.segments = vec![
+            diarized_segment("Second line", 5.0, 6.0, Speaker::Them),
+            diarized_segment("First line", 1.0, 2.0, Speaker::Me),
+            diarized_segment("Third line", 8.0, 9.0, Speaker::Me),
+        ];
+        let rendered = render_meeting(&meeting, ExportFormat::Vtt).unwrap();
+        let expected = "WEBVTT\n\
+             \n\
+             00:00:01.000 --> 00:00:02.000\n\
+             Me: First line\n\
+             \n\
+             00:00:05.000 --> 00:00:06.000\n\
+             Them: Second line\n\
+             \n\
+             00:00:08.000 --> 00:00:09.000\n\
+             Me: Third line\n";
+        assert_eq!(rendered, expected);
+    }
+
+    // ── cross-language paragraph fixture ────────────────────────────────
+
+    #[derive(serde::Deserialize)]
+    struct FixtureSegment {
+        text: String,
+        start_time: f64,
+        end_time: f64,
+        speaker: Option<Speaker>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct FixtureParagraph {
+        timestamp: String,
+        text: String,
+        speaker: Option<Speaker>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct FixtureCase {
+        name: String,
+        segments: Vec<FixtureSegment>,
+        expected: Vec<FixtureParagraph>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct Fixture {
+        pause_threshold: f64,
+        cases: Vec<FixtureCase>,
+    }
+
+    #[test]
+    fn paragraph_grouping_matches_the_typescript_reference() {
+        let raw = include_str!("../tests/fixtures/paragraph_grouping.json");
+        let fixture: Fixture = serde_json::from_str(raw).expect("valid fixture JSON");
+
+        for case in &fixture.cases {
+            let segments: Vec<crate::engine::TranscriptionSegment> = case
+                .segments
+                .iter()
+                .map(|s| crate::engine::TranscriptionSegment {
+                    text: s.text.clone(),
+                    start_time: s.start_time,
+                    end_time: s.end_time,
+                    is_final: true,
+                    language: None,
+                    confidence: None,
+                    speaker: s.speaker,
+                })
+                .collect();
+
+            let result = paragraphs::group_into_paragraphs(&segments, fixture.pause_threshold);
+
+            assert_eq!(
+                result.len(),
+                case.expected.len(),
+                "case '{}': paragraph count mismatch",
+                case.name
+            );
+            for (actual, expected) in result.iter().zip(case.expected.iter()) {
+                assert_eq!(
+                    actual.timestamp, expected.timestamp,
+                    "case '{}': timestamp mismatch",
+                    case.name
+                );
+                assert_eq!(
+                    actual.text, expected.text,
+                    "case '{}': text mismatch",
+                    case.name
+                );
+                assert_eq!(
+                    actual.speaker, expected.speaker,
+                    "case '{}': speaker mismatch",
+                    case.name
+                );
+            }
+        }
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ pub mod db;
 pub mod debug;
 pub mod engine;
 pub mod errors;
+pub mod export;
 pub mod filter;
 pub mod lock_ext;
 pub mod models;
@@ -128,6 +129,9 @@ fn specta_builder() -> Builder<tauri::Wry> {
             commands::rename_meeting,
             commands::save_meeting_notes,
             commands::save_edited_transcript,
+            commands::export_meeting_preview,
+            commands::export_meeting_filename,
+            commands::export_meeting_to_file,
             commands::check_ollama,
             commands::summarize_meeting,
             commands::search_text,
@@ -243,6 +247,7 @@ pub fn run() {
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_fs::init())
+        .plugin(tauri_plugin_dialog::init())
         .plugin(
             tauri_plugin_log::Builder::new()
                 .target(tauri_plugin_log::Target::new(

--- a/src-tauri/tests/fixtures/paragraph_grouping.json
+++ b/src-tauri/tests/fixtures/paragraph_grouping.json
@@ -1,0 +1,199 @@
+{
+  "_note": "Twin fixture at src/lib/test-helpers/paragraph-grouping.fixture.json. Keep both in sync: this proves export.rs's Rust port of groupIntoParagraphs (src/lib/utils/paragraphs.ts) matches the TS reference implementation.",
+  "pause_threshold": 1.5,
+  "cases": [
+    {
+      "name": "plain",
+      "segments": [
+        {
+          "text": "hello",
+          "start_time": 0,
+          "end_time": 0.3,
+          "speaker": null
+        },
+        {
+          "text": "there",
+          "start_time": 0.35,
+          "end_time": 0.6,
+          "speaker": null
+        },
+        {
+          "text": "friend",
+          "start_time": 0.65,
+          "end_time": 0.9,
+          "speaker": null
+        }
+      ],
+      "expected": [
+        {
+          "timestamp": "0:00",
+          "text": "hello there friend",
+          "speaker": null
+        }
+      ]
+    },
+    {
+      "name": "punctuated",
+      "segments": [
+        {
+          "text": "Hello everyone.",
+          "start_time": 0,
+          "end_time": 1,
+          "speaker": null
+        },
+        {
+          "text": "Welcome to the meeting.",
+          "start_time": 1.2,
+          "end_time": 2.5,
+          "speaker": null
+        },
+        {
+          "text": "Let's get started.",
+          "start_time": 5,
+          "end_time": 6,
+          "speaker": null
+        },
+        {
+          "text": "Any questions?",
+          "start_time": 6.3,
+          "end_time": 7,
+          "speaker": null
+        }
+      ],
+      "expected": [
+        {
+          "timestamp": "0:00",
+          "text": "Hello everyone. Welcome to the meeting.",
+          "speaker": null
+        },
+        {
+          "timestamp": "0:05",
+          "text": "Let's get started. Any questions?",
+          "speaker": null
+        }
+      ]
+    },
+    {
+      "name": "diarized_interleaved",
+      "segments": [
+        {
+          "text": "I'm good thanks.",
+          "start_time": 2,
+          "end_time": 3,
+          "speaker": "them"
+        },
+        {
+          "text": "Hi Bob, how are you?",
+          "start_time": 0,
+          "end_time": 1.5,
+          "speaker": "me"
+        },
+        {
+          "text": "Great to hear.",
+          "start_time": 3.5,
+          "end_time": 4.5,
+          "speaker": "me"
+        }
+      ],
+      "expected": [
+        {
+          "timestamp": "0:00",
+          "text": "Hi Bob, how are you?",
+          "speaker": "me"
+        },
+        {
+          "timestamp": "0:02",
+          "text": "I'm good thanks.",
+          "speaker": "them"
+        },
+        {
+          "timestamp": "0:03",
+          "text": "Great to hear.",
+          "speaker": "me"
+        }
+      ]
+    },
+    {
+      "name": "unpunctuated_long",
+      "segments": [
+        {
+          "text": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "start_time": 0,
+          "end_time": 5,
+          "speaker": null
+        },
+        {
+          "text": "bbbbb",
+          "start_time": 5.5,
+          "end_time": 6,
+          "speaker": null
+        },
+        {
+          "text": "ccccc",
+          "start_time": 6.2,
+          "end_time": 6.5,
+          "speaker": null
+        }
+      ],
+      "expected": [
+        {
+          "timestamp": "0:00",
+          "text": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "speaker": null
+        },
+        {
+          "timestamp": "0:05",
+          "text": "bbbbb ccccc",
+          "speaker": null
+        }
+      ]
+    },
+    {
+      "name": "sentence_count_cap",
+      "segments": [
+        {
+          "text": "One.",
+          "start_time": 0,
+          "end_time": 0.5,
+          "speaker": null
+        },
+        {
+          "text": "Two.",
+          "start_time": 0.6,
+          "end_time": 1,
+          "speaker": null
+        },
+        {
+          "text": "Three.",
+          "start_time": 1.1,
+          "end_time": 1.5,
+          "speaker": null
+        },
+        {
+          "text": "Four.",
+          "start_time": 1.6,
+          "end_time": 2,
+          "speaker": null
+        },
+        {
+          "text": "Five.",
+          "start_time": 2.1,
+          "end_time": 2.5,
+          "speaker": null
+        }
+      ],
+      "expected": [
+        {
+          "timestamp": "0:00",
+          "text": "One. Two. Three. Four.",
+          "speaker": null
+        },
+        {
+          "timestamp": "0:02",
+          "text": "Five.",
+          "speaker": null
+        }
+      ]
+    }
+  ]
+}

--- a/src/lib/api/meetings.test.ts
+++ b/src/lib/api/meetings.test.ts
@@ -22,6 +22,9 @@ import {
   deleteMeeting,
   searchText,
   saveEditedTranscript,
+  exportMeetingFilename,
+  exportMeetingPreview,
+  exportMeetingToFile,
 } from './meetings';
 
 describe('meetings API', () => {
@@ -130,5 +133,31 @@ describe('meetings API', () => {
     await saveEditedTranscript('meeting-1', null);
 
     expect(mockInvoke).toHaveBeenCalledWith('save_edited_transcript', expect.objectContaining({ id: 'meeting-1', editedTranscript: null }), undefined);
+  });
+
+  it('exportMeetingFilename passes id and format, returns the suggested name', async () => {
+    mockInvoke.mockResolvedValue('2026-07-09-weekly-sync.md');
+
+    const result = await exportMeetingFilename('meeting-1', 'markdown');
+
+    expect(mockInvoke).toHaveBeenCalledWith('export_meeting_filename', expect.objectContaining({ id: 'meeting-1', format: 'markdown' }), undefined);
+    expect(result).toBe('2026-07-09-weekly-sync.md');
+  });
+
+  it('exportMeetingPreview passes id and format, returns rendered text', async () => {
+    mockInvoke.mockResolvedValue('# Weekly Sync\n');
+
+    const result = await exportMeetingPreview('meeting-1', 'srt');
+
+    expect(mockInvoke).toHaveBeenCalledWith('export_meeting_preview', expect.objectContaining({ id: 'meeting-1', format: 'srt' }), undefined);
+    expect(result).toBe('# Weekly Sync\n');
+  });
+
+  it('exportMeetingToFile passes id, format and path', async () => {
+    mockInvoke.mockResolvedValue(null);
+
+    await exportMeetingToFile('meeting-1', 'vtt', '/tmp/export.vtt');
+
+    expect(mockInvoke).toHaveBeenCalledWith('export_meeting_to_file', expect.objectContaining({ id: 'meeting-1', format: 'vtt', path: '/tmp/export.vtt' }), undefined);
   });
 });

--- a/src/lib/api/meetings.ts
+++ b/src/lib/api/meetings.ts
@@ -9,6 +9,7 @@ export async function saveMeetingNotes(id: string, notes: string | null): Promis
   await unwrap(commands.saveMeetingNotes(id, notes));
 }
 import type {
+  ExportFormat,
   MeetingCalendarContext,
   MeetingListItem,
   MeetingTranscript,
@@ -74,4 +75,19 @@ export async function searchText(query: string, limit?: number): Promise<SearchR
 
 export async function saveEditedTranscript(id: string, editedTranscript: string | null): Promise<void> {
   await unwrap(commands.saveEditedTranscript(id, editedTranscript));
+}
+
+/** Suggested filename for a meeting export (e.g. "2026-07-09-weekly-sync.md"). */
+export async function exportMeetingFilename(id: string, format: ExportFormat): Promise<string> {
+  return unwrap(commands.exportMeetingFilename(id, format));
+}
+
+/** Render a meeting export without writing to disk. */
+export async function exportMeetingPreview(id: string, format: ExportFormat): Promise<string> {
+  return unwrap(commands.exportMeetingPreview(id, format));
+}
+
+/** Render a meeting export and write it to `path`. */
+export async function exportMeetingToFile(id: string, format: ExportFormat, path: string): Promise<void> {
+  await unwrap(commands.exportMeetingToFile(id, format, path));
 }

--- a/src/lib/features/meeting/components/MeetingDetail.svelte
+++ b/src/lib/features/meeting/components/MeetingDetail.svelte
@@ -51,10 +51,12 @@
       segmentCount={displaySegments.length}
       sessionCount={sessionCount}
       canResumeRecording={controller.canResumeRecording}
+      isExporting={controller.isExporting}
       onBack={() => controller.closeMeeting()}
       onRename={(title) => void controller.renameMeeting(title)}
       onResumeRecording={controller.resumeRecording}
       onStopRecording={controller.stopRecording}
+      onExport={(format) => controller.exportMeeting(format)}
     />
 
     <!-- Notes are the focus: what the user wrote, front and center. -->

--- a/src/lib/features/meeting/components/MeetingHeaderSection.svelte
+++ b/src/lib/features/meeting/components/MeetingHeaderSection.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  import { ArrowLeft, Pencil, Square, Users } from "@lucide/svelte";
+  import { ArrowLeft, ChevronDown, Download, Pencil, Square, Users } from "@lucide/svelte";
   import { t } from "svelte-i18n";
-  import type { MeetingTranscript } from "../../../types";
+  import type { ExportFormat, MeetingTranscript } from "../../../types";
   import { formatDate, formatDuration } from "../../../utils";
   import Spinner from "../../../components/ui/Spinner.svelte";
 
@@ -14,10 +14,12 @@
     segmentCount,
     sessionCount,
     canResumeRecording,
+    isExporting,
     onBack,
     onRename,
     onResumeRecording,
     onStopRecording,
+    onExport,
   }: {
     meeting: MeetingTranscript;
     isRecordingMeeting: boolean;
@@ -27,15 +29,30 @@
     segmentCount: number;
     sessionCount: number;
     canResumeRecording: boolean;
+    isExporting: boolean;
     onBack: () => void;
     onRename: (title: string) => void;
     onResumeRecording: () => void | Promise<void>;
     onStopRecording: () => void | Promise<void>;
+    onExport: (format: ExportFormat) => void | Promise<void>;
   } = $props();
 
   let isEditingTitle = $state(false);
   let titleDraft = $state("");
   let titleInput: HTMLInputElement | undefined = $state();
+  let showExportMenu = $state(false);
+
+  const EXPORT_FORMATS: { format: ExportFormat; labelKey: string }[] = [
+    { format: "markdown", labelKey: "meeting_header.export_markdown" },
+    { format: "json", labelKey: "meeting_header.export_json" },
+    { format: "srt", labelKey: "meeting_header.export_srt" },
+    { format: "vtt", labelKey: "meeting_header.export_vtt" },
+  ];
+
+  function pickExport(format: ExportFormat) {
+    showExportMenu = false;
+    onExport(format);
+  }
 
   function startTitleEdit() {
     titleDraft = meeting.title;
@@ -159,6 +176,41 @@
           {$t("meeting_header.resume_recording")}
         </button>
       {/if}
+      <div class="relative">
+        <button
+          onclick={() => (showExportMenu = !showExportMenu)}
+          disabled={isExporting}
+          class="btn btn-ghost gap-1.5 px-2.5 py-1.5 text-[12.5px]"
+          aria-haspopup="true"
+          aria-expanded={showExportMenu}
+        >
+          {#if isExporting}
+            <Spinner />
+          {:else}
+            <Download size={14} aria-hidden="true" />
+          {/if}
+          {$t("meeting_header.export")}
+          <ChevronDown size={13} aria-hidden="true" />
+        </button>
+        {#if showExportMenu}
+          <button
+            type="button"
+            class="fixed inset-0 z-10 cursor-default"
+            aria-label={$t("ui.cancel")}
+            onclick={() => (showExportMenu = false)}
+          ></button>
+          <div class="absolute right-0 z-20 mt-1.5 w-44 rounded-[11px] bg-surface-1 p-1.5 shadow-lg outline-1 outline-ghost-border">
+            {#each EXPORT_FORMATS as { format, labelKey } (format)}
+              <button
+                onclick={() => pickExport(format)}
+                class="block w-full cursor-pointer rounded-[8px] px-2.5 py-1.5 text-left text-[12.5px] text-text-primary transition-colors hover:bg-surface-2"
+              >
+                {$t(labelKey)}
+              </button>
+            {/each}
+          </div>
+        {/if}
+      </div>
     {/if}
   </div>
 </div>

--- a/src/lib/features/meeting/controller.svelte.test.ts
+++ b/src/lib/features/meeting/controller.svelte.test.ts
@@ -32,6 +32,13 @@ const mockSaveMeetingNotes = vi.fn<(id: string, notes: string | null) => Promise
 const mockSummarizeMeeting = vi.fn<
   (id: string, model: string, onProgress: (p: SummarizeProgress) => void) => Promise<void>
 >();
+const mockExportMeetingFilename = vi.fn<
+  (id: string, format: import("../../types").ExportFormat) => Promise<string>
+>();
+const mockExportMeetingToFile = vi.fn<
+  (id: string, format: import("../../types").ExportFormat, path: string) => Promise<void>
+>();
+const mockShowSaveDialog = vi.fn<(opts: unknown) => Promise<string | null>>();
 
 vi.mock("../../api/meetings", () => ({
   startMeetingRecording: (...a: unknown[]) =>
@@ -52,6 +59,14 @@ vi.mock("../../api/meetings", () => ({
     mockSummarizeMeeting(
       ...(a as [string, string, (p: SummarizeProgress) => void]),
     ),
+  exportMeetingFilename: (...a: unknown[]) =>
+    mockExportMeetingFilename(...(a as [string, import("../../types").ExportFormat])),
+  exportMeetingToFile: (...a: unknown[]) =>
+    mockExportMeetingToFile(...(a as [string, import("../../types").ExportFormat, string])),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  save: (...a: unknown[]) => mockShowSaveDialog(...(a as [unknown])),
 }));
 
 vi.mock("../../api/ollama", () => ({
@@ -356,6 +371,92 @@ describe("MeetingController", () => {
     expect(mockDeleteMeeting).toHaveBeenCalledWith("meet-1");
     expect(ctrl.meeting).toBeNull();
     expect(mockApp.currentMeetingId).toBeNull();
+  });
+
+  it("exportMeeting looks up the filename, opens the save dialog, and writes the file", async () => {
+    mockGetOllamaStatus.mockResolvedValue(makeOllamaStatus());
+    mockGetTranscriptionCatalog.mockResolvedValue(makeCatalog());
+    mockGetMeeting.mockResolvedValue(makeMeeting());
+    mockExportMeetingFilename.mockResolvedValue("2026-07-09-standup.md");
+    mockShowSaveDialog.mockResolvedValue("/Users/damien/Downloads/2026-07-09-standup.md");
+    mockExportMeetingToFile.mockResolvedValue(undefined);
+
+    const ctrl = createMeetingController();
+    await ctrl.mount();
+    await ctrl.onMeetingSelectionChange("meet-1");
+
+    await ctrl.exportMeeting("markdown");
+
+    expect(mockExportMeetingFilename).toHaveBeenCalledWith("meet-1", "markdown");
+    expect(mockShowSaveDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        defaultPath: "2026-07-09-standup.md",
+        filters: [{ name: "MD", extensions: ["md"] }],
+      }),
+    );
+    expect(mockExportMeetingToFile).toHaveBeenCalledWith(
+      "meet-1",
+      "markdown",
+      "/Users/damien/Downloads/2026-07-09-standup.md",
+    );
+    expect(ctrl.isExporting).toBe(false);
+  });
+
+  it("exportMeeting does not write a file when the save dialog is cancelled", async () => {
+    mockGetOllamaStatus.mockResolvedValue(makeOllamaStatus());
+    mockGetTranscriptionCatalog.mockResolvedValue(makeCatalog());
+    mockGetMeeting.mockResolvedValue(makeMeeting());
+    mockExportMeetingFilename.mockResolvedValue("2026-07-09-standup.srt");
+    mockShowSaveDialog.mockResolvedValue(null);
+
+    const ctrl = createMeetingController();
+    await ctrl.mount();
+    await ctrl.onMeetingSelectionChange("meet-1");
+
+    await ctrl.exportMeeting("srt");
+
+    expect(mockShowSaveDialog).toHaveBeenCalledOnce();
+    expect(mockExportMeetingToFile).not.toHaveBeenCalled();
+  });
+
+  it("exportMeeting surfaces backend errors via statusMessage", async () => {
+    mockGetOllamaStatus.mockResolvedValue(makeOllamaStatus());
+    mockGetTranscriptionCatalog.mockResolvedValue(makeCatalog());
+    mockGetMeeting.mockResolvedValue(makeMeeting());
+    mockExportMeetingFilename.mockRejectedValue(new Error("meeting not found"));
+
+    const ctrl = createMeetingController();
+    await ctrl.mount();
+    await ctrl.onMeetingSelectionChange("meet-1");
+
+    await ctrl.exportMeeting("json");
+
+    expect(ctrl.statusMessage).toContain("meeting not found");
+    expect(mockShowSaveDialog).not.toHaveBeenCalled();
+    expect(ctrl.isExporting).toBe(false);
+  });
+
+  it("exportMeeting is a no-op while the meeting is recording", async () => {
+    mockGetOllamaStatus.mockResolvedValue(makeOllamaStatus());
+    mockGetTranscriptionCatalog.mockResolvedValue(makeCatalog());
+    mockStartMeetingRecording.mockResolvedValue(undefined);
+
+    const ctrl = createMeetingController();
+    await ctrl.mount();
+    await ctrl.startRecording();
+    mockApp.machineState = {
+      state: "recording_meeting",
+      data: {
+        profile: makeMeeting().transcription_profile,
+        session_id: 1,
+        meeting_id: "live-1",
+      },
+    } as import("../../types").AppStateMachine;
+
+    await ctrl.exportMeeting("vtt");
+
+    expect(mockExportMeetingFilename).not.toHaveBeenCalled();
+    expect(mockShowSaveDialog).not.toHaveBeenCalled();
   });
 
   it("notes autosave debounces and targets the live accumulator id", async () => {

--- a/src/lib/features/meeting/controller.svelte.ts
+++ b/src/lib/features/meeting/controller.svelte.ts
@@ -1,5 +1,8 @@
+import { save as showSaveDialog } from "@tauri-apps/plugin-dialog";
 import {
   deleteMeeting as removeMeeting,
+  exportMeetingFilename,
+  exportMeetingToFile,
   getMeeting,
   renameMeeting as applyMeetingRename,
   resumeMeetingRecording,
@@ -13,7 +16,7 @@ import {
 import { getOllamaStatus } from "../../api/ollama";
 import { getTranscriptionCatalog } from "../../api/transcription";
 import { getAppState } from "../../stores/app.svelte";
-import type { MeetingCalendarContext, MeetingIdle, MeetingTranscript, OllamaModelDescriptor, SummarizeProgress, TranscriptionCatalog, TranscriptionSegment } from "../../types";
+import type { ExportFormat, MeetingCalendarContext, MeetingIdle, MeetingTranscript, OllamaModelDescriptor, SummarizeProgress, TranscriptionCatalog, TranscriptionSegment } from "../../types";
 import { errorMessage } from "../../utils";
 import { toSelectedTranscriptionProfile } from "../transcription/catalog";
 import { ensureModelLoaded } from "../transcription/runtime";
@@ -40,6 +43,7 @@ function createMeetingControllerInstance() {
 
   let isEditingTranscript = $state(false);
   let editedTranscriptDraft = $state("");
+  let isExporting = $state(false);
 
   const NOTES_DEBOUNCE_MS = 800;
   let notesDraft = $state("");
@@ -491,6 +495,33 @@ function createMeetingControllerInstance() {
     }
   }
 
+  /**
+   * Export the current meeting to a file the user picks via the native save
+   * dialog. The suggested filename (and its extension) come from the
+   * backend (`export_meeting_filename`) so the slugify/date-formatting rules
+   * live in exactly one place; the dialog plugin only needs the extension
+   * for its filter, which we read back off that filename.
+   */
+  async function exportMeeting(format: ExportFormat) {
+    if (!meeting || !meeting.id || isRecordingMeeting) return;
+    isExporting = true;
+    statusMessage = "";
+    try {
+      const filename = await exportMeetingFilename(meeting.id, format);
+      const extension = filename.split(".").pop() ?? format;
+      const path = await showSaveDialog({
+        defaultPath: filename,
+        filters: [{ name: extension.toUpperCase(), extensions: [extension] }],
+      });
+      if (!path) return; // user cancelled the dialog
+      await exportMeetingToFile(meeting.id, format, path);
+    } catch (e) {
+      statusMessage = errorMessage(e);
+    } finally {
+      isExporting = false;
+    }
+  }
+
   return {
     get app() { return app; },
     get statusMessage() { return statusMessage; },
@@ -508,6 +539,7 @@ function createMeetingControllerInstance() {
     get isStopping() { return isStopping; },
     get canResumeRecording() { return canResumeRecording; },
     get isEditingTranscript() { return isEditingTranscript; },
+    get isExporting() { return isExporting; },
     get editedTranscriptDraft() { return editedTranscriptDraft; },
     set editedTranscriptDraft(value: string) { editedTranscriptDraft = value; },
     get notesDraft() { return notesDraft; },
@@ -526,6 +558,7 @@ function createMeetingControllerInstance() {
     renameMeeting,
     summarizeMeeting,
     deleteMeeting,
+    exportMeeting,
     startEditingTranscript,
     cancelEditingTranscript,
     saveTranscriptEdit,

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -118,7 +118,12 @@
     "locked_by_dictation": "Stop the dictation before recording a meeting.",
     "system_audio_active": "System audio",
     "system_audio_unavailable": "Mic only",
-    "rename_aria": "Rename meeting"
+    "rename_aria": "Rename meeting",
+    "export": "Export",
+    "export_markdown": "Markdown (.md)",
+    "export_json": "JSON (.json)",
+    "export_srt": "Subtitles (.srt)",
+    "export_vtt": "Subtitles (.vtt)"
   },
   "meeting_transcript": {
     "title": "Transcript",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -118,7 +118,12 @@
     "locked_by_dictation": "Arrêtez la dictée avant d'enregistrer une réunion.",
     "system_audio_active": "Audio système",
     "system_audio_unavailable": "Micro seul",
-    "rename_aria": "Renommer le meeting"
+    "rename_aria": "Renommer le meeting",
+    "export": "Exporter",
+    "export_markdown": "Markdown (.md)",
+    "export_json": "JSON (.json)",
+    "export_srt": "Sous-titres (.srt)",
+    "export_vtt": "Sous-titres (.vtt)"
   },
   "meeting_transcript": {
     "title": "Transcription",

--- a/src/lib/test-helpers/paragraph-grouping.fixture.json
+++ b/src/lib/test-helpers/paragraph-grouping.fixture.json
@@ -1,0 +1,199 @@
+{
+  "_note": "Twin fixture at src-tauri/tests/fixtures/paragraph_grouping.json. Keep both in sync: this proves export.rs's Rust port of groupIntoParagraphs (this module) matches the TS reference implementation.",
+  "pause_threshold": 1.5,
+  "cases": [
+    {
+      "name": "plain",
+      "segments": [
+        {
+          "text": "hello",
+          "start_time": 0,
+          "end_time": 0.3,
+          "speaker": null
+        },
+        {
+          "text": "there",
+          "start_time": 0.35,
+          "end_time": 0.6,
+          "speaker": null
+        },
+        {
+          "text": "friend",
+          "start_time": 0.65,
+          "end_time": 0.9,
+          "speaker": null
+        }
+      ],
+      "expected": [
+        {
+          "timestamp": "0:00",
+          "text": "hello there friend",
+          "speaker": null
+        }
+      ]
+    },
+    {
+      "name": "punctuated",
+      "segments": [
+        {
+          "text": "Hello everyone.",
+          "start_time": 0,
+          "end_time": 1,
+          "speaker": null
+        },
+        {
+          "text": "Welcome to the meeting.",
+          "start_time": 1.2,
+          "end_time": 2.5,
+          "speaker": null
+        },
+        {
+          "text": "Let's get started.",
+          "start_time": 5,
+          "end_time": 6,
+          "speaker": null
+        },
+        {
+          "text": "Any questions?",
+          "start_time": 6.3,
+          "end_time": 7,
+          "speaker": null
+        }
+      ],
+      "expected": [
+        {
+          "timestamp": "0:00",
+          "text": "Hello everyone. Welcome to the meeting.",
+          "speaker": null
+        },
+        {
+          "timestamp": "0:05",
+          "text": "Let's get started. Any questions?",
+          "speaker": null
+        }
+      ]
+    },
+    {
+      "name": "diarized_interleaved",
+      "segments": [
+        {
+          "text": "I'm good thanks.",
+          "start_time": 2,
+          "end_time": 3,
+          "speaker": "them"
+        },
+        {
+          "text": "Hi Bob, how are you?",
+          "start_time": 0,
+          "end_time": 1.5,
+          "speaker": "me"
+        },
+        {
+          "text": "Great to hear.",
+          "start_time": 3.5,
+          "end_time": 4.5,
+          "speaker": "me"
+        }
+      ],
+      "expected": [
+        {
+          "timestamp": "0:00",
+          "text": "Hi Bob, how are you?",
+          "speaker": "me"
+        },
+        {
+          "timestamp": "0:02",
+          "text": "I'm good thanks.",
+          "speaker": "them"
+        },
+        {
+          "timestamp": "0:03",
+          "text": "Great to hear.",
+          "speaker": "me"
+        }
+      ]
+    },
+    {
+      "name": "unpunctuated_long",
+      "segments": [
+        {
+          "text": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "start_time": 0,
+          "end_time": 5,
+          "speaker": null
+        },
+        {
+          "text": "bbbbb",
+          "start_time": 5.5,
+          "end_time": 6,
+          "speaker": null
+        },
+        {
+          "text": "ccccc",
+          "start_time": 6.2,
+          "end_time": 6.5,
+          "speaker": null
+        }
+      ],
+      "expected": [
+        {
+          "timestamp": "0:00",
+          "text": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "speaker": null
+        },
+        {
+          "timestamp": "0:05",
+          "text": "bbbbb ccccc",
+          "speaker": null
+        }
+      ]
+    },
+    {
+      "name": "sentence_count_cap",
+      "segments": [
+        {
+          "text": "One.",
+          "start_time": 0,
+          "end_time": 0.5,
+          "speaker": null
+        },
+        {
+          "text": "Two.",
+          "start_time": 0.6,
+          "end_time": 1,
+          "speaker": null
+        },
+        {
+          "text": "Three.",
+          "start_time": 1.1,
+          "end_time": 1.5,
+          "speaker": null
+        },
+        {
+          "text": "Four.",
+          "start_time": 1.6,
+          "end_time": 2,
+          "speaker": null
+        },
+        {
+          "text": "Five.",
+          "start_time": 2.1,
+          "end_time": 2.5,
+          "speaker": null
+        }
+      ],
+      "expected": [
+        {
+          "timestamp": "0:00",
+          "text": "One. Two. Three. Four.",
+          "speaker": null
+        },
+        {
+          "timestamp": "0:02",
+          "text": "Five.",
+          "speaker": null
+        }
+      ]
+    }
+  ]
+}

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -260,6 +260,42 @@ async saveEditedTranscript(id: string, editedTranscript: string | null) : Promis
 }
 },
 /**
+ * Render a meeting export without writing to disk. Used by tests and, if
+ * ever needed, a clipboard-copy affordance.
+ */
+async exportMeetingPreview(id: string, format: ExportFormat) : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("export_meeting_preview", { id, format }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Suggested filename for a meeting export (e.g. `2026-07-09-weekly-sync.md`),
+ * used as the save dialog's default path.
+ */
+async exportMeetingFilename(id: string, format: ExportFormat) : Promise<Result<string, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("export_meeting_filename", { id, format }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Render a meeting export and write it to `path`. The save dialog itself
+ * (picking `path`) runs frontend-side via the dialog plugin.
+ */
+async exportMeetingToFile(id: string, format: ExportFormat, path: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("export_meeting_to_file", { id, format, path }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Check if Ollama is available and list models
  */
 async checkOllama() : Promise<Result<OllamaStatus, string>> {
@@ -657,6 +693,7 @@ pronunciation: string | null; category: string | null; created_at: string }
 export type DownloadProgress = { file: string; downloaded_bytes: number; total_bytes: number | null; completed_files: number; total_files: number; status: DownloadStatus }
 export type DownloadStatus = "starting" | "downloading" | "complete" | { error: string }
 export type ErrorRecovery = "retry_from_idle" | { retry_from_downloaded: { profile: TranscriptionProfile } } | { retry_from_ready: { profile: TranscriptionProfile } }
+export type ExportFormat = "markdown" | "json" | "srt" | "vtt"
 export type HealthStatus = "healthy" | 
 /**
  * Inference is behind real-time, or audio chunks were dropped.

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -11,6 +11,7 @@ export type {
   DownloadProgress,
   DownloadStatus,
   ErrorRecovery,
+  ExportFormat,
   MeetingCalendarContext,
   MeetingIdle,
   MeetingIdleReason,

--- a/src/lib/utils/paragraphs.test.ts
+++ b/src/lib/utils/paragraphs.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { buildMeetingTranscriptBlocks, groupIntoParagraphs, groupIntoParagraphsWithRanges } from './paragraphs';
-import type { MeetingRecordingSession, TranscriptionSegment } from '../types';
+import type { MeetingRecordingSession, Speaker, TranscriptionSegment } from '../types';
+import paragraphGroupingFixture from '../test-helpers/paragraph-grouping.fixture.json';
 
 function seg(text: string, start: number, end?: number): TranscriptionSegment {
   return {
@@ -279,4 +280,32 @@ describe('buildMeetingTranscriptBlocks', () => {
       startLabel: 'Resumed recording in progress',
     });
   });
+});
+
+// Cross-language fixture shared with the Rust port in src-tauri/src/export.rs
+// (tests/fixtures/paragraph_grouping.json). Both implementations must group
+// the same segment streams into the same paragraphs — this is the frozen
+// contract; if groupIntoParagraphs' behavior changes on purpose, regenerate
+// and update both copies of the fixture together.
+describe('groupIntoParagraphs cross-language fixture parity', () => {
+  const { pause_threshold, cases } = paragraphGroupingFixture;
+
+  for (const testCase of cases) {
+    it(`matches the frozen fixture for "${testCase.name}"`, () => {
+      const segments: TranscriptionSegment[] = testCase.segments.map((s) => ({
+        text: s.text,
+        start_time: s.start_time,
+        end_time: s.end_time,
+        is_final: true,
+        language: null,
+        confidence: null,
+        speaker: (s.speaker ?? undefined) as Speaker | undefined,
+      }));
+
+      const result = groupIntoParagraphs(segments, pause_threshold);
+
+      expect(result.map((p) => ({ timestamp: p.timestamp, text: p.text, speaker: p.speaker ?? null })))
+        .toEqual(testCase.expected);
+    });
+  }
 });


### PR DESCRIPTION
Adds meeting export from the detail view via a native save dialog (new tauri-plugin-dialog, scoped to dialog:allow-save).

- Markdown: metadata block, notes, summary, transcript grouped with the exact same paragraph rules as the UI. Rules are ported to Rust in one private module and locked to the TS implementation by a cross-language fixture generated from the real groupIntoParagraphs (asserted on both sides).
- JSON: full MeetingTranscript, pretty-printed.
- SRT/VTT: cues with Me/Them prefixes, minimum display duration clamp, and time-ordered diarized segments (interleaved Me/Them storage order would otherwise produce invalid non-monotonic cues; caught in review, regression-tested).
- Backend-authoritative suggested filename (slugified title + date); export hidden while recording.

Gates: 350 Rust tests, 175 frontend tests, clippy/check/build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuuJ8cV2dsbwNnc7Y8gm2b