### PR TITLE
E2E smoke tests: command-level integration + browser suite

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,26 @@
+name: E2E
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  playwright:
+    # Frontend-only smoke suite (IPC is stubbed, see tests/e2e/tauri-stub.ts):
+    # no Rust build needed, so a Linux runner is fine and cheaper than macOS.
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6.0.1
+
+      - uses: actions/setup-node@v6.1.0
+        with:
+          node-version: 24
+          check-latest: true
+          cache: npm
+
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,8 @@ src-tauri/binaries/
 
 # Generated placeholder icon (replace with real icon)
 app-icon.png
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "svelte-i18n": "^4.0.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@sveltejs/vite-plugin-svelte": "^6.0.0",
         "@tailwindcss/vite": "^4.0.0",
         "@tauri-apps/api": "^2.0.0",
@@ -830,6 +831,22 @@
       "license": "ISC",
       "peerDependencies": {
         "svelte": "^5"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3038,6 +3055,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
     "generate:types": "cargo test export_typescript_bindings --manifest-path src-tauri/Cargo.toml -- --nocapture",
     "check:generated-types": "npm run generate:types && git diff --exit-code src/lib/types/generated.ts src/lib/api/generated.ts",
     "tauri": "tauri",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@sveltejs/vite-plugin-svelte": "^6.0.0",
     "@tailwindcss/vite": "^4.0.0",
     "@tauri-apps/api": "^2.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// Frontend-only browser smoke suite. tauri-driver (the WebDriver bridge for
+// driving the real Tauri window) does not support macOS, so this exercises
+// the Svelte app in a real Chromium browser against the Vite dev server,
+// with the Tauri IPC layer stubbed (see tests/e2e/tauri-stub.ts) instead of
+// a real Rust backend.
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? "line" : "list",
+  use: {
+    baseURL: "http://localhost:1420",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:1420",
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+});

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6374,6 +6374,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sonora",
+ "souffle",
  "souffle-mcp",
  "specta",
  "specta-typescript",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -99,9 +99,22 @@ sonora = "0.1"
 block2 = "0.6"
 dispatch2 = "0.3"
 
+[features]
+# Exposes the mock transcription engine (normally `#[cfg(test)]`-only) so the
+# `tests/` integration binaries — which link the lib as a normal, non-`cfg(test)`
+# dependency — can use it too. Enabled automatically for `cargo test` via the
+# self dev-dependency below. Must not gate anything that itself needs a
+# dev-dependency (e.g. `tempfile`): dev-dependencies aren't available when the
+# lib is built as a dependency, even via this self-reference.
+test-support = []
+
 [dev-dependencies]
 tempfile = "3"
 souffle-mcp = { path = "souffle-mcp" }
+souffle = { path = ".", features = ["test-support"] }
+# MockRuntime + mock_builder for driving Tauri commands in integration tests
+# without a real webview.
+tauri = { version = "2", features = ["test"] }
 
 [profile.release]
 strip = true

--- a/src-tauri/src/engine/mock.rs
+++ b/src-tauri/src/engine/mock.rs
@@ -1,5 +1,5 @@
 //! Mock transcription engine for testing pipeline behavior without GPU/hardware.
