### PR TITLE
Fix the end-of-dictation deadlock and make the release link clickable

### DIFF
--- a/src-tauri/src/commands/diagnostics.rs
+++ b/src-tauri/src/commands/diagnostics.rs
@@ -59,3 +59,21 @@ pub async fn get_release_notes_for_version(version: String) -> Result<Option<Str
     .await
     .map_err(|e| format!("Release notes task failed: {e}"))
 }
+
+/// Open a GitHub release page in the default browser. WKWebView suppresses
+/// new-window navigation for `target="_blank"` links, so a plain `<a>` tag
+/// silently does nothing; this shells out to `open` instead. Restricted to
+/// `https://github.com/` URLs since it's only ever passed the release URL
+/// returned by `check_for_updates`.
+#[tauri::command]
+#[specta::specta]
+pub fn open_release_page(url: String) -> Result<(), String> {
+    if !url.starts_with("https://github.com/") {
+        return Err("Refusing to open a non-GitHub URL".into());
+    }
+    std::process::Command::new("open")
+        .arg(&url)
+        .spawn()
+        .map_err(|e| format!("Failed to open release page: {e}"))?;
+    Ok(())
+}

--- a/src-tauri/src/commands/pill.rs
+++ b/src-tauri/src/commands/pill.rs
@@ -1,4 +1,4 @@
-use tauri::{Manager, State};
+use tauri::{AppHandle, Manager};
 
 use crate::app_events::PillHoldKind;
 use crate::state::AppState;
@@ -8,11 +8,17 @@ use crate::state::AppState;
 /// background after transcription stops. See `pill::sync` for how a hold
 /// combines with state-machine-driven visibility, and its safety net (a hold
 /// is auto-released the moment a new recording starts).
+///
+/// Takes `AppHandle` directly rather than `State<'_, AppState>`: this command
+/// runs on the main thread, and reading `AppState.app_handle` (a mutex) would
+/// risk deadlocking against `AppState::apply_transition`, which briefly holds
+/// that same mutex from a background thread while dispatching to the main
+/// thread for window operations.
 #[tauri::command]
 #[specta::specta]
