### PR TITLE
Make homebrew-bump manually dispatchable

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -1,27 +1,34 @@
 name: Bump Homebrew Cask
 
-# When a GitHub Release is published, recompute the .dmg sha256 and push the new
-# version into the damione1/homebrew-tap cask. Requires a HOMEBREW_TAP_TOKEN
-# secret: a fine-grained PAT with Contents:write on damione1/homebrew-tap
-# (GITHUB_TOKEN cannot push to another repo).
+# Recompute the .dmg sha256 and push the new version into the
+# damione1/homebrew-tap cask. Runs automatically when a release is published,
+# and can be triggered manually (e.g. to backfill a release that was published
+# before this workflow existed). Requires a HOMEBREW_TAP_TOKEN secret: a
+# fine-grained PAT with Contents:write on damione1/homebrew-tap (GITHUB_TOKEN
+# cannot push to another repo).
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to publish to the cask (e.g. v0.5.2)"
+        required: true
 
 permissions:
   contents: read
 
 jobs:
   bump:
-    if: ${{ !github.event.release.prerelease }}
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     steps:
       - name: Compute version and sha256
         id: meta
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event.release.tag_name }}
+          TAG: ${{ github.event.release.tag_name || github.event.inputs.tag }}
         run: |
           VERSION="${TAG#v}"
           ASSET="Souffle_${VERSION}_aarch64.dmg"
@@ -45,7 +52,6 @@ jobs:
           CASK="tap/Casks/souffle.rb"
           sed -i -E "s/^  version \".*\"/  version \"${VERSION}\"/" "$CASK"
           sed -i -E "s/^  sha256 \".*\"/  sha256 \"${SHA}\"/" "$CASK"
-          git -C tap diff --exit-code && echo "No change" && exit 0 || true
 
       - name: Commit and push
         working-directory: tap
@@ -53,5 +59,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Casks/souffle.rb
+          git diff --cached --quiet && echo "No change" && exit 0
           git commit -m "souffle ${{ steps.meta.outputs.version }}"
           git push


### PR DESCRIPTION
Ajoute `workflow_dispatch` (input `tag`) au workflow d'auto-bump Homebrew, en plus du déclencheur `release: published` existant.

## Pourquoi
Le bump automatique de v0.5.2 n'a pas fired : le workflow venait d'être mergé sur master ~19s avant la publication de la release, GitHub n'avait pas encore armé le nouveau workflow. Une course ponctuelle, mais utile d'avoir un déclencheur manuel pour :
- backfiller une release publiée avant l'existence du workflow
- tester le workflow sans attendre une release

## Usage
Actions → Bump Homebrew Cask → Run workflow → saisir le tag (ex `v0.5.2`).

Le tap est déjà à jour sur 0.5.2 (bump manuel). Ce changement ne modifie pas le chemin `release: published`, qui fonctionnera pour les prochaines releases.