### PR TITLE
Render release notes as Markdown and reuse tag notes for releases

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+# Structure for GitHub's auto-generated release notes. Only used when a tag
+# is pushed without an annotated message (see .github/workflows/release.yml);
+# hand-written notes in the tag annotation always take precedence.
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - github-actions
+  categories:
+    # Label-based buckets first; PRs without labels land in the catch-all.
+    - title: Fixes
+      labels:
+        - bug
+        - fix
+    - title: Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,16 +41,54 @@ jobs:
         with:
           script: |
             const tag = process.env.GITHUB_REF_NAME;
+            const footer = [
+              'Download the .dmg below for Apple Silicon Macs.',
+              '',
+              'Requires macOS 13 or newer on Apple Silicon (M1 or newer).',
+            ].join('\n');
+
+            // Hand-written notes live in the annotated tag message (see
+            // CLAUDE.md, "Release changelogs"). Use them as the release body
+            // when present; a lightweight or empty-message tag falls back to
+            // GitHub's auto-generated notes (merged PR titles, structured by
+            // .github/release.yml) so no release ever ships without notes.
+            let notes = '';
+            try {
+              const { data: ref } = await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `tags/${tag}`,
+              });
+              if (ref.object.type === 'tag') {
+                const { data: tagObj } = await github.rest.git.getTag({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  tag_sha: ref.object.sha,
+                });
+                notes = (tagObj.message ?? '')
+                  .replace(/-----BEGIN (PGP|SSH) SIGNATURE-----[\s\S]*$/, '')
+                  .trim();
+                // Drop a leading title line that just repeats the release
+                // name (the common `git tag -a` habit) to avoid duplication.
+                const lines = notes.split('\n');
+                if (/^(Soufflé\s+)?v?\d+\.\d+\.\d+$/.test(lines[0]?.trim() ?? '')) {
+                  notes = lines.slice(1).join('\n').trim();
+                }
+              }
+            } catch (e) {
+              core.warning(`Could not read tag annotation: ${e.message}`);
+            }
+
+            // With generate_release_notes, GitHub appends its generated
+            // "What's Changed" section after the provided body, so
+            // hand-written notes are never overwritten either way.
             const { data } = await github.rest.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: tag,
               name: `Soufflé ${tag}`,
-              body: [
-                'Download the .dmg below for Apple Silicon Macs.',
-                '',
-                'Requires macOS 13 or newer on Apple Silicon (M1 or newer).',
-              ].join('\n'),
+              body: notes ? `${notes}\n\n---\n\n${footer}` : `${footer}\n`,
+              generate_release_notes: notes === '',
               draft: true,
               prerelease: false,
             });

--- a/src/app.css
+++ b/src/app.css
@@ -470,6 +470,71 @@ img {
   color: var(--color-text-muted);
 }
 
