### PR TITLE
Meeting audio retention with click-to-seek playback (opt-in)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -360,6 +360,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "audiopus_sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62314a1546a2064e033665d658e88c620a62904be945f8147e6b16c3db9f8651"
+dependencies = [
+ "cmake",
+ "log",
+ "pkg-config",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2851,6 +2862,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4373,6 +4390,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ogg"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdab8dcd8d4052eaacaf8fb07a3ccd9a6e26efadb42878a413c68fc4af1dee2b"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4455,6 +4481,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "opus"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3809943dff6fbad5f0484449ea26bdb9cb7d8efdf26ed50d3c7f227f69eb5c"
+dependencies = [
+ "audiopus_sys",
+]
 
 [[package]]
 name = "ordered-stream"
@@ -6361,6 +6396,8 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-event-kit",
  "objc2-foundation 0.3.2",
+ "ogg",
+ "opus",
  "ort",
  "parakeet-rs",
  "regex",
@@ -6762,6 +6799,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "image",
  "jni",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/main.rs"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon", "macos-private-api", "image-png"] }
+tauri = { version = "2", features = ["tray-icon", "macos-private-api", "image-png", "protocol-asset"] }
 tauri-plugin-global-shortcut = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-fs = "2"
@@ -98,6 +98,14 @@ ringbuf = "0.5"
 sonora = "0.1"
 block2 = "0.6"
 dispatch2 = "0.3"
+
+# Meeting audio recording: Opus encoding (statically linked on macOS via
+# audiopus_sys — pkg-config finds a static libopus.a if present, otherwise
+# audiopus_sys builds vendored libopus via cmake, but either way the result
+# is statically linked, so no libopus.dylib ships in the bundle) into an Ogg
+# container.
+opus = "0.3"
+ogg = "0.9"
 
 [features]
 # Exposes the mock transcription engine (normally `#[cfg(test)]`-only) so the

--- a/src-tauri/src/archive.rs
+++ b/src-tauri/src/archive.rs
@@ -12,12 +12,14 @@ use serde::{Deserialize, Serialize};
 use crate::db::Database;
 use crate::export::{self, ExportFormat};
 
-/// Settings > Data stats line: database size and row counts.
+/// Settings > Data stats line: database size, row counts, and recorded
+/// meeting audio size.
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 pub struct DataStats {
     pub db_size_bytes: u64,
     pub meeting_count: u32,
     pub dictation_count: u32,
+    pub recordings_size_bytes: u64,
 }
 
 /// `manifest.json` written at the root of every archive.

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -3,12 +3,14 @@ use cpal::{Device, SampleFormat, Stream, StreamConfig};
 use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
 use ringbuf::HeapRb;
 use ringbuf::traits::{Producer, Split};
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tracing::{debug, error, info, warn};
 
 use super::mixer::MeetingMixer;
+use super::recorder::MeetingRecorder;
 use super::resampler::Resampler;
 use crate::state::AudioCommand;
 
@@ -216,6 +218,10 @@ struct StartParams {
     mic_gain: f32,
     capture_system_audio: bool,
     diarize: bool,
+    /// File to record mixed meeting audio to, if the retention setting is
+    /// not `off`. `None` for dictation sessions and for meetings recorded
+    /// with retention off.
+    record_path: Option<PathBuf>,
 }
 
 /// Per-session state for meeting mode (mic + system audio).
