### PR TITLE
Support persistent speaker identities in the transcript data model

### DIFF
--- a/src-tauri/souffle-mcp/src/db.rs
+++ b/src-tauri/souffle-mcp/src/db.rs
@@ -128,6 +128,15 @@ pub struct MeetingSummary {
     pub has_notes: bool,
 }
 
+/// A persistent speaker referenced by a meeting's segments, resolved for
+/// display. Mirrors the app crate's `MeetingSpeaker` DTO (kept independent,
+/// see the module doc comment); empty for Me/Them-only meetings.
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+pub struct MeetingSpeakerInfo {
+    pub id: i64,
+    pub name: String,
+}
+
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct MeetingMetadata {
     pub calendar_event_id: Option<String>,
@@ -149,6 +158,10 @@ pub struct MeetingDetail {
     pub structured_summary: Option<StructuredSummary>,
     pub notes: Option<String>,
     pub metadata: Option<MeetingMetadata>,
+    /// Persistent speakers referenced by this meeting's segments, for
+    /// resolving `spk:<id>` labels in `transcript`. Empty for Me/Them-only
+    /// meetings, or when neither `transcript` nor `metadata` was requested.
+    pub speakers: Vec<MeetingSpeakerInfo>,
 }
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
@@ -350,12 +363,17 @@ impl McpDb {
         } else {
             Vec::new()
         };
+        let speakers = if need_segments {
+            self.speakers_for_meeting(&row.id)?
+        } else {
+            Vec::new()
+        };
 
         let transcript = if include.transcript {
             Some(
                 row.edited_transcript
                     .clone()
-                    .unwrap_or_else(|| render_transcript(&segments)),
+                    .unwrap_or_else(|| render_transcript(&segments, &speakers)),
             )
         } else {
             None
@@ -391,7 +409,47 @@ impl McpDb {
             structured_summary,
             notes,
             metadata,
+            speakers,
         })
+    }
+
+    /// Persistent speakers referenced by `meeting_id`'s segments (`spk:<id>`
+    /// labels), resolved against the `speakers` table. Mirrors the app
+    /// crate's `Database::speakers_for_meeting`.
+    fn speakers_for_meeting(&self, meeting_id: &str) -> Result<Vec<MeetingSpeakerInfo>, McpDbError> {
+        let conn = self.conn()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT DISTINCT speaker FROM segments
+                 WHERE meeting_id = ?1 AND speaker LIKE 'spk:%'",
+            )
+            .map_err(McpDbError::Query)?;
+        let ids: Vec<i64> = stmt
+            .query_map(params![meeting_id], |row| row.get::<_, String>(0))
+            .map_err(McpDbError::Query)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(McpDbError::Query)?
+            .into_iter()
+            .filter_map(|raw| raw.strip_prefix("spk:")?.parse::<i64>().ok())
+            .collect();
+
+        let mut speakers = Vec::with_capacity(ids.len());
+        for id in ids {
+            let name: Option<String> = conn
+                .query_row("SELECT name FROM speakers WHERE id = ?1", params![id], |row| {
+                    row.get(0)
+                })
+                .map(Some)
+                .or_else(|e| match e {
+                    rusqlite::Error::QueryReturnedNoRows => Ok(None),
+                    other => Err(McpDbError::Query(other)),
+                })?;
+            if let Some(name) = name {
+                speakers.push(MeetingSpeakerInfo { id, name });
+            }
+        }
+        speakers.sort_by_key(|s| s.id);
+        Ok(speakers)
     }
 
     fn load_segments(&self, meeting_id: &str) -> Result<Vec<SegmentRow>, McpDbError> {
@@ -601,6 +659,25 @@ fn cluster_into_turns(segments: &[SegmentRow]) -> Vec<&SegmentRow> {
     turns.into_iter().flat_map(|t| t.segments).collect()
 }
 
+/// Display label for a raw `segments.speaker` value: "me" -> "Me", "them" ->
+/// "Them", "spk:<id>" -> the matching `MeetingSpeakerInfo.name` if resolvable,
+/// else a "Speaker <id>" fallback. An unrecognized raw value (shouldn't
+/// happen) passes through unchanged.
+fn speaker_label(raw: &str, speakers: &[MeetingSpeakerInfo]) -> String {
+    match raw {
+        "me" => "Me".to_string(),
+        "them" => "Them".to_string(),
+        other => match other.strip_prefix("spk:").and_then(|id| id.parse::<i64>().ok()) {
+            Some(id) => speakers
+                .iter()
+                .find(|s| s.id == id)
+                .map(|s| s.name.clone())
+                .unwrap_or_else(|| format!("Speaker {id}")),
+            None => other.to_string(),
+        },
+    }
+}
+
 /// Simplified stand-in for the frontend's paragraph engine
 /// (`src/lib/utils/paragraphs.ts`): breaks on every speaker/turn change and
 /// on gaps over `PARAGRAPH_GAP_SECONDS`, prefixing each new paragraph with
@@ -611,7 +688,7 @@ fn cluster_into_turns(segments: &[SegmentRow]) -> Vec<&SegmentRow> {
 /// uses for on-screen readability: this is meant to be a faithful, readable
 /// text dump for an AI assistant, not pixel-identical to the app's
 /// transcript view.
-fn render_transcript(segments: &[SegmentRow]) -> String {
+fn render_transcript(segments: &[SegmentRow], speakers: &[MeetingSpeakerInfo]) -> String {
     let diarized = segments.iter().any(|s| s.speaker.is_some());
     let ordered: Vec<&SegmentRow> = if diarized {
         cluster_into_turns(segments)
@@ -640,12 +717,7 @@ fn render_transcript(segments: &[SegmentRow]) -> String {
 
         if current.is_empty() {
             if let Some(speaker) = &seg.speaker {
-                let label = match speaker.as_str() {
-                    "me" => "Me",
-                    "them" => "Them",
-                    other => other,
-                };
-                current.push_str(label);
+                current.push_str(&speaker_label(speaker, speakers));
                 current.push_str(": ");
             }
         } else {
@@ -720,10 +792,27 @@ mod tests {
             CREATE VIRTUAL TABLE text_search USING fts5(
                 content, source_type, source_id
             );
+            CREATE TABLE speakers (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                centroid BLOB,
+                embedding_count INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                last_seen_at TEXT NOT NULL
+            );
             ",
         )
         .unwrap();
         (conn, dir, path)
+    }
+
+    fn insert_speaker(conn: &Connection, id: i64, name: &str) {
+        conn.execute(
+            "INSERT INTO speakers (id, name, embedding_count, created_at, last_seen_at)
+             VALUES (?1, ?2, 0, '2026-01-01T00:00:00+00:00', '2026-01-01T00:00:00+00:00')",
+            params![id, name],
+        )
+        .unwrap();
     }
 
     fn insert_meeting(
@@ -1031,6 +1120,79 @@ mod tests {
         let db = McpDb::open(&path).unwrap();
         let err = db.get_meeting("nope", IncludeSet::all()).unwrap_err();
         assert!(matches!(err, McpDbError::MeetingNotFound(id) if id == "nope"));
+    }
+
+    #[test]
+    fn get_meeting_resolves_persistent_speaker_names() {
+        let (conn, _dir, path) = fixture_db();
+        insert_speaker(&conn, 1, "Alice");
+        insert_speaker(&conn, 2, "Bob");
+        insert_meeting(
+            &conn,
+            "m1",
+            "Standup",
+            "2026-01-01T10:00:00+00:00",
+            &[
+                ("Hi Bob.", 0.0, 1.0, Some("spk:1")),
+                ("Hi Alice.", 1.2, 2.0, Some("spk:2")),
+            ],
+            None,
+        );
+        drop(conn);
+
+        let db = McpDb::open(&path).unwrap();
+        let detail = db.get_meeting("m1", IncludeSet::all()).unwrap();
+        let transcript = detail.transcript.unwrap();
+        assert!(transcript.contains("Alice: Hi Bob."));
+        assert!(transcript.contains("Bob: Hi Alice."));
+        assert_eq!(
+            detail.speakers.iter().map(|s| s.id).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        assert_eq!(detail.speakers[0].name, "Alice");
+        assert_eq!(detail.speakers[1].name, "Bob");
+    }
+
+    #[test]
+    fn get_meeting_falls_back_to_speaker_id_when_speaker_row_is_missing() {
+        let (conn, _dir, path) = fixture_db();
+        insert_meeting(
+            &conn,
+            "m1",
+            "Standup",
+            "2026-01-01T10:00:00+00:00",
+            &[("Orphaned reference.", 0.0, 1.0, Some("spk:99"))],
+            None,
+        );
+        drop(conn);
+
+        let db = McpDb::open(&path).unwrap();
+        let detail = db.get_meeting("m1", IncludeSet::all()).unwrap();
+        let transcript = detail.transcript.unwrap();
+        assert!(transcript.contains("Speaker 99: Orphaned reference."));
+        assert!(detail.speakers.is_empty());
+    }
+
+    #[test]
+    fn get_meeting_speakers_empty_when_transcript_and_metadata_excluded() {
+        let (conn, _dir, path) = fixture_db();
+        insert_speaker(&conn, 1, "Alice");
+        insert_meeting(
+            &conn,
+            "m1",
+            "Standup",
+            "2026-01-01T10:00:00+00:00",
+            &[("Hello.", 0.0, 1.0, Some("spk:1"))],
+            None,
+        );
+        drop(conn);
+
+        let db = McpDb::open(&path).unwrap();
+        let names = vec!["summary".to_string()];
+        let detail = db
+            .get_meeting("m1", IncludeSet::from_names(Some(&names)))
+            .unwrap();
+        assert!(detail.speakers.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -52,6 +52,8 @@ fn meeting_header(acc: &MeetingAccumulator) -> MeetingTranscript {
         notes: acc.notes.clone(),
         calendar_event_id: acc.calendar_event_id.clone(),
         participants: acc.participants.clone(),
+        // Header-only write; `speakers` is recomputed by `load_meeting`.
+        speakers: Vec::new(),
     }
 }
 

--- a/src-tauri/src/db/meetings.rs
+++ b/src-tauri/src/db/meetings.rs
@@ -4,8 +4,8 @@ use rusqlite::params;
 use crate::engine::{Speaker, TranscriptionProfile, TranscriptionSegment};
 use crate::lock_ext::MutexExt;
 use crate::transcript::{
-    MeetingListItem, MeetingParticipant, MeetingRecordingSession, MeetingTranscript,
-    StructuredSummary,
+    MeetingListItem, MeetingParticipant, MeetingRecordingSession, MeetingSpeaker,
+    MeetingTranscript, StructuredSummary,
 };
 
 use super::Database;
@@ -332,10 +332,24 @@ impl Database {
             .map_err(|e| format!("Query segments: {e}"))?
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| format!("Collect segments: {e}"))?;
+        drop(stmt);
+        // `speakers_for_meeting` acquires the connection lock itself, so the
+        // guard held by this function must be released first (the Mutex is
+        // not reentrant).
+        drop(conn);
+
         let transcription_profile = meeting.transcription_profile()?;
         let recording_sessions = meeting.recording_sessions()?;
         let participants = meeting.participants()?;
         let structured_summary = meeting.structured_summary()?;
+        let speakers = self
+            .speakers_for_meeting(id)?
+            .into_iter()
+            .map(|record| MeetingSpeaker {
+                id: record.id,
+                name: record.name,
+            })
+            .collect();
         let started_at = parse_datetime(&meeting.started_at)?;
         let ended_at = meeting
             .ended_at
@@ -366,6 +380,7 @@ impl Database {
             calendar_event_id: meeting.calendar_event_id,
             participants,
             structured_summary,
+            speakers,
         })
     }
 
@@ -624,6 +639,38 @@ fn parse_datetime(value: &str) -> Result<DateTime<Utc>, String> {
 mod tests {
     use crate::engine::TranscriptionProfile;
     use crate::test_helpers::fixtures::{sample_meeting, test_db};
+
+    #[test]
+    fn load_meeting_resolves_persistent_speakers() {
+        use crate::engine::Speaker;
+
+        let (db, _dir) = test_db();
+        let alice = db.create_speaker("Alice").unwrap();
+        let bob = db.create_speaker("Bob").unwrap();
+
+        let mut meeting = sample_meeting("m1");
+        meeting.segments[0].speaker = Some(Speaker::Persistent(alice));
+        meeting.segments[1].speaker = Some(Speaker::Persistent(bob));
+        db.save_meeting(&meeting).unwrap();
+
+        let loaded = db.load_meeting("m1").unwrap();
+        assert_eq!(loaded.segments[0].speaker, Some(Speaker::Persistent(alice)));
+        assert_eq!(loaded.segments[1].speaker, Some(Speaker::Persistent(bob)));
+        assert_eq!(
+            loaded.speakers.iter().map(|s| s.id).collect::<Vec<_>>(),
+            vec![alice, bob]
+        );
+        assert_eq!(loaded.speakers[0].name, "Alice");
+        assert_eq!(loaded.speakers[1].name, "Bob");
+    }
+
+    #[test]
+    fn load_meeting_speakers_empty_for_me_them_only() {
+        let (db, _dir) = test_db();
+        db.save_meeting(&sample_meeting("m1")).unwrap();
+        let loaded = db.load_meeting("m1").unwrap();
+        assert!(loaded.speakers.is_empty());
+    }
 
     #[test]
     fn save_and_load_meeting() {

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -5,6 +5,7 @@ pub mod migrate;
 pub mod schema;
 pub mod search;
 pub mod settings;
+pub mod speakers;
 
 use std::path::Path;
 use std::sync::Mutex;
@@ -176,6 +177,12 @@ impl Database {
                 schema::migrate_add_structured_summary_to_v11(&conn)?;
                 conn.execute("UPDATE schema_version SET version = 11", [])
                     .map_err(|e| format!("Update schema version v11: {e}"))?;
+            }
+
+            if current_version < 12 {
+                schema::migrate_add_speakers_to_v12(&conn)?;
+                conn.execute("UPDATE schema_version SET version = 12", [])
+                    .map_err(|e| format!("Update schema version v12: {e}"))?;
             }
 
             info!("Schema migration complete");

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -4,8 +4,9 @@ use rusqlite::{Connection, params};
 use crate::engine::TranscriptionProfile;
 use crate::transcript::{legacy_recording_session, resolve_legacy_transcription_profile};
 
-/// Schema version 11: meetings.structured_summary JSON column.
-pub const SCHEMA_VERSION: i64 = 11;
+/// Schema version 12: `speakers` table for persistent, cross-meeting speaker
+/// identities resolved by offline diarization.
+pub const SCHEMA_VERSION: i64 = 12;
 
 pub const CREATE_SCHEMA_VERSION: &str = "
     CREATE TABLE IF NOT EXISTS schema_version (
@@ -117,6 +118,20 @@ pub const CREATE_DICTIONARY: &str = "
         category TEXT,
         created_at TEXT NOT NULL,
         UNIQUE(term)
+    );
+";
+
+/// Persistent, cross-meeting speaker identities resolved by offline
+/// diarization. `centroid` is an opaque BLOB from the DB layer's point of
+/// view: the diarization crate encodes it as 256 little-endian f32s.
+pub const CREATE_SPEAKERS: &str = "
+    CREATE TABLE IF NOT EXISTS speakers (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        centroid BLOB,
+        embedding_count INTEGER NOT NULL DEFAULT 0,
+        created_at TEXT NOT NULL,
+        last_seen_at TEXT NOT NULL
     );
 ";
 
@@ -405,6 +420,15 @@ pub fn migrate_add_structured_summary_to_v11(conn: &Connection) -> Result<(), St
     Ok(())
 }
 
+/// v12: `speakers` table for persistent, cross-meeting speaker identities.
+/// `segments.speaker` values of the form `spk:<id>` reference this table;
+/// existing "me"/"them" segments are untouched.
+pub fn migrate_add_speakers_to_v12(conn: &Connection) -> Result<(), String> {
+    conn.execute_batch(CREATE_SPEAKERS)
+        .map_err(|e| format!("Create speakers table: {e}"))?;
+    Ok(())
+}
+
 fn parse_datetime(value: &str) -> Result<DateTime<Utc>, String> {
     DateTime::parse_from_rfc3339(value)
         .map(|dt| dt.with_timezone(&Utc))
@@ -599,6 +623,67 @@ mod tests {
             columns.iter().any(|column| column == "structured_summary"),
             "v11 migration should add structured_summary column"
         );
+    }
+
+    #[test]
+    fn v11_migrate_to_v12_adds_speakers_table() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        // Minimal v11-era fixture: meetings v3 shape plus the structured_summary
+        // column v11 added, no speakers table yet.
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(CREATE_SCHEMA_VERSION).unwrap();
+        conn.execute_batch(super::CREATE_MEETINGS_V3).unwrap();
+        conn.execute(
+            "ALTER TABLE meetings ADD COLUMN structured_summary TEXT",
+            [],
+        )
+        .unwrap();
+        conn.execute_batch(CREATE_SEGMENTS).unwrap();
+        conn.execute_batch(CREATE_SEGMENTS_INDEX).unwrap();
+        conn.execute_batch(CREATE_DICTATION_ENTRIES).unwrap();
+        conn.execute_batch(CREATE_SETTINGS).unwrap();
+        conn.execute_batch(super::CREATE_TEXT_SEARCH).unwrap();
+        conn.execute("INSERT INTO schema_version (version) VALUES (11)", [])
+            .unwrap();
+        drop(conn);
+
+        let db = Database::open(&db_path).unwrap();
+
+        let conn = db.conn.lock().unwrap();
+        let table_exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='speakers'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(
+            table_exists,
+            "v12 migration should create the speakers table"
+        );
+
+        let columns: Vec<String> = {
+            let mut stmt = conn.prepare("PRAGMA table_info(speakers)").unwrap();
+            stmt.query_map([], |row| row.get(1))
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+        };
+        for expected in [
+            "id",
+            "name",
+            "centroid",
+            "embedding_count",
+            "created_at",
+            "last_seen_at",
+        ] {
+            assert!(
+                columns.iter().any(|column| column == expected),
+                "speakers table should have column {expected}"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/db/speakers.rs
+++ b/src-tauri/src/db/speakers.rs
@@ -1,0 +1,276 @@
+use chrono::{DateTime, Utc};
+use rusqlite::params;
+
+use crate::lock_ext::MutexExt;
+
+use super::Database;
+
+/// A persistent, cross-meeting speaker identity row. `centroid` is an opaque
+/// BLOB from this layer's point of view (the diarization crate encodes it as
+/// 256 little-endian f32s); it is `None` until at least one embedding has
+/// been recorded for this speaker.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpeakerRecord {
+    pub id: i64,
+    pub name: String,
+    pub centroid: Option<Vec<u8>>,
+    pub embedding_count: i64,
+    pub created_at: DateTime<Utc>,
+    pub last_seen_at: DateTime<Utc>,
+}
+
+impl Database {
+    /// Create a new persistent speaker with the given display name. Returns
+    /// the new row's id. `centroid`/`embedding_count` start empty; call
+    /// `update_speaker_centroid` once diarization has a centroid for it.
+    pub fn create_speaker(&self, name: &str) -> Result<i64, String> {
+        let conn = self.conn.acquire()?;
+        let now = Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO speakers (name, centroid, embedding_count, created_at, last_seen_at)
+             VALUES (?1, NULL, 0, ?2, ?2)",
+            params![name, now],
+        )
+        .map_err(|e| format!("Insert speaker: {e}"))?;
+        Ok(conn.last_insert_rowid())
+    }
+
+    /// Look up a single speaker by id. `None` if it doesn't exist (e.g. it
+    /// was deleted after a meeting's segments referenced it).
+    pub fn get_speaker(&self, id: i64) -> Result<Option<SpeakerRecord>, String> {
+        let conn = self.conn.acquire()?;
+        let row = conn
+            .query_row(
+                "SELECT id, name, centroid, embedding_count, created_at, last_seen_at
+                 FROM speakers WHERE id = ?1",
+                params![id],
+                map_speaker_row,
+            )
+            .map(Some)
+            .or_else(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => Ok(None),
+                other => Err(format!("Query speaker: {other}")),
+            })?;
+        row.map(SpeakerRow::into_record).transpose()
+    }
+
+    /// All persistent speakers, ordered by id.
+    pub fn list_speakers(&self) -> Result<Vec<SpeakerRecord>, String> {
+        let conn = self.conn.acquire()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT id, name, centroid, embedding_count, created_at, last_seen_at
+                 FROM speakers ORDER BY id",
+            )
+            .map_err(|e| format!("Prepare list speakers: {e}"))?;
+        let rows = stmt
+            .query_map([], map_speaker_row)
+            .map_err(|e| format!("Query list speakers: {e}"))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("Collect list speakers: {e}"))?;
+        rows.into_iter().map(SpeakerRow::into_record).collect()
+    }
+
+    /// Overwrite a speaker's centroid, embedding count, and `last_seen_at`
+    /// (typically after re-clustering embeddings into a fresh centroid).
+    pub fn update_speaker_centroid(
+        &self,
+        id: i64,
+        centroid: &[u8],
+        embedding_count: i64,
+        last_seen_at: DateTime<Utc>,
+    ) -> Result<(), String> {
+        let conn = self.conn.acquire()?;
+        conn.execute(
+            "UPDATE speakers SET centroid = ?1, embedding_count = ?2, last_seen_at = ?3 WHERE id = ?4",
+            params![centroid, embedding_count, last_seen_at.to_rfc3339(), id],
+        )
+        .map_err(|e| format!("Update speaker centroid: {e}"))?;
+        Ok(())
+    }
+
+    /// Persistent speakers referenced by any segment of `meeting_id`
+    /// (`speaker` column values of the form `spk:<id>`), ordered by id. A
+    /// referenced id that no longer has a `speakers` row (deleted) is
+    /// silently skipped; callers fall back to a "Speaker <id>" label.
+    pub fn speakers_for_meeting(&self, meeting_id: &str) -> Result<Vec<SpeakerRecord>, String> {
+        let ids: Vec<i64> = {
+            let conn = self.conn.acquire()?;
+            let mut stmt = conn
+                .prepare(
+                    "SELECT DISTINCT speaker FROM segments
+                     WHERE meeting_id = ?1 AND speaker LIKE 'spk:%'",
+                )
+                .map_err(|e| format!("Prepare speakers for meeting: {e}"))?;
+            stmt.query_map(params![meeting_id], |row| row.get::<_, String>(0))
+                .map_err(|e| format!("Query speakers for meeting: {e}"))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| format!("Collect speakers for meeting: {e}"))?
+                .into_iter()
+                .filter_map(|raw| match crate::engine::Speaker::parse(&raw) {
+                    Some(crate::engine::Speaker::Persistent(id)) => Some(id),
+                    _ => None,
+                })
+                .collect()
+        };
+
+        let mut records = Vec::with_capacity(ids.len());
+        for id in ids {
+            if let Some(record) = self.get_speaker(id)? {
+                records.push(record);
+            }
+        }
+        records.sort_by_key(|record| record.id);
+        Ok(records)
+    }
+}
+
+/// Raw row shape before datetime parsing, so parse errors can be reported
+/// with a consistent "Parse <field>" message.
+struct SpeakerRow {
+    id: i64,
+    name: String,
+    centroid: Option<Vec<u8>>,
+    embedding_count: i64,
+    created_at: String,
+    last_seen_at: String,
+}
+
+impl SpeakerRow {
+    fn into_record(self) -> Result<SpeakerRecord, String> {
+        Ok(SpeakerRecord {
+            id: self.id,
+            name: self.name,
+            centroid: self.centroid,
+            embedding_count: self.embedding_count,
+            created_at: parse_datetime(&self.created_at)?,
+            last_seen_at: parse_datetime(&self.last_seen_at)?,
+        })
+    }
+}
+
+fn map_speaker_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SpeakerRow> {
+    Ok(SpeakerRow {
+        id: row.get(0)?,
+        name: row.get(1)?,
+        centroid: row.get(2)?,
+        embedding_count: row.get(3)?,
+        created_at: row.get(4)?,
+        last_seen_at: row.get(5)?,
+    })
+}
+
+fn parse_datetime(value: &str) -> Result<DateTime<Utc>, String> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| format!("Parse datetime '{value}': {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::engine::Speaker;
+    use crate::test_helpers::fixtures::{sample_meeting, test_db};
+
+    #[test]
+    fn create_and_get_speaker_round_trips() {
+        let (db, _dir) = test_db();
+        let id = db.create_speaker("Alice").unwrap();
+
+        let record = db.get_speaker(id).unwrap().expect("speaker exists");
+        assert_eq!(record.name, "Alice");
+        assert_eq!(record.embedding_count, 0);
+        assert!(record.centroid.is_none());
+        assert_eq!(record.created_at, record.last_seen_at);
+    }
+
+    #[test]
+    fn get_speaker_missing_id_returns_none() {
+        let (db, _dir) = test_db();
+        assert!(db.get_speaker(999).unwrap().is_none());
+    }
+
+    #[test]
+    fn list_speakers_orders_by_id() {
+        let (db, _dir) = test_db();
+        let a = db.create_speaker("Alice").unwrap();
+        let b = db.create_speaker("Bob").unwrap();
+
+        let all = db.list_speakers().unwrap();
+        assert_eq!(all.iter().map(|s| s.id).collect::<Vec<_>>(), vec![a, b]);
+        assert_eq!(all[0].name, "Alice");
+        assert_eq!(all[1].name, "Bob");
+    }
+
+    #[test]
+    fn update_speaker_centroid_overwrites_fields() {
+        let (db, _dir) = test_db();
+        let id = db.create_speaker("Alice").unwrap();
+        let centroid = vec![0u8; 1024]; // 256 f32s
+        let now = chrono::Utc::now();
+
+        db.update_speaker_centroid(id, &centroid, 5, now).unwrap();
+
+        let record = db.get_speaker(id).unwrap().unwrap();
+        assert_eq!(record.centroid, Some(centroid));
+        assert_eq!(record.embedding_count, 5);
+        // Sub-second precision may be lost in the RFC3339 round trip; compare
+        // at second resolution.
+        assert_eq!(record.last_seen_at.timestamp(), now.timestamp());
+    }
+
+    #[test]
+    fn speakers_for_meeting_resolves_distinct_persistent_ids() {
+        let (db, _dir) = test_db();
+        let alice = db.create_speaker("Alice").unwrap();
+        let bob = db.create_speaker("Bob").unwrap();
+
+        let mut meeting = sample_meeting("m1");
+        meeting.segments[0].speaker = Some(Speaker::Persistent(alice));
+        meeting.segments[1].speaker = Some(Speaker::Persistent(bob));
+        db.save_meeting(&meeting).unwrap();
+
+        let speakers = db.speakers_for_meeting("m1").unwrap();
+        assert_eq!(
+            speakers.iter().map(|s| s.id).collect::<Vec<_>>(),
+            vec![alice, bob]
+        );
+    }
+
+    #[test]
+    fn speakers_for_meeting_ignores_me_and_them() {
+        let (db, _dir) = test_db();
+        let mut meeting = sample_meeting("m1");
+        meeting.segments[0].speaker = Some(Speaker::Me);
+        meeting.segments[1].speaker = Some(Speaker::Them);
+        db.save_meeting(&meeting).unwrap();
+
+        assert!(db.speakers_for_meeting("m1").unwrap().is_empty());
+    }
+
+    #[test]
+    fn speakers_for_meeting_skips_deleted_speaker_rows() {
+        let (db, _dir) = test_db();
+        // A segment references a persistent speaker id that was never (or no
+        // longer is) a row in `speakers` — should be silently dropped, not
+        // error, so the caller's fallback label kicks in instead.
+        let mut meeting = sample_meeting("m1");
+        meeting.segments[0].speaker = Some(Speaker::Persistent(4242));
+        db.save_meeting(&meeting).unwrap();
+
+        assert!(db.speakers_for_meeting("m1").unwrap().is_empty());
+    }
+
+    #[test]
+    fn speakers_for_meeting_deduplicates_repeated_references() {
+        let (db, _dir) = test_db();
+        let alice = db.create_speaker("Alice").unwrap();
+
+        let mut meeting = sample_meeting("m1");
+        meeting.segments[0].speaker = Some(Speaker::Persistent(alice));
+        meeting.segments[1].speaker = Some(Speaker::Persistent(alice));
+        db.save_meeting(&meeting).unwrap();
+
+        let speakers = db.speakers_for_meeting("m1").unwrap();
+        assert_eq!(speakers.len(), 1);
+    }
+}

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -265,20 +265,31 @@ pub trait TranscriptionEngine {
 }
 
 /// Who produced a segment in a diarized meeting: the microphone is the local
-/// user (Me), system audio is everyone else (Them). `None` = single-stream
-/// session (dictation, or a meeting recorded without diarization).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, specta::Type)]
-#[serde(rename_all = "lowercase")]
+/// user (Me), system audio is everyone else (Them), or a persistent speaker
+/// identity resolved by offline diarization (`Persistent`, keyed by the
+/// `speakers.id` row). `None` = single-stream session (dictation, or a
+/// meeting recorded without diarization).
+///
+/// Wire/DB encoding is always a plain string: "me", "them", or "spk:<id>".
+/// Serialize/Deserialize/specta::Type are implemented by hand below (instead
+/// of derived) so the `Persistent` variant's payload still round-trips
+/// through a single string on the wire, and the generated TypeScript type is
+/// a plain `string` rather than a tagged union.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Speaker {
     Me,
     Them,
+    /// A persistent, cross-meeting speaker identity. The `i64` is the
+    /// `speakers.id` primary key.
+    Persistent(i64),
 }
 
 impl Speaker {
-    pub fn as_str(self) -> &'static str {
+    pub fn as_str(self) -> String {
         match self {
-            Speaker::Me => "me",
-            Speaker::Them => "them",
+            Speaker::Me => "me".to_string(),
+            Speaker::Them => "them".to_string(),
+            Speaker::Persistent(id) => format!("spk:{id}"),
         }
     }
 
@@ -286,8 +297,43 @@ impl Speaker {
         match s {
             "me" => Some(Speaker::Me),
             "them" => Some(Speaker::Them),
-            _ => None,
+            other => other
+                .strip_prefix("spk:")
+                .and_then(|id| id.parse::<i64>().ok())
+                .map(Speaker::Persistent),
         }
+    }
+}
+
+impl serde::Serialize for Speaker {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.as_str())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Speaker {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Speaker::parse(&s)
+            .ok_or_else(|| serde::de::Error::custom(format!("invalid speaker: {s:?}")))
+    }
+}
+
+/// Manual impl (rather than `#[derive(specta::Type)]`) so the generated
+/// TypeScript type is a plain `string` ("me" | "them" | `spk:<id>`), matching
+/// the hand-written `Serialize`/`Deserialize` above.
+impl specta::Type for Speaker {
+    fn inline(
+        type_map: &mut specta::TypeCollection,
+        generics: specta::Generics,
+    ) -> specta::DataType {
+        <String as specta::Type>::inline(type_map, generics)
     }
 }
 

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -11,7 +11,7 @@ use std::path::{Path, PathBuf};
 use chrono::{DateTime, Utc};
 
 use crate::engine::{Speaker, TranscriptionSegment};
-use crate::transcript::{MeetingTranscript, StructuredSummary};
+use crate::transcript::{MeetingSpeaker, MeetingTranscript, StructuredSummary};
 
 /// Minimum on-screen duration given to a subtitle cue whose segment has a
 /// zero or inverted end time, so SRT/VTT players never render a cue with
@@ -180,7 +180,7 @@ fn render_markdown(meeting: &MeetingTranscript) -> String {
             );
             let rendered = grouped
                 .iter()
-                .map(render_paragraph_markdown)
+                .map(|p| render_paragraph_markdown(p, &meeting.speakers))
                 .collect::<Vec<_>>()
                 .join("\n\n");
             out.push_str(&rendered);
@@ -241,10 +241,29 @@ fn render_structured_markdown(out: &mut String, structured: &StructuredSummary) 
     }
 }
 
-fn render_paragraph_markdown(p: &paragraphs::Paragraph) -> String {
+/// Display name for a speaker label: Me -> "Me", Them -> "Them", a
+/// persistent speaker -> its `MeetingSpeaker.name` if it's in the list
+/// (i.e. still referenced and resolvable), else a "Speaker <id>" fallback.
+fn speaker_display_name(speaker: Speaker, speakers: &[MeetingSpeaker]) -> String {
+    match speaker {
+        Speaker::Me => "Me".to_string(),
+        Speaker::Them => "Them".to_string(),
+        Speaker::Persistent(id) => speakers
+            .iter()
+            .find(|s| s.id == id)
+            .map(|s| s.name.clone())
+            .unwrap_or_else(|| format!("Speaker {id}")),
+    }
+}
+
+fn render_paragraph_markdown(p: &paragraphs::Paragraph, speakers: &[MeetingSpeaker]) -> String {
     match p.speaker {
-        Some(Speaker::Me) => format!("**Me** [{}] {}", p.timestamp, p.text),
-        Some(Speaker::Them) => format!("**Them** [{}] {}", p.timestamp, p.text),
+        Some(speaker) => format!(
+            "**{}** [{}] {}",
+            speaker_display_name(speaker, speakers),
+            p.timestamp,
+            p.text
+        ),
         None => format!("[{}] {}", p.timestamp, p.text),
     }
 }
@@ -273,10 +292,9 @@ fn time_ordered_segments(segments: &[TranscriptionSegment]) -> Vec<&Transcriptio
     ordered
 }
 
-fn speaker_prefix(speaker: Option<Speaker>, text: &str) -> String {
+fn speaker_prefix(speaker: Option<Speaker>, text: &str, speakers: &[MeetingSpeaker]) -> String {
     match speaker {
-        Some(Speaker::Me) => format!("Me: {text}"),
-        Some(Speaker::Them) => format!("Them: {text}"),
+        Some(speaker) => format!("{}: {text}", speaker_display_name(speaker, speakers)),
         None => text.to_string(),
     }
 }
@@ -318,7 +336,7 @@ fn render_srt(meeting: &MeetingTranscript) -> String {
             "{index}\n{} --> {}\n{}\n\n",
             srt_timestamp(start),
             srt_timestamp(end),
-            speaker_prefix(seg.speaker, text),
+            speaker_prefix(seg.speaker, text, &meeting.speakers),
         ));
         index += 1;
     }