-#![cfg(test)]
+#![cfg(any(test, feature = "test-support"))]
 
 use super::{
     AudioInputRequirements, EngineError, Speaker, TranscriptionEngine, TranscriptionSegment,

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -2,7 +2,7 @@ pub mod kyutai;
 pub mod parakeet;
 pub mod whisper;
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 pub mod mock;
 
 use std::path::{Path, PathBuf};

--- a/src-tauri/tests/app_flows.rs
+++ b/src-tauri/tests/app_flows.rs
@@ -1,0 +1,369 @@
+//! Smoke-level end-to-end tests for the two critical lifecycles: dictation
+//! round-trip and "meeting stop persists a meeting". Drives the real Tauri
+//! command functions from `souffle_lib::commands` against a
+//! `tauri::test::MockRuntime` app, with a `MockEngine` swapped in for the
+//! transcription engine (via the actor's injectable `EngineFactory`) and a
+//! temp-file SQLite database. No GPU, no real audio hardware, no webview —
+//! `tauri-driver` does not support macOS, so this exercises the command
+//! layer directly instead of driving a real window through WebDriver.
+//!
+//! ## Coverage note: why `stop_meeting_recording` isn't called directly
+//!
+//! `AppState::app_handle` is a concrete `tauri::AppHandle` — the
+//! `#[default_runtime(crate::Wry, wry)]` macro Tauri applies to `AppHandle`
+//! makes the bare (unparameterized) name mean `AppHandle<Wry>`, not generic
+//! over the runtime. A `MockRuntime`-backed app can never produce one (that
+//! would be a type error), so `state.app_handle` stays `None` for this whole
+//! suite — exactly what `AppState::apply_transition` already tolerates (its
+//! event-emission block is a no-op when `app_handle` is unset, clearly
+//! designed with this in mind).
+//!
+//! `start_meeting_recording`, `resume_meeting_recording`, `start_transcription`,
+//! `stop_transcription`, and every read-path command never touch
+//! `app_handle`, so those run as the literal, unmodified `#[tauri::command]`
+//! functions below. `stop_meeting_recording` is the one exception: it calls
+//! `state.app_handle()` to spawn a background finalize task that looks
+//! itself up again via `AppHandle::state()` and emits `MeetingFinalized` for
+//! the frontend. Building a real, window-backed `AppHandle<Wry>` needs the
+//! platform event loop on the main thread, which conflicts with the
+//! `cargo test` harness's threading model — the same class of fragility as
+//! the tauri-driver-on-macOS gap this test suite exists to work around. So
+//! `stop_meeting_and_persist` below drives the exact same primitives that
+//! background task uses (`EngineActorHandle::stop_session`,
+//! `MeetingAccumulator::into_transcript`, `Database::save_meeting`, the
+//! `StopRecording`/`StopComplete` transitions) directly, synchronously,
+//! instead of through the outer AppHandle-spawning wrapper. Everything
+//! except that background-task glue itself is exercised.
+
+use std::path::PathBuf;
+use std::sync::atomic::AtomicU32;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crossbeam_channel::{Receiver, Sender};
+use tauri::Manager;
+use tauri::ipc::{Channel, InvokeResponseBody};
+use tempfile::TempDir;
+
+use souffle_lib::audio::{AudioChunk, AudioMessage};
+use souffle_lib::audio::system_activity::SystemAudioActivity;
+use souffle_lib::commands;
+use souffle_lib::constants::MIMI_FRAME_SIZE;
+use souffle_lib::db::Database;
+use souffle_lib::engine::mock::MockEngine;
+use souffle_lib::engine::{TranscriptionEngine, TranscriptionSegment, default_transcription_profile};
+use souffle_lib::pipeline::EngineActorHandle;
+use souffle_lib::settings::AppSettings;
+use souffle_lib::state::{AppState, AudioCommand};
+use souffle_lib::state_machine::{AppStateMachine, StateAction};
+
+/// Spawn the engine actor with a `MockEngine` in place of the real
+/// transcription backend, mirroring `pipeline::actor::tests::spawn_with_mock`.
+fn spawn_mock_actor(mock: MockEngine) -> (EngineActorHandle, Sender<AudioMessage>) {
+    let (audio_tx, audio_rx) = crossbeam_channel::unbounded();
+    let cell = Mutex::new(Some(mock));
+    let actor = EngineActorHandle::spawn(
+        audio_rx,
+        Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        Arc::new(Mutex::new(None)),
+        Box::new(move |_profile| {
+            cell.lock()
+                .unwrap()
+                .take()
+                .map(|m| Box::new(m) as Box<dyn TranscriptionEngine>)
+                .ok_or_else(|| "mock engine already taken".to_string())
+        }),
+    )
+    .expect("spawn engine actor");
+    (actor, audio_tx)
+}
+
+/// Drive the app-level state machine through Idle -> Ready, the same
+/// sequence `commands::load_model` runs, and load the mock engine so the
+/// actor has something to transcribe with.
+fn bring_to_ready(state: &AppState, actor: &EngineActorHandle) {
+    let profile = default_transcription_profile();
+    actor
+        .load_model(profile.clone(), PathBuf::from("/tmp"))
+        .expect("mock engine load");
+
+    state
+        .apply_transition(StateAction::StartDownload {
+            profile: profile.clone(),
+        })
+        .unwrap();
+    state
+        .apply_transition(StateAction::DownloadComplete)
+        .unwrap();
+    state.apply_transition(StateAction::StartLoad).unwrap();
+    state.apply_transition(StateAction::LoadComplete).unwrap();
+}
+
+/// Test harness: everything needed to call commands end-to-end plus the
+/// pieces (audio channel, actor, db) needed to drive/inspect them directly.
+struct Harness {
+    app: tauri::App<tauri::test::MockRuntime>,
+    db: Arc<Database>,
+    actor: Arc<EngineActorHandle>,
+    audio_msg_tx: Sender<AudioMessage>,
+    /// Kept alive so `AppState::audio_cmd_sender.send(...)` never errors with
+    /// "all receivers dropped" — nothing needs to read from it since there is
+    /// no real audio-capture thread in this test.
+    _audio_cmd_rx: Receiver<AudioCommand>,
+    _tmp: TempDir,
+}
+
+fn build_harness(mock: MockEngine) -> Harness {
+    let tmp = TempDir::new().expect("tempdir");
+    let db = Arc::new(Database::open(&tmp.path().join("test.db")).expect("open test db"));
+
+    // Test-friendly settings: no system-audio capture (keeps the session in
+    // single-stream mode, avoiding the diarized dual-lane path), no VAD/text
+    // filters (so the mock's fixed segment text round-trips unmodified), no
+    // auto-stop timers, no feedback sound playback.
+    AppSettings {
+        capture_system_audio: false,
+        vad_enabled: false,
+        filler_removal: false,
+        stutter_collapse: false,
+        dictionary_correction: false,
+        meeting_autostop_enabled: false,
+        feedback_sounds_enabled: false,
+        ..AppSettings::default()
+    }
+    .save(&db)
+    .expect("save test settings");
+
+    let (actor, audio_msg_tx) = spawn_mock_actor(mock);
+    let actor = Arc::new(actor);
+
+    let (audio_cmd_tx, audio_cmd_rx) = crossbeam_channel::unbounded::<AudioCommand>();
+    let audio_rms = Arc::new(AtomicU32::new(0f32.to_bits()));
+    let system_audio_activity = Arc::new(SystemAudioActivity::default());
+
+    let app_state = AppState::new(
+        audio_cmd_tx,
+        Arc::clone(&actor),
+        Arc::clone(&db),
+        audio_rms,
+        system_audio_activity,
+    );
+    bring_to_ready(&app_state, &actor);
+
+    let app = tauri::test::mock_builder()
+        .manage(app_state)
+        .build(tauri::test::mock_context(tauri::test::noop_assets()))
+        .expect("build mock tauri app");
+
+    Harness {
+        app,
+        db,
+        actor,
+        audio_msg_tx,
+        _audio_cmd_rx: audio_cmd_rx,
+        _tmp: tmp,
+    }
+}
+
+/// A non-silent chunk carrying exactly one engine frame's worth of samples,
+/// tagged for the given session (matches `pipeline::actor::tests::audio_chunk`).
+fn audio_chunk(session_id: u64) -> AudioMessage {
+    AudioMessage::Chunk(AudioChunk {
+        session_id,
+        samples: vec![0.1f32; MIMI_FRAME_SIZE],
+        captured_at: std::time::Instant::now(),
+        speaker: None,
+    })
+}
+
+/// A `Channel` that deserializes every message as `TranscriptionSegment` and
+/// appends it to a shared `Vec`, so tests can assert on what streamed back.
+fn collecting_channel() -> (
+    Arc<Mutex<Vec<TranscriptionSegment>>>,
+    Channel<TranscriptionSegment>,
+) {
+    let collected: Arc<Mutex<Vec<TranscriptionSegment>>> = Arc::new(Mutex::new(Vec::new()));
+    let collected_ref = Arc::clone(&collected);
+    let channel = Channel::new(move |body| {
+        if let InvokeResponseBody::Json(json) = body
+            && let Ok(segment) = serde_json::from_str::<TranscriptionSegment>(&json)
+        {
+            collected_ref.lock().unwrap().push(segment);
+        }
+        Ok(())
+    });
+    (collected, channel)
+}
+
+/// Stop an active meeting recording and persist it, driving the same
+/// primitives `commands::stop_meeting_recording`'s background task uses (see
+/// the module doc for why the command itself isn't called here).
+fn stop_meeting_and_persist(h: &Harness, state: &tauri::State<'_, AppState>) {
+    assert!(
+        state.current_machine_state().unwrap().is_recording(),
+        "expected an active recording session before stopping"
+    );
+    state
+        .apply_transition(StateAction::StopRecording)
+        .expect("StopRecording transition");
+
+    let _ = state.audio_cmd_sender.send(AudioCommand::Stop);
+    h.actor
+        .stop_session(Duration::from_secs(5))
+        .expect("actor stop_session");
+
+    if let Ok(mut guard) = state.meeting_accumulator.lock()
+        && let Some(meeting) = guard.take()
+    {
+        let transcript = meeting.into_transcript(chrono::Utc::now());
+        h.db.save_meeting(&transcript).expect("save meeting");
+    }
+
+    state
+        .apply_transition(StateAction::StopComplete)
+        .expect("StopComplete transition");
+}
+
+#[tokio::test]
+async fn meeting_stop_persists_meeting() {
+    let mock = MockEngine::new().with_transcribe_response(
+        Ok(vec![TranscriptionSegment {
+            text: "hello meeting".to_string(),
+            start_time: 0.0,
+            end_time: 1.0,
+            is_final: true,
+            language: Some("en".to_string()),
+            confidence: Some(0.9),
+            speaker: None,
+        }]),
+        1,
+    );
+    let h = build_harness(mock);
+    let state = h.app.state::<AppState>();
+
+    let (collected, channel) = collecting_channel();
+
+    commands::start_meeting_recording(state.clone(), "Weekly Sync".to_string(), None, channel)
+        .await
+        .expect("start_meeting_recording");
+
+    let (session_id, meeting_id) = match state.current_machine_state().unwrap() {
+        AppStateMachine::RecordingMeeting {
+            session_id,
+            meeting_id,
+            ..
+        } => (session_id, meeting_id),
+        other => panic!("expected RecordingMeeting after start, got {other:?}"),
+    };
+
+    // Feed one synthetic audio frame through the actor's audio channel
+    // directly — there's no real AudioCapture thread in this test, so this
+    // stands in for the microphone.
+    h.audio_msg_tx.send(audio_chunk(session_id)).unwrap();
+    h.audio_msg_tx
+        .send(AudioMessage::EndOfStream { session_id })
+        .unwrap();
+
+    stop_meeting_and_persist(&h, &state);
+
+    assert!(matches!(
+        state.current_machine_state().unwrap(),
+        AppStateMachine::Ready { .. }
+    ));
+
+    // Segments streamed live to the frontend during the meeting.
+    let streamed = collected.lock().unwrap();
+    assert!(
+        streamed.iter().any(|s| s.text == "hello meeting"),
+        "expected a live-streamed 'hello meeting' segment, got: {:?}",
+        streamed.iter().map(|s| &s.text).collect::<Vec<_>>()
+    );
+    drop(streamed);
+
+    // The meeting row exists with ended_at set and the segment persisted —
+    // the actual "stop persists a meeting" assertion.
+    let meeting = h.db.load_meeting(&meeting_id).expect("load persisted meeting");
+    assert_eq!(meeting.title, "Weekly Sync");
+    assert!(meeting.ended_at.is_some(), "meeting should be finalized");
+    assert!(
+        meeting.segments.iter().any(|s| s.text == "hello meeting"),
+        "expected the transcribed segment to be persisted, got: {:?}",
+        meeting.segments.iter().map(|s| &s.text).collect::<Vec<_>>()
+    );
+
+    let list = commands::list_meetings(state.clone()).expect("list_meetings");
+    assert!(
+        list.iter().any(|m| m.id == meeting_id),
+        "expected the finalized meeting to show up in list_meetings"
+    );
+}
+
+#[tokio::test]
+async fn dictation_round_trip() {
+    let mock = MockEngine::new().with_transcribe_response(
+        Ok(vec![TranscriptionSegment {
+            text: "hello dictation".to_string(),
+            start_time: 0.0,
+            end_time: 1.0,
+            is_final: true,
+            language: Some("en".to_string()),
+            confidence: Some(0.9),
+            speaker: None,
+        }]),
+        1,
+    );
+    let h = build_harness(mock);
+    let state = h.app.state::<AppState>();
+
+    let (collected, channel) = collecting_channel();
+
+    commands::start_transcription(state.clone(), channel)
+        .await
+        .expect("start_transcription");
+
+    let session_id = match state.current_machine_state().unwrap() {
+        AppStateMachine::RecordingDictation { session_id, .. } => session_id,
+        other => panic!("expected RecordingDictation after start, got {other:?}"),
+    };
+
+    h.audio_msg_tx.send(audio_chunk(session_id)).unwrap();
+    h.audio_msg_tx
+        .send(AudioMessage::EndOfStream { session_id })
+        .unwrap();
+
+    // `stop_transcription` never touches `AppState::app_handle`, so — unlike
+    // the meeting stop above — it runs as the real, unmodified command.
+    commands::stop_transcription(state.clone())
+        .await
+        .expect("stop_transcription");
+
+    assert!(matches!(
+        state.current_machine_state().unwrap(),
+        AppStateMachine::Ready { .. }
+    ));
+
+    let streamed = collected.lock().unwrap();
+    let full_text: String = streamed
+        .iter()
+        .map(|s| s.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert!(
+        full_text.contains("hello dictation"),
+        "expected the dictation callback to receive the transcribed text, got: {full_text:?}"
+    );
+    drop(streamed);
+
+    // Mirrors what the frontend does after a dictation session ends: save
+    // the assembled text to history.
+    commands::add_dictation_entry(state.clone(), full_text.clone())
+        .expect("add_dictation_entry");
+
+    let history = commands::list_dictation_entries(state.clone(), None)
+        .expect("list_dictation_entries");
+    assert!(
+        history.iter().any(|e| e.text == full_text),
+        "expected the dictation entry to be saved to history, got: {:?}",
+        history.iter().map(|e| &e.text).collect::<Vec<_>>()
+    );
+}

--- a/tests/e2e/boot.spec.ts
+++ b/tests/e2e/boot.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "@playwright/test";
+import { installTauriStub } from "./tauri-stub";
+
+test("app boots to the home view with no console errors", async ({ page }) => {
+  const consoleErrors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") consoleErrors.push(message.text());
+  });
+  page.on("pageerror", (error) => consoleErrors.push(error.message));
+
+  await installTauriStub(page);
+  await page.goto("/");
+
+  await expect(page.getByRole("button", { name: "Dictate" })).toBeVisible();
+  await expect(page.getByRole("button", { name: /^Meeting\b/ })).toBeVisible();
+
+  expect(consoleErrors, `unexpected console errors:\n${consoleErrors.join("\n")}`).toEqual([]);
+});