@@ -341,6 +347,11 @@ pub struct AudioCapture {
     dropped_counter: Arc<AtomicU64>,
     /// Active meeting-mode session (mic + system audio mixed on this thread).
     meeting: Option<MeetingState>,
+    /// Encodes meeting audio to disk when the retention setting is not off.
+    /// Lives outside `MeetingState` (not torn down/rebuilt with it) because
+    /// a mic rebuild mid-session must keep recording to the same file —
+    /// only a genuinely new `session_id` (or no `record_path`) replaces it.
+    recorder: Option<MeetingRecorder>,
     /// For emitting SystemAudioStatus events (set during app setup).
     app: Option<tauri::AppHandle>,
     /// Parameters of the running session, kept for mid-session rebuilds.
@@ -399,6 +410,7 @@ impl AudioCapture {
                     resampler: None,
                     dropped_counter,
                     meeting: None,
+                    recorder: None,
                     app: None,
                     active_params: None,
                     mic_device_name: None,
@@ -468,6 +480,7 @@ impl AudioCapture {
                             mic_gain,
                             capture_system_audio,
                             diarize,
+                            record_path,
                         } => {
                             if let Err(e) = capture.start(
                                 session_id,
@@ -475,6 +488,7 @@ impl AudioCapture {
                                 mic_gain,
                                 capture_system_audio,
                                 diarize,
+                                record_path,
                             ) {
                                 warn!("Failed to start audio capture: {e}");
                             }
@@ -557,6 +571,7 @@ impl AudioCapture {
             .ok_or_else(|| "No input device available".to_string())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn start(
         &mut self,
         session_id: u64,
@@ -564,12 +579,16 @@ impl AudioCapture {
         mic_gain: f32,
         capture_system_audio: bool,
         diarize: bool,
+        record_path: Option<PathBuf>,
     ) -> Result<(), String> {
         // Ensure any previous callback stops emitting immediately, and tear
-        // down any leftover meeting state (tap included).
+        // down any leftover meeting state (tap included). The recorder is
+        // NOT torn down here — see `sync_recorder` — so a mid-session mic
+        // rebuild (same session_id) keeps recording to the same file.
         self.active_session_id.store(0, Ordering::Release);
         self.stream.take();
         self.meeting.take();
+        self.sync_recorder(session_id, record_path.as_deref(), target_sample_rate);
 
         // Stored before any fallible step so a failed (re)build is retried
         // by the next mic health check instead of killing the session.
@@ -579,6 +598,7 @@ impl AudioCapture {
             mic_gain,
             capture_system_audio,
             diarize,
+            record_path,
         });
         self.stream_failed
             .store(false, std::sync::atomic::Ordering::Relaxed);
@@ -696,6 +716,75 @@ impl AudioCapture {
 
         info!("Audio capture started on '{device_name}'");
         Ok(())
+    }
+
+    /// Reconcile `self.recorder` with what this `start()` call wants:
+    /// - Same `session_id` as the existing recorder: keep it — this is a
+    ///   mid-session capture rebuild (mic loss, device change), not a new
+    ///   recording session, so it must keep writing to the same file.
+    /// - Different session (or none yet) and a path was given: finalize any
+    ///   stale recorder and start a new one.
+    /// - No path (dictation, or retention off): finalize any stale recorder.
+    ///
+    /// A failure to start the recorder is logged and otherwise ignored —
+    /// recording is a best-effort opt-in feature, never a reason to fail the
+    /// audio session itself.
+    fn sync_recorder(&mut self, session_id: u64, record_path: Option<&std::path::Path>, sample_rate: u32) {
+        let same_session = self.recorder.as_ref().is_some_and(|r| r.session_id() == session_id);
+        match record_path {
+            Some(_) if same_session => {}
+            Some(path) => {
+                self.finish_recording();
+                match MeetingRecorder::start(path.to_path_buf(), sample_rate, session_id) {
+                    Ok(recorder) => self.recorder = Some(recorder),
+                    Err(e) => warn!("Failed to start meeting audio recorder: {e}"),
+                }
+            }
+            None => self.finish_recording(),
+        }
+    }
+
+    /// Finalize and drop the active recorder, if any, logging how many
+    /// chunks the realtime audio thread had to drop because the writer
+    /// thread couldn't keep up.
+    fn finish_recording(&mut self) {
+        if let Some(recorder) = self.recorder.take() {
+            let dropped = recorder.dropped_chunks();
+            if dropped > 0 {
+                warn!("Meeting recorder dropped {dropped} audio chunks this session");
+            }
+            // Drop joins the writer thread, flushing the encoder and closing
+            // the file — not on the realtime path, only at session end.
+        }
+    }
+
+    /// Feed one mono meeting-audio chunk to the active recorder, if any.
+    fn push_recording_mono(&self, samples: &[f32]) {
+        if let Some(recorder) = &self.recorder {
+            recorder.push(samples);
+        }
+    }
+
+    /// Feed one diarized meeting-audio tick to the active recorder, if any:
+    /// the two legs are summed with soft clipping into the single mixed
+    /// stream the recording represents (diarization only affects
+    /// transcription, not the recorded audio).
+    fn push_recording_diarized(&self, me: &[f32], them: &[f32]) {
+        let Some(recorder) = &self.recorder else {
+            return;
+        };
+        let n = me.len().max(them.len());
+        if n == 0 {
+            return;
+        }
+        let mixed: Vec<f32> = (0..n)
+            .map(|i| {
+                let a = me.get(i).copied().unwrap_or(0.0);
+                let b = them.get(i).copied().unwrap_or(0.0);
+                (a + b).clamp(-1.0, 1.0)
+            })
+            .collect();
+        recorder.push(&mixed);
     }
 
     /// Meeting mode: the cpal callback only pushes raw samples into a ring
@@ -851,6 +940,7 @@ impl AudioCapture {
             params.mic_gain,
             params.capture_system_audio,
             params.diarize,
+            params.record_path.clone(),
         ) {
             Ok(()) => {
                 self.mic_rebuild_failures = 0;
@@ -912,10 +1002,12 @@ impl AudioCapture {
 
         use crate::engine::Speaker;
         if diarize {
+            self.push_recording_diarized(&me, &them);
             self.store_meeting_rms(&me, &them);
             self.send_meeting_chunk(session_id, me, Some(Speaker::Me));
             self.send_meeting_chunk(session_id, them, Some(Speaker::Them));
         } else {
+            self.push_recording_mono(&mixed);
             self.store_meeting_rms(&mixed, &[]);
             self.send_meeting_chunk(session_id, mixed, None);
         }
@@ -1021,6 +1113,10 @@ impl AudioCapture {
         {
             self.meeting.take();
         }
+        // Best-effort close: no final flush from the (possibly corrupt)
+        // mixer, just whatever the recorder already buffered. A truncated
+        // but structurally valid Ogg file is acceptable here.
+        self.finish_recording();
         self.emit_audio_level(0.0);
         self.level_throttle.reset();
     }
@@ -1073,10 +1169,12 @@ impl AudioCapture {
             if session_id != 0 {
                 if meeting.diarize {
                     let (me, them) = meeting.mixer.flush_split();
+                    self.push_recording_diarized(&me, &them);
                     self.send_meeting_chunk(session_id, me, Some(crate::engine::Speaker::Me));
                     self.send_meeting_chunk(session_id, them, Some(crate::engine::Speaker::Them));
                 } else {
                     let tail = meeting.mixer.flush();
+                    self.push_recording_mono(&tail);
                     self.send_meeting_chunk(session_id, tail, None);
                 }
                 let discarded = meeting.mixer.tap_discarded();
@@ -1085,12 +1183,14 @@ impl AudioCapture {
                 }
                 self.send_end_of_stream(session_id);
             }
+            self.finish_recording();
 
             if had_stream {
                 info!("Meeting audio capture stopped");
             }
             return;
         }
+        self.finish_recording();
 
         if session_id != 0 {
             // Flush the resampler's remaining partial chunk so the last

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -3,7 +3,9 @@ pub mod capture;
 pub mod feedback;
 pub mod mixer;
 pub mod output_route;
+pub mod recorder;
 pub mod resampler;
+pub mod retention;
 pub mod system_activity;
 pub mod system_tap;
 

--- a/src-tauri/src/audio/recorder.rs
+++ b/src-tauri/src/audio/recorder.rs
@@ -1,0 +1,426 @@
+//! Compressed on-disk recording of meeting audio (opt-in — see
+//! `settings::MeetingAudioRetention`). Encoding and file I/O run on a
+//! dedicated writer thread fed by a bounded channel, so the realtime
+//! audio-capture thread (`capture::AudioCapture`) never blocks on codec or
+//! disk work: `MeetingRecorder::push` is a `try_send`, and a full channel
+//! just drops the chunk (counted, logged at session end).
+//!
+//! Container: Ogg, built by hand (OpusHead/OpusTags packets plus one Opus
+//! packet per 20ms frame, with granule positions expressed as 48kHz-
+//! equivalent samples per RFC 7845) via the `ogg` crate's `PacketWriter`.
+//! Verified to load, report correct duration, and seek correctly in WebKit
+//! (Safari on macOS 15.6, the same engine Tauri's WKWebView embeds).
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{SyncSender, sync_channel};
+use std::thread::JoinHandle;
+
+use ogg::writing::{PacketWriteEndInfo, PacketWriter};
+use opus::{Application, Channels, Encoder as OpusEncoder};
+
+use crate::constants::app_data_dir;
+
+/// Sample rates Opus accepts directly; anything else must be resampled to
+/// the nearest one before encoding.
+const OPUS_VALID_RATES: [u32; 5] = [8_000, 12_000, 16_000, 24_000, 48_000];
+
+/// Frame duration used for encoding: the standard "good default" for voice,
+/// small enough for low latency and large enough to amortize per-frame
+/// overhead.
+const FRAME_MS: u32 = 20;
+
+/// Target bitrate for the voice-tuned Opus profile.
+const BITRATE_BPS: i32 = 32_000;
+
+/// Ogg logical-stream serial number. Each file holds exactly one stream, so
+/// any constant works — it only has to be unique within the file.
+const STREAM_SERIAL: u32 = 1;
+
+/// Bounded channel capacity between the audio thread and the writer thread:
+/// generous enough that a brief disk/encoder stall doesn't drop chunks
+/// before the writer catches up, without letting a wedged writer thread
+/// build up unbounded memory.
+const CHANNEL_CAPACITY: usize = 256;
+
+/// Comfortably above the largest Opus packet this encoder ever produces at
+/// 32kbps/20ms frames; matches the size libopus's own examples use.
+const MAX_OPUS_PACKET_BYTES: usize = 4000;
+
+/// Pick the Opus-valid sample rate closest to `rate`.
+fn nearest_opus_rate(rate: u32) -> u32 {
+    OPUS_VALID_RATES
+        .iter()
+        .copied()
+        .min_by_key(|candidate| candidate.abs_diff(rate))
+        .unwrap_or(48_000)
+}
+
+/// Root directory for all meeting recordings.
+pub fn recordings_root() -> PathBuf {
+    app_data_dir().join("recordings")
+}
+
+/// Directory holding every recorded session file for one meeting.
+pub fn meeting_recordings_dir(meeting_id: &str) -> PathBuf {
+    recordings_root().join(meeting_id)
+}
+
+/// File path for one recording session within a meeting. `session_index` is
+/// the position of that session in the meeting's `recording_sessions`.
+pub fn session_path(meeting_id: &str, session_index: usize) -> PathBuf {
+    meeting_recordings_dir(meeting_id).join(format!("{session_index}.ogg"))
+}
+
+fn opus_head(pre_skip: u16, input_rate: u32) -> Vec<u8> {
+    let mut v = Vec::with_capacity(19);
+    v.extend_from_slice(b"OpusHead");
+    v.push(1); // version
+    v.push(1); // channel count (mono)
+    v.extend_from_slice(&pre_skip.to_le_bytes());
+    v.extend_from_slice(&input_rate.to_le_bytes());
+    v.extend_from_slice(&0i16.to_le_bytes()); // output gain
+    v.push(0); // channel mapping family (mono/stereo, no extra table)
+    v
+}
+
+fn opus_tags() -> Vec<u8> {
+    let mut v = Vec::new();
+    v.extend_from_slice(b"OpusTags");
+    let vendor = b"souffle";
+    v.extend_from_slice(&(vendor.len() as u32).to_le_bytes());
+    v.extend_from_slice(vendor);
+    v.extend_from_slice(&0u32.to_le_bytes()); // no user comments
+    v
+}
+
+/// Encodes mono f32 PCM into an Ogg Opus stream. Buffers samples into exact
+/// `FRAME_MS` frames (Opus requires one of a handful of exact frame sizes)
+/// and tracks the RFC 7845 granule position (48kHz-equivalent samples,
+/// regardless of the actual encode rate) so players report correct duration
+/// and can seek.
+struct OggOpusWriter<W: Write> {
+    encoder: OpusEncoder,
+    packet_writer: PacketWriter<'static, W>,
+    input_rate: u32,
+    frame_samples: usize,
+    pending: Vec<f32>,
+    granule_position: u64,
+    packets_written: u64,
+    finished: bool,
+}
+
+impl<W: Write> OggOpusWriter<W> {
+    fn new(writer: W, input_rate: u32) -> Result<Self, String> {
+        let mut encoder = OpusEncoder::new(input_rate, Channels::Mono, Application::Voip)
+            .map_err(|e| format!("Create Opus encoder: {e}"))?;
+        encoder
+            .set_bitrate(opus::Bitrate::Bits(BITRATE_BPS))
+            .map_err(|e| format!("Set Opus bitrate: {e}"))?;
+        let lookahead = encoder
+            .get_lookahead()
+            .map_err(|e| format!("Read Opus lookahead: {e}"))?;
+        // Pre-skip is always expressed in 48kHz-equivalent samples per RFC
+        // 7845, regardless of the actual input/encode rate.
+        let pre_skip = ((lookahead as u64) * 48_000 / u64::from(input_rate)) as u16;
+
+        let mut packet_writer = PacketWriter::new(writer);
+        packet_writer
+            .write_packet(
+                opus_head(pre_skip, input_rate),
+                STREAM_SERIAL,
+                PacketWriteEndInfo::EndPage,
+                0,
+            )
+            .map_err(|e| format!("Write OpusHead: {e}"))?;
+        packet_writer
+            .write_packet(opus_tags(), STREAM_SERIAL, PacketWriteEndInfo::EndPage, 0)
+            .map_err(|e| format!("Write OpusTags: {e}"))?;
+
+        let frame_samples = (input_rate * FRAME_MS / 1000) as usize;
+
+        Ok(Self {
+            encoder,
+            packet_writer,
+            input_rate,
+            frame_samples,
+            pending: Vec::with_capacity(frame_samples * 2),
+            granule_position: 0,
+            packets_written: 0,
+            finished: false,
+        })
+    }
+
+    fn encode_and_write(&mut self, frame: &[f32], end_info: PacketWriteEndInfo) -> Result<(), String> {
+        let mut out_buf = [0u8; MAX_OPUS_PACKET_BYTES];
+        let len = self
+            .encoder
+            .encode_float(frame, &mut out_buf)
+            .map_err(|e| format!("Opus encode: {e}"))?;
+        self.granule_position += (self.frame_samples as u64) * 48_000 / u64::from(self.input_rate);
+        self.packet_writer
+            .write_packet(out_buf[..len].to_vec(), STREAM_SERIAL, end_info, self.granule_position)
+            .map_err(|e| format!("Write Opus packet: {e}"))?;
+        self.packets_written += 1;
+        Ok(())
+    }
+
+    fn write_chunk(&mut self, samples: &[f32]) -> Result<(), String> {
+        self.pending.extend_from_slice(samples);
+        while self.pending.len() >= self.frame_samples {
+            let frame: Vec<f32> = self.pending.drain(..self.frame_samples).collect();
+            self.encode_and_write(&frame, PacketWriteEndInfo::NormalPacket)?;
+        }
+        Ok(())
+    }
+
+    /// Flush any partial frame (zero-padded) and mark the Ogg stream ended.
+    /// Idempotent — a second call is a no-op, so callers don't have to track
+    /// whether finalize already ran.
+    fn finish(&mut self) -> Result<(), String> {
+        if self.finished {
+            return Ok(());
+        }
+        self.finished = true;
+
+        if !self.pending.is_empty() {
+            let mut frame = std::mem::take(&mut self.pending);
+            frame.resize(self.frame_samples, 0.0);
+            self.encode_and_write(&frame, PacketWriteEndInfo::EndStream)?;
+        } else if self.packets_written > 0 {
+            // Every audio packet so far was a full frame with no pending
+            // tail; the Ogg stream still needs one page carrying the
+            // end-of-stream flag, so close it out with a frame of silence.
+            let silence = vec![0.0f32; self.frame_samples];
+            self.encode_and_write(&silence, PacketWriteEndInfo::EndStream)?;
+        }
+        // No audio was ever written (near-instant start/stop): the file has
+        // only OpusHead/OpusTags and no EndStream page. Acceptable — this is
+        // the same "truncated but structurally valid" tolerance as a crash.
+
+        self.packet_writer
+            .inner_mut()
+            .flush()
+            .map_err(|e| format!("Flush recording file: {e}"))
+    }
+}
+
+enum RecorderMsg {
+    Chunk(Vec<f32>),
+}
+
+/// Feeds mono f32 PCM to a background writer thread that encodes it to an
+/// Ogg Opus file. One instance per recording session (see
+/// `capture::AudioCapture`'s recorder field — it survives mid-session
+/// capture rebuilds by session id, matching the session lifecycle).
+pub struct MeetingRecorder {
+    session_id: u64,
+    sender: Option<SyncSender<RecorderMsg>>,
+    handle: Option<JoinHandle<()>>,
+    dropped: Arc<AtomicU64>,
+}
+
+impl MeetingRecorder {
+    /// Start recording `session_id`'s audio to `path`, at the nearest
+    /// Opus-valid rate to `sample_rate` (resampling on the writer thread if
+    /// they differ — never on the caller's, presumably realtime, thread).
+    pub fn start(path: PathBuf, sample_rate: u32, session_id: u64) -> Result<Self, String> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| format!("Create recordings dir: {e}"))?;
+        }
+        let encode_rate = nearest_opus_rate(sample_rate);
+
+        let file = std::fs::File::create(&path).map_err(|e| format!("Create recording file: {e}"))?;
+        let mut writer = OggOpusWriter::new(std::io::BufWriter::new(file), encode_rate)?;
+
+        let (tx, rx) = sync_channel::<RecorderMsg>(CHANNEL_CAPACITY);
+        let dropped = Arc::new(AtomicU64::new(0));
+
+        let handle = std::thread::Builder::new()
+            .name("meeting-recorder".into())
+            .spawn(move || {
+                let mut resampler = (encode_rate != sample_rate)
+                    .then(|| super::resampler::Resampler::new(sample_rate, 1, encode_rate, 1.0));
+
+                while let Ok(RecorderMsg::Chunk(samples)) = rx.recv() {
+                    let owned;
+                    let encode_samples: &[f32] = match resampler.as_mut() {
+                        Some(r) => {
+                            owned = r.process(&samples);
+                            &owned
+                        }
+                        None => &samples,
+                    };
+                    if let Err(e) = writer.write_chunk(encode_samples) {
+                        tracing::warn!("Meeting recorder encode error: {e}");
+                    }
+                }
+
+                if let Some(r) = resampler.as_mut() {
+                    let tail = r.flush();
+                    if !tail.is_empty()
+                        && let Err(e) = writer.write_chunk(&tail)
+                    {
+                        tracing::warn!("Meeting recorder tail flush error: {e}");
+                    }
+                }
+                if let Err(e) = writer.finish() {
+                    tracing::warn!("Meeting recorder finalize error: {e}");
+                }
+            })
+            .map_err(|e| format!("Spawn meeting recorder thread: {e}"))?;
+
+        Ok(Self {
+            session_id,
+            sender: Some(tx),
+            handle: Some(handle),
+            dropped,
+        })
+    }
+
+    pub fn session_id(&self) -> u64 {
+        self.session_id
+    }
+
+    /// Queue a chunk for encoding. Non-blocking: a full channel drops the
+    /// chunk (and counts it) instead of ever stalling the realtime
+    /// audio-capture thread that calls this.
+    pub fn push(&self, samples: &[f32]) {
+        if samples.is_empty() {
+            return;
+        }
+        if let Some(sender) = &self.sender
+            && sender.try_send(RecorderMsg::Chunk(samples.to_vec())).is_err()
+        {
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    pub fn dropped_chunks(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+}
+
+impl Drop for MeetingRecorder {
+    fn drop(&mut self) {
+        // Dropping the sender closes the channel, so the writer thread's
+        // `recv()` returns and it finalizes (flush + close) before exiting.
+        // This runs whenever a `MeetingRecorder` goes out of scope — normal
+        // stop, a session end after mic loss, or stack unwinding from a
+        // caught panic (`panic = "unwind"`) — so every teardown path closes
+        // the file. Only a hard crash (SIGKILL/abort) skips it, leaving a
+        // truncated but structurally valid Ogg file.
+        self.sender.take();
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sine(seconds: f64, rate: u32) -> Vec<f32> {
+        let n = (seconds * f64::from(rate)) as usize;
+        (0..n)
+            .map(|i| ((2.0 * std::f64::consts::PI * 440.0 * i as f64 / f64::from(rate)).sin() * 0.3) as f32)
+            .collect()
+    }
+
+    #[test]
+    fn nearest_opus_rate_snaps_to_valid_values() {
+        assert_eq!(nearest_opus_rate(48_000), 48_000);
+        assert_eq!(nearest_opus_rate(24_000), 24_000);
+        assert_eq!(nearest_opus_rate(16_000), 16_000);
+        assert_eq!(nearest_opus_rate(44_100), 48_000);
+        assert_eq!(nearest_opus_rate(22_050), 24_000);
+    }
+
+    #[test]
+    fn encodes_sine_to_valid_nonempty_ogg_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("out.ogg");
+        let file = std::fs::File::create(&path).expect("create");
+        let mut writer = OggOpusWriter::new(std::io::BufWriter::new(file), 24_000).expect("writer");
+
+        let samples = sine(2.0, 24_000);
+        writer.write_chunk(&samples).expect("write");
+        writer.finish().expect("finish");
+
+        let bytes = std::fs::read(&path).expect("read back");
+        assert!(!bytes.is_empty());
+        assert_eq!(&bytes[0..4], b"OggS", "file must start with an Ogg page");
+        // Granule position should reflect ~2s at 48kHz-equivalent samples.
+        assert!(writer.granule_position >= 95_000 && writer.granule_position <= 97_000);
+    }
+
+    #[test]
+    fn finish_is_idempotent() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("out.ogg");
+        let file = std::fs::File::create(&path).expect("create");
+        let mut writer = OggOpusWriter::new(std::io::BufWriter::new(file), 24_000).expect("writer");
+
+        writer.write_chunk(&sine(0.5, 24_000)).expect("write");
+        writer.finish().expect("finish once");
+        let granule_after_first = writer.granule_position;
+        writer.finish().expect("finish twice must not error");
+        assert_eq!(writer.granule_position, granule_after_first, "second finish must be a no-op");
+    }
+
+    #[test]
+    fn finish_with_no_audio_does_not_error() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("empty.ogg");
+        let file = std::fs::File::create(&path).expect("create");
+        let mut writer = OggOpusWriter::new(std::io::BufWriter::new(file), 16_000).expect("writer");
+        writer.finish().expect("finish with no audio");
+    }
+
+    #[test]
+    fn recorder_encodes_end_to_end_and_closes_file_on_drop() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("session.ogg");
+
+        let recorder = MeetingRecorder::start(path.clone(), 24_000, 1).expect("start");
+        assert_eq!(recorder.session_id(), 1);
+        for _ in 0..5 {
+            recorder.push(&sine(0.1, 24_000));
+        }
+        drop(recorder); // joins the writer thread, finalizing the file
+
+        let bytes = std::fs::read(&path).expect("recording file must exist");
+        assert!(!bytes.is_empty());
+        assert_eq!(&bytes[0..4], b"OggS");
+    }
+
+    /// Exercises the exact `try_send`-or-count-a-drop mechanism `push` uses,
+    /// against a rendezvous channel (capacity 0) with no receiver draining
+    /// it: every send is guaranteed to fail immediately, so this is
+    /// deterministic (unlike starving a real writer thread, which races the
+    /// scheduler) and never blocks.
+    #[test]
+    fn full_channel_drops_chunks_without_blocking() {
+        let (tx, _rx) = sync_channel::<RecorderMsg>(0);
+        let dropped = Arc::new(AtomicU64::new(0));
+
+        let push = |samples: &[f32]| {
+            if tx.try_send(RecorderMsg::Chunk(samples.to_vec())).is_err() {
+                dropped.fetch_add(1, Ordering::Relaxed);
+            }
+        };
+
+        for _ in 0..10 {
+            push(&[0.1, 0.2, 0.3]);
+        }
+
+        assert_eq!(
+            dropped.load(Ordering::Relaxed),
+            10,
+            "an undrained rendezvous channel must drop every chunk, never block"
+        );
+    }
+}

--- a/src-tauri/src/audio/retention.rs
+++ b/src-tauri/src/audio/retention.rs
@@ -1,0 +1,181 @@
+//! Retention sweep for recorded meeting audio: deletes recording directories
+//! older than the configured policy. Runs once at app startup (see
+//! `lib::run`); `off` never deletes existing recordings (the user may
+//! re-enable recording later), only `keep_7d`/`keep_30d` do.
+
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+use crate::settings::MeetingAudioRetention;
+
+use super::recorder;
+
+const DAY: Duration = Duration::from_secs(24 * 3600);
+
+/// Pure decision: is a meeting recording whose newest file has `age` old
+/// past the retention window for `policy`?
+pub fn is_expired(age: Duration, policy: MeetingAudioRetention) -> bool {
+    match policy {
+        MeetingAudioRetention::Off | MeetingAudioRetention::KeepForever => false,
+        MeetingAudioRetention::Keep7d => age > DAY * 7,
+        MeetingAudioRetention::Keep30d => age > DAY * 30,
+    }
+}
+
+fn newest_mtime(dir: &Path) -> Option<SystemTime> {
+    std::fs::read_dir(dir)
+        .ok()?
+        .flatten()
+        .filter_map(|entry| entry.metadata().ok()?.modified().ok())
+        .max()
+}
+
+/// Delete every meeting recording directory directly under `root` whose
+/// newest file is older than `policy`'s window, as of `now`. Best-effort:
+/// missing/unreadable entries are skipped rather than failing the sweep.
+fn sweep_dir(root: &Path, policy: MeetingAudioRetention, now: SystemTime) {
+    if matches!(policy, MeetingAudioRetention::Off | MeetingAudioRetention::KeepForever) {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let Some(newest) = newest_mtime(&path) else {
+            continue;
+        };
+        let age = now.duration_since(newest).unwrap_or_default();
+        if !is_expired(age, policy) {
+            continue;
+        }
+        match std::fs::remove_dir_all(&path) {
+            Ok(()) => tracing::info!(dir = %path.display(), "Deleted expired meeting recording"),
+            Err(e) => tracing::warn!(dir = %path.display(), "Failed to delete expired meeting recording: {e}"),
+        }
+    }
+}
+
+/// Sweep the real recordings directory. Called once at app startup on a
+/// background thread (directory walks can take a moment with a large
+/// history).
+pub fn sweep_expired_recordings(policy: MeetingAudioRetention, now: SystemTime) {
+    sweep_dir(&recorder::recordings_root(), policy, now);
+}
+
+fn dir_size_bytes(dir: &Path) -> u64 {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    entries
+        .flatten()
+        .map(|entry| {
+            let path = entry.path();
+            if path.is_dir() {
+                dir_size_bytes(&path)
+            } else {
+                entry.metadata().map(|m| m.len()).unwrap_or(0)
+            }
+        })
+        .sum()
+}
+
+/// Total size on disk of every meeting recording, for the Settings > Data
+/// stats line.
+pub fn recordings_size_bytes() -> u64 {
+    dir_size_bytes(&recorder::recordings_root())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn touch_with_age(path: &Path, age: Duration, now: SystemTime) {
+        std::fs::write(path, b"opus data").expect("write");
+        let file = std::fs::File::options().write(true).open(path).expect("open");
+        file.set_modified(now - age).expect("set_modified");
+    }
+
+    #[test]
+    fn is_expired_matrix() {
+        assert!(!is_expired(DAY * 1000, MeetingAudioRetention::Off));
+        assert!(!is_expired(DAY * 1000, MeetingAudioRetention::KeepForever));
+
+        assert!(!is_expired(DAY * 6, MeetingAudioRetention::Keep7d));
+        assert!(!is_expired(DAY * 7, MeetingAudioRetention::Keep7d));
+        assert!(is_expired(DAY * 8, MeetingAudioRetention::Keep7d));
+
+        assert!(!is_expired(DAY * 29, MeetingAudioRetention::Keep30d));
+        assert!(is_expired(DAY * 31, MeetingAudioRetention::Keep30d));
+    }
+
+    #[test]
+    fn sweep_deletes_only_expired_meeting_dirs() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let now = SystemTime::now();
+
+        let old_meeting = root.path().join("old-meeting");
+        std::fs::create_dir_all(&old_meeting).expect("mkdir");
+        touch_with_age(&old_meeting.join("0.ogg"), DAY * 10, now);
+
+        let recent_meeting = root.path().join("recent-meeting");
+        std::fs::create_dir_all(&recent_meeting).expect("mkdir");
+        touch_with_age(&recent_meeting.join("0.ogg"), Duration::from_secs(3600), now);
+
+        sweep_dir(root.path(), MeetingAudioRetention::Keep7d, now);
+
+        assert!(!old_meeting.exists(), "expired meeting recording must be deleted");
+        assert!(recent_meeting.exists(), "recent meeting recording must survive");
+    }
+
+    #[test]
+    fn sweep_keeps_a_multi_session_meeting_whose_newest_session_is_recent() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let now = SystemTime::now();
+
+        let meeting = root.path().join("resumed-meeting");
+        std::fs::create_dir_all(&meeting).expect("mkdir");
+        touch_with_age(&meeting.join("0.ogg"), DAY * 20, now); // old first session
+        touch_with_age(&meeting.join("1.ogg"), Duration::from_secs(60), now); // fresh resumed session
+
+        sweep_dir(root.path(), MeetingAudioRetention::Keep7d, now);
+
+        assert!(meeting.exists(), "a meeting with any recent session file must survive");
+    }
+
+    #[test]
+    fn sweep_is_noop_when_off_or_forever() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let now = SystemTime::now();
+        let meeting = root.path().join("ancient-meeting");
+        std::fs::create_dir_all(&meeting).expect("mkdir");
+        touch_with_age(&meeting.join("0.ogg"), DAY * 365, now);
+
+        sweep_dir(root.path(), MeetingAudioRetention::Off, now);
+        assert!(meeting.exists(), "off must never delete existing recordings");
+
+        sweep_dir(root.path(), MeetingAudioRetention::KeepForever, now);
+        assert!(meeting.exists(), "forever must never delete");
+    }
+
+    #[test]
+    fn sweep_on_missing_root_does_not_panic() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let missing = root.path().join("does-not-exist");
+        sweep_dir(&missing, MeetingAudioRetention::Keep7d, SystemTime::now());
+    }
+
+    #[test]
+    fn dir_size_bytes_sums_nested_files() {
+        let root = tempfile::tempdir().expect("tempdir");
+        let meeting = root.path().join("m1");
+        std::fs::create_dir_all(&meeting).expect("mkdir");
+        std::fs::write(meeting.join("0.ogg"), vec![0u8; 100]).expect("write");
+        std::fs::write(meeting.join("1.ogg"), vec![0u8; 250]).expect("write");
+
+        assert_eq!(dir_size_bytes(root.path()), 350);
+    }
+}

--- a/src-tauri/src/commands/data.rs
+++ b/src-tauri/src/commands/data.rs
@@ -73,6 +73,7 @@ pub fn get_data_stats(state: State<'_, AppState>) -> Result<DataStats, String> {
         db_size_bytes,
         meeting_count: state.db.count_meetings()?,
         dictation_count: state.db.count_dictation_entries()?,
+        recordings_size_bytes: crate::audio::retention::recordings_size_bytes(),
     })
 }
 

--- a/src-tauri/src/commands/meetings.rs
+++ b/src-tauri/src/commands/meetings.rs
@@ -25,11 +25,53 @@ pub fn get_meeting(
     state.db.load_meeting(&id)
 }
 
-/// Delete a meeting by ID
+/// Delete a meeting by ID, including any recorded audio.
 #[tauri::command]
 #[specta::specta]
 pub fn delete_meeting(state: State<'_, AppState>, id: String) -> Result<(), String> {
-    state.db.delete_meeting(&id)
+    state.db.delete_meeting(&id)?;
+
+    let recordings_dir = crate::audio::recorder::meeting_recordings_dir(&id);
+    if recordings_dir.exists()
+        && let Err(e) = std::fs::remove_dir_all(&recordings_dir)
+    {
+        tracing::warn!(meeting_id = %id, "Failed to delete meeting recordings: {e}");
+    }
+
+    Ok(())
+}
+
+/// List the recorded audio files for a meeting (empty if recording was never
+/// enabled, or none survived retention). Reads the filesystem directly —
+/// nothing here is persisted in the database.
+#[tauri::command]
+#[specta::specta]
+pub fn get_meeting_audio(
+    meeting_id: String,
+) -> Result<Vec<crate::transcript::MeetingAudioSession>, String> {
+    let dir = crate::audio::recorder::meeting_recordings_dir(&meeting_id);
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Ok(Vec::new());
+    };
+
+    let mut sessions: Vec<crate::transcript::MeetingAudioSession> = entries
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("ogg") {
+                return None;
+            }
+            let session_index = path.file_stem()?.to_str()?.parse::<usize>().ok()?;
+            Some(crate::transcript::MeetingAudioSession {
+                session_index,
+                path: path.to_string_lossy().to_string(),
+                duration_seconds: None,
+            })
+        })
+        .collect();
+
+    sessions.sort_by_key(|session| session.session_index);
+    Ok(sessions)
 }
 
 /// Save the user's live meeting notes. Targets the in-memory accumulator