@@ -337,7 +355,7 @@ fn render_vtt(meeting: &MeetingTranscript) -> String {
             "{} --> {}\n{}\n\n",
             vtt_timestamp(start),
             vtt_timestamp(end),
-            speaker_prefix(seg.speaker, text),
+            speaker_prefix(seg.speaker, text, &meeting.speakers),
         ));
     }
     finish_cue_block(out)
@@ -436,8 +454,9 @@ mod paragraphs {
     /// speaker's currently open turn if the gap since that turn's last
     /// segment is under `pause_threshold`; otherwise that speaker's turn
     /// closes and a new one opens. Port of `clusterIntoTurns` in
-    /// `src/lib/utils/paragraphs.ts`; only `Speaker::Me`/`Speaker::Them`
-    /// exist so two plain slots stand in for the TS `Map`.
+    /// `src/lib/utils/paragraphs.ts`; a `HashMap<Speaker, usize>` of open
+    /// turn indices stands in for the TS `Map`, generalizing to any number of
+    /// speakers (not just Me/Them).
     ///
     /// Without a pause, a monologue would otherwise absorb everything
     /// indefinitely, so a second speaker's interjection would render far
@@ -461,50 +480,38 @@ mod paragraphs {
             interrupted: bool,
         }
 
-        let mut open_me: Option<usize> = None;
-        let mut open_them: Option<usize> = None;
+        let mut open_turns: std::collections::HashMap<Speaker, usize> =
+            std::collections::HashMap::new();
         let mut turns: Vec<Turn<'a>> = Vec::new();
 
         for seg in sorted {
             let end = if seg.end_time != 0.0 { seg.end_time } else { seg.start_time };
-            match seg.speaker {
-                None => {
-                    turns.push(Turn { start: seg.start_time, last_end: end, segments: vec![seg], interrupted: false });
+            let Some(speaker) = seg.speaker else {
+                turns.push(Turn { start: seg.start_time, last_end: end, segments: vec![seg], interrupted: false });
+                continue;
+            };
+
+            let open_idx = open_turns.get(&speaker).copied();
+            let joins = match open_idx {
+                Some(idx) => seg.start_time - turns[idx].last_end < pause_threshold,
+                None => false,
+            };
+            if let Some(idx) = open_idx.filter(|_| joins) {
+                turns[idx].segments.push(seg);
+                turns[idx].last_end = turns[idx].last_end.max(end);
+                if turns[idx].interrupted && ends_sentence(seg.text.trim()) {
+                    // First sentence end at or after the interruption: close
+                    // now so the speaker's next segment starts a fresh,
+                    // later-sorting turn.
+                    open_turns.remove(&speaker);
                 }
-                Some(speaker) => {
-                    let open_idx = match speaker {
-                        Speaker::Me => open_me,
-                        Speaker::Them => open_them,
-                    };
-                    let joins = match open_idx {
-                        Some(idx) => seg.start_time - turns[idx].last_end < pause_threshold,
-                        None => false,
-                    };
-                    if let Some(idx) = open_idx.filter(|_| joins) {
-                        turns[idx].segments.push(seg);
-                        turns[idx].last_end = turns[idx].last_end.max(end);
-                        if turns[idx].interrupted && ends_sentence(seg.text.trim()) {
-                            // First sentence end at or after the
-                            // interruption: close now so the speaker's next
-                            // segment starts a fresh, later-sorting turn.
-                            match speaker {
-                                Speaker::Me => open_me = None,
-                                Speaker::Them => open_them = None,
-                            }
-                        }
-                    } else {
-                        turns.push(Turn { start: seg.start_time, last_end: end, segments: vec![seg], interrupted: false });
-                        let new_idx = turns.len() - 1;
-                        match speaker {
-                            Speaker::Me => open_me = Some(new_idx),
-                            Speaker::Them => open_them = Some(new_idx),
-                        }
-                        if let Some(idx) = open_me.filter(|_| speaker != Speaker::Me) {
-                            turns[idx].interrupted = true;
-                        }
-                        if let Some(idx) = open_them.filter(|_| speaker != Speaker::Them) {
-                            turns[idx].interrupted = true;
-                        }
+            } else {
+                turns.push(Turn { start: seg.start_time, last_end: end, segments: vec![seg], interrupted: false });
+                let new_idx = turns.len() - 1;
+                open_turns.insert(speaker, new_idx);
+                for (&other_speaker, &idx) in open_turns.iter() {
+                    if other_speaker != speaker {
+                        turns[idx].interrupted = true;
                     }
                 }
             }
@@ -856,6 +863,39 @@ mod tests {
         let rendered = render_meeting(&meeting, ExportFormat::Markdown).unwrap();
         assert!(rendered.contains("**Me** [0:00] Hi there"));
         assert!(rendered.contains("**Them** [0:02] Hello back"));
+    }
+
+    #[test]
+    fn markdown_paragraphs_resolve_persistent_speaker_name() {
+        let mut meeting = sample_meeting("m1");
+        meeting.segments = vec![diarized_segment("Hi there", 0.0, 1.0, Speaker::Persistent(1))];
+        meeting.speakers = vec![crate::transcript::MeetingSpeaker {
+            id: 1,
+            name: "Alice".to_string(),
+        }];
+        let rendered = render_meeting(&meeting, ExportFormat::Markdown).unwrap();
+        assert!(rendered.contains("**Alice** [0:00] Hi there"));
+    }
+
+    #[test]
+    fn markdown_paragraphs_fall_back_to_speaker_id_when_unresolved() {
+        let mut meeting = sample_meeting("m1");
+        meeting.segments = vec![diarized_segment("Hi there", 0.0, 1.0, Speaker::Persistent(99))];
+        // No matching entry in meeting.speakers (deleted, or never resolved).
+        let rendered = render_meeting(&meeting, ExportFormat::Markdown).unwrap();
+        assert!(rendered.contains("**Speaker 99** [0:00] Hi there"));
+    }
+
+    #[test]
+    fn srt_resolves_persistent_speaker_name() {
+        let mut meeting = sample_meeting("m1");
+        meeting.segments = vec![diarized_segment("Hi there", 0.0, 1.0, Speaker::Persistent(7))];
+        meeting.speakers = vec![crate::transcript::MeetingSpeaker {
+            id: 7,
+            name: "Bob".to_string(),
+        }];
+        let rendered = render_meeting(&meeting, ExportFormat::Srt).unwrap();
+        assert!(rendered.contains("Bob: Hi there"));
     }
 
     #[test]

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -125,6 +125,10 @@ impl MeetingAccumulator {
             notes: self.notes,
             calendar_event_id: self.calendar_event_id,
             participants: self.participants,
+            // Recomputed from segments by `Database::load_meeting`; this
+            // transcript goes through `save_meeting`/`upsert_meeting_header`,
+            // neither of which reads this field.
+            speakers: Vec::new(),
         }
     }
 }

--- a/src-tauri/src/test_helpers.rs
+++ b/src-tauri/src/test_helpers.rs
@@ -66,6 +66,7 @@ pub mod fixtures {
             notes: None,
             calendar_event_id: None,
             participants: Vec::new(),
+            speakers: Vec::new(),
         }
     }
 

--- a/src-tauri/src/transcript.rs
+++ b/src-tauri/src/transcript.rs
@@ -36,6 +36,17 @@ pub struct StructuredSummary {
     pub open_questions: Vec<String>,
 }
 
+/// A persistent speaker referenced by a meeting's segments, resolved for
+/// display. Computed at read time from the `speakers` table joined against
+/// the distinct `spk:<id>` labels in the meeting's segments, not itself
+/// persisted on the meeting row. Empty for meetings with only Me/Them
+/// segments (or no diarization at all).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, specta::Type)]
+pub struct MeetingSpeaker {
+    pub id: i64,
+    pub name: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, specta::Type)]
 pub struct MeetingRecordingSession {
     pub id: String,
@@ -105,6 +116,10 @@ pub struct MeetingTranscript {
     /// Attendees captured from the calendar event; shown in the UI and fed
     /// into the summary prompt.
     pub participants: Vec<MeetingParticipant>,
+    /// Persistent speakers referenced by this meeting's segments, for
+    /// resolving `Speaker::Persistent(id)` labels to a display name. Computed
+    /// at read time (see `MeetingSpeaker`); empty for Me/Them-only meetings.
+    pub speakers: Vec<MeetingSpeaker>,
 }
 
 /// Calendar context passed by the frontend when starting a meeting from a
@@ -148,6 +163,11 @@ struct MeetingTranscriptWire {
     calendar_event_id: Option<String>,
     #[serde(default)]
     participants: Vec<MeetingParticipant>,
+    /// Always recomputed at read time (see `Database::load_meeting`); a
+    /// value in a legacy JSON file or wire payload is intentionally ignored.
+    #[serde(default)]
+    #[allow(dead_code)]
+    speakers: Vec<MeetingSpeaker>,
 }
 
 impl<'de> Deserialize<'de> for MeetingTranscript {
@@ -188,6 +208,9 @@ impl<'de> Deserialize<'de> for MeetingTranscript {
             notes: wire.notes,
             calendar_event_id: wire.calendar_event_id,
             participants: wire.participants,
+            // Recomputed by the DB layer at read time, never carried over
+            // the wire or from a legacy JSON file.
+            speakers: Vec::new(),
         })
     }
 }
@@ -312,6 +335,7 @@ mod tests {
             notes: None,
             calendar_event_id: None,
             participants: Vec::new(),
+            speakers: Vec::new(),
         };
 
         let json = serde_json::to_string(&meeting).unwrap();
@@ -353,6 +377,7 @@ mod tests {
             notes: None,
             calendar_event_id: None,
             participants: Vec::new(),
+            speakers: Vec::new(),
         };
 
         let item = MeetingListItem::from(&transcript);

--- a/src-tauri/tests/fixtures/paragraph_grouping.json
+++ b/src-tauri/tests/fixtures/paragraph_grouping.json
@@ -305,6 +305,161 @@
           "speaker": null
         }
       ]