--- a/tests/e2e/dictation.spec.ts
+++ b/tests/e2e/dictation.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+import { mockRuntimeStatus } from "../../src/lib/test-helpers/fixtures";
+import { emitTauriEvent, installTauriStub, stubbedCalls } from "./tauri-stub";
+
+const PROFILE = mockRuntimeStatus.profile;
+
+test("toggling dictation from the UI returns to idle after stopping", async ({ page }) => {
+  await installTauriStub(page);
+  await page.goto("/");
+
+  const dictateButton = page.getByRole("button", { name: "Dictate" });
+  await expect(dictateButton).toBeVisible();
+  await dictateButton.click();
+
+  await expect
+    .poll(async () => (await stubbedCalls(page)).some((call) => call.cmd === "start_transcription"))
+    .toBe(true);
+  await emitTauriEvent(page, "state-changed", {
+    state: "recording_dictation",
+    data: { profile: PROFILE, session_id: 1 },
+  });
+
+  const stopButton = page.getByRole("button", { name: "Stop", exact: true });
+  await expect(page.getByText("Dictating")).toBeVisible();
+  await expect(stopButton).toBeVisible();
+
+  await stopButton.click();
+  await expect
+    .poll(async () => (await stubbedCalls(page)).some((call) => call.cmd === "stop_transcription"))
+    .toBe(true);
+  await emitTauriEvent(page, "state-changed", { state: "ready", data: { profile: PROFILE } });
+
+  // Dictation has no detail view to fall into, so this goes all the way
+  // back to the idle home screen with both start buttons showing again.
+  await expect(stopButton).not.toBeVisible();
+  await expect(page.getByRole("button", { name: "Dictate" })).toBeVisible();
+  await expect(page.getByRole("button", { name: /^Meeting\b/ })).toBeVisible();
+});