--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -143,6 +143,14 @@ async fn launch_meeting(
         ],
     );
 
+    // This session's position in the meeting's recording_sessions — 0 for a
+    // new meeting, len() for a resume — is exactly the on-disk file index a
+    // recorder should write to, if recording is on.
+    let recording_target = RecordingTarget {
+        meeting_id: accumulator.id.clone(),
+        session_index: accumulator.recording_sessions.len(),
+    };
+
     // Persist the header before any segments so a crash leaves a recoverable
     // row (ended_at IS NULL) and segment FK targets exist.
     state
@@ -172,6 +180,7 @@ async fn launch_meeting(
             session_id,
             PipelineMode::Meeting,
             session_terms,
+            Some(recording_target),
             on_segment,
         )
     })
@@ -217,10 +226,21 @@ enum PipelineMode {
     Meeting,
 }
 
+/// Identifies where a meeting recording session's audio file belongs, if
+/// the retention setting turns out to be on. Resolved before the session
+/// starts (`launch_meeting` knows the meeting id and the session's position
+/// in `recording_sessions`); whether to actually record is decided inside
+/// `start_pipeline_blocking` once settings are loaded.
+struct RecordingTarget {
+    meeting_id: String,
+    session_index: usize,
+}
+
 /// Blocking core of starting a recording session, run via `spawn_blocking` so
 /// the long crossbeam reply wait (engine reset + filter-chain build) never
 /// blocks the Tauri command thread / window event loop. Preconditions and
 /// session-id allocation are done on the command thread before this runs.