+    },
+    {
+      "name": "three_speakers_round_robin",
+      "segments": [
+        {
+          "text": "Hello everyone.",
+          "start_time": 0.0,
+          "end_time": 1.0,
+          "speaker": "spk:1"
+        },
+        {
+          "text": "Hi there.",
+          "start_time": 3.0,
+          "end_time": 4.0,
+          "speaker": "spk:2"
+        },
+        {
+          "text": "Good morning.",
+          "start_time": 6.0,
+          "end_time": 7.0,
+          "speaker": "spk:3"
+        },
+        {
+          "text": "Let's begin.",
+          "start_time": 9.0,
+          "end_time": 10.0,
+          "speaker": "spk:1"
+        }
+      ],
+      "expected": [
+        {
+          "timestamp": "0:00",
+          "text": "Hello everyone.",
+          "speaker": "spk:1"
+        },
+        {
+          "timestamp": "0:03",
+          "text": "Hi there.",
+          "speaker": "spk:2"
+        },
+        {
+          "timestamp": "0:06",
+          "text": "Good morning.",
+          "speaker": "spk:3"
+        },
+        {
+          "timestamp": "0:09",
+          "text": "Let's begin.",
+          "speaker": "spk:1"
+        }
+      ]
+    },
+    {
+      "name": "three_speakers_crosstalk_and_interjection",
+      "segments": [
+        {
+          "text": "hello",
+          "start_time": 0.0,
+          "end_time": 0.3,
+          "speaker": "spk:1"
+        },
+        {
+          "text": "hi",
+          "start_time": 0.15,
+          "end_time": 0.35,
+          "speaker": "spk:2"
+        },
+        {
+          "text": "how",
+          "start_time": 0.5,
+          "end_time": 0.7,
+          "speaker": "spk:1"
+        },
+        {
+          "text": "good",
+          "start_time": 0.6,
+          "end_time": 0.8,
+          "speaker": "spk:2"
+        },
+        {
+          "text": "are",
+          "start_time": 0.9,
+          "end_time": 1.1,
+          "speaker": "spk:1"
+        },
+        {
+          "text": "thanks",
+          "start_time": 1.0,
+          "end_time": 1.2,
+          "speaker": "spk:2"
+        },
+        {
+          "text": "you",
+          "start_time": 1.3,
+          "end_time": 1.5,
+          "speaker": "spk:1"
+        },
+        {
+          "text": "Let me explain the whole plan",
+          "start_time": 5.0,
+          "end_time": 5.5,
+          "speaker": "spk:1"
+        },
+        {
+          "text": "in detail because it's",
+          "start_time": 5.6,
+          "end_time": 6.1,
+          "speaker": "spk:1"
+        },
+        {
+          "text": "wait",
+          "start_time": 6.2,
+          "end_time": 6.7,
+          "speaker": "spk:3"
+        },
+        {
+          "text": "complicated.",
+          "start_time": 6.8,
+          "end_time": 7.3,
+          "speaker": "spk:1"
+        },
+        {
+          "text": "So let's start now",
+          "start_time": 8.0,
+          "end_time": 8.5,
+          "speaker": "spk:1"
+        }
+      ],
+      "expected": [
+        {
+          "timestamp": "0:00",
+          "text": "hello how are you",
+          "speaker": "spk:1"
+        },
+        {
+          "timestamp": "0:00",
+          "text": "hi good thanks",
+          "speaker": "spk:2"
+        },
+        {
+          "timestamp": "0:05",
+          "text": "Let me explain the whole plan in detail because it's complicated.",
+          "speaker": "spk:1"
+        },
+        {
+          "timestamp": "0:06",
+          "text": "wait",
+          "speaker": "spk:3"
+        },
+        {
+          "timestamp": "0:08",
+          "text": "So let's start now",
+          "speaker": "spk:1"
+        }
+      ]
     }
   ]
 }