--- a/tests/e2e/meeting.spec.ts
+++ b/tests/e2e/meeting.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "@playwright/test";
+import { mockRuntimeStatus } from "../../src/lib/test-helpers/fixtures";
+import { emitTauriEvent, installTauriStub, sendChannelMessage, stubbedCalls } from "./tauri-stub";
+
+const PROFILE = mockRuntimeStatus.profile;
+
+test("starting and stopping a meeting recording returns the UI to a non-recording state", async ({ page }) => {
+  await installTauriStub(page);
+  await page.goto("/");
+
+  const meetingButton = page.getByRole("button", { name: /^Meeting\b/ });
+  await expect(meetingButton).toBeVisible();
+  await meetingButton.click();
+
+  // `start_meeting_recording` resolves (stubbed to succeed) but nothing
+  // flips the store to "recording" until the backend's `state-changed`
+  // event arrives — simulate that the way the real backend would.
+  await expect
+    .poll(async () => (await stubbedCalls(page)).some((call) => call.cmd === "start_meeting_recording"))
+    .toBe(true);
+  await emitTauriEvent(page, "state-changed", {
+    state: "recording_meeting",
+    data: { profile: PROFILE, session_id: 1, meeting_id: "meeting-e2e-1" },
+  });
+
+  const stopButton = page.getByRole("button", { name: "Stop", exact: true });
+  await expect(page.getByText("Live meeting")).toBeVisible();
+  await expect(stopButton).toBeVisible();
+
+  // Exercise the streamed-segment path through the same Channel mechanism a
+  // real recording session uses.
+  await sendChannelMessage(page, "start_meeting_recording", {
+    text: "hello from the stub",
+    start_time: 0,
+    end_time: 1,
+    is_final: true,
+    language: "en",
+    confidence: 0.9,
+    speaker: null,
+  });
+  await expect(page.getByText("hello from the stub")).toBeVisible();
+
+  await stopButton.click();
+  await expect
+    .poll(async () => (await stubbedCalls(page)).some((call) => call.cmd === "stop_meeting_recording"))
+    .toBe(true);
+  await emitTauriEvent(page, "state-changed", { state: "ready", data: { profile: PROFILE } });
+
+  // Back to a non-recording state: the live session card (and its Stop
+  // button) is gone. The optimistic post-stop load takes the user to the
+  // meeting detail view rather than the idle action buttons, so assert on
+  // the absence of the recording UI rather than presence of "Meeting".
+  await expect(stopButton).not.toBeVisible();
+  await expect(page.getByText("Live meeting")).not.toBeVisible();
+});