+#[allow(clippy::too_many_arguments)]
 fn start_pipeline_blocking(
     engine_actor: &EngineActorHandle,
     audio_cmd_sender: &Sender<AudioCommand>,
@@ -228,6 +248,7 @@ fn start_pipeline_blocking(
     session_id: u64,
     mode: PipelineMode,
     session_terms: Vec<String>,
+    recording_target: Option<RecordingTarget>,
     on_segment: SegmentCallback,
 ) -> Result<(), String> {
     // Snapshot settings and dictionary; the actor builds filter chains on its
@@ -273,6 +294,18 @@ fn start_pipeline_blocking(
     // The actor replies once the engine is reset and ready for audio.
     let info = engine_actor.start_session(session_id, config, on_segment)?;
 
+    // Recording is opt-in and meeting-only; resolve the actual path only
+    // once the retention setting is known (a `RecordingTarget` just means
+    // "this session's audio would live here if recording is on").
+    let record_path = if mode == PipelineMode::Meeting
+        && settings.meeting_audio_retention != crate::settings::MeetingAudioRetention::Off
+    {
+        recording_target
+            .map(|target| crate::audio::recorder::session_path(&target.meeting_id, target.session_index))
+    } else {
+        None
+    };
+
     audio_cmd_sender
         .send(AudioCommand::Start {
             session_id,
@@ -280,6 +313,7 @@ fn start_pipeline_blocking(
             mic_gain: info.mic_gain,
             capture_system_audio,
             diarize,
+            record_path,
         })
         .map_err(|e| format!("Audio start: {e}"))?;
 
@@ -354,6 +388,7 @@ pub async fn start_transcription(
             session_id,
             PipelineMode::Dictation,
             Vec::new(),
+            None,
             on_segment,
         )
     })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -97,6 +97,7 @@ fn specta_builder() -> Builder<tauri::Wry> {
             commands::list_meetings,
             commands::get_meeting,
             commands::delete_meeting,
+            commands::get_meeting_audio,
             commands::rename_meeting,
             commands::save_meeting_notes,
             commands::save_edited_transcript,
@@ -298,6 +299,12 @@ pub fn run() {
                     let _ = state.audio_cmd_sender.send(state::AudioCommand::SetClamshellDevice(
                         app_settings.clamshell_audio_device,
                     ));
+                    // Directory walk over recordings/ can take a moment with
+                    // a large history; never block startup on it.
+                    let retention = app_settings.meeting_audio_retention;
+                    std::thread::spawn(move || {
+                        audio::retention::sweep_expired_recordings(retention, std::time::SystemTime::now());
+                    });
                 }
                 Err(e) => {
                     tracing::warn!("Failed to load settings on startup: {e}");

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -43,6 +43,7 @@ const DICTATION_POLISH_TEMPLATES_KEY: &str = "dictation_polish_templates";
 const LOG_LEVEL_KEY: &str = "log_level";
 const PASTE_METHOD_KEY: &str = "paste_method";
 const LAST_SEEN_VERSION_KEY: &str = "last_seen_version";
+const MEETING_AUDIO_RETENTION_KEY: &str = "meeting_audio_retention";
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default, specta::Type)]
 #[serde(rename_all = "snake_case")]
@@ -66,6 +67,26 @@ pub enum Theme {
     Dark,
     Light,
     System,
+}
+
+/// How long recorded meeting audio is kept on disk before the startup sweep
+/// deletes it. Opt-in: recording itself only happens when this is not `Off`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default, specta::Type)]
+#[serde(rename_all = "snake_case")]
+pub enum MeetingAudioRetention {
+    /// No recording at all; existing recordings from a previous, more
+    /// permissive setting are left alone (the user may re-enable).
+    #[default]
+    Off,
+    // Explicit renames: serde's snake_case heuristic and specta's TS-type
+    // heuristic disagree on letter/digit boundaries (serde emits "keep7d",
+    // specta types it as "keep_7d") — pin the wire value explicitly so both
+    // sides agree instead of relying on either deriving it the same way.
+    #[serde(rename = "keep_7d")]
+    Keep7d,
+    #[serde(rename = "keep_30d")]
+    Keep30d,
+    KeepForever,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, specta::Type)]
@@ -123,6 +144,9 @@ pub struct AppSettings {
     /// Hard failsafe: stop the meeting after this many minutes regardless of
     /// speech activity.
     pub meeting_max_duration_minutes: u32,
+    /// Opt-in recording of meeting audio to compressed files on disk, and
+    /// for how long they're kept. Off by default.
+    pub meeting_audio_retention: MeetingAudioRetention,
     /// Optional LLM post-processing applied to dictation before paste/history.
     pub dictation_polish_enabled: bool,
     /// Active polish template id (email, bullets, no_fillers).
@@ -172,6 +196,7 @@ impl Default for AppSettings {
             meeting_autostop_enabled: true,
             meeting_autostop_minutes: 10,
             meeting_max_duration_minutes: 240,
+            meeting_audio_retention: MeetingAudioRetention::default(),
             dictation_polish_enabled: false,
             dictation_polish_template_id: crate::summary::TEMPLATE_EMAIL.to_string(),
             dictation_polish_templates: crate::summary::default_polish_templates(),
@@ -319,6 +344,11 @@ impl AppSettings {
             read_json_setting::<u32>(db, MEETING_MAX_DURATION_MINUTES_KEY)?
         {
             settings.meeting_max_duration_minutes = meeting_max_duration_minutes;
+        }
+        if let Some(meeting_audio_retention) =
+            read_json_setting::<MeetingAudioRetention>(db, MEETING_AUDIO_RETENTION_KEY)?
+        {
+            settings.meeting_audio_retention = meeting_audio_retention;
         }
         if let Some(dictation_polish_enabled) =
             read_json_setting::<bool>(db, DICTATION_POLISH_ENABLED_KEY)?
@@ -569,6 +599,11 @@ impl AppSettings {
         )?;
         write_json_setting(
             db,
+            MEETING_AUDIO_RETENTION_KEY,
+            &normalized.meeting_audio_retention,
+        )?;
+        write_json_setting(
+            db,
             DICTATION_POLISH_ENABLED_KEY,
             &normalized.dictation_polish_enabled,
         )?;
@@ -686,7 +721,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{AppSettings, PasteMethod, ShortcutSettings, Theme};
+    use super::{AppSettings, MeetingAudioRetention, PasteMethod, ShortcutSettings, Theme};
     use crate::logging::LogLevel;
     use crate::constants::OLLAMA_DEFAULT_URL;
     use crate::test_helpers::fixtures::test_db;
@@ -724,6 +759,7 @@ mod tests {
             meeting_autostop_enabled: false,
             meeting_autostop_minutes: 15,
             meeting_max_duration_minutes: 120,
+            meeting_audio_retention: MeetingAudioRetention::Keep30d,
             dictation_polish_enabled: true,
             dictation_polish_template_id: "email".into(),
             dictation_polish_templates: crate::summary::default_polish_templates(),
@@ -1025,4 +1061,30 @@ mod tests {
         assert_eq!(shortcuts.toggle, "F6");
         assert_eq!(shortcuts.push_to_talk, "");
     }
+
+    /// `Keep7d`/`Keep30d` pin an explicit `#[serde(rename)]` because serde's
+    /// `snake_case` heuristic and specta's TS-type heuristic disagree at
+    /// letter/digit boundaries (serde alone would emit "keep7d", specta
+    /// would type it as "keep_7d") — this guards the wire value the
+    /// frontend actually depends on against a future regression.
+    #[test]
+    fn meeting_audio_retention_wire_format_is_stable() {
+        assert_eq!(
+            serde_json::to_string(&MeetingAudioRetention::Off).unwrap(),
+            "\"off\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MeetingAudioRetention::Keep7d).unwrap(),
+            "\"keep_7d\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MeetingAudioRetention::Keep30d).unwrap(),
+            "\"keep_30d\""
+        );
+        assert_eq!(
+            serde_json::to_string(&MeetingAudioRetention::KeepForever).unwrap(),
+            "\"keep_forever\""
+        );
+    }
 }
+

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -28,6 +28,10 @@ pub enum AudioCommand {
         /// source-tagged streams instead of one mixed stream, so each can be
         /// transcribed by its own engine. Only meaningful with system audio.
         diarize: bool,
+        /// Where to record this meeting's mixed audio, if the retention
+        /// setting is not off. `None` for dictation and for meetings
+        /// recorded with retention off.
+        record_path: Option<std::path::PathBuf>,
     },
     Stop,
     SelectDevice(String),

--- a/src-tauri/src/transcript.rs
+++ b/src-tauri/src/transcript.rs
@@ -65,6 +65,21 @@ impl MeetingRecordingSession {
     }
 }
 
+/// One recorded audio file for a meeting, as seen on disk — not persisted
+/// itself, `get_meeting_audio` derives this by listing the meeting's
+/// recordings directory. `session_index` matches the corresponding
+/// `MeetingRecordingSession`'s position in `recording_sessions`.
+#[derive(Debug, Clone, Serialize, specta::Type)]
+pub struct MeetingAudioSession {
+    pub session_index: usize,
+    /// Absolute filesystem path; the frontend turns this into a playable URL
+    /// via Tauri's asset protocol (`convertFileSrc`).
+    pub path: String,
+    /// Not computed here (would require decoding the file) — left `None`;
+    /// the frontend reads it from the `<audio>` element once loaded.
+    pub duration_seconds: Option<f64>,
+}
+
 /// Full meeting transcript stored as JSON
 #[derive(Debug, Clone, Serialize, specta::Type)]
 pub struct MeetingTranscript {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -51,7 +51,13 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://localhost:* https://huggingface.co https://*.hf.co; img-src 'self' data:; font-src 'self'"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' http://localhost:* https://huggingface.co https://*.hf.co; img-src 'self' data:; font-src 'self'; media-src 'self' asset: http://asset.localhost",
+      "assetProtocol": {
+        "enable": true,
+        "scope": [
+          "$APPDATA/recordings/**"
+        ]
+      }
     },
     "macOSPrivateApi": true
   },

--- a/src/lib/api/meetings.ts
+++ b/src/lib/api/meetings.ts
@@ -10,6 +10,7 @@ export async function saveMeetingNotes(id: string, notes: string | null): Promis
 }
 import type {
   ExportFormat,
+  MeetingAudioSession,
   MeetingCalendarContext,
   MeetingListItem,
   MeetingTranscript,
@@ -24,6 +25,12 @@ export async function listMeetings(): Promise<MeetingListItem[]> {
 
 export async function getMeeting(id: string): Promise<MeetingTranscript> {
   return unwrap(commands.getMeeting(id));
+}
+
+/** Recorded audio files for a meeting (empty if recording was off, or
+ * nothing survived retention). */
+export async function getMeetingAudio(meetingId: string): Promise<MeetingAudioSession[]> {
+  return unwrap(commands.getMeetingAudio(meetingId));
 }
 
 export async function startMeetingRecording(

--- a/src/lib/components/SettingsView.svelte
+++ b/src/lib/components/SettingsView.svelte
@@ -172,7 +172,10 @@
       onLogLevelChange={controller.onLogLevelChange}
     />
 
-    <DataSettingsSection />
+    <DataSettingsSection
+      retention={controller.app.settings.meeting_audio_retention}
+      onRetentionChange={controller.onMeetingAudioRetentionChange}
+    />
 
     <section class="settings-group">
       <h3>{$t("settings_advanced.model_storage")}</h3>

--- a/src/lib/features/meeting/audio-map.test.ts
+++ b/src/lib/features/meeting/audio-map.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { buildPlayCommand, defaultAudioTarget, resolveAudioSeekTarget } from "./audio-map";
+import type { MeetingAudioSession } from "../../types";
+
+function audioSession(sessionIndex: number, path: string): MeetingAudioSession {
+  return { session_index: sessionIndex, path, duration_seconds: null };
+}
+
+describe("resolveAudioSeekTarget", () => {
+  it("returns null when the paragraph has no known recording session", () => {
+    const result = resolveAudioSeekTarget(null, 12.5, [audioSession(0, "/rec/0.ogg")]);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when the session has no matching audio file", () => {
+    const result = resolveAudioSeekTarget(2, 5, [audioSession(0, "/rec/0.ogg"), audioSession(1, "/rec/1.ogg")]);
+    expect(result).toBeNull();
+  });
+
+  it("maps a paragraph to its session's file and offset", () => {
+    const sessions = [audioSession(0, "/rec/0.ogg"), audioSession(1, "/rec/1.ogg")];
+    const result = resolveAudioSeekTarget(1, 42.3, sessions);
+    expect(result).toEqual({ path: "/rec/1.ogg", sessionIndex: 1, offsetSeconds: 42.3 });
+  });
+
+  it("clamps a negative start time to zero", () => {
+    const result = resolveAudioSeekTarget(0, -0.2, [audioSession(0, "/rec/0.ogg")]);
+    expect(result?.offsetSeconds).toBe(0);
+  });
+
+  it("resolves the correct session in a multi-session meeting regardless of array order", () => {
+    // audioSessions from get_meeting_audio is sorted by session_index, but
+    // the mapping must not assume that ordering.
+    const sessions = [audioSession(2, "/rec/2.ogg"), audioSession(0, "/rec/0.ogg"), audioSession(1, "/rec/1.ogg")];
+    expect(resolveAudioSeekTarget(0, 1, sessions)?.path).toBe("/rec/0.ogg");
+    expect(resolveAudioSeekTarget(1, 1, sessions)?.path).toBe("/rec/1.ogg");
+    expect(resolveAudioSeekTarget(2, 1, sessions)?.path).toBe("/rec/2.ogg");
+  });
+
+  it("handles a meeting where only the second session was recorded", () => {
+    // e.g. retention was turned on between the first and second recording.
+    const sessions = [audioSession(1, "/rec/1.ogg")];
+    expect(resolveAudioSeekTarget(0, 1, sessions)).toBeNull();
+    expect(resolveAudioSeekTarget(1, 7, sessions)).toEqual({
+      path: "/rec/1.ogg",
+      sessionIndex: 1,
+      offsetSeconds: 7,
+    });
+  });
+});
+
+describe("defaultAudioTarget", () => {
+  it("returns null when there are no recorded sessions", () => {
+    expect(defaultAudioTarget([])).toBeNull();
+  });
+
+  it("picks the earliest session at offset zero, regardless of input order", () => {
+    const sessions = [audioSession(2, "/rec/2.ogg"), audioSession(0, "/rec/0.ogg"), audioSession(1, "/rec/1.ogg")];
+    expect(defaultAudioTarget(sessions)).toEqual({ path: "/rec/0.ogg", sessionIndex: 0, offsetSeconds: 0 });
+  });
+
+  it("works for a single-session meeting", () => {
+    expect(defaultAudioTarget([audioSession(0, "/rec/0.ogg")])).toEqual({
+      path: "/rec/0.ogg",
+      sessionIndex: 0,
+      offsetSeconds: 0,
+    });
+  });
+});
+
+describe("buildPlayCommand", () => {
+  it("flags a session change when the target's file differs from the current one", () => {
+    const target = { path: "/rec/1.ogg", sessionIndex: 1, offsetSeconds: 10 };
+    const command = buildPlayCommand(target, "/rec/0.ogg");
+    expect(command).toEqual({ path: "/rec/1.ogg", seekSeconds: 10, sessionChanged: true });
+  });
+
+  it("does not flag a session change for another paragraph in the same file", () => {
+    const target = { path: "/rec/0.ogg", sessionIndex: 0, offsetSeconds: 33 };
+    const command = buildPlayCommand(target, "/rec/0.ogg");
+    expect(command).toEqual({ path: "/rec/0.ogg", seekSeconds: 33, sessionChanged: false });
+  });
+
+  it("flags a session change when there was no current path yet", () => {
+    const target = { path: "/rec/0.ogg", sessionIndex: 0, offsetSeconds: 0 };
+    const command = buildPlayCommand(target, null);
+    expect(command.sessionChanged).toBe(true);
+  });
+});

--- a/src/lib/features/meeting/audio-map.ts
+++ b/src/lib/features/meeting/audio-map.ts
@@ -1,0 +1,71 @@
+import type { MeetingAudioSession } from "../../types";
+
+/** Where to play from: which file, and at what offset within it. */
+export interface AudioSeekTarget {
+  path: string;
+  sessionIndex: number;
+  offsetSeconds: number;
+}
+
+/**
+ * Resolve a transcript paragraph's playback target.
+ *
+ * `recordingSessionIndex` is the paragraph's recording-session position (see
+ * `buildMeetingTranscriptBlocks` in `../../utils/paragraphs`) — the same
+ * position a recorder used for that session's filename on the backend
+ * (`{session_index}.ogg`, listed by `get_meeting_audio`). `startTime` is the
+ * paragraph's first segment's `start_time`; the transcription pipeline
+ * resets each recording session's clock near zero when it starts (a fresh
+ * engine/session), so that value already doubles as a seek offset into that
+ * session's audio file — no extra alignment is needed.
+ *
+ * Returns `null` when there's nothing to seek to: no session was
+ * attributed to the paragraph, or that session has no matching audio file
+ * (recording was off for it, or it didn't survive retention).
+ */
+export function resolveAudioSeekTarget(
+  recordingSessionIndex: number | null,
+  startTime: number,
+  audioSessions: MeetingAudioSession[],
+): AudioSeekTarget | null {
+  if (recordingSessionIndex === null) return null;
+  const match = audioSessions.find((session) => session.session_index === recordingSessionIndex);
+  if (!match) return null;
+
+  return {
+    path: match.path,
+    sessionIndex: match.session_index,
+    offsetSeconds: Math.max(0, startTime),
+  };
+}
+
+/** The audio file to show by default, before any paragraph has been
+ * clicked: the earliest recorded session, at its start. `null` when there's
+ * nothing to play. */
+export function defaultAudioTarget(audioSessions: MeetingAudioSession[]): AudioSeekTarget | null {
+  if (audioSessions.length === 0) return null;
+  const first = audioSessions.reduce((earliest, session) =>
+    session.session_index < earliest.session_index ? session : earliest,
+  );
+  return { path: first.path, sessionIndex: first.session_index, offsetSeconds: 0 };
+}
+
+/** What a player should do in response to a seek target: which path to
+ * play (only different from `currentPath` when the paragraph belongs to a
+ * different recording session) and where to seek once it's loaded. */
+export interface PlayCommand {
+  path: string;
+  seekSeconds: number;
+  /** `true` when the player must swap `<audio src>` before it can seek —
+   * the caller should wait for `loadedmetadata` before setting
+   * `currentTime`, rather than setting it immediately. */
+  sessionChanged: boolean;
+}
+
+export function buildPlayCommand(target: AudioSeekTarget, currentPath: string | null): PlayCommand {
+  return {
+    path: target.path,
+    seekSeconds: target.offsetSeconds,
+    sessionChanged: currentPath !== target.path,
+  };
+}

--- a/src/lib/features/meeting/components/MeetingAudioPlayerSection.svelte
+++ b/src/lib/features/meeting/components/MeetingAudioPlayerSection.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+  import { convertFileSrc } from "@tauri-apps/api/core";
+  import { Pause, Play } from "@lucide/svelte";
+  import { t } from "svelte-i18n";
+  import { defaultAudioTarget, buildPlayCommand, type AudioSeekTarget } from "../audio-map";
+  import type { MeetingAudioSession } from "../../../types";
+  import { formatDuration } from "../../../utils";
+
+  let {
+    audioSessions,
+    seekTarget,
+    seekRequestId,
+  }: {
+    audioSessions: MeetingAudioSession[];
+    seekTarget: AudioSeekTarget | null;
+    seekRequestId: number;
+  } = $props();
+
+  let audioEl: HTMLAudioElement | undefined = $state();
+  let currentPath = $state<string | null>(null);
+  let playing = $state(false);
+  let currentTime = $state(0);
+  let duration = $state(0);
+  // Guards re-applying the same click twice (e.g. an unrelated prop update
+  // re-running the effect) without needing seekRequestId in a closure ref.
+  let lastAppliedSeekId = -1;
+
+  // Show something to play as soon as sessions arrive, before any paragraph
+  // has been clicked.
+  $effect(() => {
+    if (currentPath === null) {
+      const target = defaultAudioTarget(audioSessions);
+      if (target) currentPath = target.path;
+    }
+  });
+
+  $effect(() => {
+    if (!seekTarget || !audioEl || seekRequestId === lastAppliedSeekId) return;
+    lastAppliedSeekId = seekRequestId;
+
+    const command = buildPlayCommand(seekTarget, currentPath);
+    const el = audioEl;
+    const applySeek = () => {
+      el.currentTime = command.seekSeconds;
+      void el.play();
+    };
+
+    if (command.sessionChanged) {
+      currentPath = command.path;
+      el.addEventListener("loadedmetadata", applySeek, { once: true });
+    } else {
+      applySeek();
+    }
+  });
+
+  function togglePlay() {
+    if (!audioEl) return;
+    if (audioEl.paused) void audioEl.play();
+    else audioEl.pause();
+  }
+
+  function onScrub(event: Event) {
+    if (!audioEl) return;
+    audioEl.currentTime = Number((event.currentTarget as HTMLInputElement).value);
+  }
+</script>
+
+{#if currentPath}
+  <section class="surface-card flex items-center gap-3 px-4 py-2.5">
+    <!-- svelte-ignore a11y_media_has_caption -->
+    <audio
+      bind:this={audioEl}
+      src={convertFileSrc(currentPath)}
+      preload="metadata"
+      onplay={() => { playing = true; }}
+      onpause={() => { playing = false; }}
+      ontimeupdate={() => { if (audioEl) currentTime = audioEl.currentTime; }}
+      onloadedmetadata={() => { if (audioEl) duration = audioEl.duration; }}
+    ></audio>
+    <button
+      class="btn btn-icon shrink-0"
+      onclick={togglePlay}
+      aria-label={playing ? $t("meeting_audio.pause") : $t("meeting_audio.play")}
+    >
+      {#if playing}
+        <Pause size={16} />
+      {:else}
+        <Play size={16} />
+      {/if}
+    </button>
+    <span class="w-10 shrink-0 text-right font-mono text-[11px] text-text-muted">{formatDuration(currentTime)}</span>
+    <input
+      type="range"
+      class="flex-1"
+      min="0"
+      max={duration || 0}
+      value={currentTime}
+      oninput={onScrub}
+      aria-label={$t("meeting_audio.scrubber")}
+    />
+    <span class="w-10 shrink-0 font-mono text-[11px] text-text-muted">{formatDuration(duration)}</span>
+  </section>
+{/if}

--- a/src/lib/features/meeting/components/MeetingDetail.svelte
+++ b/src/lib/features/meeting/components/MeetingDetail.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { t } from "svelte-i18n";
   import type { createMeetingController } from "../controller.svelte";
+  import MeetingAudioPlayerSection from "./MeetingAudioPlayerSection.svelte";
   import MeetingHeaderSection from "./MeetingHeaderSection.svelte";
   import MeetingNotesSection from "./MeetingNotesSection.svelte";
   import MeetingSummarySection from "./MeetingSummarySection.svelte";
@@ -68,6 +69,14 @@
       onNotesChange={controller.onNotesChange}
     />
 
+    {#if controller.audioSessions.length > 0}
+      <MeetingAudioPlayerSection
+        audioSessions={controller.audioSessions}
+        seekTarget={controller.seekTarget}
+        seekRequestId={controller.seekRequestId}
+      />
+    {/if}
+
     <!-- Transcript is the hero: prominent card right under the notes. -->
     <MeetingTranscriptSection
       segments={displaySegments}
@@ -83,6 +92,7 @@
       onSaveAndSummarize={controller.saveTranscriptAndSummarize}
       onResetEdited={controller.resetEditedTranscript}
       onEditDraftChange={(value) => { controller.editedTranscriptDraft = value; }}
+      onParagraphClick={controller.audioSessions.length > 0 ? controller.requestAudioSeek : undefined}
     />
 
     <!-- AI summary, generated from notes + transcript. -->

--- a/src/lib/features/meeting/components/MeetingTranscriptSection.svelte
+++ b/src/lib/features/meeting/components/MeetingTranscriptSection.svelte
@@ -19,6 +19,7 @@
     onSaveAndSummarize,
     onResetEdited,
     onEditDraftChange,
+    onParagraphClick,
   }: {
     segments: TranscriptionSegment[];
     recordingSessions: MeetingRecordingSession[];
@@ -33,6 +34,9 @@
     onSaveAndSummarize?: () => void | Promise<void>;
     onResetEdited?: () => void | Promise<void>;
     onEditDraftChange?: (value: string) => void;
+    /** A paragraph's timestamp was clicked; seeks the audio player if that
+     * paragraph maps to a recorded session (no-op otherwise). */
+    onParagraphClick?: (recordingSessionIndex: number | null, startTime: number) => void;
   } = $props();
 
   type TranscriptPhase = "has_content" | "recording_empty" | "empty";
@@ -129,7 +133,16 @@
                     class:text-secondary={block.speaker === "them"}
                   >{block.speaker === "me" ? $t("transcript.me") : $t("transcript.them")}</span>
                 {/if}
-                <span class="font-mono text-[10.5px] text-text-faint">{block.timestamp}</span>
+                {#if onParagraphClick}
+                  <button
+                    type="button"
+                    class="font-mono text-[10.5px] text-text-faint hover:text-accent hover:underline"
+                    onclick={() => onParagraphClick?.(block.recordingSessionIndex, block.startTime)}
+                    aria-label={$t("meeting_audio.seek_to", { values: { timestamp: block.timestamp } })}
+                  >{block.timestamp}</button>
+                {:else}
+                  <span class="font-mono text-[10.5px] text-text-faint">{block.timestamp}</span>
+                {/if}
               </div>
               <p class="m-0 text-sm leading-[1.7] text-text-secondary">{block.text}</p>
             </div>

--- a/src/lib/features/meeting/controller.svelte.ts
+++ b/src/lib/features/meeting/controller.svelte.ts
@@ -4,6 +4,7 @@ import {
   exportMeetingFilename,
   exportMeetingToFile,
   getMeeting,
+  getMeetingAudio,
   renameMeeting as applyMeetingRename,
   resumeMeetingRecording,
   saveEditedTranscript,
@@ -16,10 +17,11 @@ import {
 import { getSummaryProvidersStatus } from "../../api/summary";
 import { getTranscriptionCatalog } from "../../api/transcription";
 import { getAppState } from "../../stores/app.svelte";
-import type { ExportFormat, MeetingCalendarContext, MeetingIdle, MeetingTranscript, SummaryModelDescriptor, SummarizeProgress, TranscriptionCatalog, TranscriptionSegment } from "../../types";
+import type { ExportFormat, MeetingAudioSession, MeetingCalendarContext, MeetingIdle, MeetingTranscript, SummaryModelDescriptor, SummarizeProgress, TranscriptionCatalog, TranscriptionSegment } from "../../types";
 import { errorMessage } from "../../utils";
 import { toSelectedTranscriptionProfile } from "../transcription/catalog";
 import { ensureModelLoaded } from "../transcription/runtime";
+import { type AudioSeekTarget, resolveAudioSeekTarget } from "./audio-map";
 import { createLiveTranscript } from "./live-transcript.svelte";
 
 function defaultMeetingTitle(): string {
@@ -72,6 +74,14 @@ function createMeetingControllerInstance() {
 
   let meeting = $state<MeetingTranscript | null>(null);
   let isLoadingMeeting = $state(false);
+  // Recorded audio files for the open meeting (empty when recording was off,
+  // or nothing survived retention) — drives whether the player bar shows.
+  let audioSessions = $state<MeetingAudioSession[]>([]);
+  // A paragraph-click seek request for the player: `requestId` changes on
+  // every click (even to the same target) so an `$effect` watching it always
+  // fires, including re-clicking the same paragraph after manually pausing.
+  let seekTarget = $state<AudioSeekTarget | null>(null);
+  let seekRequestId = $state(0);
   // True from the moment Stop is clicked until the backend finishes draining +
   // saving (machine leaves "stopping"). Drives the Stop button's spinner and
   // guards against double-stop. `stopRequested` covers the brief gap before the
@@ -131,11 +141,24 @@ function createMeetingControllerInstance() {
       syncSelectedModel(meeting.summary_model);
       notesDraft = meeting.notes ?? "";
       notesSaveState = "idle";
+      // Best-effort: a missing/unreadable recordings directory should never
+      // block loading the meeting itself, the player bar just stays hidden.
+      audioSessions = await getMeetingAudio(id).catch(() => []);
     } catch (e) {
       statusMessage = errorMessage(e);
     } finally {
       isLoadingMeeting = false;
     }
+  }
+
+  /** A paragraph's timestamp was clicked: resolve it to a playable audio
+   * target (no-op if the paragraph isn't attributed to a recorded session,
+   * e.g. recording was off or the file didn't survive retention). */
+  function requestAudioSeek(recordingSessionIndex: number | null, startTime: number) {
+    const target = resolveAudioSeekTarget(recordingSessionIndex, startTime, audioSessions);
+    if (!target) return;
+    seekTarget = target;
+    seekRequestId += 1;
   }
 
   /** The meeting id to write notes against: the accumulator id while
@@ -330,6 +353,7 @@ function createMeetingControllerInstance() {
     liveTranscript.reset();
     liveMeetingSegments = [];
     meeting = null;
+    audioSessions = [];
     app.currentMeetingId = null;
     clearIdleState();
     statusMessage =
@@ -395,6 +419,8 @@ function createMeetingControllerInstance() {
   function closeMeeting() {
     void flushNotes();
     meeting = null;
+    audioSessions = [];
+    seekTarget = null;
     liveTranscript.reset();
     liveMeetingSegments = [];
     statusMessage = "";
@@ -541,6 +567,10 @@ function createMeetingControllerInstance() {
     get liveTranscript() { return liveTranscript; },
     get liveMeetingSegments() { return liveMeetingSegments; },
     get meeting() { return meeting; },
+    get audioSessions() { return audioSessions; },
+    get seekTarget() { return seekTarget; },
+    get seekRequestId() { return seekRequestId; },
+    requestAudioSeek,
     get isLoadingMeeting() { return isLoadingMeeting; },
     get isStopping() { return isStopping; },
     get canResumeRecording() { return canResumeRecording; },

--- a/src/lib/features/settings/components/DataSettingsSection.svelte
+++ b/src/lib/features/settings/components/DataSettingsSection.svelte
@@ -13,8 +13,24 @@
     testMcpConnection,
   } from "../../../api/data";
   import { events } from "../../../api/generated";
-  import type { ArchiveExportProgress, DataStats, McpSetupInfo } from "../../../types";
+  import type { ArchiveExportProgress, DataStats, McpSetupInfo, MeetingAudioRetention } from "../../../types";
   import { errorMessage, formatBytes } from "../../../utils";
+
+  const retentionOptions: MeetingAudioRetention[] = ["off", "keep_7d", "keep_30d", "keep_forever"];
+  const retentionKeys: Record<MeetingAudioRetention, string> = {
+    off: "settings_data.retention_off",
+    keep_7d: "settings_data.retention_7d",
+    keep_30d: "settings_data.retention_30d",
+    keep_forever: "settings_data.retention_forever",
+  };
+
+  let {
+    retention,
+    onRetentionChange,
+  }: {
+    retention: MeetingAudioRetention;
+    onRetentionChange: (event: Event) => void | Promise<void>;
+  } = $props();
 
   let stats = $state<DataStats | null>(null);
   let mcpSetup = $state<McpSetupInfo | null>(null);
@@ -130,7 +146,26 @@
           },
         })}
       </p>
+      {#if stats.recordings_size_bytes > 0}
+        <p class="setting-desc">
+          {$t("settings_data.recordings_size", { values: { size: formatBytes(stats.recordings_size_bytes) } })}
+        </p>
+      {/if}
     {/if}
+
+    <SettingsField
+      label={$t("settings_data.retention_title")}
+      description={$t("settings_data.retention_desc")}
+      htmlFor="meeting-audio-retention"
+    >
+      {#snippet control()}
+        <select id="meeting-audio-retention" value={retention} onchange={onRetentionChange} class="field-select max-w-48">
+          {#each retentionOptions as option}
+            <option value={option}>{$t(retentionKeys[option])}</option>
+          {/each}
+        </select>
+      {/snippet}
+    </SettingsField>
 
     <SettingsField label={$t("settings_data.export_title")} description={$t("settings_data.export_desc")}>
       {#snippet control()}

--- a/src/lib/features/settings/controller.svelte.test.ts
+++ b/src/lib/features/settings/controller.svelte.test.ts
@@ -75,6 +75,7 @@ const defaultSettings: AppSettings = {
   meeting_autostop_enabled: true,
   meeting_autostop_minutes: 10,
   meeting_max_duration_minutes: 240,
+  meeting_audio_retention: "off",
   dictation_polish_enabled: false,
   dictation_polish_template_id: "email",
   dictation_polish_templates: [

--- a/src/lib/features/settings/controller.svelte.ts
+++ b/src/lib/features/settings/controller.svelte.ts
@@ -469,6 +469,13 @@ export function createSettingsController() {
     });
   }
 
+  function onMeetingAudioRetentionChange(event: Event) {
+    const value = (event.target as HTMLSelectElement).value as AppSettings["meeting_audio_retention"];
+    void persistSettings((settings) => {
+      settings.meeting_audio_retention = value;
+    });
+  }
+
   /** Populate the calendar picker without prompting: only fetch calendars
    * when the integration is on (which implies access was granted). */
   async function loadCalendars() {
@@ -718,6 +725,7 @@ export function createSettingsController() {
     onMeetingAutostopEnabledChange,
     onMeetingAutostopMinutesChange,
     onMeetingMaxDurationMinutesChange,
+    onMeetingAudioRetentionChange,
     onVadEnabledChange,
     onFillerRemovalChange,
     onStutterCollapseChange,

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -143,6 +143,13 @@
   "settings_data": {
     "title": "Data",
     "stats": "{size} on disk · {meetings} meetings · {dictations} dictations",
+    "recordings_size": "{size} of recorded meeting audio",
+    "retention_title": "Meeting audio recording",
+    "retention_desc": "Save a compressed recording of each meeting's audio for playback. Off by default; a change takes effect on the next meeting, not the one in progress.",
+    "retention_off": "Off",
+    "retention_7d": "Keep 7 days",
+    "retention_30d": "Keep 30 days",
+    "retention_forever": "Keep forever",
     "export_title": "Export all data",
     "export_desc": "Save every meeting, dictation entry, and a manifest into a folder you choose.",
     "export_button": "Export…",
@@ -219,6 +226,12 @@
   "transcript": {
     "me": "Me",
     "them": "Them"
+  },
+  "meeting_audio": {
+    "play": "Play",
+    "pause": "Pause",
+    "scrubber": "Seek",
+    "seek_to": "Play from {timestamp}"
   },
   "meeting_summary": {
     "title": "AI Summary",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -143,6 +143,13 @@
   "settings_data": {
     "title": "Données",
     "stats": "{size} sur le disque · {meetings} réunions · {dictations} dictées",
+    "recordings_size": "{size} d'audio de réunion enregistré",
+    "retention_title": "Enregistrement audio des réunions",
+    "retention_desc": "Enregistre l'audio de chaque réunion, sous forme compressée, pour pouvoir le réécouter. Désactivé par défaut ; un changement s'applique à la prochaine réunion, pas à celle en cours.",
+    "retention_off": "Désactivé",
+    "retention_7d": "Conserver 7 jours",
+    "retention_30d": "Conserver 30 jours",
+    "retention_forever": "Conserver indéfiniment",
     "export_title": "Exporter toutes les données",
     "export_desc": "Enregistre chaque réunion, chaque dictée et un manifeste dans un dossier de votre choix.",
     "export_button": "Exporter…",
@@ -219,6 +226,12 @@
   "transcript": {
     "me": "Moi",
     "them": "Eux"
+  },
+  "meeting_audio": {
+    "play": "Lecture",
+    "pause": "Pause",
+    "scrubber": "Position de lecture",
+    "seek_to": "Lire depuis {timestamp}"
   },
   "meeting_summary": {
     "title": "Résumé IA",

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -80,6 +80,7 @@ let settings = $state<AppSettings>({
   meeting_autostop_enabled: true,
   meeting_autostop_minutes: 10,
   meeting_max_duration_minutes: 240,
+  meeting_audio_retention: "off",
   dictation_polish_enabled: false,
   dictation_polish_template_id: "email",
   dictation_polish_templates: [

--- a/src/lib/test-helpers/fixtures.ts
+++ b/src/lib/test-helpers/fixtures.ts
@@ -207,6 +207,7 @@ export const mockSettings: AppSettings = {
   meeting_autostop_enabled: true,
   meeting_autostop_minutes: 10,
   meeting_max_duration_minutes: 240,
+  meeting_audio_retention: "off",
   dictation_polish_enabled: false,
   dictation_polish_template_id: "email",
   dictation_polish_templates: [

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -213,11 +213,24 @@ async getMeeting(id: string) : Promise<Result<MeetingTranscript, string>> {
 }
 },
 /**
- * Delete a meeting by ID
+ * Delete a meeting by ID, including any recorded audio.
  */
 async deleteMeeting(id: string) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("delete_meeting", { id }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * List the recorded audio files for a meeting (empty if recording was never
+ * enabled, or none survived retention). Reads the filesystem directly —
+ * nothing here is persisted in the database.
+ */
+async getMeetingAudio(meetingId: string) : Promise<Result<MeetingAudioSession[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_meeting_audio", { meetingId }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -800,6 +813,11 @@ meeting_autostop_minutes: number;
  */
 meeting_max_duration_minutes: number; 
 /**
+ * Opt-in recording of meeting audio to compressed files on disk, and
+ * for how long they're kept. Off by default.
+ */
+meeting_audio_retention: MeetingAudioRetention; 
+/**
  * Optional LLM post-processing applied to dictation before paste/history.
  */
 dictation_polish_enabled: boolean; 
@@ -878,9 +896,10 @@ export type CalendarMeetingNudgeKind =
  */
 "autostart"
 /**
- * Settings > Data stats line: database size and row counts.
+ * Settings > Data stats line: database size, row counts, and recorded
+ * meeting audio size.
  */
-export type DataStats = { db_size_bytes: number; meeting_count: number; dictation_count: number }
+export type DataStats = { db_size_bytes: number; meeting_count: number; dictation_count: number; recordings_size_bytes: number }
 export type DiagnosticsBundle = { app_version: string; data_dir: string; log_dir: string; log_file: string | null; db_path: string; models_dir: string; machine_state: string; log_level: string; debug_transcription: boolean }
 /**
  * A dictation history entry
@@ -922,6 +941,33 @@ export type HealthStatus = "healthy" |
 "stalled"
 export type LogLevel = "error" | "warn" | "info" | "debug" | "trace"
 export type McpSetupInfo = { binary_path: string; exists: boolean; claude_desktop_snippet: string; claude_code_command: string }
+/**
+ * How long recorded meeting audio is kept on disk before the startup sweep
+ * deletes it. Opt-in: recording itself only happens when this is not `Off`.
+ */
+export type MeetingAudioRetention = 
+/**
+ * No recording at all; existing recordings from a previous, more
+ * permissive setting are left alone (the user may re-enable).
+ */
+"off" | "keep_7d" | "keep_30d" | "keep_forever"
+/**
+ * One recorded audio file for a meeting, as seen on disk — not persisted
+ * itself, `get_meeting_audio` derives this by listing the meeting's
+ * recordings directory. `session_index` matches the corresponding
+ * `MeetingRecordingSession`'s position in `recording_sessions`.
+ */
+export type MeetingAudioSession = { session_index: number; 
+/**
+ * Absolute filesystem path; the frontend turns this into a playable URL
+ * via Tauri's asset protocol (`convertFileSrc`).
+ */
+path: string; 
+/**
+ * Not computed here (would require decoding the file) — left `None`;
+ * the frontend reads it from the `<audio>` element once loaded.
+ */
+duration_seconds: number | null }
 /**
  * Calendar context passed by the frontend when starting a meeting from a
  * calendar event.

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -18,6 +18,8 @@ export type {
   ErrorRecovery,
   ExportFormat,
   LogLevel,
+  MeetingAudioRetention,
+  MeetingAudioSession,
   MeetingCalendarContext,
   MeetingIdle,
   MeetingIdleReason,

--- a/src/lib/utils/paragraphs.ts
+++ b/src/lib/utils/paragraphs.ts
@@ -1,8 +1,16 @@
 import type { MeetingRecordingSession, Speaker, TranscriptionSegment } from "../types";
 import { formatTimestamp } from "./format";
 
-export type Paragraph = { timestamp: string; text: string; speaker?: Speaker | null };
-export type TranscriptParagraphBlock = Paragraph & { type: "paragraph" };
+export type Paragraph = { timestamp: string; startTime: number; text: string; speaker?: Speaker | null };
+export type TranscriptParagraphBlock = Paragraph & {
+  type: "paragraph";
+  /** Position of this paragraph's recording session in `recordingSessions`
+   * (see `buildMeetingTranscriptBlocks`), or `null` when it can't be
+   * attributed to a known session (legacy data, or a gap not covered by any
+   * saved session). Used to map a paragraph to its playable audio file —
+   * see `features/meeting/audio-map.ts`. */
+  recordingSessionIndex: number | null;
+};
 export type TranscriptSessionBreakBlock = {
   type: "session-break";
   endLabel: string;
@@ -66,6 +74,7 @@ export function groupIntoParagraphsWithRanges(
   const ranges: ParagraphRange[] = [];
   let rangeStart = 0;
   let currentTimestamp = formatTimestamp(ordered[0].start_time);
+  let currentStartTime = ordered[0].start_time;
   let currentSpeaker: Speaker | null = ordered[0].speaker ?? null;
   let currentWords: string[] = [];
   let currentChars = 0;
@@ -76,12 +85,14 @@ export function groupIntoParagraphsWithRanges(
   const flush = (boundaryIndex: number, nextStart: number, nextSpeaker: Speaker | null) => {
     paragraphs.push({
       timestamp: currentTimestamp,
+      startTime: currentStartTime,
       text: currentWords.join(" "),
       speaker: currentSpeaker,
     });
     ranges.push({ start: rangeStart, end: boundaryIndex });
     rangeStart = boundaryIndex;
     currentTimestamp = formatTimestamp(nextStart);
+    currentStartTime = nextStart;
     currentSpeaker = nextSpeaker;
     currentWords = [];
     currentChars = 0;
@@ -129,6 +140,7 @@ export function groupIntoParagraphsWithRanges(
   if (currentWords.length > 0) {
     paragraphs.push({
       timestamp: currentTimestamp,
+      startTime: currentStartTime,
       text: currentWords.join(" "),
       speaker: currentSpeaker,
     });
@@ -150,9 +162,13 @@ export function groupIntoParagraphs(
   return groupIntoParagraphsWithRanges(segments, pauseThreshold).paragraphs;
 }
 
-function toParagraphBlocks(paragraphs: Paragraph[]): TranscriptParagraphBlock[] {
+function toParagraphBlocks(
+  paragraphs: Paragraph[],
+  recordingSessionIndex: number | null,
+): TranscriptParagraphBlock[] {
   return paragraphs.map((paragraph) => ({
     type: "paragraph",
+    recordingSessionIndex,
     ...paragraph,
   }));
 }
@@ -169,8 +185,13 @@ export function buildMeetingTranscriptBlocks(
 ): TranscriptBlock[] {
   if (segments.length === 0) return [];
 
-  const normalizedSavedSessions = [...recordingSessions]
-    .map((session) => ({
+  // `sessionIndex` keeps each session's position in the original (already
+  // chronological) `recordingSessions` array — that position is also the
+  // audio filename a recorder wrote for it (see `commands::get_meeting_audio`
+  // on the backend) — before sorting loses it.
+  const normalizedSavedSessions = recordingSessions
+    .map((session, sessionIndex) => ({
+      sessionIndex,
       start: Math.max(0, Number(session.start_segment_index)),
       end: Math.min(segments.length, Number(session.end_segment_index)),
     }))
@@ -183,7 +204,7 @@ export function buildMeetingTranscriptBlocks(
     && liveSessionStartIndex < segments.length;
 
   if (normalizedSavedSessions.length === 0 && !hasLiveSession) {
-    return toParagraphBlocks(groupIntoParagraphs(segments, pauseThreshold));
+    return toParagraphBlocks(groupIntoParagraphs(segments, pauseThreshold), null);
   }
 
   const blocks: TranscriptBlock[] = [];
@@ -192,6 +213,7 @@ export function buildMeetingTranscriptBlocks(
     sessionSegments: TranscriptionSegment[],
     isFirstSession: boolean,
     isLiveSession: boolean,
+    recordingSessionIndex: number | null,
   ) => {
     if (sessionSegments.length === 0) return;
 
@@ -203,7 +225,7 @@ export function buildMeetingTranscriptBlocks(
       });
     }
 
-    blocks.push(...toParagraphBlocks(groupIntoParagraphs(sessionSegments, pauseThreshold)));
+    blocks.push(...toParagraphBlocks(groupIntoParagraphs(sessionSegments, pauseThreshold), recordingSessionIndex));
   };
 
   let appendedAnySession = false;
@@ -212,23 +234,27 @@ export function buildMeetingTranscriptBlocks(
   for (const session of normalizedSavedSessions) {
     const start = Math.max(consumedUntil, session.start);
     if (start > consumedUntil) {
-      appendSession(segments.slice(consumedUntil, start), !appendedAnySession, false);
+      // Segments not covered by any known recording session (gap in the
+      // saved ranges) can't be attributed to an audio file.
+      appendSession(segments.slice(consumedUntil, start), !appendedAnySession, false, null);
       appendedAnySession = true;
     }
 
-    appendSession(segments.slice(start, session.end), !appendedAnySession, false);
+    appendSession(segments.slice(start, session.end), !appendedAnySession, false, session.sessionIndex);
     appendedAnySession = appendedAnySession || session.end > start;
     consumedUntil = Math.max(consumedUntil, session.end);
   }
 
   if (hasLiveSession && liveSessionStartIndex !== null) {
     const start = Math.max(consumedUntil, liveSessionStartIndex);
-    appendSession(segments.slice(start), !appendedAnySession, true);
+    // The in-progress session hasn't been saved yet, so it isn't in
+    // `recordingSessions` — its eventual position is the next index.
+    appendSession(segments.slice(start), !appendedAnySession, true, recordingSessions.length);
     return blocks;
   }
 
   if (consumedUntil < segments.length) {
-    appendSession(segments.slice(consumedUntil), !appendedAnySession, false);
+    appendSession(segments.slice(consumedUntil), !appendedAnySession, false, null);
   }
 
   return blocks;


### PR DESCRIPTION
Records the meeting mix to Ogg Opus (32 kbps mono, engine sample rate, static libopus so nothing new to sign), one file per recording session, behind an opt-in retention setting (off by default; 7d/30d/forever with startup cleanup that never deletes when off). Encoding runs on a writer thread behind a bounded channel; the audio thread only try_sends. Deleting a meeting deletes its audio; data stats show recordings size.

Playback: compact player in the meeting detail, click a paragraph timestamp to seek (session-aware file switching; segment times restart per session so offsets map directly). Asset protocol scoped to the recordings dir, CSP media-src updated. WKWebView Ogg/Opus support verified empirically (Safari canPlayType 'probably', real playback + seek); documented caveat for macOS 13.0-13.2.

Also caught and regression-tested a specta/serde wire-format mismatch on digit-boundary enum variants (keep_30d).

Gates: 440 workspace tests, 206 frontend tests, clippy/check/build clean, 3/3 Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VuuJ8cV2dsbwNnc7Y8gm2b