### PR TITLE
Apply the pill frame without animation to avoid a main-thread deadlock

### DIFF
--- a/src-tauri/src/pill.rs
+++ b/src-tauri/src/pill.rs
@@ -163,6 +163,14 @@ fn frame_origin(monitor_width: f64, monitor_height: f64, width: f64, height: f64
 /// edge into the menu bar until AppKit's `constrainFrameRect` clamps it) and
 /// bypasses the two-step JS resize-then-recenter dance, which raced because
 /// tao dispatches the resize asynchronously.
+///
+/// The frame is applied without animation (`setFrame:display:`, not
+/// `setFrame:display:animate:`). `animate:YES` runs synchronously on the
+/// main thread via a nested run loop (`NSAnimation`) until the animation
+/// finishes, and it does not bail out early if the window is ordered out
+/// mid-animation. At end-of-dictation the pill resizes back to compact at
+/// the same moment the backend hides the window, so an animated call here
+/// can spin forever and deadlock the main thread.
 pub(crate) fn set_frame_top_center(pill: &tauri::WebviewWindow, width: f64, height: f64) -> tauri::Result<()> {
     let width = width.clamp(MIN_WIDTH, MAX_WIDTH);
     let height = height.clamp(MIN_HEIGHT, MAX_HEIGHT);
@@ -189,7 +197,7 @@ pub(crate) fn set_frame_top_center(pill: &tauri::WebviewWindow, width: f64, heig
             origin: objc2_foundation::NSPoint { x, y },
             size: objc2_foundation::NSSize { width, height },
         };
-        ns_window.setFrame_display_animate(frame, true, true);
+        ns_window.setFrame_display(frame, true);
     })
 }
 


### PR DESCRIPTION
## Problem
Since v0.5.4, finishing a dictation could freeze the whole app: the main window stayed on "Finishing…", the app beachballed, and no further log lines appeared even though the backend had cleanly reached ready and pre-warmed the engine.

## Root cause
`set_frame_top_center` applied the pill frame with `setFrame:display:animate:` and `animate:YES`, which runs **synchronously on the main thread** in a nested run loop (NSAnimation blocking mode) until the animation completes. At end-of-dictation the pill webview resizes back to compact at the same moment the backend hides the pill window; the animation on a window being ordered out never terminates, the nested run loop spins forever, and the main thread deadlocks (the ready event is never even delivered to the main window).

## Fix
Apply the frame with `setFrame:display:` (no animate parameter, instant, no nested run loop). Doc comment explains why animation must stay off. Everything else (clamps, frame_origin math, run_on_main_thread structure, tests) unchanged.

## Verification
- `cargo test --workspace`: 478+ passed
- `cargo clippy --all-targets -- -D warnings`: clean
- `npm test -- --run`: 224 passed; `npm run check`: 0 errors; `npm run build`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZhpVtoNnm4VXd7NLMC52e