--- a/tests/e2e/tauri-stub.ts
+++ b/tests/e2e/tauri-stub.ts
@@ -1,0 +1,234 @@
+/**
+ * Stubs the Tauri IPC layer (`window.__TAURI_INTERNALS__`) for browser-only
+ * Playwright smoke tests. `tauri-driver` (the WebDriver bridge that would
+ * drive a real Tauri window) does not support macOS, so these tests run the
+ * built Svelte app in a plain Chromium tab via the Vite dev server and fake
+ * the backend at the IPC boundary instead.
+ *
+ * How it works: the generated command bindings (`src/lib/types/generated.ts`)
+ * all funnel through `invoke()` from `@tauri-apps/api/core`, which reads
+ * `window.__TAURI_INTERNALS__.invoke`. This installs a minimal stand-in for
+ * that object — modeled on Tauri's own `@tauri-apps/api/mocks` helper
+ * (`mockIPC` / `mockWindows`) — that:
+ *   - resolves `invoke(cmd, args)` from a data-driven `cmd -> response` map
+ *     (see `DEFAULT_RESPONSES`), so tests can override per command without
+ *     touching the shim itself;
+ *   - auto-handles the `plugin:event|listen` / `unlisten` / `emit` calls
+ *     `@tauri-apps/api/event`'s `listen()` makes, so `emitTauriEvent` below
+ *     can push a synthetic backend event (e.g. `state-changed`) to whatever
+ *     the app already subscribed to;
+ *   - captures any `Channel` passed as a command argument (e.g.
+ *     `start_meeting_recording`'s segment channel) so `sendChannelMessage`
+ *     can push streamed messages through it, the same way a real streaming
+ *     command would.
+ *
+ * The injected function runs inside the page, so it cannot close over
+ * anything from this module — only over the JSON-serializable `responses`
+ * argument Playwright passes through `addInitScript`.
+ */
+import type { Page } from "@playwright/test";
+import {
+  mockCatalog,
+  mockDictationEntry,
+  mockMeeting,
+  mockMeetingList,
+  mockRuntimeStatus,
+  mockSettings,
+  mockShortcuts,
+  mockSummaryProvidersStatus,
+} from "../../src/lib/test-helpers/fixtures";
+
+/** Response map keyed by the snake_case Tauri command name (as emitted by
+ * tauri-specta), matching what `souffle_lib::lib::specta_builder` registers. */
+export const DEFAULT_RESPONSES: Record<string, unknown> = {
+  get_machine_state: { state: "ready", data: { profile: mockRuntimeStatus.profile } },
+  get_settings: { ...mockSettings, audio_device: null, last_seen_version: "" },
+  save_settings: null,
+  get_transcription_catalog: mockCatalog,
+  get_model_status: mockRuntimeStatus,
+  get_app_version: "0.1.0",
+  get_shortcuts: mockShortcuts,
+  check_summary_providers: mockSummaryProvidersStatus,
+  list_todays_calendar_events: [],
+  list_calendars: [],
+  list_meetings: mockMeetingList,
+  get_meeting: mockMeeting,
+  list_dictation_entries: [mockDictationEntry],
+  list_dictionary: [],
+  get_data_stats: { meetings_count: 0, dictation_entries_count: 0, database_bytes: 0 },
+  recover_state: { state: "ready", data: { profile: mockRuntimeStatus.profile } },
+  // Recording lifecycle — overridden per test where the flow matters.
+  start_meeting_recording: null,
+  resume_meeting_recording: null,
+  stop_meeting_recording: "meeting-e2e-1",
+  start_transcription: null,
+  stop_transcription: null,
+  add_dictation_entry: null,
+  take_sleep_paused_meeting: null,
+};
+
+export interface TauriStubOptions {
+  /** Overrides/additions merged over `DEFAULT_RESPONSES`, keyed by command name. */
+  responses?: Record<string, unknown>;
+}
+
+/** Install the IPC stub. Must be called before `page.goto(...)` (it uses
+ * `addInitScript`, which only affects documents navigated to afterwards). */
+export async function installTauriStub(page: Page, options: TauriStubOptions = {}): Promise<void> {
+  const responses = { ...DEFAULT_RESPONSES, ...options.responses };
+
+  // Skip the first-run "grant permissions" walkthrough (App.svelte gates it
+  // on this key) — it's a modal overlay unrelated to the flows under test
+  // and would otherwise block every click.
+  await page.addInitScript(() => {
+    try {
+      window.localStorage.setItem("permissionsOnboarded", "1");
+    } catch {
+      // Storage may be unavailable in some contexts; the dialog just shows.
+    }
+  });
+
+  await page.addInitScript((responses: Record<string, unknown>) => {
+    interface StubState {
+      calls: Array<{ cmd: string; args: unknown }>;
+      channels: Record<string, { id: number }>;
+      runCallback: (id: number, data: unknown) => void;
+    }
+
+    const listeners = new Map<string, number[]>();
+    const callbacks = new Map<number, (data: unknown) => unknown>();
+
+    function registerCallback(cb: (data: unknown) => unknown, once = false): number {
+      const id = Math.floor(Math.random() * 1_000_000_000);
+      callbacks.set(id, (data: unknown) => {
+        if (once) callbacks.delete(id);
+        return cb && cb(data);
+      });
+      return id;
+    }
+
+    function unregisterCallback(id: number) {
+      callbacks.delete(id);
+    }
+
+    function runCallback(id: number, data: unknown) {
+      const cb = callbacks.get(id);
+      if (cb) {
+        cb(data);
+      } else {
+        console.warn(`[tauri-stub] no callback registered for id ${id}`);
+      }
+    }
+
+    function isEventPluginInvoke(cmd: string): boolean {
+      return cmd.startsWith("plugin:event|");
+    }
+
+    function handleEventPlugin(cmd: string, args: any): unknown {
+      switch (cmd) {
+        case "plugin:event|listen": {
+          if (!listeners.has(args.event)) listeners.set(args.event, []);
+          listeners.get(args.event)!.push(args.handler);
+          return args.handler;
+        }
+        case "plugin:event|emit": {
+          const handlers = listeners.get(args.event) ?? [];
+          for (const handler of handlers) runCallback(handler, args);
+          return null;
+        }
+        case "plugin:event|unlisten": {
+          const handlers = listeners.get(args.event);
+          if (handlers) {
+            const index = handlers.indexOf(args.eventId);
+            if (index !== -1) handlers.splice(index, 1);
+          }
+          return null;
+        }
+        default:
+          return null;
+      }
+    }
+
+    const state: StubState = { calls: [], channels: {}, runCallback };
+    (window as any).__soufflStub = state;
+
+    async function invoke(cmd: string, args?: any) {
+      state.calls.push({ cmd, args });
+
+      if (isEventPluginInvoke(cmd)) {
+        return handleEventPlugin(cmd, args);
+      }
+
+      // A `Channel` argument serializes itself with a `toJSON()` that
+      // returns `__CHANNEL__:<id>`, but the mock invoke path never
+      // serializes — `args.channel` is still the live Channel instance, so
+      // its `.id` can be driven directly via `runCallback`.
+      if (args && typeof args === "object") {
+        for (const [key, value] of Object.entries(args)) {
+          if (value && typeof value === "object" && typeof (value as any).id === "number" && typeof (value as any).onmessage !== "undefined") {
+            state.channels[cmd] = value as { id: number };
+          } else if (key === "channel" && value && typeof value === "object") {
+            state.channels[cmd] = value as { id: number };
+          }
+        }
+      }
+
+      if (Object.prototype.hasOwnProperty.call(responses, cmd)) {
+        const value = responses[cmd];
+        if (value instanceof Error) throw value;
+        // `get_meeting` must echo the requested id: the frontend compares
+        // the loaded meeting's `id` against `app.currentMeetingId` in a
+        // reactive effect and keeps re-fetching until they match, so a
+        // fixed fixture id here would spin forever instead of settling.
+        if (cmd === "get_meeting" && value && typeof value === "object" && args?.id) {
+          return { ...(value as object), id: args.id };
+        }
+        return value;
+      }
+
+      console.warn(`[tauri-stub] no response stubbed for command "${cmd}", returning null`);
+      return null;
+    }
+
+    (window as any).__TAURI_INTERNALS__ = (window as any).__TAURI_INTERNALS__ ?? {};
+    (window as any).__TAURI_INTERNALS__.invoke = invoke;
+    (window as any).__TAURI_INTERNALS__.transformCallback = registerCallback;
+    (window as any).__TAURI_INTERNALS__.unregisterCallback = unregisterCallback;
+    (window as any).__TAURI_INTERNALS__.runCallback = runCallback;
+    (window as any).__TAURI_INTERNALS__.metadata = {
+      currentWindow: { label: "main" },
+      currentWebview: { windowLabel: "main", label: "main" },
+    };
+  }, responses);
+}
+
+/** Simulate a backend-pushed event (`StateChanged`, `MeetingFinalized`, ...)
+ * reaching whatever the app already registered via `events.x.listen(...)`. */
+export async function emitTauriEvent(page: Page, event: string, payload: unknown): Promise<void> {
+  await page.evaluate(
+    ([event, payload]) => (window as any).__TAURI_INTERNALS__.invoke("plugin:event|emit", { event, payload }),
+    [event, payload] as const,
+  );
+}
+
+/** Push a streamed message through the `Channel` captured for `cmd` (the
+ * command name whose args included a `Channel`, e.g. `start_meeting_recording`). */
+export async function sendChannelMessage(page: Page, cmd: string, message: unknown, index = 0): Promise<void> {
+  await page.evaluate(
+    ([cmd, message, index]) => {
+      const stub = (window as any).__soufflStub;
+      const channel = stub?.channels?.[cmd as string];
+      if (!channel) {
+        throw new Error(`[tauri-stub] no channel captured for command "${cmd}"`);
+      }
+      stub.runCallback(channel.id, { message, index });
+    },
+    [cmd, message, index] as const,
+  );
+}
+
+/** All `{cmd, args}` pairs invoked so far, in order — for assertions like
+ * "the app called start_meeting_recording exactly once". */
+export async function stubbedCalls(page: Page): Promise<Array<{ cmd: string; args: unknown }>> {
+  return page.evaluate(() => (window as any).__soufflStub?.calls ?? []);
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -2,7 +2,10 @@
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
     "target": "ES2023",
-    "lib": ["ES2023"],
+    // DOM is only needed for tests/e2e/*.ts, whose Playwright callbacks
+    // (addInitScript/evaluate) reference `window` — they run in the
+    // browser, but are type-checked here since vite.config.ts is too.
+    "lib": ["ES2023", "DOM"],
     "module": "ESNext",
     "types": ["node"],
     "skipLibCheck": true,
@@ -22,5 +25,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.ts", "playwright.config.ts", "tests/e2e/**/*.ts"]
 }


### PR DESCRIPTION
Adds the missing smoke coverage for the two critical lifecycles.

- src-tauri/tests/app_flows.rs: real command fns driven under tauri::test mock runtime with MockEngine (new test-support feature, verified not to leak into normal builds). meeting_stop_persists_meeting and dictation_round_trip. One documented exception: stop_meeting_recording's wrapper needs a concrete AppHandle<Wry>, so the stop test drives the same primitives its background task uses.
- tests/e2e (Playwright, chromium): data-driven Tauri IPC stub via addInitScript with real Channel capture and synthetic backend events; boot, meeting start/stream/stop, dictation toggle. npm run test:e2e, wired into a new ubuntu e2e workflow. tauri-driver does not support macOS, hence the hybrid.

Gates: workspace tests green (423 lib + integration + contract), clippy clean, 194 vitest, check/build clean, 3/3 Playwright locally and under CI=true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuuJ8cV2dsbwNnc7Y8gm2b