-pub fn pill_hold(state: State<'_, AppState>, kind: PillHoldKind) -> Result<(), String> {
-    let app = state.app_handle()?;
+pub fn pill_hold(app: AppHandle, kind: PillHoldKind) -> Result<(), String> {
     crate::pill::set_hold(&app, kind);
+    let state = app.state::<AppState>();
     crate::pill::sync(&app, &state.current_machine_state()?);
     Ok(())
 }
@@ -21,9 +27,9 @@ pub fn pill_hold(state: State<'_, AppState>, kind: PillHoldKind) -> Result<(), S
 /// paste succeeded without dictation polish ever engaging a hold).
 #[tauri::command]
 #[specta::specta]
-pub fn pill_release(state: State<'_, AppState>) -> Result<(), String> {
-    let app = state.app_handle()?;
+pub fn pill_release(app: AppHandle) -> Result<(), String> {
     crate::pill::clear_hold(&app);
+    let state = app.state::<AppState>();
     crate::pill::sync(&app, &state.current_machine_state()?);
     Ok(())
 }
@@ -36,8 +42,7 @@ pub fn pill_release(state: State<'_, AppState>) -> Result<(), String> {
 /// resize-then-recenter pair produces.
 #[tauri::command]
 #[specta::specta]
-pub fn pill_resize(state: State<'_, AppState>, width: f64, height: f64) -> Result<(), String> {
-    let app = state.app_handle()?;
+pub fn pill_resize(app: AppHandle, width: f64, height: f64) -> Result<(), String> {
     let Some(pill) = app.get_webview_window("pill") else {
         return Ok(());
     };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -144,6 +144,7 @@ fn specta_builder() -> Builder<tauri::Wry> {
             commands::check_for_updates,
             commands::get_release_notes_for_version,
             commands::get_app_version,
+            commands::open_release_page,
         ])
         .events(collect_events![
             app_events::Navigate,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -179,23 +179,34 @@ impl AppState {
     }
 
     /// Apply a state transition, update the machine, and emit a StateChanged event.
+    ///
+    /// INVARIANT: never call window/AppKit operations (they dispatch to the
+    /// main thread and block until it services them) while holding an
+    /// AppState mutex. A `#[tauri::command]` running on the main thread may
+    /// be waiting on that very mutex (e.g. `state.app_handle()`), which
+    /// deadlocks both threads permanently: this method waits forever for the
+    /// main thread to drain its queue, and the main thread waits forever for
+    /// this method to release the lock. So the `machine` lock is scoped to
+    /// just the transition itself, and the `AppHandle` is cloned out of its
+    /// lock before any emit/sync call runs.
     pub fn apply_transition(&self, action: StateAction) -> Result<AppStateMachine, String> {
-        let mut machine = self.machine.acquire()?;
-        let new_state = machine.clone().transition(action)?;
-        debug!(
-            from = machine.variant_name(),
-            to = new_state.variant_name(),
-            "State transition"
-        );
-        *machine = new_state.clone();
+        let new_state = {
+            let mut machine = self.machine.acquire()?;
+            let new_state = machine.clone().transition(action)?;
+            debug!(
+                from = machine.variant_name(),
+                to = new_state.variant_name(),
+                "State transition"
+            );
+            *machine = new_state.clone();
+            new_state
+        };
 
-        // Emit event to frontend if app_handle is available
-        if let Ok(handle_guard) = self.app_handle.lock()
-            && let Some(ref handle) = *handle_guard
-        {
-            let _ = StateChanged(new_state.clone()).emit(handle);
-            crate::pill::sync(handle, &new_state);
-            crate::tray::sync(handle, &new_state);
+        let handle = self.app_handle.acquire()?.as_ref().cloned();
+        if let Some(handle) = handle {
+            let _ = StateChanged(new_state.clone()).emit(&handle);
+            crate::pill::sync(&handle, &new_state);
+            crate::tray::sync(&handle, &new_state);
         }
 
         Ok(new_state)

--- a/src/lib/api/diagnostics.ts
+++ b/src/lib/api/diagnostics.ts
@@ -29,4 +29,8 @@ export async function getAppVersion(): Promise<string> {
   return commands.getAppVersion();
 }
 
+export async function openReleasePage(url: string): Promise<void> {
+  await unwrap(commands.openReleasePage(url));
+}
+
 export type { LogLevel };

--- a/src/lib/features/settings/components/AboutSettingsSection.svelte
+++ b/src/lib/features/settings/components/AboutSettingsSection.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { t } from "svelte-i18n";
-  import { checkForUpdates, getAppVersion } from "../../../api/diagnostics";
+  import { checkForUpdates, getAppVersion, openReleasePage } from "../../../api/diagnostics";
   import type { UpdateCheckResult } from "../../../types";
   import { errorMessage } from "../../../utils";
 
@@ -80,14 +80,12 @@
           {checking ? $t("settings_about.checking") : $t("settings_about.check_updates")}
         </button>
         {#if updateResult?.update_available && updateResult.release_url}
-          <a
-            href={updateResult.release_url}
-            target="_blank"
-            rel="noreferrer"
-            class="text-xs text-accent hover:underline"
+          <button
+            onclick={() => void openReleasePage(updateResult!.release_url!)}
+            class="text-xs text-accent hover:underline cursor-pointer"
           >
             {$t("settings_about.download_update")}
-          </a>
+          </button>
         {/if}
       </div>
     </div>

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -406,6 +406,12 @@ async polishDictation(text: string) : Promise<Result<DictationPolishResult, stri
  * background after transcription stops. See `pill::sync` for how a hold
  * combines with state-machine-driven visibility, and its safety net (a hold
  * is auto-released the moment a new recording starts).
+ * 
+ * Takes `AppHandle` directly rather than `State<'_, AppState>`: this command
+ * runs on the main thread, and reading `AppState.app_handle` (a mutex) would
+ * risk deadlocking against `AppState::apply_transition`, which briefly holds
+ * that same mutex from a background thread while dispatching to the main
+ * thread for window operations.
  */
 async pillHold(kind: PillHoldKind) : Promise<Result<null, string>> {
     try {
@@ -761,6 +767,21 @@ async getReleaseNotesForVersion(version: string) : Promise<Result<string | null,
  */
 async getAppVersion() : Promise<string> {
     return await TAURI_INVOKE("get_app_version");
+},
+/**
+ * Open a GitHub release page in the default browser. WKWebView suppresses
+ * new-window navigation for `target="_blank"` links, so a plain `<a>` tag
+ * silently does nothing; this shells out to `open` instead. Restricted to
+ * `https://github.com/` URLs since it's only ever passed the release URL
+ * returned by `check_for_updates`.
+ */
+async openReleasePage(url: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("open_release_page", { url }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 


### PR DESCRIPTION
## Problem 1: app froze at end of dictation (v0.5.4/v0.5.5)
Diagnosed with `sample` on the frozen process: `AppState::apply_transition` (stop flow, tokio thread) held the `machine` and `app_handle` mutexes while `pill::sync` dispatched synchronously to the macOS main queue; at the same instant the main thread was executing the pill webview's `pill_resize` invoke (Tauri sync commands run on the main thread), blocked on the same `app_handle` mutex. Circular wait, permanent freeze (UI stuck on "Finishing…"). The bug predates v0.5.4, but `pill_resize` firing instantly on state changes made the race deterministic.

## Fix
- `apply_transition` never holds a lock across emit/pill/tray sync: the `machine` lock is scoped to the transition, the `AppHandle` is cloned out before any window call. Invariant documented on the method.
- `pill_hold`/`pill_release`/`pill_resize` take `AppHandle` directly — zero AppState locks in main-thread commands. Generated TS bindings unchanged.

## Problem 2: GitHub release link did nothing
WKWebView suppresses `target="_blank"` navigation. New `open_release_page` command (validates `https://github.com/` prefix, shells out to `open`), and the About section link is now a button calling it.

## Verification
- Deadlock fix verified end-to-end on a dev build: scripted dictation with live text (the exact freeze trigger), clean stop, and a second dictation ran fine afterwards.
- `cargo test --workspace`: 501 passed; clippy `-D warnings` clean; `npm test`: 224 passed; `npm run check`: 0 errors; `npm run build`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZhpVtoNnm4VXd7NLMC52e