--- a/src-tauri/tests/mcp_sidecar_contract.rs
+++ b/src-tauri/tests/mcp_sidecar_contract.rs
@@ -10,7 +10,7 @@
 
 use chrono::Utc;
 use souffle_lib::db::Database;
-use souffle_lib::engine::{TranscriptionProfile, TranscriptionSegment};
+use souffle_lib::engine::{Speaker, TranscriptionProfile, TranscriptionSegment};
 use souffle_lib::transcript::{
     MeetingParticipant, MeetingRecordingSession, MeetingTranscript, StructuredActionItem,
     StructuredSummary,
@@ -77,6 +77,7 @@ fn build_meeting() -> MeetingTranscript {
             is_organizer: true,
             is_current_user: false,
         }],
+        speakers: Vec::new(),
     }
 }
 
@@ -142,6 +143,43 @@ fn sidecar_round_trips_data_written_by_the_real_app() {
     assert_eq!(dictations.len(), 1);
     assert_eq!(dictations[0].id, "dict-1");
     assert_eq!(dictations[0].text, "Buy milk on the way home");
+}
+
+#[test]
+fn sidecar_resolves_persistent_speaker_names_written_by_the_real_app() {
+    let dir = TempDir::new().unwrap();
+    let db_path = dir.path().join("souffle.db");
+
+    let app_db = Database::open(&db_path).unwrap();
+    let alice_id = app_db.create_speaker("Alice Martin").unwrap();
+    let bob_id = app_db.create_speaker("Bob Chen").unwrap();
+
+    let mut meeting = build_meeting();
+    meeting.id = "contract-speakers".to_string();
+    meeting.segments[0].speaker = Some(Speaker::Persistent(alice_id));
+    meeting.segments[1].speaker = Some(Speaker::Persistent(bob_id));
+    app_db.save_meeting(&meeting).unwrap();
+
+    // The app's own read path resolves the same speakers list.
+    let loaded = app_db.load_meeting("contract-speakers").unwrap();
+    assert_eq!(loaded.speakers.len(), 2);
+    drop(app_db);
+
+    let sidecar = McpDb::open(&db_path).unwrap();
+    let detail = sidecar
+        .get_meeting("contract-speakers", IncludeSet::all())
+        .unwrap();
+
+    assert_eq!(
+        detail.speakers.iter().map(|s| s.id).collect::<Vec<_>>(),
+        vec![alice_id, bob_id]
+    );
+    assert_eq!(detail.speakers[0].name, "Alice Martin");
+    assert_eq!(detail.speakers[1].name, "Bob Chen");
+
+    let transcript = detail.transcript.unwrap();
+    assert!(transcript.contains("Alice Martin: Hello from the contract test meeting."));
+    assert!(transcript.contains("Bob Chen: This checks schema drift end to end."));
 }
 
 #[test]

