### PR TITLE
Prevent dictionary names from replacing common words

### DIFF
--- a/src-tauri/src/filter/text_dictionary.rs
+++ b/src-tauri/src/filter/text_dictionary.rs
@@ -11,9 +11,50 @@ const LEVENSHTEIN_THRESHOLD: f64 = 0.82; // similarity > 0.82 means distance < 0
 /// does far more harm than good.
 const MIN_WORD_LEN: usize = 3;
 
-/// Minimum similarity for a phonetic-only (session term) match, on top of
-/// Soundex equality.
-const SESSION_SIMILARITY_FLOOR: f64 = 0.5;
+/// Words shorter than this are never corrected through a Soundex-only match
+/// (no strong spelling similarity backing it up). Standard Soundex reduces a
+/// word to a first letter plus 3 digits, so short tokens run out of letters
+/// to differentiate themselves and collide with many unrelated codes. The
+/// Levenshtein spelling-correction path below is unaffected by this floor.
+const MIN_PHONETIC_WORD_LEN: usize = 4;
+
+/// Minimum normalized similarity, on top of Soundex equality, required for a
+/// *derived* phonetic match: one computed from the term's own spelling (or a
+/// session term), not from an explicit user pronunciation. Soundex equality
+/// alone is a weak signal, collapsing "dans" and "Denis" to the same code
+/// (D520); this floor keeps that kind of orthographically unrelated pair
+/// from matching while still allowing real misheard spellings through, e.g.
+/// "Delphine" transcribed as "Delfine" (similarity 0.75).
+const PHONETIC_SIMILARITY_FLOOR: f64 = 0.65;
+
+/// High-frequency French and English function words that a *derived*
+/// phonetic match must never replace. These are exactly the words most
+/// likely to collide with a name added to the dictionary purely by
+/// coincidence (short, common, phonetically generic). An explicit
+/// user-typed pronunciation is the only thing allowed to override this list
+/// (see `DictionaryMatch::explicit_pronunciation`): that's a deliberate
+/// instruction from the user, not an accidental Soundex collision.
+///
+/// Extend this list as new false positives get reported; it is intentionally
+/// a curated sample of common short words, not an exhaustive stopword corpus.
+const PROTECTED_STOPWORDS: &[&str] = &[
+    // French
+    "dans", "donc", "des", "dont", "doit", "deux", "par", "pour", "pas", "peu", "peut", "plus",
+    "avec", "sans", "sous", "sur", "vers", "chez", "mais", "car", "que", "qui", "quoi", "quand",
+    "comme", "alors", "aussi", "bien", "bon", "cette", "cet", "ces", "ses", "son", "sa", "ton",
+    "leur", "leurs", "nos", "vos", "tout", "tous", "toute", "toutes", "etre", "avoir", "fait",
+    "faire", "dit", "dire", "cela", "ceci", "ainsi", "puis", "encore", "toujours", "jamais",
+    "rien", "ici",
+    // English
+    "the", "then", "than", "this", "that", "these", "those", "with", "from", "have", "been",
+    "were", "when", "what", "which", "who", "whom", "where", "there", "their", "they", "them",
+    "will", "would", "could", "should", "just", "very", "also", "into", "onto", "over", "under",
+    "about", "after", "before",
+];
+
+fn is_protected_stopword(word_lower: &str) -> bool {
+    PROTECTED_STOPWORDS.contains(&word_lower)
+}
 
 pub struct DictionaryFilter {
     entries: Vec<DictionaryMatch>,
@@ -29,19 +70,26 @@ struct DictionaryMatch {
     /// injected names like "Martin" from rewriting ordinary words such as
     /// "matin" (similarity 0.83, above the fuzzy threshold).
     phonetic_only: bool,
+    /// True when `phonetic_code` came from a pronunciation the user typed in
+    /// explicitly, rather than being derived from the term's own spelling.
+    /// A deliberate instruction ("correct this sound to this term") is
+    /// exempt from the stopword list and similarity floor below: the user
+    /// asked for it, so a Soundex hit on it isn't a coincidence.
+    explicit_pronunciation: bool,
 }
 
 /// Phonetic code used for matching: the user-provided pronunciation wins;
 /// otherwise the term's own Soundex, except for digit-bearing terms ("V6",
 /// "K8s") whose alphabetic Soundex would collide with unrelated short words.
-fn derive_phonetic_code(term: &str, pronunciation: Option<&str>) -> Option<String> {
+/// Returns the code plus whether it came from an explicit pronunciation.
+fn derive_phonetic_code(term: &str, pronunciation: Option<&str>) -> (Option<String>, bool) {
     if let Some(p) = pronunciation.map(str::trim).filter(|p| !p.is_empty()) {
-        return soundex(p);
+        return (soundex(p), true);
     }
     if term.chars().any(|c| c.is_ascii_digit()) {
-        return None;
+        return (None, false);
     }
-    soundex(term)
+    (soundex(term), false)
 }
 
 impl DictionaryFilter {
@@ -52,12 +100,14 @@ impl DictionaryFilter {
             .into_iter()
             .map(|e| {
                 let term_lower = e.term.to_lowercase();
-                let phonetic_code = derive_phonetic_code(&e.term, e.pronunciation.as_deref());
+                let (phonetic_code, explicit_pronunciation) =
+                    derive_phonetic_code(&e.term, e.pronunciation.as_deref());
                 DictionaryMatch {
                     term: e.term,
                     term_lower,
                     phonetic_code,
                     phonetic_only: false,
+                    explicit_pronunciation,
                 }
             })
             .collect();
@@ -72,17 +122,20 @@ impl DictionaryFilter {
                 term_lower,
                 phonetic_code: soundex(term),
                 phonetic_only: true,
+                explicit_pronunciation: false,
             });
         }
         Self { entries: matches }
     }
 
     fn find_replacement(&self, word: &str) -> Option<&str> {
-        if word.chars().count() < MIN_WORD_LEN {
+        let word_char_count = word.chars().count();
+        if word_char_count < MIN_WORD_LEN {
             return None;
         }
         let word_lower = word.to_lowercase();
         let word_soundex = soundex(word);
+        let is_stopword = is_protected_stopword(&word_lower);
 
         let mut best_match: Option<(&str, f64)> = None;
 
@@ -90,6 +143,13 @@ impl DictionaryFilter {
             // Skip if the word already matches exactly
             if word_lower == entry.term_lower {
                 return None;
+            }
+
+            // A protected stopword can only be corrected by an explicit
+            // user-typed pronunciation, never by a coincidental Soundex or
+            // fuzzy-spelling hit.
+            if is_stopword && !entry.explicit_pronunciation {
+                continue;
             }
 
             // Check Levenshtein similarity
@@ -101,11 +161,21 @@ impl DictionaryFilter {
                 _ => false,
             };
 
-            let accepted = if entry.phonetic_only {
-                soundex_match && similarity >= SESSION_SIMILARITY_FLOOR
-            } else {
-                // Accept if either condition is met
+            let accepted = if entry.explicit_pronunciation {
+                // The user typed this pronunciation on purpose: honor it
+                // exactly as before, with no extra length/similarity floor.
                 similarity >= LEVENSHTEIN_THRESHOLD || soundex_match
+            } else {
+                let derived_phonetic_match = soundex_match
+                    && word_char_count >= MIN_PHONETIC_WORD_LEN
+                    && similarity >= PHONETIC_SIMILARITY_FLOOR;
+                if entry.phonetic_only {
+                    // Session terms never get the plain-spelling path either:
+                    // they were not chosen by the user (see struct doc).
+                    derived_phonetic_match
+                } else {
+                    similarity >= LEVENSHTEIN_THRESHOLD || derived_phonetic_match
+                }
             };
             if accepted {
                 let score = if soundex_match {
@@ -289,5 +359,91 @@ mod tests {
             &["v6".to_string()],
         );
         assert_eq!(f.apply("le vésix arrive"), "le V6 arrive");
+    }
+
+    // ── Overmatch regression: "Dans" -> "Paris" (production report) ──
+    //
+    // Root cause: standard Soundex keeps the literal first letter, so
+    // "Dans" (D520) and "Paris" (P620) never collide; that exact pair
+    // cannot reproduce through this filter. The real defect is structural:
+    // a *derived* (non-alias) dictionary entry accepted a Soundex match with
+    // no similarity floor at all, so any common word sharing a Soundex code
+    // with a dictionary name got replaced regardless of how different the
+    // spelling was. "Dans" and a "Denis" entry both hash to D520
+    // (similarity only 0.6) and reproduce the same class of bug the report
+    // describes. These tests pin both the specific reported pair and the
+    // general mechanism.
+
+    #[test]
+    fn dans_is_never_replaced_by_paris() {
+        // Confirms the reported pair does not collide via Soundex, and stays
+        // untouched end-to-end regardless.
+        assert_ne!(soundex("Dans"), soundex("Paris"));
+        let f = DictionaryFilter::with_session_terms(vec![entry("Paris")], &[]);
+        assert_eq!(f.apply("Dans la maison"), "Dans la maison");
+        assert_eq!(f.apply("dans la maison"), "dans la maison");
+    }
+
+    #[test]
+    fn stopword_blocks_derived_phonetic_collision() {
+        // The actual matching path behind the report: a derived (no
+        // pronunciation) dictionary entry whose Soundex organically collides
+        // with a common word. "Denis" and "Dans" both hash to D520.
+        assert_eq!(soundex("Dans"), soundex("Denis"));
+        let f = DictionaryFilter::with_session_terms(vec![entry("Denis")], &[]);
+        assert_eq!(f.apply("Dans la maison"), "Dans la maison");
+
+        // Same collision through a session term (e.g. a calendar attendee
+        // named "Denis") must be blocked too.
+        let session = DictionaryFilter::with_session_terms(vec![], &["Denis".to_string()]);
+        assert_eq!(session.apply("Dans la maison"), "Dans la maison");
+    }
+
+    #[test]
+    fn explicit_alias_overrides_stopword_protection() {
+        // An explicit pronunciation is a deliberate user instruction, so it
+        // is allowed to touch a protected stopword even though a derived
+        // match on the same word would be blocked.
+        let f = DictionaryFilter::with_session_terms(
+            vec![entry_with_pronunciation("Denis", "dans")],
+            &[],
+        );
+        assert_eq!(f.apply("Dans la maison"), "Denis la maison");
+    }
+
+    #[test]
+    fn short_word_blocks_soundex_only_match() {
+        // "toi" (3 chars, not on the stopword list) meets MIN_WORD_LEN but
+        // not MIN_PHONETIC_WORD_LEN; a derived entry relying on Soundex
+        // alone must not touch it.
+        let f = DictionaryFilter::with_session_terms(vec![entry("Toy")], &[]);
+        assert_eq!(soundex("toi"), soundex("Toy"));
+        assert_eq!(f.apply("regarde toi"), "regarde toi");
+    }
+
+    #[test]
+    fn legitimate_phonetic_correction_still_fires() {
+        // "Delphine" misheard as "Delfine" (soundex match, similarity 0.75):
+        // above the new floor, so the correction still applies.
+        assert_eq!(soundex("Delphine"), soundex("Delfine"));
+        let f = DictionaryFilter::with_session_terms(vec![entry("Delphine")], &[]);
+        assert_eq!(f.apply("bonjour Delfine"), "bonjour Delphine");
+
+        // Case of the original word is not preserved by design (the
+        // dictionary term's own casing always wins).
+        let session = DictionaryFilter::with_session_terms(vec![], &["Delphine".to_string()]);
+        assert_eq!(session.apply("bonjour delfine"), "bonjour Delphine");
+    }
+
+    #[test]
+    fn low_similarity_soundex_match_is_rejected_even_off_stopword_list() {
+        // "marche" (to walk) is not on the stopword list, so this isolates
+        // the PHONETIC_SIMILARITY_FLOOR guard from stopword protection: the
+        // same weak-similarity shape as "dans"/"denis" must still be
+        // rejected on its own merits.
+        let f = DictionaryFilter::with_session_terms(vec![entry("Mauriac")], &[]);
+        assert_eq!(soundex("marche"), soundex("Mauriac"));
+        assert!(normalized_levenshtein("marche", "mauriac") < PHONETIC_SIMILARITY_FLOOR);
+        assert_eq!(f.apply("il marche vite"), "il marche vite");
     }
 }


### PR DESCRIPTION
Dictionary and session-term phonetic matching accepted a bare Soundex hit with no similarity floor, so common words could be rewritten into dictionary names that merely sound alike ("Dans" becoming a person's name mid-transcript).

- Derived phonetic matches (entry has no user-typed pronunciation) now require a minimum word length of 4 and a normalized similarity of at least 0.65 on top of Soundex equality.
- A curated French/English protected-stopword list can never be replaced by a derived match; an explicit user-typed pronunciation remains the only override, preserving intentional aliases.
- Session terms lose their weaker 0.5 floor and follow the same guards.
- Six regression tests pin the reported pair, the real collision mechanism (Soundex D520 for "Dans"/"Denis"), short-word and stopword protection, the explicit-alias override, and a legitimate correction that must keep firing ("Delfine" to "Delphine").

All thresholds are named constants for retuning.