### PR TITLE
Resize the pill natively with the top edge anchored

### DIFF
--- a/src-tauri/src/commands/pill.rs
+++ b/src-tauri/src/commands/pill.rs
@@ -28,16 +28,18 @@ pub fn pill_release(state: State<'_, AppState>) -> Result<(), String> {
     Ok(())
 }
 
-/// Recenter the pill window below the menu bar. `setSize` keeps the window's
-/// top-left corner fixed, so the frontend calls this after resizing (e.g.
-/// switching between the compact and expanded live-text layouts) to keep the
-/// pill horizontally centered instead of drifting sideways.
+/// Resize the pill window to `width` x `height` (logical pixels), keeping
+/// its top edge pinned below the menu bar and staying horizontally
+/// centered. The frontend calls this as the live transcript grows/shrinks
+/// (e.g. switching between the compact and expanded live-text layouts): a
+/// single native frame change avoids the top-edge drift that a separate
+/// resize-then-recenter pair produces.
 #[tauri::command]
 #[specta::specta]
-pub fn pill_recenter(state: State<'_, AppState>) -> Result<(), String> {
+pub fn pill_resize(state: State<'_, AppState>, width: f64, height: f64) -> Result<(), String> {
     let app = state.app_handle()?;
     let Some(pill) = app.get_webview_window("pill") else {
         return Ok(());
     };
-    crate::pill::position_top_center(&pill).map_err(|e| e.to_string())
+    crate::pill::set_frame_top_center(&pill, width, height).map_err(|e| e.to_string())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -114,7 +114,7 @@ fn specta_builder() -> Builder<tauri::Wry> {
             commands::polish_dictation,
             commands::pill_hold,
             commands::pill_release,
-            commands::pill_recenter,
+            commands::pill_resize,
             commands::get_settings,
             commands::save_settings,
             commands::save_shortcuts,

--- a/src-tauri/src/pill.rs
+++ b/src-tauri/src/pill.rs
@@ -121,11 +121,8 @@ pub fn live_text_tail(text: &str, max_chars: usize) -> String {
     text.chars().skip(total - max_chars).collect()
 }
 
-/// Recenters the pill horizontally below the menu bar. `pub(crate)` so the
-/// `pill_recenter` command can call it after the frontend resizes the window
-/// for a state change (e.g. compact <-> expanded live-text). `setSize` keeps
-/// the window's top-left corner fixed, so a width change alone would
-/// otherwise drift the pill off-center.
+/// Recenters the pill horizontally below the menu bar. `pub(crate)` so
+/// `sync` can call it when showing the pill in its compact state.
 pub(crate) fn position_top_center(pill: &tauri::WebviewWindow) -> tauri::Result<()> {
     let Some(monitor) = pill.primary_monitor()? else {
         return Ok(());
@@ -137,6 +134,63 @@ pub(crate) fn position_top_center(pill: &tauri::WebviewWindow) -> tauri::Result<
         (monitor_width - pill_width) / 2.0,
         TOP_MARGIN,
     ))
+}
+
+/// Lower/upper bounds on the pill's size, defensively clamped in
+/// `set_frame_top_center` against whatever the frontend's live-text
+/// measurement comes up with.
+const MIN_WIDTH: f64 = 280.0;
+const MAX_WIDTH: f64 = 600.0;
+const MIN_HEIGHT: f64 = 64.0;
+const MAX_HEIGHT: f64 = 260.0;
+
+/// AppKit frame origin (bottom-left corner, in the primary screen's
+/// coordinate space) that keeps the pill's TOP edge pinned at `top_margin`
+/// below the menu bar and horizontally centered. Pure so the anchoring math
+/// is unit-testable without a live window.
+fn frame_origin(monitor_width: f64, monitor_height: f64, width: f64, height: f64, top_margin: f64) -> (f64, f64) {
+    let x = (monitor_width - width) / 2.0;
+    let y = monitor_height - top_margin - height;
+    (x, y)
+}
+
+/// Resizes and repositions the pill in a single native `setFrame:` call, so
+/// the top edge stays pinned at `TOP_MARGIN` and the window stays centered
+/// as its height grows with the live transcript.
+///
+/// This bypasses tao's `set_inner_size` (AppKit's `setContentSize:` anchors
+/// the window's BOTTOM-left corner, so growing the height pushes the top
+/// edge into the menu bar until AppKit's `constrainFrameRect` clamps it) and
+/// bypasses the two-step JS resize-then-recenter dance, which raced because
+/// tao dispatches the resize asynchronously.
+pub(crate) fn set_frame_top_center(pill: &tauri::WebviewWindow, width: f64, height: f64) -> tauri::Result<()> {
+    let width = width.clamp(MIN_WIDTH, MAX_WIDTH);
+    let height = height.clamp(MIN_HEIGHT, MAX_HEIGHT);
+
+    let Some(monitor) = pill.primary_monitor()? else {
+        return Ok(());
+    };
+    let scale = monitor.scale_factor();
+    let monitor_size = monitor.size().to_logical::<f64>(scale);
+    let (x, y) = frame_origin(monitor_size.width, monitor_size.height, width, height, TOP_MARGIN);
+
+    let window = pill.clone();
+    pill.run_on_main_thread(move || {
+        let Ok(ns_window_ptr) = window.ns_window() else {
+            warn!("Pill resize: failed to get the native NSWindow handle");
+            return;
+        };
+        // SAFETY: `ns_window_ptr` comes from `WebviewWindow::ns_window`, which
+        // returns the pill's own NSWindow* for as long as the window is
+        // alive; we're on the main thread (required for AppKit calls) inside
+        // this `run_on_main_thread` closure.
+        let ns_window: &objc2_app_kit::NSWindow = unsafe { &*ns_window_ptr.cast() };
+        let frame = objc2_foundation::NSRect {
+            origin: objc2_foundation::NSPoint { x, y },
+            size: objc2_foundation::NSSize { width, height },
+        };
+        ns_window.setFrame_display_animate(frame, true, true);
+    })
 }
 
 #[cfg(test)]
@@ -192,6 +246,34 @@ mod tests {
         let tail = live_text_tail(text, 5);
         assert_eq!(tail.chars().count(), 5);
         assert!(String::from_utf8(tail.into_bytes()).is_ok());
+    }
+
+    #[test]
+    fn frame_origin_centers_horizontally() {
+        let (x, _y) = frame_origin(1920.0, 1080.0, 400.0, 100.0, 40.0);
+        assert_eq!(x, (1920.0 - 400.0) / 2.0);
+    }
+
+    #[test]
+    fn frame_origin_pins_the_top_edge_at_top_margin() {
+        let monitor_height = 1080.0;
+        let top_margin = 40.0;
+        let (_x, y) = frame_origin(1920.0, monitor_height, 400.0, 100.0, top_margin);
+        // AppKit's y is measured from the bottom, so the top edge sits at
+        // `y + height`; that must land exactly `top_margin` below the
+        // monitor's top (i.e. `monitor_height - top_margin`).
+        assert_eq!(y + 100.0 + top_margin, monitor_height);
+    }
+
+    #[test]
+    fn frame_origin_keeps_top_edge_fixed_as_height_grows() {
+        let monitor_height = 1080.0;
+        let top_margin = 40.0;
+        let (_x, y_short) = frame_origin(1920.0, monitor_height, 400.0, 100.0, top_margin);
+        let (_x, y_tall) = frame_origin(1920.0, monitor_height, 400.0, 180.0, top_margin);
+        // Growing height by 80 must shift y down by exactly 80 to keep the
+        // top edge (y + height) fixed.
+        assert_eq!(y_short - y_tall, 80.0);
     }
 
     /// Exercises the full hold lifecycle against the shared module-level

--- a/src/lib/api/transcription.ts
+++ b/src/lib/api/transcription.ts
@@ -90,9 +90,10 @@ export async function pillRelease(): Promise<void> {
   await unwrap(commands.pillRelease());
 }
 
-/** Recenter the pill window; call after resizing it so it stays centered. */
-export async function pillRecenter(): Promise<void> {
-  await unwrap(commands.pillRecenter());
+/** Resize the pill window, keeping its top edge pinned below the menu bar
+ * and staying horizontally centered. */
+export async function pillResize(width: number, height: number): Promise<void> {
+  await unwrap(commands.pillResize(width, height));
 }
 
 export async function recoverState(): Promise<AppStateMachine> {

--- a/src/lib/pill/PillApp.svelte
+++ b/src/lib/pill/PillApp.svelte
@@ -1,11 +1,9 @@
 <script lang="ts">
-  import { LogicalSize } from "@tauri-apps/api/dpi";
-  import { getCurrentWindow } from "@tauri-apps/api/window";
   import { Square } from "@lucide/svelte";
   import { onMount } from "svelte";
   import { t } from "svelte-i18n";
   import { events } from "../api/generated";
-  import { getMachineState, pillRecenter } from "../api/transcription";
+  import { getMachineState, pillResize } from "../api/transcription";
   import Spinner from "../components/ui/Spinner.svelte";
   import Waveform from "../components/Waveform.svelte";
   import type { AppStateMachine, PillHoldKind } from "../types";
@@ -88,12 +86,9 @@
     }
     appliedWidth = targetWidth;
     appliedHeight = targetHeight;
-    // setSize keeps the window's top-left corner fixed, so a width change
-    // drifts the pill off-center. Recenter once the resize lands.
-    void getCurrentWindow()
-      .setSize(new LogicalSize(targetWidth, targetHeight))
-      .then(() => pillRecenter())
-      .catch((e) => console.warn("Pill resize/recenter failed:", e));
+    // A single native frame change keeps the top edge pinned and the pill
+    // centered, instead of the old setSize-then-recenter pair.
+    void pillResize(targetWidth, targetHeight).catch((e) => console.warn("Pill resize failed:", e));
   });
 
   onMount(() => {

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -428,14 +428,16 @@ async pillRelease() : Promise<Result<null, string>> {
 }
 },
 /**
- * Recenter the pill window below the menu bar. `setSize` keeps the window's
- * top-left corner fixed, so the frontend calls this after resizing (e.g.
- * switching between the compact and expanded live-text layouts) to keep the
- * pill horizontally centered instead of drifting sideways.
+ * Resize the pill window to `width` x `height` (logical pixels), keeping
+ * its top edge pinned below the menu bar and staying horizontally
+ * centered. The frontend calls this as the live transcript grows/shrinks
+ * (e.g. switching between the compact and expanded live-text layouts): a
+ * single native frame change avoids the top-edge drift that a separate
+ * resize-then-recenter pair produces.
  */
-async pillRecenter() : Promise<Result<null, string>> {
+async pillResize(width: number, height: number) : Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("pill_recenter") };
+    return { status: "ok", data: await TAURI_INVOKE("pill_resize", { width, height }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };


### PR DESCRIPTION
## Problem
The pill's live-text area could never grow past ~100px no matter what height was requested (v0.5.1's fixed 152px box was silently clamped too, v0.5.2's progressive growth stalled the same way).

Root cause, confirmed in tao 0.35.3 sources: `setSize()` maps to AppKit's `setContentSize:`, which anchors the window's **bottom-left** corner. The pill sits 40px below the menu bar, so any height increase pushes the top edge up into the menu bar and AppKit's `constrainFrameRect` clamps the frame. The call is also dispatched async, so the JS promise resolved before the resize landed and the chained `pill_recenter` read stale dimensions.

## Fix
One atomic native frame change instead of the JS resize-then-recenter pair:
- New `pill_resize(width, height)` command replaces `pill_recenter`. It computes the frame from the primary monitor (pure, unit-tested `frame_origin`: x centered, top edge pinned at `TOP_MARGIN`) and applies it on the main thread via `NSWindow.setFrame:display:animate:` (`objc2-app-kit`, already a direct dependency; `animate:true` gives a smooth grow).
- Defensive clamps: width [280, 600], height [64, 260].
- Frontend: the resize `$effect` calls `pillResize(w, h)`; all measurement/monotonic-growth logic unchanged. TS bindings regenerated.

## Verification
- `cargo test --workspace`: 478+ passed incl. 3 new `frame_origin` tests
- `cargo clippy --all-targets -- -D warnings`: clean
- `npm test -- --run`: 224 passed; `npm run check`: 0 errors; `npm run build`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZhpVtoNnm4VXd7NLMC52e