+/* ─── Release notes (rendered Markdown from GitHub releases) ─── */
+.release-notes h1,
+.release-notes h2,
+.release-notes h3,
+.release-notes h4 {
+  font-family: var(--font-heading);
+  color: var(--color-text-primary);
+  margin: 1em 0 0.375em;
+}
+
+.release-notes h1 { font-size: 1.05rem; }
+.release-notes h2 { font-size: 0.95rem; }
+.release-notes h3,
+.release-notes h4 { font-size: 0.875rem; }
+
+.release-notes > :first-child {
+  margin-top: 0;
+}
+
+.release-notes p {
+  margin: 0.5em 0;
+}
+
+.release-notes ul,
+.release-notes ol {
+  margin: 0.5em 0;
+  padding-left: 1.25em;
+}
+
+.release-notes li {
+  margin: 0.25em 0;
+}
+
+.release-notes ul li {
+  list-style: disc;
+}
+
+.release-notes ol li {
+  list-style: decimal;
+}
+
+.release-notes strong {
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.release-notes code {
+  font-family: var(--font-mono);
+  font-size: 0.8em;
+  background: var(--color-surface-3);
+  border-radius: 4px;
+  padding: 0.1em 0.35em;
+}
+
+.release-notes a {
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  word-break: break-all;
+}
+
+.release-notes a:hover {
+  color: var(--color-accent-hover);
+}
+
 /* ─── Search highlight (FTS5 <mark> tags) ─── */
 .search-highlight mark {
   background: color-mix(in srgb, var(--color-accent) 25%, transparent);

--- a/src/lib/features/onboarding/WhatsNewDialog.svelte
+++ b/src/lib/features/onboarding/WhatsNewDialog.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
   import { t } from "svelte-i18n";
+  import { openReleasePage } from "../../api/diagnostics";
+  import { renderReleaseNotesMarkdown } from "../../utils";
 
   let {
     version,
@@ -10,6 +12,21 @@
     releaseNotes: string;
     onDismiss: () => void;
   } = $props();
+
+  // renderReleaseNotesMarkdown escapes all input text and emits only a fixed
+  // set of tags, so this HTML is safe to inject (see its module docs).
+  let notesHtml = $derived(renderReleaseNotesMarkdown(releaseNotes));
+
+  // WKWebView suppresses new-window navigation and the dialog must not
+  // navigate in place, so link clicks are routed to the system browser via
+  // the backend command (which only accepts https://github.com/ URLs, the
+  // only kind the renderer emits).
+  function handleNotesClick(event: MouseEvent) {
+    const anchor = (event.target as HTMLElement).closest("a");
+    if (!anchor) return;
+    event.preventDefault();
+    void openReleasePage(anchor.href);
+  }
 </script>
 
 <div
@@ -26,8 +43,12 @@
       </p>
     </div>
 
-    <div class="min-h-0 flex-1 overflow-y-auto rounded-lg bg-surface-1/70 p-4 text-sm leading-relaxed text-text-secondary whitespace-pre-wrap">
-      {releaseNotes}
+    <!-- svelte-ignore a11y_no_static_element_interactions, a11y_click_events_have_key_events -->
+    <div
+      class="release-notes min-h-0 flex-1 overflow-y-auto rounded-lg bg-surface-1/70 p-4 text-sm leading-relaxed text-text-secondary"
+      onclick={handleNotesClick}
+    >
+      {@html notesHtml}
     </div>
 
     <div class="flex justify-end">

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -3,5 +3,6 @@ export { applyTheme } from "./theme";
 export { buildMeetingTranscriptBlocks, groupIntoParagraphs } from "./paragraphs";
 export type { Paragraph, TranscriptBlock } from "./paragraphs";
 export { errorMessage } from "./errors";
+export { renderReleaseNotesMarkdown } from "./markdown";
 export { createDebouncedSearch, filterResultsByType, findSnippet, matchedIdsForType } from "./search.svelte";
 export type { DebouncedSearch } from "./search.svelte";

--- a/src/lib/utils/markdown.test.ts
+++ b/src/lib/utils/markdown.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { renderReleaseNotesMarkdown } from "./markdown";
+
+describe("renderReleaseNotesMarkdown", () => {
+  it("renders headings up to level 4", () => {
+    expect(renderReleaseNotesMarkdown("# Title")).toBe("<h1>Title</h1>");
+    expect(renderReleaseNotesMarkdown("## Fixes")).toBe("<h2>Fixes</h2>");
+    expect(renderReleaseNotesMarkdown("#### Deep")).toBe("<h4>Deep</h4>");
+  });
+
+  it("does not treat deeper hashes as headings", () => {
+    expect(renderReleaseNotesMarkdown("##### Nope")).toBe("<p>##### Nope</p>");
+  });
+
+  it("renders unordered lists from - and * bullets", () => {
+    expect(renderReleaseNotesMarkdown("- one\n- two")).toBe("<ul><li>one</li><li>two</li></ul>");
+    expect(renderReleaseNotesMarkdown("* one\n* two")).toBe("<ul><li>one</li><li>two</li></ul>");
+  });
+
+  it("renders ordered lists", () => {
+    expect(renderReleaseNotesMarkdown("1. first\n2. second")).toBe(
+      "<ol><li>first</li><li>second</li></ol>",
+    );
+  });
+
+  it("renders bold, italic, and inline code", () => {
+    expect(renderReleaseNotesMarkdown("**bold** and _italic_ and `code`")).toBe(
+      "<p><strong>bold</strong> and <em>italic</em> and <code>code</code></p>",
+    );
+  });
+
+  it("groups consecutive plain lines into one paragraph with line breaks", () => {
+    expect(renderReleaseNotesMarkdown("line one\nline two\n\nnext para")).toBe(
+      "<p>line one<br>line two</p>\n<p>next para</p>",
+    );
+  });
+
+  it("linkifies markdown links to github.com", () => {
+    expect(renderReleaseNotesMarkdown("[PR #50](https://github.com/damione1/souffle/pull/50)")).toBe(
+      '<p><a href="https://github.com/damione1/souffle/pull/50">PR #50</a></p>',
+    );
+  });
+
+  it("linkifies bare github.com URLs", () => {
+    expect(renderReleaseNotesMarkdown("See https://github.com/damione1/souffle/pull/50")).toBe(
+      '<p>See <a href="https://github.com/damione1/souffle/pull/50">https://github.com/damione1/souffle/pull/50</a></p>',
+    );
+  });
+
+  it("leaves non-github and non-https destinations as plain text", () => {
+    expect(renderReleaseNotesMarkdown("[x](https://evil.example.com/)")).toBe(
+      "<p>[x](https://evil.example.com/)</p>",
+    );
+    expect(renderReleaseNotesMarkdown("[x](javascript:alert(1))")).toBe(
+      "<p>[x](javascript:alert(1))</p>",
+    );
+    expect(renderReleaseNotesMarkdown("http://github.com/insecure")).toBe(
+      "<p>http://github.com/insecure</p>",
+    );
+  });
+
+  it("escapes raw HTML instead of passing it through", () => {
+    expect(renderReleaseNotesMarkdown('<img src=x onerror="alert(1)">')).toBe(
+      "<p>&lt;img src=x onerror=&quot;alert(1)&quot;&gt;</p>",
+    );
+    expect(renderReleaseNotesMarkdown("<script>alert(1)</script>")).toBe(
+      "<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>",
+    );
+  });
+
+  it("escapes HTML inside list items and headings", () => {
+    expect(renderReleaseNotesMarkdown("- <b>hi</b>")).toBe("<ul><li>&lt;b&gt;hi&lt;/b&gt;</li></ul>");
+    expect(renderReleaseNotesMarkdown("## <script>x</script>")).toBe(
+      "<h2>&lt;script&gt;x&lt;/script&gt;</h2>",
+    );
+  });
+
+  it("does not let a quote in link text break out of the href", () => {
+    const html = renderReleaseNotesMarkdown('["><img src=x>](https://github.com/x)');
+    expect(html).not.toContain("<img");
+    expect(html).toContain("&quot;&gt;&lt;img src=x&gt;");
+  });
+
+  it("does not read underscores inside URLs or code spans as emphasis", () => {
+    expect(
+      renderReleaseNotesMarkdown("https://github.com/a/b/compare/v0_1...v0_2"),
+    ).toContain('href="https://github.com/a/b/compare/v0_1...v0_2"');
+    expect(renderReleaseNotesMarkdown("`snake_case_name`")).toBe(
+      "<p><code>snake_case_name</code></p>",
+    );
+  });
+
+  it("strips NUL characters from input so placeholders cannot be forged", () => {
+    const nul = String.fromCharCode(0);
+    const html = renderReleaseNotesMarkdown(`before ${nul}0${nul} after **b**`);
+    expect(html).toBe("<p>before 0 after <strong>b</strong></p>");
+  });
+
+  it("handles CRLF line endings", () => {
+    expect(renderReleaseNotesMarkdown("# Title\r\n\r\n- item")).toBe(
+      "<h1>Title</h1>\n<ul><li>item</li></ul>",
+    );
+  });
+
+  it("renders the current release template shape", () => {
+    const notes = [
+      "Download the .dmg below for Apple Silicon Macs.",
+      "",
+      "## What's Changed",
+      "* Fix a bug by @damione1 in https://github.com/damione1/souffle/pull/50",
+      "",
+      "**Full Changelog**: https://github.com/damione1/souffle/compare/v0.5.6...v0.5.7",
+    ].join("\n");
+    const html = renderReleaseNotesMarkdown(notes);
+    expect(html).toContain("<h2>What&#39;s Changed</h2>");
+    expect(html).toContain('<a href="https://github.com/damione1/souffle/pull/50">');
+    expect(html).toContain("<strong>Full Changelog</strong>");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(renderReleaseNotesMarkdown("")).toBe("");
+    expect(renderReleaseNotesMarkdown("\n\n")).toBe("");
+  });
+});

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -1,0 +1,137 @@
+/**
+ * Minimal, dependency-free Markdown-to-HTML renderer for GitHub release
+ * notes. Release note bodies come from the GitHub API (hand-written by a
+ * maintainer or auto-generated from merged PR titles), so they're treated as
+ * untrusted input for rendering purposes: every text run is HTML-escaped
+ * before any markup is added, and only a fixed, closed set of tags is ever
+ * emitted. There is no raw-HTML passthrough, so `{@html ...}` on the result
+ * is safe without an external sanitizer.
+ *
+ * Supported subset: headings (`#`..`####`), bold (`**text**`), italic
+ * (`_text_`), inline code (`` `code` ``), links (`[text](https://...)`),
+ * bare `https://` autolinks, and unordered/ordered lists. Anything else
+ * renders as plain escaped text. Only `https://github.com/` links are
+ * linkified, mirroring the `open_release_page` command's validation so every
+ * rendered link is guaranteed to open; other URLs and schemes (javascript:,
+ * data:, mailto:, http:) are left as literal text.
+ */
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+const BULLET_RE = /^[-*]\s+(.*)$/;
+const ORDERED_RE = /^\d+\.\s+(.*)$/;
+const HEADING_RE = /^(#{1,4})\s+(.*)$/;
+
+// U+0000 never appears in escapeHtml output and is stripped from the source
+// markdown up front (see renderReleaseNotesMarkdown), so it's a
+// collision-free delimiter for stashed inline HTML below.
+// Built at runtime so this source file stays pure ASCII.
+const PLACEHOLDER_BOUND = String.fromCharCode(0);
+const PLACEHOLDER_RE = new RegExp(`${PLACEHOLDER_BOUND}(\\d+)${PLACEHOLDER_BOUND}`, "g");
+
+/**
+ * Renders inline markup (links, bold, italic, code) on already-escaped text.
+ * Links and inline code are extracted into placeholders before bold/italic
+ * run, so a `_`/`*` inside a URL or code span can never be misread as
+ * emphasis, and bold/italic can never inject markup into a link's `href`.
+ */
+function renderInline(escaped: string): string {
+  const placeholders: string[] = [];
+  const stash = (html: string): string => {
+    placeholders.push(html);
+    return `${PLACEHOLDER_BOUND}${placeholders.length - 1}${PLACEHOLDER_BOUND}`;
+  };
+
+  let out = escaped;
+
+  // Markdown links: only https://github.com/ destinations are linkified.
+  out = out.replace(
+    /\[([^[\]]+)\]\((https:\/\/github\.com\/[^\s)]+)\)/g,
+    (_m, text: string, url: string) => stash(`<a href="${url}">${text}</a>`),
+  );
+
+  // Bare github.com URLs not already consumed by a markdown link above.
+  out = out.replace(/https:\/\/github\.com\/[^\s<]+/g, (url) => stash(`<a href="${url}">${url}</a>`));
+
+  // Inline code.
+  out = out.replace(/`([^`]+)`/g, (_m, code: string) => stash(`<code>${code}</code>`));
+
+  // Bold, then italic (order matters so `**_x_**` and `_**x**_` both work).
+  out = out.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+  out = out.replace(/_([^_]+)_/g, "<em>$1</em>");
+
+  out = out.replace(PLACEHOLDER_RE, (_m, i: string) => placeholders[Number(i)]);
+
+  return out;
+}
+
+/** Renders a release-notes Markdown string into a safe HTML string. */
+export function renderReleaseNotesMarkdown(markdown: string): string {
+  const lines = markdown
+    .split(PLACEHOLDER_BOUND)
+    .join("")
+    .replace(/\r\n/g, "\n")
+    .split("\n");
+  const html: string[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (line.trim() === "") {
+      i++;
+      continue;
+    }
+
+    const heading = line.match(HEADING_RE);
+    if (heading) {
+      const level = heading[1].length;
+      html.push(`<h${level}>${renderInline(escapeHtml(heading[2].trim()))}</h${level}>`);
+      i++;
+      continue;
+    }
+
+    if (BULLET_RE.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && BULLET_RE.test(lines[i])) {
+        items.push(lines[i].replace(BULLET_RE, "$1"));
+        i++;
+      }
+      html.push(`<ul>${items.map((it) => `<li>${renderInline(escapeHtml(it))}</li>`).join("")}</ul>`);
+      continue;
+    }
+
+    if (ORDERED_RE.test(line)) {
+      const items: string[] = [];
+      while (i < lines.length && ORDERED_RE.test(lines[i])) {
+        items.push(lines[i].replace(ORDERED_RE, "$1"));
+        i++;
+      }
+      html.push(`<ol>${items.map((it) => `<li>${renderInline(escapeHtml(it))}</li>`).join("")}</ol>`);
+      continue;
+    }
+
+    // Paragraph: consecutive plain lines, soft-wrapped with <br>.
+    const paragraphLines: string[] = [];
+    while (
+      i < lines.length &&
+      lines[i].trim() !== "" &&
+      !HEADING_RE.test(lines[i]) &&
+      !BULLET_RE.test(lines[i]) &&
+      !ORDERED_RE.test(lines[i])
+    ) {
+      paragraphLines.push(lines[i]);
+      i++;
+    }
+    html.push(`<p>${paragraphLines.map((l) => renderInline(escapeHtml(l))).join("<br>")}</p>`);
+  }
+
+  return html.join("\n");
+}


### PR DESCRIPTION
The What's New dialog showed raw Markdown syntax, and the release workflow discarded the hand-written notes already present in annotated tag messages in favor of a hard-coded body.

- New dependency-free Markdown subset renderer for release notes (headings, bold, italic, inline code, lists, links). All text is HTML-escaped before markup is added and only a closed set of tags is emitted, so the output is safe to inject without an external sanitizer; 17 unit tests cover XSS vectors. Only https://github.com/ links are linkified, matching the existing open-release-page validation, and clicks are routed to the system browser since WKWebView swallows target=_blank.
- The What's New dialog and its styles use existing design tokens, so light and dark themes both render correctly.
- The release workflow now uses the annotated tag message as the release body (signature blocks and a duplicated title line stripped) and falls back to GitHub's auto-generated notes only when the tag has no message, structured by a new .github/release.yml (bot PRs excluded). Signing and notarization steps are untouched.