### PR TITLE
Add timeouts and recovery to Apple Intelligence summarization

### DIFF
--- a/src-tauri/src/summary/apple.rs
+++ b/src-tauri/src/summary/apple.rs
@@ -1,3 +1,6 @@
+use std::sync::mpsc;
+use std::time::Duration;
+
 use crate::apple_intelligence;
 use crate::constants::{
     OLLAMA_DICTATION_POLISH_PROMPT, OLLAMA_MAP_PROMPT, OLLAMA_MERGE_PROMPT,
@@ -9,10 +12,251 @@ pub const MERGE_SYSTEM_PROMPT: &str = OLLAMA_MERGE_PROMPT;
 pub const STRUCTURED_EXTRACT_SYSTEM_PROMPT: &str = OLLAMA_STRUCTURED_EXTRACT_PROMPT;
 pub const DICTATION_POLISH_SYSTEM_PROMPT: &str = OLLAMA_DICTATION_POLISH_PROMPT;
 
+/// Hard wall-clock budget for ONE FoundationModels request. The FFI call is
+/// blocking and non-cancellable from Rust, so each request runs on its own
+/// thread and the caller stops waiting after this long. The Swift bridge
+/// enforces its own shorter timeout (see swift/apple_intelligence.swift) so
+/// the request thread normally exits on its own; this is the backstop for a
+/// bridge that wedges before even reaching its semaphore wait.
+pub const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Pause before the single retry of a failed (non-timeout) request, so a
+/// transient condition such as `rate_limited` has a chance to clear.
+pub const RETRY_BACKOFF: Duration = Duration::from_secs(2);
+
+/// Attempts per request: the original call plus one retry.
+pub const MAX_ATTEMPTS: u32 = 2;
+
+// Stable machine-readable markers produced by the Swift bridge
+// (classifyGenerationError in swift/apple_intelligence.swift).
+const CONTEXT_OVERFLOW_MARKER: &str = "exceeded_context_window";
+const GUARDRAIL_MARKER: &str = "guardrail_violation";
+const UNSUPPORTED_LANGUAGE_MARKER: &str = "unsupported_language";
+
 pub fn validate_availability() -> Result<(), String> {
     if apple_intelligence::check_apple_intelligence_availability() {
         Ok(())
     } else {
         Err("Apple Intelligence is not available on this device.".into())
+    }
+}
+
+/// True when the provider rejected the request because the prompt exceeded
+/// the FoundationModels context window. The reduce tree treats this as a
+/// signal that the token estimate undershot the real tokenizer and re-batches
+/// with a smaller budget instead of retrying the same oversized prompt.
+pub(crate) fn is_context_overflow(error: &str) -> bool {
+    error.contains(CONTEXT_OVERFLOW_MARKER)
+}
+
+/// Deterministic failures repeat on an identical retry; everything else
+/// (timeouts, rate limiting, transient model/asset hiccups) gets one retry.
+fn is_retryable(error: &str) -> bool {
+    !(error.contains(GUARDRAIL_MARKER)
+        || error.contains(UNSUPPORTED_LANGUAGE_MARKER)
+        || is_context_overflow(error))
+}
+
+enum AttemptOutcome {
+    Completed(Result<String, String>),
+    TimedOut,
+}
+
+/// Run one blocking call on a dedicated thread and wait at most `timeout`.
+///
+/// On timeout the thread is abandoned: it keeps running (one leaked thread
+/// plus one in-flight FoundationModels request) until the call returns, then
+/// its `send` fails against the dropped receiver and it exits. The handoff is
+/// channel-owned and the closure captures only its own data, so an abandoned
+/// call can never touch shared state.
+fn run_attempt<F>(call: F, timeout: Duration) -> AttemptOutcome
+where
+    F: FnOnce() -> Result<String, String> + Send + 'static,
+{
+    let (tx, rx) = mpsc::channel();
+    let spawned = std::thread::Builder::new()
+        .name("apple-ai-request".into())
+        .spawn(move || {
+            let _ = tx.send(call());
+        });
+    if spawned.is_err() {
+        return AttemptOutcome::Completed(Err(
+            "Failed to spawn Apple Intelligence request thread".into()
+        ));
+    }
+    match rx.recv_timeout(timeout) {
+        Ok(result) => AttemptOutcome::Completed(result),
+        Err(_) => AttemptOutcome::TimedOut,
+    }
+}
+
+/// Run one FoundationModels request with a hard timeout and a single retry.
+///
+/// `make_attempt` builds a fresh blocking call per attempt (the closure moves
+/// onto the attempt thread, so a retry needs its own copy). Retryable
+/// failures and timeouts are attempted `MAX_ATTEMPTS` times in total; the
+/// last error is returned so the pipeline fails cleanly instead of hanging.
+pub(crate) fn generate_guarded<C, F>(
+    mut make_attempt: C,
+    timeout: Duration,
+    retry_backoff: Duration,
+) -> Result<String, String>
+where
+    C: FnMut() -> F,
+    F: FnOnce() -> Result<String, String> + Send + 'static,
+{
+    let mut last_error = String::new();
+    for attempt in 1..=MAX_ATTEMPTS {
+        match run_attempt(make_attempt(), timeout) {
+            AttemptOutcome::Completed(Ok(text)) => return Ok(text),
+            AttemptOutcome::Completed(Err(error)) => {
+                if !is_retryable(&error) {
+                    return Err(error);
+                }
+                tracing::warn!(attempt, error = %error, "Apple Intelligence request failed");
+                last_error = error;
+                if attempt < MAX_ATTEMPTS && !retry_backoff.is_zero() {
+                    std::thread::sleep(retry_backoff);
+                }
+            }
+            AttemptOutcome::TimedOut => {
+                tracing::warn!(
+                    attempt,
+                    timeout_secs = timeout.as_secs(),
+                    "Apple Intelligence request timed out; request thread abandoned"
+                );
+                last_error = format!(
+                    "Apple Intelligence request timed out after {}s",
+                    timeout.as_secs()
+                );
+                // No backoff after a timeout: the wall-clock budget is spent.
+            }
+        }
+    }
+    Err(last_error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{generate_guarded, is_context_overflow, is_retryable};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Duration;
+
+    const SHORT_TIMEOUT: Duration = Duration::from_millis(50);
+    const NO_BACKOFF: Duration = Duration::ZERO;
+
+    #[test]
+    fn success_propagates_on_first_attempt() {
+        let attempts = Arc::new(AtomicU32::new(0));
+        let counter = attempts.clone();
+        let result = generate_guarded(
+            move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                || Ok("summary".to_string())
+            },
+            SHORT_TIMEOUT,
+            NO_BACKOFF,
+        );
+        assert_eq!(result.as_deref(), Ok("summary"));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn timeout_then_success_retries_once_and_discards_late_result() {
+        let attempts = Arc::new(AtomicU32::new(0));
+        let counter = attempts.clone();
+        let result = generate_guarded(
+            move || {
+                let attempt = counter.fetch_add(1, Ordering::SeqCst) + 1;
+                move || {
+                    if attempt == 1 {
+                        // Outlives the timeout: the late Ok must be discarded
+                        // (its channel receiver is gone) and never returned.
+                        std::thread::sleep(Duration::from_millis(200));
+                        Ok("late result from abandoned thread".to_string())
+                    } else {
+                        Ok("fresh result".to_string())
+                    }
+                }
+            },
+            SHORT_TIMEOUT,
+            NO_BACKOFF,
+        );
+        assert_eq!(result.as_deref(), Ok("fresh result"));
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        // Let the abandoned thread finish its doomed send; nothing to assert
+        // beyond not panicking or corrupting the returned value.
+        std::thread::sleep(Duration::from_millis(250));
+    }
+
+    #[test]
+    fn two_timeouts_fail_with_timeout_error() {
+        let attempts = Arc::new(AtomicU32::new(0));
+        let counter = attempts.clone();
+        let result = generate_guarded(
+            move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                || {
+                    std::thread::sleep(Duration::from_millis(200));
+                    Ok("never delivered".to_string())
+                }
+            },
+            SHORT_TIMEOUT,
+            NO_BACKOFF,
+        );
+        let error = result.unwrap_err();
+        assert!(error.contains("timed out"), "unexpected error: {error}");
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        std::thread::sleep(Duration::from_millis(400));
+    }
+
+    #[test]
+    fn transient_error_retries_then_fails_with_last_error() {
+        let attempts = Arc::new(AtomicU32::new(0));
+        let counter = attempts.clone();
+        let result = generate_guarded(
+            move || {
+                counter.fetch_add(1, Ordering::SeqCst);
+                || Err("rate_limited: system is busy".to_string())
+            },
+            SHORT_TIMEOUT,
+            NO_BACKOFF,
+        );
+        assert_eq!(result.unwrap_err(), "rate_limited: system is busy");
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn non_retryable_error_fails_on_first_attempt() {
+        for marker in [
+            "guardrail_violation: safety filter",
+            "unsupported_language: locale",
+            "exceeded_context_window: 4096 tokens",
+        ] {
+            let attempts = Arc::new(AtomicU32::new(0));
+            let counter = attempts.clone();
+            let result = generate_guarded(
+                move || {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    move || Err(marker.to_string())
+                },
+                SHORT_TIMEOUT,
+                NO_BACKOFF,
+            );
+            assert_eq!(result.unwrap_err(), marker);
+            assert_eq!(attempts.load(Ordering::SeqCst), 1, "marker: {marker}");
+        }
+    }
+
+    #[test]
+    fn error_classification_markers() {
+        assert!(is_context_overflow("exceeded_context_window: too big"));
+        assert!(!is_context_overflow("rate_limited: busy"));
+        assert!(is_retryable("request_timeout: no answer in 100s"));
+        assert!(is_retryable("rate_limited: busy"));
+        assert!(is_retryable("some opaque transient failure"));
+        assert!(!is_retryable("guardrail_violation: refused"));
+        assert!(!is_retryable("exceeded_context_window: too big"));
     }
 }

--- a/src-tauri/src/summary/mod.rs
+++ b/src-tauri/src/summary/mod.rs
@@ -268,8 +268,22 @@ pub(crate) async fn generate_with_provider(
         }
         SummaryProviderKind::AppleIntelligence => {
             let system = system.to_string();
+            // Guarded call: dedicated thread per attempt, hard wall-clock
+            // timeout, one retry (see apple::generate_guarded). Without it a
+            // wedged FoundationModels request blocks this future forever and
+            // the summarize command never resolves.
             let full = tokio::task::spawn_blocking(move || {
-                apple_intelligence::process_text_with_system_prompt(&system, &prompt, 0)
+                apple::generate_guarded(
+                    || {
+                        let system = system.clone();
+                        let prompt = prompt.clone();
+                        move || {
+                            apple_intelligence::process_text_with_system_prompt(&system, &prompt, 0)
+                        }
+                    },
+                    apple::REQUEST_TIMEOUT,
+                    apple::RETRY_BACKOFF,
+                )
             })
             .await
             .map_err(|e| format!("Apple Intelligence task: {e}"))??;
@@ -521,24 +535,40 @@ where
     G: FnMut(bool, String) -> Fut,
     Fut: std::future::Future<Output = Result<String, String>>,
 {
-    if skip_initial_fit_check
-        || reduce::reduce_prompt_fits(part_summaries, notes, participants, reduce_token_limit)
-    {
-        return generate(true, build_reduce_prompt(part_summaries, notes, participants)).await;
-    }
+    let mut token_limit = reduce_token_limit;
+    // The token budget is an ESTIMATE (estimate_tokens); the real
+    // FoundationModels tokenizer can exceed it and reject a prompt with a
+    // context-overflow error even though the fit check passed. One structural
+    // recovery is allowed per reduce: halve the budget and re-batch. Ollama
+    // never emits the overflow marker, so its path is unaffected.
+    let mut overflow_shrink_available = !skip_initial_fit_check;
 
     let mut current: Vec<String> = part_summaries.to_vec();
-    loop {
-        if reduce::reduce_prompt_fits(&current, notes, participants, reduce_token_limit) {
-            return generate(true, build_reduce_prompt(&current, notes, participants)).await;
+    'rounds: loop {
+        if skip_initial_fit_check
+            || reduce::reduce_prompt_fits(&current, notes, participants, token_limit)
+        {
+            match generate(true, build_reduce_prompt(&current, notes, participants)).await {
+                Ok(text) => return Ok(text),
+                Err(error)
+                    if overflow_shrink_available
+                        && current.len() > 1
+                        && apple::is_context_overflow(&error) =>
+                {
+                    overflow_shrink_available = false;
+                    token_limit /= 2;
+                    continue 'rounds;
+                }
+                Err(error) => return Err(error),
+            }
         }
 
-        let batches = reduce::partition_for_reduce(&current, reduce_token_limit)?;
+        let batches = reduce::partition_for_reduce(&current, token_limit)?;
         if batches.len() == 1 && batches[0].len() == current.len() {
             let tokens = estimate_tokens(&build_reduce_prompt(&current, None, &[]));
             return Err(format!(
                 "Meeting summary is too large for Apple Intelligence after batching \
-                 ({tokens} estimated tokens, limit {reduce_token_limit}). Use Ollama for very long meetings."
+                 ({tokens} estimated tokens, limit {token_limit}). Use Ollama for very long meetings."
             ));
         }
 
@@ -546,8 +576,20 @@ where
         let mut next = Vec::with_capacity(batches.len());
         for (i, batch) in batches.into_iter().enumerate() {
             on_batch_start(i as u32 + 1, total_batches);
-            let merged = generate(false, build_reduce_prompt(&batch, None, &[])).await?;
-            next.push(merged);
+            match generate(false, build_reduce_prompt(&batch, None, &[])).await {
+                Ok(merged) => next.push(merged),
+                Err(error)
+                    if overflow_shrink_available && apple::is_context_overflow(&error) =>
+                {
+                    // Redo the whole round with the tighter budget; merges
+                    // already done this round are discarded, which is the
+                    // price of a one-time recovery.
+                    overflow_shrink_available = false;
+                    token_limit /= 2;
+                    continue 'rounds;
+                }
+                Err(error) => return Err(error),
+            }
         }
         current = next;
     }
@@ -782,6 +824,108 @@ mod tests {
 
         assert_eq!(final_calls.get(), 1);
         assert_eq!(result.matches("## Summary").count(), 1);
+    }
+
+    // --- Context-overflow recovery ---------------------------------------
+
+    /// Parts sized so the reduce prompt fits the full Apple budget (3200)
+    /// but not half of it: after one overflow shrink the tree must re-batch
+    /// instead of retrying the same oversized final prompt.
+    fn overflow_test_parts() -> Vec<String> {
+        (1..=6)
+            .map(|i| format!("Part {i}: {}", "decision topic detail ".repeat(80)))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn run_reduce_tree_shrinks_budget_once_on_context_overflow() {
+        let parts = overflow_test_parts();
+        let limit = ChunkConfig::APPLE_INTELLIGENCE.reduce_token_limit;
+        // Sanity: fits the full budget, does not fit half of it.
+        assert!(super::reduce::reduce_prompt_fits(&parts, None, &[], limit));
+        assert!(!super::reduce::reduce_prompt_fits(&parts, None, &[], limit / 2));
+
+        let final_calls = std::cell::Cell::new(0u32);
+        let merge_calls = std::cell::Cell::new(0u32);
+
+        let result = run_reduce_tree(
+            &parts,
+            None,
+            &[],
+            limit,
+            false,
+            &|_current, _total| {},
+            |is_final, _prompt| {
+                if is_final {
+                    final_calls.set(final_calls.get() + 1);
+                } else {
+                    merge_calls.set(merge_calls.get() + 1);
+                }
+                let first_final = is_final && final_calls.get() == 1;
+                async move {
+                    if first_final {
+                        // The estimate said it fits; the real tokenizer says no.
+                        Err("exceeded_context_window: prompt exceeds 4096 tokens".to_string())
+                    } else if is_final {
+                        Ok("## Summary\n- recovered\n".to_string())
+                    } else {
+                        Ok("- merged note\n".to_string())
+                    }
+                }
+            },
+        )
+        .await
+        .expect("reduce tree should recover from one context overflow");
+
+        assert_eq!(result, "## Summary\n- recovered\n");
+        assert_eq!(final_calls.get(), 2, "overflowed final + recovered final");
+        assert!(
+            merge_calls.get() >= 1,
+            "the halved budget must force at least one merge round"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_reduce_tree_gives_up_after_second_context_overflow() {
+        let parts = overflow_test_parts();
+        let error = run_reduce_tree(
+            &parts,
+            None,
+            &[],
+            ChunkConfig::APPLE_INTELLIGENCE.reduce_token_limit,
+            false,
+            &|_current, _total| {},
+            |_is_final, _prompt| async move {
+                Err::<String, _>("exceeded_context_window: still too large".to_string())
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(error.contains("exceeded_context_window"), "got: {error}");
+    }
+
+    #[tokio::test]
+    async fn run_reduce_tree_skip_fit_check_propagates_overflow_untouched() {
+        // Ollama path (skip_initial_fit_check): no shrink recovery, the error
+        // surfaces as-is from the single final call.
+        let parts = vec!["- a fact".to_string()];
+        let final_calls = std::cell::Cell::new(0u32);
+        let error = run_reduce_tree(
+            &parts,
+            None,
+            &[],
+            ChunkConfig::OLLAMA.reduce_token_limit,
+            true,
+            &|_current, _total| {},
+            |_is_final, _prompt| {
+                final_calls.set(final_calls.get() + 1);
+                async move { Err::<String, _>("exceeded_context_window: whatever".to_string()) }
+            },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(final_calls.get(), 1);
+        assert!(error.contains("exceeded_context_window"));
     }
 
     /// A user-selected summary template must reach ONLY the terminal

--- a/src-tauri/swift/apple_intelligence.swift
+++ b/src-tauri/swift/apple_intelligence.swift
@@ -6,6 +6,11 @@ import FoundationModels
 
 private typealias ResponsePointer = UnsafeMutablePointer<AppleLLMResponse>
 
+/// Inner per-request timeout. The Rust caller (summary/apple.rs) enforces a
+/// 120s hard wall and abandons its waiting thread; resolving earlier on the
+/// Swift side lets that thread exit normally instead of leaking.
+private let requestTimeoutSeconds = 100
+
 private func duplicateCString(_ text: String) -> UnsafeMutablePointer<CChar>? {
     text.withCString { basePointer in
         guard let duplicated = strdup(basePointer) else {
@@ -26,6 +31,54 @@ private func truncatedText(_ text: String, limit: Int) -> String {
         return text
     }
     return words.prefix(limit).joined(separator: " ")
+}
+
+/// Stable machine-readable markers parsed by the Rust caller (summary/apple.rs)
+/// to decide between retry, structural re-batching, and clean failure.
+@available(macOS 26.0, *)
+private func classifyGenerationError(_ error: LanguageModelSession.GenerationError) -> String {
+    switch error {
+    case .exceededContextWindowSize:
+        return "exceeded_context_window: \(error.localizedDescription)"
+    case .guardrailViolation:
+        return "guardrail_violation: \(error.localizedDescription)"
+    case .rateLimited:
+        return "rate_limited: \(error.localizedDescription)"
+    case .unsupportedLanguageOrLocale:
+        return "unsupported_language: \(error.localizedDescription)"
+    default:
+        return error.localizedDescription
+    }
+}
+
+/// Single-consumer outcome holder shared between the request task and the
+/// waiting FFI thread. Once the waiter times out and abandons the request,
+/// a late completion is dropped instead of racing the reader.
+private final class ResultBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var response: String?
+    private var error: String?
+    private var abandoned = false
+
+    func complete(response: String?, error: String?) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !abandoned else { return }
+        self.response = response
+        self.error = error
+    }
+
+    func abandon() {
+        lock.lock()
+        defer { lock.unlock() }
+        abandoned = true
+    }
+
+    func take() -> (response: String?, error: String?) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (response, error)
+    }
 }
 
 @_cdecl("is_apple_intelligence_available")
@@ -95,16 +148,15 @@ public func processTextWithSystemPrompt(
 
     let tokenLimit = max(0, Int(maxTokens))
     let semaphore = DispatchSemaphore(value: 0)
-
-    final class ResultBox: @unchecked Sendable {
-        var response: String?
-        var error: String?
-    }
     let box = ResultBox()
 
-    Task.detached(priority: .userInitiated) {
+    let task = Task.detached(priority: .userInitiated) {
         defer { semaphore.signal() }
         do {
+            // A fresh session per request keeps every call single-turn: no
+            // context accumulates across map/reduce chunks (each prompt
+            // re-provides its own transcript excerpt), and one wedged
+            // request cannot poison later ones through shared session state.
             let session = LanguageModelSession(
                 model: model,
                 instructions: swiftSystemPrompt
@@ -114,19 +166,33 @@ public func processTextWithSystemPrompt(
             if tokenLimit > 0 {
                 output = truncatedText(output, limit: tokenLimit)
             }
-            box.response = output
+            box.complete(response: output, error: nil)
+        } catch let error as LanguageModelSession.GenerationError {
+            box.complete(response: nil, error: classifyGenerationError(error))
         } catch {
-            box.error = error.localizedDescription
+            box.complete(response: nil, error: error.localizedDescription)
         }
     }
 
-    semaphore.wait()
+    let waitResult = semaphore.wait(timeout: .now() + .seconds(requestTimeoutSeconds))
+    if waitResult == .timedOut {
+        // Abandon the request: drop any late completion and ask the task to
+        // stop (respond may or may not honor cancellation). The Rust caller
+        // treats this marker as retryable.
+        box.abandon()
+        task.cancel()
+        responsePtr.pointee.error_message = duplicateCString(
+            "request_timeout: FoundationModels did not respond within \(requestTimeoutSeconds)s"
+        )
+        return responsePtr
+    }
 
-    if let response = box.response {
+    let outcome = box.take()
+    if let response = outcome.response {
         responsePtr.pointee.response = duplicateCString(response)
         responsePtr.pointee.success = 1
     } else {
-        responsePtr.pointee.error_message = duplicateCString(box.error ?? "Unknown error")
+        responsePtr.pointee.error_message = duplicateCString(outcome.error ?? "Unknown error")
     }
 
     return responsePtr


### PR DESCRIPTION
Apple Intelligence meeting summaries could freeze mid-pipeline (e.g. at chunk 5/8) and never finish: the FoundationModels FFI call blocked with no timeout on either side, the map stage is sequential for this provider, and the summarize command promise never resolved, so the UI stayed stuck until restart.

- Rust side: every FoundationModels request now runs on a dedicated thread with a hard 120s wall-clock timeout and a single retry for timeouts and transient errors (rate limiting). Deterministic failures (guardrail violation, unsupported language, context overflow) fail fast instead of burning a retry. A timed-out thread is abandoned safely: the handoff is channel-owned and a late result is discarded.
- Swift side: the semaphore wait is bounded at 100s (inside the Rust wall so the request thread usually exits cleanly), the request task is cancelled on timeout, late completions are dropped behind a lock, and generation errors are classified into stable machine-readable markers. Fresh session per request is kept and documented.
- Reduce tree: a real-tokenizer context overflow mid-reduce now halves the token budget and re-batches once per summary instead of failing outright. The Ollama path never produces the marker and is behaviorally untouched.

Nine new unit tests cover the timeout/retry wrapper with fake blocking calls (including a late abandoned result being discarded) and the overflow shrink path. Full workspace tests and clippy -D warnings pass. The real Swift path compiles on the Xcode 26 release runner; the stub path builds locally.