--- a/src/lib/features/home/LiveSessionCard.svelte
+++ b/src/lib/features/home/LiveSessionCard.svelte
@@ -7,6 +7,7 @@
   import MeetingNotesSection from "../meeting/components/MeetingNotesSection.svelte";
   import type { createMeetingController } from "../meeting/controller.svelte";
   import type { createTranscriptionController } from "../transcription/controller.svelte";
+  import { resolveSpeakerLabel } from "../../utils";
 
   let {
     mode,
@@ -17,6 +18,12 @@
     transcription: ReturnType<typeof createTranscriptionController>;
     meeting: ReturnType<typeof createMeetingController>;
   } = $props();
+
+  // Live paragraphs only ever tag Me/Them today (persistent speaker
+  // identities aren't wired into the live pipeline yet), but resolve
+  // through the same helper as the finished transcript view for consistency
+  // and forward-compatibility.
+  const liveSpeakers = $derived(meeting.meeting?.speakers ?? []);
 
   /** Only the most recent paragraphs stay in the DOM; older ones are still in
    * `meeting.liveTranscript.committed` but are never rendered live. */
@@ -191,14 +198,21 @@
           <span class="text-sm text-text-muted">{$t("home.listening")}</span>
         {:else}
           {#each liveParagraphs as paragraph, i (paragraph.id)}
+            {@const label = resolveSpeakerLabel(paragraph.speaker, liveSpeakers)}
             <div class="flex flex-col gap-[3px]" style="animation: rise-in 240ms ease;">
               <div class="flex items-center gap-2">
-                {#if paragraph.speaker}
+                {#if label}
                   <span
                     class="text-[11.5px] font-semibold"
-                    class:text-accent={paragraph.speaker === "me"}
-                    class:text-secondary={paragraph.speaker === "them"}
-                  >{paragraph.speaker === "me" ? $t("transcript.me") : $t("transcript.them")}</span>
+                    class:text-accent={label.kind === "me"}
+                    class:text-secondary={label.kind === "them"}
+                  >{label.kind === "me"
+                    ? $t("transcript.me")
+                    : label.kind === "them"
+                      ? $t("transcript.them")
+                      : label.kind === "named"
+                        ? label.name
+                        : $t("transcript.speaker_fallback", { values: { id: label.id } })}</span>
                 {/if}
                 <span class="font-mono text-[10.5px] text-text-faint">{paragraph.timestamp}</span>
               </div>

--- a/src/lib/features/meeting/components/MeetingDetail.svelte
+++ b/src/lib/features/meeting/components/MeetingDetail.svelte
@@ -83,6 +83,7 @@
       recordingSessions={controller.meeting.recording_sessions}
       liveSessionStartIndex={liveSessionStartIndex}
       isRecordingMeeting={controller.isRecordingMeeting}
+      speakers={controller.meeting.speakers}
       hasEditedTranscript={controller.meeting.edited_transcript != null}
       isEditing={controller.isEditingTranscript}
       editedTranscriptDraft={controller.editedTranscriptDraft}

--- a/src/lib/features/meeting/components/MeetingTranscriptSection.svelte
+++ b/src/lib/features/meeting/components/MeetingTranscriptSection.svelte
@@ -2,14 +2,15 @@
   import { Pencil, RotateCcw } from "@lucide/svelte";
   import { t } from "svelte-i18n";
   import CopyButton from "../../../components/ui/CopyButton.svelte";
-  import type { MeetingRecordingSession, TranscriptionSegment } from "../../../types";
-  import { buildMeetingTranscriptBlocks } from "../../../utils";
+  import type { MeetingRecordingSession, MeetingSpeaker, Speaker, TranscriptionSegment } from "../../../types";
+  import { buildMeetingTranscriptBlocks, resolveSpeakerLabel, speakerPlainLabel } from "../../../utils";
 
   let {
     segments,
     recordingSessions,
     liveSessionStartIndex,
     isRecordingMeeting,
+    speakers = [],
     hasEditedTranscript = false,
     isEditing = false,
     editedTranscriptDraft = "",
@@ -25,6 +26,9 @@
     recordingSessions: MeetingRecordingSession[];
     liveSessionStartIndex: number | null;
     isRecordingMeeting: boolean;
+    /** Persistent speakers referenced by this meeting, for resolving
+     * `spk:<id>` labels to a display name; empty for Me/Them-only meetings. */
+    speakers?: MeetingSpeaker[];
     hasEditedTranscript?: boolean;
     isEditing?: boolean;
     editedTranscriptDraft?: string;
@@ -50,11 +54,16 @@
     if (isRecordingMeeting) return "recording_empty";
     return "empty";
   });
+  function copyLinePrefix(speaker: Speaker | null | undefined): string {
+    const label = speakerPlainLabel(speaker, speakers);
+    return label ? `${label} ` : "";
+  }
+
   let copyText = $derived(
     transcriptBlocks
       .map((block) =>
         block.type === "paragraph"
-          ? `${block.speaker ? (block.speaker === "me" ? "Me" : "Them") + " " : ""}[${block.timestamp}] ${block.text}`
+          ? `${copyLinePrefix(block.speaker)}[${block.timestamp}] ${block.text}`
           : `--- ${block.endLabel} ---\n--- ${block.startLabel} ---`,
       )
       .join("\n\n"),
@@ -124,14 +133,21 @@
       {#if phase === "has_content"}
         {#each transcriptBlocks as block}
           {#if block.type === "paragraph"}
+            {@const label = resolveSpeakerLabel(block.speaker, speakers)}
             <div class="flex flex-col gap-[3px]">
               <div class="flex items-center gap-2">
-                {#if block.speaker}
+                {#if label}
                   <span
                     class="text-[11.5px] font-semibold"
-                    class:text-accent={block.speaker === "me"}
-                    class:text-secondary={block.speaker === "them"}
-                  >{block.speaker === "me" ? $t("transcript.me") : $t("transcript.them")}</span>
+                    class:text-accent={label.kind === "me"}
+                    class:text-secondary={label.kind === "them"}
+                  >{label.kind === "me"
+                    ? $t("transcript.me")
+                    : label.kind === "them"
+                      ? $t("transcript.them")
+                      : label.kind === "named"
+                        ? label.name
+                        : $t("transcript.speaker_fallback", { values: { id: label.id } })}</span>
                 {/if}
                 {#if onParagraphClick}
                   <button

--- a/src/lib/features/meeting/controller.svelte.test.ts
+++ b/src/lib/features/meeting/controller.svelte.test.ts
@@ -152,6 +152,7 @@ function makeMeeting(overrides: Partial<MeetingTranscript> = {}): MeetingTranscr
     notes: null,
     calendar_event_id: null,
     participants: [],
+    speakers: [],
     ...overrides,
   };
 }

--- a/src/lib/features/meeting/controller.svelte.ts
+++ b/src/lib/features/meeting/controller.svelte.ts
@@ -288,6 +288,7 @@ function createMeetingControllerInstance() {
         notes: null,
         calendar_event_id: calendar?.event_id ?? null,
         participants: calendar?.participants ?? [],
+        speakers: [],
       };
     } catch (e) {
       statusMessage = errorMessage(e);

--- a/src/lib/features/meeting/live-transcript.svelte.test.ts
+++ b/src/lib/features/meeting/live-transcript.svelte.test.ts
@@ -68,6 +68,22 @@ describe("createLiveTranscript equivalence", () => {
     expect(all).toEqual(groupIntoParagraphs(segments, PAUSE_THRESHOLD));
   });
 
+  it("matches batch grouping for three interleaved persistent speakers", () => {
+    // Same "arrive slightly interleaved, sorted by start_time" shape as the
+    // two-speaker case above, but with three persistent speaker ids
+    // (spk:1/spk:2/spk:3) instead of just me/them.
+    const segments = [
+      dseg("hi everyone", 0, "spk:1"),
+      dseg("hello", 2.1, "spk:2"),
+      dseg("morning", 2.15, "spk:3"),
+      dseg("how's it going", 4.3, "spk:1"),
+      dseg("good thanks", 4.35, "spk:2"),
+      dseg("same here", 6.5, "spk:3"),
+    ];
+    const { all } = runStream(segments);
+    expect(all).toEqual(groupIntoParagraphs(segments, PAUSE_THRESHOLD));
+  });
+
   it("matches batch grouping for a long unpunctuated stream (hard length cap)", () => {
     const segments = Array.from({ length: 300 }, (_, i) => seg(`word${i}`, i * 0.1));
     const { all } = runStream(segments);

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -233,7 +233,8 @@
   },
   "transcript": {
     "me": "Me",
-    "them": "Them"
+    "them": "Them",
+    "speaker_fallback": "Speaker {id}"
   },
   "meeting_audio": {
     "play": "Play",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -233,7 +233,8 @@
   },
   "transcript": {
     "me": "Moi",
-    "them": "Eux"
+    "them": "Eux",
+    "speaker_fallback": "Intervenant {id}"
   },
   "meeting_audio": {
     "play": "Lecture",

--- a/src/lib/test-helpers/fixtures.ts
+++ b/src/lib/test-helpers/fixtures.ts
@@ -152,6 +152,7 @@ export const mockMeeting: MeetingTranscript = {
   notes: null,
   calendar_event_id: null,
   participants: [],
+  speakers: [],
 };
 
 export const mockMeetingList: MeetingListItem[] = [

--- a/src/lib/test-helpers/paragraph-grouping.fixture.json
+++ b/src/lib/test-helpers/paragraph-grouping.fixture.json
@@ -305,6 +305,161 @@
           "speaker": null
         }
       ]
+    },
+    {
+      "name": "three_speakers_round_robin",
+      "segments": [
+        {
+          "text": "Hello everyone.",
+          "start_time": 0.0,
+          "end_time": 1.0,
+          "speaker": "spk:1"
+        },
+        {
+          "text": "Hi there.",
+          "start_time": 3.0,
+          "end_time": 4.0,
+          "speaker": "spk:2"
+        },
+        {
+          "text": "Good morning.",
+          "start_time": 6.0,
+          "end_time": 7.0,
+          "speaker": "spk:3"
+        },
+        {
+          "text": "Let's begin.",
+          "start_time": 9.0,
+          "end_time": 10.0,
+          "speaker": "spk:1"
+        }
+      ],
+      "expected": [
+        {
+          "timestamp": "0:00",
+          "text": "Hello everyone.",
+          "speaker": "spk:1"
+        },
+        {
+          "timestamp": "0:03",
+          "text": "Hi there.",
+          "speaker": "spk:2"
+        },
+        {
+          "timestamp": "0:06",
+          "text": "Good morning.",
+          "speaker": "spk:3"
+        },
+        {
+          "timestamp": "0:09",
+          "text": "Let's begin.",
+          "speaker": "spk:1"
+        }
+      ]
+    },
+    {
+      "name": "three_speakers_crosstalk_and_interjection",
+      "segments": [
+        {
+          "text": "hello",
+          "start_time": 0.0,
+          "end_time": 0.3,
+          "speaker": "spk:1"
+        },
+        {
+          "text": "hi",
+          "start_time": 0.15,
+          "end_time": 0.35,
+          "speaker": "spk:2"
+        },
+        {
+          "text": "how",
+          "start_time": 0.5,
+          "end_time": 0.7,
+          "speaker": "spk:1"
+        },
+        {
+          "text": "good",
+          "start_time": 0.6,
+          "end_time": 0.8,
+          "speaker": "spk:2"
+        },
+        {
+          "text": "are",
+          "start_time": 0.9,
+          "end_time": 1.1,
+          "speaker": "spk:1"
+        },
+        {
+          "text": "thanks",
+          "start_time": 1.0,
+          "end_time": 1.2,
+          "speaker": "spk:2"
+        },
+        {
+          "text": "you",
+          "start_time": 1.3,
+          "end_time": 1.5,
+          "speaker": "spk:1"
+        },
+        {
+          "text": "Let me explain the whole plan",
+          "start_time": 5.0,
+          "end_time": 5.5,
+          "speaker": "spk:1"
+        },
+        {
+          "text": "in detail because it's",
+          "start_time": 5.6,
+          "end_time": 6.1,
+          "speaker": "spk:1"
+        },
+        {
+          "text": "wait",
+          "start_time": 6.2,
+          "end_time": 6.7,
+          "speaker": "spk:3"
+        },
+        {
+          "text": "complicated.",
+          "start_time": 6.8,
+          "end_time": 7.3,
+          "speaker": "spk:1"
+        },
+        {
+          "text": "So let's start now",
+          "start_time": 8.0,
+          "end_time": 8.5,
+          "speaker": "spk:1"
+        }
+      ],
+      "expected": [
+        {
+          "timestamp": "0:00",
+          "text": "hello how are you",
+          "speaker": "spk:1"
+        },
+        {
+          "timestamp": "0:00",
+          "text": "hi good thanks",
+          "speaker": "spk:2"
+        },
+        {
+          "timestamp": "0:05",
+          "text": "Let me explain the whole plan in detail because it's complicated.",
+          "speaker": "spk:1"
+        },
+        {
+          "timestamp": "0:06",
+          "text": "wait",
+          "speaker": "spk:3"
+        },
+        {
+          "timestamp": "0:08",
+          "text": "So let's start now",
+          "speaker": "spk:1"
+        }
+      ]
     }
   ]
 }

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -1119,6 +1119,14 @@ export type MeetingListItem = { id: string; title: string; started_at: string; d
 export type MeetingParticipant = { name: string; email: string | null; is_organizer: boolean; is_current_user: boolean }
 export type MeetingRecordingSession = { id: string; started_at: string; ended_at: string; duration_seconds: number; start_segment_index: number; end_segment_index: number }
 /**
+ * A persistent speaker referenced by a meeting's segments, resolved for
+ * display. Computed at read time from the `speakers` table joined against
+ * the distinct `spk:<id>` labels in the meeting's segments, not itself
+ * persisted on the meeting row. Empty for meetings with only Me/Them
+ * segments (or no diarization at all).
+ */
+export type MeetingSpeaker = { id: number; name: string }
+/**
  * Emitted by the floating recording pill (or the tray) to ask the meeting
  * controller in the main window to stop the active meeting through its
  * normal stop pipeline.
@@ -1141,7 +1149,13 @@ calendar_event_id: string | null;
  * Attendees captured from the calendar event; shown in the UI and fed
  * into the summary prompt.
  */
-participants: MeetingParticipant[] }
+participants: MeetingParticipant[]; 
+/**
+ * Persistent speakers referenced by this meeting's segments, for
+ * resolving `Speaker::Persistent(id)` labels to a display name. Computed
+ * at read time (see `MeetingSpeaker`); empty for Me/Them-only meetings.
+ */
+speakers: MeetingSpeaker[] }
 export type ModelArtifactDescriptor = { id: string; label: string; description: string; provider: string; repository: string; revision: string | null; file_format: string; download_size_bytes: number | null; required_files: string[] }
 export type Navigate = AppView
 export type PasteMethod = "clipboard" | "type"
@@ -1197,12 +1211,6 @@ export type ShortcutPttStart = null
 export type ShortcutPttStop = null
 export type ShortcutSettings = { toggle: string; push_to_talk: string }
 export type ShortcutToggle = null
-/**
- * Who produced a segment in a diarized meeting: the microphone is the local
- * user (Me), system audio is everyone else (Them). `None` = single-stream
- * session (dictation, or a meeting recorded without diarization).
- */
-export type Speaker = "me" | "them"
 export type StateChanged = AppStateMachine
 /**
  * A single action item extracted from a meeting summary pass.
@@ -1315,7 +1323,7 @@ export type TranscriptionSegment = { text: string; start_time: number; end_time:
 /**
  * Set by the pipeline for diarized meetings; `None` otherwise.
  */
-speaker?: Speaker | null }
+speaker?: string | null }
 /**
  * Emitted by the calendar reminder scheduler shortly before a calendar
  * event starts, so the frontend can offer a one-click transcription start.

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -29,6 +29,7 @@ export type {
   MeetingListItem,
   MeetingParticipant,
   MeetingRecordingSession,
+  MeetingSpeaker,
   MeetingTranscript,
   ModelArtifactDescriptor,
   SummaryModelDescriptor,
@@ -41,7 +42,6 @@ export type {
   PillHoldKind,
   RecordingKind,
   ShortcutSettings,
-  Speaker,
   SummarizeProgress,
   Theme,
   TodayCalendar,
@@ -64,3 +64,12 @@ export type {
   SearchResult,
   UpdateCheckResult,
 } from "./generated";
+
+/** Who produced a transcript segment: "me", "them", or a persistent
+ * cross-meeting speaker identity encoded as `spk:<id>`. Backend wire format
+ * (see `engine::Speaker` in Rust); specta emits it as a plain `string`
+ * rather than a named union so the `spk:<id>` case doesn't need a literal
+ * type per id. Compare with `===` and use as a `Record` key like any string;
+ * resolve a persistent id's display name via a meeting's `speakers` list
+ * (see `resolveSpeakerLabel` in `../utils/speaker-label`). */
+export type Speaker = string;

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -5,3 +5,5 @@ export type { Paragraph, TranscriptBlock } from "./paragraphs";
 export { errorMessage } from "./errors";
 export { createDebouncedSearch, filterResultsByType, findSnippet, matchedIdsForType } from "./search.svelte";
 export type { DebouncedSearch } from "./search.svelte";
+export { resolveSpeakerLabel, speakerPlainLabel } from "./speaker-label";
+export type { SpeakerLabel } from "./speaker-label";

--- a/src/lib/utils/speaker-label.test.ts
+++ b/src/lib/utils/speaker-label.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { resolveSpeakerLabel, speakerPlainLabel } from "./speaker-label";
+import type { MeetingSpeaker } from "../types";
+
+const speakers: MeetingSpeaker[] = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+];
+
+describe("resolveSpeakerLabel", () => {
+  it("returns null for no speaker", () => {
+    expect(resolveSpeakerLabel(null, speakers)).toBeNull();
+    expect(resolveSpeakerLabel(undefined, speakers)).toBeNull();
+  });
+
+  it("resolves me and them", () => {
+    expect(resolveSpeakerLabel("me", speakers)).toEqual({ kind: "me" });
+    expect(resolveSpeakerLabel("them", speakers)).toEqual({ kind: "them" });
+  });
+
+  it("resolves a persistent speaker id to its name", () => {
+    expect(resolveSpeakerLabel("spk:1", speakers)).toEqual({ kind: "named", name: "Alice" });
+    expect(resolveSpeakerLabel("spk:2", speakers)).toEqual({ kind: "named", name: "Bob" });
+  });
+
+  it("falls back to unknown when the id isn't in the speakers list", () => {
+    expect(resolveSpeakerLabel("spk:99", speakers)).toEqual({ kind: "unknown", id: 99 });
+    expect(resolveSpeakerLabel("spk:1", [])).toEqual({ kind: "unknown", id: 1 });
+  });
+
+  it("returns null for a malformed label", () => {
+    expect(resolveSpeakerLabel("garbage", speakers)).toBeNull();
+    expect(resolveSpeakerLabel("spk:abc", speakers)).toBeNull();
+  });
+});
+
+describe("speakerPlainLabel", () => {
+  it("mirrors the Rust exporters' Me/Them/name/Speaker <id> convention", () => {
+    expect(speakerPlainLabel("me", speakers)).toBe("Me");
+    expect(speakerPlainLabel("them", speakers)).toBe("Them");
+    expect(speakerPlainLabel("spk:1", speakers)).toBe("Alice");
+    expect(speakerPlainLabel("spk:99", speakers)).toBe("Speaker 99");
+    expect(speakerPlainLabel(null, speakers)).toBeNull();
+  });
+});

--- a/src/lib/utils/speaker-label.ts
+++ b/src/lib/utils/speaker-label.ts
@@ -1,0 +1,52 @@
+import type { MeetingSpeaker, Speaker } from "../types";
+
+/** Parsed result of a speaker label: the fixed "me"/"them" cases, a
+ * persistent speaker resolved to its display name, or a persistent speaker
+ * whose id isn't (or is no longer) in the meeting's `speakers` list. */
+export type SpeakerLabel =
+  | { kind: "me" }
+  | { kind: "them" }
+  | { kind: "named"; name: string }
+  | { kind: "unknown"; id: number };
+
+const PERSISTENT_ID = /^spk:(\d+)$/;
+
+/** Resolve a segment/paragraph's `speaker` value against a meeting's
+ * `speakers` list. `null`/`undefined` (no diarization) and a malformed
+ * label both resolve to `null` — callers should just not render a badge. */
+export function resolveSpeakerLabel(
+  speaker: Speaker | null | undefined,
+  speakers: MeetingSpeaker[],
+): SpeakerLabel | null {
+  if (speaker == null) return null;
+  if (speaker === "me") return { kind: "me" };
+  if (speaker === "them") return { kind: "them" };
+
+  const match = PERSISTENT_ID.exec(speaker);
+  if (!match) return null;
+  const id = Number(match[1]);
+  const found = speakers.find((s) => s.id === id);
+  return found ? { kind: "named", name: found.name } : { kind: "unknown", id };
+}
+
+/** Plain (non-localized) display label, matching the Rust exporters' "Me"/
+ * "Them"/name/"Speaker <id>" convention. For UI text that goes through
+ * i18n (svelte-i18n's `$t`), branch on `resolveSpeakerLabel`'s `kind`
+ * instead so "me"/"them" get translated. */
+export function speakerPlainLabel(
+  speaker: Speaker | null | undefined,
+  speakers: MeetingSpeaker[],
+): string | null {
+  const label = resolveSpeakerLabel(speaker, speakers);
+  if (!label) return null;
+  switch (label.kind) {
+    case "me":
+      return "Me";
+    case "them":
+      return "Them";
+    case "named":
+      return label.name;
+    case "unknown":
+      return `Speaker ${label.id}`;
+  }
+}


### PR DESCRIPTION
Groundwork for multi-speaker diarization: transcript segments can now be labeled with a persistent, cross-meeting speaker identity in addition to Me/Them, with zero behavior change for existing data.

- Schema v12 adds a `speakers` table (name, embedding centroid blob, counters) with CRUD helpers and migration tests.
- `Speaker` gains a `Persistent(i64)` variant; the wire and DB format stays a plain string ("me", "them", "spk:<id>") via hand-written serde and specta impls, so the generated TypeScript type is a plain string and existing comparisons keep working.
- Meeting transcript DTOs (app and MCP sidecar) now carry a `speakers` list resolving ids to names; display falls back to "Speaker <id>" for missing rows. The sidecar contract test covers the round trip.
- The turn-clustering paragraph grouping is generalized from two hardcoded open-turn slots to per-speaker tracking in the Rust exporters and MCP sidecar; the TypeScript implementation was already speaker-agnostic and is unchanged. Two new cross-language fixture cases pin three-speaker round-robin and crosstalk-with-interjection behavior; all existing cases pass unchanged.
- Frontend renders resolved speaker names wherever Me/Them appeared (live card, meeting detail, exports), with i18n for the fixed labels.

Gates: full Rust workspace tests, clippy -D warnings, 233 frontend tests, svelte-check, build, Playwright e2e, regenerated bindings.