### PR TITLE
Fix generated-contracts CI after MCP sidecar (#25)

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: Swatinem/rust-cache@v2.8.1
+      - uses: Swatinem/rust-cache@v2.9.1
         with:
           workspaces: src-tauri -> target
 
@@ -26,4 +26,7 @@ jobs:
           cache: npm
 
       - run: npm ci
+      # Tauri's build script validates `externalBin` entries during `cargo test`,
+      # so the MCP sidecar must exist before type export (same as release builds).
+      - run: ./scripts/build-mcp-sidecar.sh
       - run: npm run check:generated-types

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
       # GitHub's macOS runner images, so no separate setup step is needed.
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v2.9.1
         with:
           workspaces: "./src-tauri -> target"
 


### PR DESCRIPTION
## Summary

- **Root cause:** PR #25 added `souffle-mcp` as a Tauri `externalBin`. Tauri's build script validates those paths during `cargo test`, so `npm run check:generated-types` fails on a clean checkout where the sidecar binary was never built.
- **Fix:** Run `./scripts/build-mcp-sidecar.sh` in the contracts workflow before type export (same as release builds).
- **Also:** Bump `Swatinem/rust-cache` to v2.9.1 in contracts and release workflows for Node 24 compatibility on GitHub runners.

## Test plan

- [x] Contracts workflow runs green on this PR
- [x] Release workflow rust-cache pin unchanged in behavior aside from version bump