### PR TITLE
Enlarge the pill live-text area

### DIFF
--- a/src-tauri/src/commands/pill.rs
+++ b/src-tauri/src/commands/pill.rs
@@ -1,4 +1,4 @@
-use tauri::State;
+use tauri::{Manager, State};
 
 use crate::app_events::PillHoldKind;
 use crate::state::AppState;
@@ -26,4 +26,18 @@ pub fn pill_release(state: State<'_, AppState>) -> Result<(), String> {
     crate::pill::clear_hold(&app);
     crate::pill::sync(&app, &state.current_machine_state()?);
     Ok(())
+}
+
+/// Recenter the pill window below the menu bar. `setSize` keeps the window's
+/// top-left corner fixed, so the frontend calls this after resizing (e.g.
+/// switching between the compact and expanded live-text layouts) to keep the
+/// pill horizontally centered instead of drifting sideways.
+#[tauri::command]
+#[specta::specta]
+pub fn pill_recenter(state: State<'_, AppState>) -> Result<(), String> {
+    let app = state.app_handle()?;
+    let Some(pill) = app.get_webview_window("pill") else {
+        return Ok(());
+    };
+    crate::pill::position_top_center(&pill).map_err(|e| e.to_string())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -114,6 +114,7 @@ fn specta_builder() -> Builder<tauri::Wry> {
             commands::polish_dictation,
             commands::pill_hold,
             commands::pill_release,
+            commands::pill_recenter,
             commands::get_settings,
             commands::save_settings,
             commands::save_shortcuts,

--- a/src-tauri/src/pill.rs
+++ b/src-tauri/src/pill.rs
@@ -21,9 +21,10 @@ const TOP_MARGIN: f64 = 40.0;
 /// 5-10Hz cap so it reads as "live" without flooding the pill's IPC channel.
 pub const LIVE_TEXT_MIN_INTERVAL: Duration = Duration::from_millis(120);
 
-/// Tail length (characters) sent to the pill: enough for a compact 2-3 line
-/// preview without shipping the whole running dictation on every update.
-pub const LIVE_TEXT_MAX_CHARS: usize = 240;
+/// Tail length (characters) sent to the pill: enough to fill the expanded
+/// live-text preview (3-4 lines at the wider width) without shipping the
+/// whole running dictation on every update.
+pub const LIVE_TEXT_MAX_CHARS: usize = 360;
 
 /// Frontend-driven hold on pill visibility, independent of the state
 /// machine (set/cleared via the `pill_hold` / `pill_release` commands).
@@ -120,7 +121,12 @@ pub fn live_text_tail(text: &str, max_chars: usize) -> String {
     text.chars().skip(total - max_chars).collect()
 }
 
-fn position_top_center(pill: &tauri::WebviewWindow) -> tauri::Result<()> {
+/// Recenters the pill horizontally below the menu bar. `pub(crate)` so the
+/// `pill_recenter` command can call it after the frontend resizes the window
+/// for a state change (e.g. compact <-> expanded live-text). `setSize` keeps
+/// the window's top-left corner fixed, so a width change alone would
+/// otherwise drift the pill off-center.
+pub(crate) fn position_top_center(pill: &tauri::WebviewWindow) -> tauri::Result<()> {
     let Some(monitor) = pill.primary_monitor()? else {
         return Ok(());
     };

--- a/src/lib/api/transcription.ts
+++ b/src/lib/api/transcription.ts
@@ -90,6 +90,11 @@ export async function pillRelease(): Promise<void> {
   await unwrap(commands.pillRelease());
 }
 
+/** Recenter the pill window; call after resizing it so it stays centered. */
+export async function pillRecenter(): Promise<void> {
+  await unwrap(commands.pillRecenter());
+}
+
 export async function recoverState(): Promise<AppStateMachine> {
   return unwrap(commands.recoverState());
 }

--- a/src/lib/pill/PillApp.svelte
+++ b/src/lib/pill/PillApp.svelte
@@ -5,16 +5,19 @@
   import { onMount } from "svelte";
   import { t } from "svelte-i18n";
   import { events } from "../api/generated";
-  import { getMachineState } from "../api/transcription";
+  import { getMachineState, pillRecenter } from "../api/transcription";
   import Spinner from "../components/ui/Spinner.svelte";
   import Waveform from "../components/Waveform.svelte";
   import type { AppStateMachine, PillHoldKind } from "../types";
 
-  // Must match the "pill" window's initial size in tauri.conf.json.
+  // Compact state (idle row only): must match the "pill" window's initial
+  // size in tauri.conf.json.
   const PILL_WIDTH = 280;
   const BASE_HEIGHT = 64;
-  // Extra room for the 2-3 line live-text preview below the main row.
-  const EXPANDED_HEIGHT = 108;
+  // Expanded state (live-text preview showing): wide and tall enough for a
+  // comfortably readable 3-4 line tail of the running dictation.
+  const EXPANDED_WIDTH = 440;
+  const EXPANDED_HEIGHT = 152;
 
   let machineState = $state<AppStateMachine>({ state: "idle" });
   let holdKind = $state<PillHoldKind | null>(null);
@@ -55,8 +58,14 @@
   }
 
   $effect(() => {
+    const targetWidth = showLiveText ? EXPANDED_WIDTH : PILL_WIDTH;
     const targetHeight = showLiveText ? EXPANDED_HEIGHT : BASE_HEIGHT;
-    void getCurrentWindow().setSize(new LogicalSize(PILL_WIDTH, targetHeight));
+    // setSize keeps the window's top-left corner fixed, so a width change
+    // drifts the pill off-center. Recenter once the resize lands.
+    void getCurrentWindow()
+      .setSize(new LogicalSize(targetWidth, targetHeight))
+      .then(() => pillRecenter())
+      .catch((e) => console.warn("Pill resize/recenter failed:", e));
   });
 
   onMount(() => {
@@ -104,7 +113,7 @@
 
 <div
   data-tauri-drag-region
-  class="flex h-full w-full flex-col justify-center gap-1.5 rounded-[28px] border border-white/10 bg-black/75 px-4 py-2.5 shadow-lg backdrop-blur-md"
+  class="flex h-full w-full flex-col justify-center gap-1 rounded-[28px] border border-white/10 bg-black/75 px-4 py-2.5 shadow-lg backdrop-blur-md"
 >
   <div class="flex shrink-0 items-center gap-3">
     <span class="recording-dot shrink-0" aria-hidden="true"></span>
@@ -136,7 +145,7 @@
   </div>
   {#if showLiveText}
     <p
-      class="line-clamp-3 pl-[19px] text-[11px] leading-snug text-white/60"
+      class="line-clamp-4 border-t border-accent/15 pt-2 pl-[19px] text-[13px] leading-snug text-white/70"
       data-tauri-drag-region
     >
       {liveText}

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -428,6 +428,20 @@ async pillRelease() : Promise<Result<null, string>> {
 }
 },
 /**
+ * Recenter the pill window below the menu bar. `setSize` keeps the window's
+ * top-left corner fixed, so the frontend calls this after resizing (e.g.
+ * switching between the compact and expanded live-text layouts) to keep the
+ * pill horizontally centered instead of drifting sideways.
+ */
+async pillRecenter() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("pill_recenter") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Get the typed application settings.
  */
 async getSettings() : Promise<Result<AppSettings, string>> {


### PR DESCRIPTION
The live transcript box added in #39 was too small to read. The pill now expands to 440x152 while live text is shown (4 lines at 13px, 360-char tail, subtle amber divider) and recenters after each resize via a new pill_recenter command; the compact 280x64 state is unchanged for idle/meetings, and the window still never takes focus.

Verified: cargo test (pill 6/6) + clippy -D warnings clean, npm check 0 errors, 224 front tests, build clean.