### PR TITLE
Stabilize bilingual meeting language flips

### DIFF
--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -289,6 +289,7 @@ fn start_pipeline_blocking(
         session_terms,
         diarize,
         idle_config,
+        meeting_transcription_language: settings.meeting_transcription_language,
     };
 
     // The actor replies once the engine is reset and ready for audio.

--- a/src-tauri/src/engine/kyutai.rs
+++ b/src-tauri/src/engine/kyutai.rs
@@ -4,14 +4,16 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use candle_core::{Device, Tensor};
-use tracing::{debug, info, trace};
+use tracing::{debug, info, trace, warn};
 
 use super::{
     AudioInputRequirements, EngineError, Speaker, TranscriptionEngine, TranscriptionSegment,
     collapse_whitespace,
 };
 use crate::constants::{MIMI_FRAME_SIZE, MIMI_FRAMES_PER_SECOND, SAMPLE_RATE};
+use crate::lid::{LanguageTracker, detect_word};
 use crate::platform::with_autorelease_pool;
+use crate::settings::MeetingTranscriptionLanguage;
 
 /// Extra-head index used for pause detection, matching Kyutai's reference
 /// stt-rs example (`prs[2][0] > 0.5`).
@@ -117,37 +119,74 @@ impl KyutaiConfig {
 
 /// Whether a proactive KV-cache refresh should run, and why.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RefreshKind {
+pub enum RefreshKind {
     /// Pause-aligned refresh inside the soft context window (preferred).
     SoftPause,
     /// Forced refresh before the LM context window saturates.
     HardDeadline,
+    /// Per-lane reset triggered by consecutive language mismatches.
+    LanguageMismatch,
 }
 
-/// Decide whether to clear the ASR KV cache before the next frame.
-///
-/// Kyutai STT is a decoder-only model with a finite `context` (375 frames /
-/// ~30s on stt-2.6b). Past that window inference still runs but Word emission
-/// can starve — matching the production "frames climb, segments flat" freeze.
-/// Upstream guidance (Unmute #168) is to reset between speech turns; we do the
-/// local equivalent with `State::reset()` rather than a full Metal rebuild.
-fn should_refresh(
+/// Whether to clear KV cache and how.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RefreshDecision {
+    None,
+    Full(RefreshKind),
+    Lane {
+        batch_idx: usize,
+        kind: RefreshKind,
+    },
+}
+
+/// Decide proactive KV refresh before the next frame.
+fn decide_refresh(
     frames_since_refresh: usize,
     context: usize,
-    pausing: bool,
-) -> Option<RefreshKind> {
+    vad_pause_streak: &[usize],
+    batch_size: usize,
+) -> RefreshDecision {
     if context == 0 || frames_since_refresh == 0 {
-        return None;
+        return RefreshDecision::None;
     }
     let soft = (context * REFRESH_SOFT_CONTEXT_NUM) / REFRESH_SOFT_CONTEXT_DEN;
     let hard = context.saturating_sub(REFRESH_HARD_MARGIN_FRAMES);
+
     if frames_since_refresh >= hard {
-        Some(RefreshKind::HardDeadline)
-    } else if pausing && frames_since_refresh >= soft {
-        Some(RefreshKind::SoftPause)
-    } else {
-        None
+        return RefreshDecision::Full(RefreshKind::HardDeadline);
     }
+
+    if frames_since_refresh < soft {
+        return RefreshDecision::None;
+    }
+
+    let pausing: Vec<usize> = vad_pause_streak
+        .iter()
+        .enumerate()
+        .filter(|(_, streak)| **streak >= REFRESH_PAUSE_FRAMES)
+        .map(|(idx, _)| idx)
+        .collect();
+
+    if pausing.is_empty() {
+        return RefreshDecision::None;
+    }
+
+    if batch_size == 1 {
+        return RefreshDecision::Full(RefreshKind::SoftPause);
+    }
+
+    if pausing.len() == 1 {
+        let paused = pausing[0];
+        let other = 1 - paused;
+        if vad_pause_streak.get(other).copied().unwrap_or(0) < REFRESH_PAUSE_FRAMES {
+            return RefreshDecision::Lane {
+                batch_idx: paused,
+                kind: RefreshKind::SoftPause,
+            };
+        }
+    }
+
+    RefreshDecision::Full(RefreshKind::SoftPause)
 }
 
 /// Loaded model components — kept together so they can be used by the inference loop
@@ -170,8 +209,10 @@ struct LoadedModel {
     frames_since_refresh: usize,
     /// Soft context refreshes performed this session (diagnostics).
     refresh_count: u64,
-    /// Consecutive frames where the semantic VAD pause head fired.
-    vad_pause_streak: usize,
+    /// Consecutive frames where the semantic VAD pause head fired, per batch lane.
+    vad_pause_streak: Vec<usize>,
+    /// Per-lane LID and mismatch streak tracking.
+    language_tracker: LanguageTracker,
 }
 
 /// Kyutai STT engine implementation.
@@ -183,6 +224,8 @@ pub struct KyutaiEngine {
     /// and system audio (Them) legs are transcribed as independent batch lanes
     /// of one model. Takes effect on the next `reset_state`.
     diarize: bool,
+    /// Heuristic prior for LID/mismatch resets (never passed to moshi).
+    meeting_language_prior: MeetingTranscriptionLanguage,
 }
 
 impl Default for KyutaiEngine {
@@ -196,6 +239,7 @@ impl KyutaiEngine {
         Self {
             model: None,
             diarize: false,
+            meeting_language_prior: MeetingTranscriptionLanguage::Auto,
         }
     }
 
@@ -254,6 +298,7 @@ impl KyutaiEngine {
         config: KyutaiConfig,
         text_tokenizer: sentencepiece::SentencePieceProcessor,
         batch_size: usize,
+        meeting_language_prior: MeetingTranscriptionLanguage,
     ) -> Result<LoadedModel, EngineError> {
         let state = Self::build_state(&device, &model_path, &config, batch_size)?;
         Ok(LoadedModel {
@@ -267,7 +312,8 @@ impl KyutaiEngine {
             epoch_origin_seconds: 0.0,
             frames_since_refresh: 0,
             refresh_count: 0,
-            vad_pause_streak: 0,
+            vad_pause_streak: vec![0; batch_size],
+            language_tracker: LanguageTracker::new(batch_size, meeting_language_prior),
         })
     }
 
@@ -326,7 +372,8 @@ impl KyutaiEngine {
         model.prefix_pending = true;
         model.time_offset_seconds = 0.0;
         model.frames_since_refresh = 0;
-        model.vad_pause_streak = 0;
+        model.vad_pause_streak = vec![0; model.state.batch_size()];
+        model.language_tracker.reset_all();
         model.refresh_count = model.refresh_count.saturating_add(1);
         info!(
             kind = ?kind,
@@ -339,22 +386,50 @@ impl KyutaiEngine {
         Ok(())
     }
 
+    /// Per-lane KV clear via moshi `reset_batch_idx`. Does not rebuild Metal or
+    /// re-feed the silence prefix; the other lane keeps decoding uninterrupted.
+    fn refresh_lane(model: &mut LoadedModel, batch_idx: usize, kind: RefreshKind) -> Result<(), EngineError> {
+        model
+            .state
+            .reset_batch_idx(batch_idx)
+            .map_err(|e| EngineError::InferenceError(format!("ASR lane reset: {e}")))?;
+        if let Some(streak) = model.vad_pause_streak.get_mut(batch_idx) {
+            *streak = 0;
+        }
+        model.language_tracker.reset_lane(batch_idx);
+        debug!(
+            kind = ?kind,
+            batch_idx,
+            "ASR lane context reset (per-batch KV clear)"
+        );
+        Ok(())
+    }
+
     fn maybe_refresh_before_frame(model: &mut LoadedModel) -> Result<(), EngineError> {
-        let pausing = model.vad_pause_streak >= REFRESH_PAUSE_FRAMES;
-        if let Some(kind) =
-            should_refresh(model.frames_since_refresh, model.config.context, pausing)
-        {
-            Self::refresh_loaded(model, kind)?;
+        let batch_size = model.state.batch_size();
+        match decide_refresh(
+            model.frames_since_refresh,
+            model.config.context,
+            &model.vad_pause_streak,
+            batch_size,
+        ) {
+            RefreshDecision::None => {}
+            RefreshDecision::Full(kind) => Self::refresh_loaded(model, kind)?,
+            RefreshDecision::Lane { batch_idx, kind } => Self::refresh_lane(model, batch_idx, kind)?,
         }
         Ok(())
     }
 
     fn note_vad_pause(model: &mut LoadedModel, prs: &[Vec<f32>]) {
-        if let Some(p) = prs.get(VAD_PAUSE_HEAD).and_then(|h| h.first()) {
-            if *p > VAD_PAUSE_THRESHOLD {
-                model.vad_pause_streak += 1;
-            } else {
-                model.vad_pause_streak = 0;
+        if let Some(pause_head) = prs.get(VAD_PAUSE_HEAD) {
+            for (batch_idx, p) in pause_head.iter().enumerate() {
+                if let Some(streak) = model.vad_pause_streak.get_mut(batch_idx) {
+                    if *p > VAD_PAUSE_THRESHOLD {
+                        *streak += 1;
+                    } else {
+                        *streak = 0;
+                    }
+                }
             }
         }
     }
@@ -521,6 +596,14 @@ impl KyutaiEngine {
                     if text.is_empty() {
                         continue;
                     }
+                    let language = detect_word(&text).map(|code| code.as_str().to_string());
+                    let mismatch_reset = model.language_tracker.on_word(&text, *batch_idx);
+                    if mismatch_reset
+                        && let Err(e) =
+                            Self::refresh_lane(model, *batch_idx, RefreshKind::LanguageMismatch)
+                    {
+                        warn!(batch_idx, "Language mismatch lane reset failed: {e}");
+                    }
                     let start_time = Self::word_start_time(model, *start_time);
                     let speaker = if diarized {
                         Some(if *batch_idx == 0 {
@@ -536,7 +619,7 @@ impl KyutaiEngine {
                         start_time,
                         end_time: start_time,
                         is_final: true,
-                        language: None,
+                        language,
                         confidence: None,
                         speaker,
                     });
@@ -555,6 +638,16 @@ impl KyutaiEngine {
             frames_since_refresh: m.frames_since_refresh,
             refresh_count: m.refresh_count,
         })
+    }
+
+    pub fn set_meeting_language_prior(&mut self, prior: MeetingTranscriptionLanguage) {
+        self.meeting_language_prior = prior;
+        if let Some(model) = self.model.as_mut() {
+            let batch_size = model.state.batch_size();
+            model
+                .language_tracker
+                .resize(batch_size, self.meeting_language_prior);
+        }
     }
 
     /// Reset the ASR state for a new recording session.
@@ -579,6 +672,7 @@ impl KyutaiEngine {
 
         // Captured before the rebuild closure moves the model fields.
         let batch_size = self.batch_size();
+        let meeting_language_prior = self.meeting_language_prior;
         let old = self.model.take().ok_or(EngineError::NotInitialized)?;
         let LoadedModel {
             state: old_state,
@@ -596,7 +690,14 @@ impl KyutaiEngine {
 
         let rebuilt = with_autorelease_pool(move || -> Result<LoadedModel, EngineError> {
             let device = Self::select_device()?;
-            Self::build_loaded_model(device, model_path, config, text_tokenizer, batch_size)
+            Self::build_loaded_model(
+                device,
+                model_path,
+                config,
+                text_tokenizer,
+                batch_size,
+                meeting_language_prior,
+            )
         })?;
 
         self.model = Some(rebuilt);
@@ -631,6 +732,7 @@ impl TranscriptionEngine for KyutaiEngine {
         // Initial load is always single-stream; diarization is enabled later via
         // set_diarization + reset_state.
         let batch_size = self.batch_size();
+        let meeting_language_prior = self.meeting_language_prior;
         let loaded = with_autorelease_pool(move || {
             Self::build_loaded_model(
                 device,
@@ -638,6 +740,7 @@ impl TranscriptionEngine for KyutaiEngine {
                 config,
                 text_tokenizer,
                 batch_size,
+                meeting_language_prior,
             )
         })?;
 
@@ -764,7 +867,11 @@ impl TranscriptionEngine for KyutaiEngine {
         let suffix_seconds = model.config.stt_config.audio_delay_seconds + 1.0;
         let silence_samples = (suffix_seconds * SAMPLE_RATE as f64) as usize;
         let diarize = self.diarize;
-        let pause_streak = model.vad_pause_streak;
+        let pause_streak = model
+            .vad_pause_streak
+            .first()
+            .copied()
+            .unwrap_or(0);
 
         if !diarize && pause_streak >= delay_frames + VAD_FLUSH_MARGIN_FRAMES {
             info!(
@@ -795,6 +902,10 @@ impl TranscriptionEngine for KyutaiEngine {
 
     fn set_diarization(&mut self, enabled: bool) {
         self.diarize = enabled;
+    }
+
+    fn set_meeting_language_prior(&mut self, prior: crate::settings::MeetingTranscriptionLanguage) {
+        KyutaiEngine::set_meeting_language_prior(self, prior);
     }
 
     fn transcribe_dual(
@@ -883,37 +994,56 @@ mod tests {
     }
 
     #[test]
-    fn should_refresh_none_before_soft_window() {
-        // stt-2.6b context = 375 → soft at 225, hard at 350
-        assert_eq!(should_refresh(100, 375, true), None);
-        assert_eq!(should_refresh(224, 375, true), None);
-        assert_eq!(should_refresh(225, 375, false), None);
+    fn decide_refresh_none_before_soft_window() {
+        let streak = [0usize];
+        assert_eq!(decide_refresh(100, 375, &streak, 1), RefreshDecision::None);
+        assert_eq!(decide_refresh(224, 375, &streak, 1), RefreshDecision::None);
+        assert_eq!(decide_refresh(225, 375, &[0], 1), RefreshDecision::None);
     }
 
     #[test]
-    fn should_refresh_soft_pause_at_60_percent_context() {
+    fn decide_refresh_soft_pause_at_60_percent_context() {
         assert_eq!(
-            should_refresh(225, 375, true),
-            Some(RefreshKind::SoftPause)
+            decide_refresh(225, 375, &[8], 1),
+            RefreshDecision::Full(RefreshKind::SoftPause)
         );
     }
 
     #[test]
-    fn should_refresh_hard_deadline_near_context() {
+    fn decide_refresh_hard_deadline_near_context() {
         assert_eq!(
-            should_refresh(350, 375, false),
-            Some(RefreshKind::HardDeadline)
+            decide_refresh(350, 375, &[0], 1),
+            RefreshDecision::Full(RefreshKind::HardDeadline)
         );
         assert_eq!(
-            should_refresh(350, 375, true),
-            Some(RefreshKind::HardDeadline)
+            decide_refresh(350, 375, &[8], 1),
+            RefreshDecision::Full(RefreshKind::HardDeadline)
         );
     }
 
     #[test]
-    fn should_refresh_ignores_zero_context_or_fresh_epoch() {
-        assert_eq!(should_refresh(400, 0, true), None);
-        assert_eq!(should_refresh(0, 375, true), None);
+    fn decide_refresh_ignores_zero_context_or_fresh_epoch() {
+        assert_eq!(decide_refresh(400, 0, &[8], 1), RefreshDecision::None);
+        assert_eq!(decide_refresh(0, 375, &[8], 1), RefreshDecision::None);
+    }
+
+    #[test]
+    fn decide_refresh_dual_one_lane_paused_other_active() {
+        assert_eq!(
+            decide_refresh(300, 375, &[8, 2], 2),
+            RefreshDecision::Lane {
+                batch_idx: 0,
+                kind: RefreshKind::SoftPause,
+            }
+        );
+    }
+
+    #[test]
+    fn decide_refresh_dual_both_paused_full_refresh() {
+        assert_eq!(
+            decide_refresh(300, 375, &[8, 10], 2),
+            RefreshDecision::Full(RefreshKind::SoftPause)
+        );
     }
 
     #[test]

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -245,6 +245,10 @@ pub trait TranscriptionEngine {
     /// batch size). No-op for engines that don't support diarization.
     fn set_diarization(&mut self, _enabled: bool) {}
 
+    /// Heuristic meeting-language prior for LID and lane resets (Kyutai only).
+    /// Never passed to the engine as a forced decode language.
+    fn set_meeting_language_prior(&mut self, _prior: crate::settings::MeetingTranscriptionLanguage) {}
+
     /// Transcribe one paired frame from both streams (mic = Me, system = Them),
     /// returning segments already tagged with their speaker. Only valid after
     /// `set_diarization(true)` + `reset_state` on an engine that supports it.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ pub mod engine;
 pub mod errors;
 pub mod export;
 pub mod filter;
+pub mod lid;
 pub mod lock_ext;
 pub mod logging;
 pub mod models;

--- a/src-tauri/src/lid.rs
+++ b/src-tauri/src/lid.rs
@@ -1,0 +1,323 @@
+//! Lightweight French/English language identification for meeting segments.
+//!
+//! Heuristic-only: accent density plus stopword hits. Used to populate
+//! `segment.language` when Kyutai leaves it unset and to drive per-lane
+//! mismatch resets. Never passed to moshi as a forced language.
+
+use crate::settings::MeetingTranscriptionLanguage;
+
+/// BCP-47-ish codes we emit on segments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LanguageCode {
+    En,
+    Fr,
+}
+
+impl LanguageCode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LanguageCode::En => "en",
+            LanguageCode::Fr => "fr",
+        }
+    }
+
+    pub fn from_setting(prior: MeetingTranscriptionLanguage) -> Option<Self> {
+        match prior {
+            MeetingTranscriptionLanguage::Auto => None,
+            MeetingTranscriptionLanguage::En => Some(LanguageCode::En),
+            MeetingTranscriptionLanguage::Fr => Some(LanguageCode::Fr),
+        }
+    }
+}
+
+/// Score a token for English vs French cues.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct LangScore {
+    en: u32,
+    fr: u32,
+}
+
+impl LangScore {
+    fn winner(self) -> Option<LanguageCode> {
+        if self.fr > self.en {
+            Some(LanguageCode::Fr)
+        } else if self.en > self.fr {
+            Some(LanguageCode::En)
+        } else {
+            None
+        }
+    }
+}
+
+const FR_STOPWORDS: &[&str] = &[
+    "le", "la", "les", "de", "des", "du", "un", "une", "et", "est", "en", "que", "qui", "dans",
+    "pour", "pas", "sur", "avec", "ce", "cette", "mon", "ma", "mes", "ton", "ta", "tes", "son",
+    "sa", "ses", "nous", "vous", "ils", "elles", "je", "tu", "il", "elle", "on", "ne", "au", "aux",
+    "ou", "mais", "donc", "car", "comme", "plus", "tout", "tous", "toute", "toutes", "chez", "bien",
+    "très", "aussi", "être", "avoir", "faire", "dit", "peut", "sont", "été", "c'est", "qu'il",
+    "qu'on", "d'un", "d'une", "l'on", "l'un", "l'une", "bonjour", "merci", "réunion", "reunion",
+    "oui", "non", "alors", "voilà", "voila", "parce", "quoi", "comment", "pourquoi", "maintenant",
+    "aujourd'hui", "demain", "hier", "français", "francais",
+];
+
+const EN_STOPWORDS: &[&str] = &[
+    "the", "and", "is", "are", "was", "were", "have", "has", "had", "not", "but", "for", "with",
+    "this", "that", "from", "they", "you", "your", "our", "their", "what", "when", "where", "who",
+    "which", "will", "would", "could", "should", "about", "into", "there", "here", "been", "being",
+    "does", "did", "can", "just", "also", "very", "because", "than", "then", "them", "these",
+    "those", "some", "any", "all", "out", "over", "after", "before", "between", "through",
+];
+
+fn normalize_token(raw: &str) -> String {
+    raw.trim()
+        .trim_matches(|c: char| !c.is_alphanumeric())
+        .to_ascii_lowercase()
+}
+
+fn score_token(token: &str) -> LangScore {
+    let mut score = LangScore::default();
+    if token.is_empty() {
+        return score;
+    }
+
+    for ch in token.chars() {
+        match ch {
+            'é' | 'è' | 'ê' | 'ë' | 'à' | 'â' | 'ù' | 'û' | 'ô' | 'î' | 'ï' | 'ç' | 'œ' | 'æ' => {
+                score.fr += 2;
+            }
+            _ => {}
+        }
+    }
+
+    if FR_STOPWORDS.contains(&token) {
+        score.fr += 3;
+    }
+    if EN_STOPWORDS.contains(&token) {
+        score.en += 3;
+    }
+
+    if token.ends_with("ment") || token.ends_with("tion") && token.contains('é') {
+        score.fr += 1;
+    }
+    if token.ends_with("ing") || token.ends_with("ness") || token.ends_with("tion") {
+        score.en += 1;
+    }
+
+    score
+}
+
+/// Detect language for a single word or short fragment.
+pub fn detect_word(text: &str) -> Option<LanguageCode> {
+    let token = normalize_token(text);
+    if token.len() < 2 {
+        return None;
+    }
+    let score = score_token(&token);
+    if score.fr == 0 && score.en == 0 {
+        return None;
+    }
+    score.winner()
+}
+
+/// Detect language for a longer phrase (multiple tokens).
+pub fn detect_text(text: &str) -> Option<LanguageCode> {
+    let mut total = LangScore::default();
+    for token in text.split_whitespace() {
+        let normalized = normalize_token(token);
+        if normalized.len() < 2 {
+            continue;
+        }
+        let s = score_token(&normalized);
+        total.en += s.en;
+        total.fr += s.fr;
+    }
+    total.winner()
+}
+
+/// Consecutive words that disagree with the lane prior before forcing reset.
+pub const MISMATCH_STREAK_THRESHOLD: usize = 3;
+
+/// Rolling per-lane language state with hysteresis for mismatch resets.
+#[derive(Debug, Clone)]
+pub struct LanguageLaneTracker {
+    setting_prior: MeetingTranscriptionLanguage,
+    /// Inferred majority when setting is Auto (after enough evidence).
+    inferred_prior: Option<LanguageCode>,
+    en_hits: u32,
+    fr_hits: u32,
+    mismatch_lang: Option<LanguageCode>,
+    mismatch_streak: usize,
+}
+
+impl LanguageLaneTracker {
+    pub fn new(setting_prior: MeetingTranscriptionLanguage) -> Self {
+        Self {
+            setting_prior,
+            inferred_prior: None,
+            en_hits: 0,
+            fr_hits: 0,
+            mismatch_lang: None,
+            mismatch_streak: 0,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.inferred_prior = None;
+        self.en_hits = 0;
+        self.fr_hits = 0;
+        self.mismatch_lang = None;
+        self.mismatch_streak = 0;
+    }
+
+    fn effective_prior(&self) -> Option<LanguageCode> {
+        LanguageCode::from_setting(self.setting_prior).or(self.inferred_prior)
+    }
+
+    fn note_majority(&mut self, detected: LanguageCode) {
+        match detected {
+            LanguageCode::En => self.en_hits += 1,
+            LanguageCode::Fr => self.fr_hits += 1,
+        }
+        let total = self.en_hits + self.fr_hits;
+        if total >= 5 {
+            self.inferred_prior = if self.fr_hits > self.en_hits {
+                Some(LanguageCode::Fr)
+            } else if self.en_hits > self.fr_hits {
+                Some(LanguageCode::En)
+            } else {
+                None
+            };
+        }
+    }
+
+    /// Record a word; returns true when a lane reset should be forced.
+    pub fn on_word(&mut self, text: &str) -> bool {
+        let Some(detected) = detect_word(text) else {
+            return false;
+        };
+
+        self.note_majority(detected);
+
+        let Some(prior) = self.effective_prior() else {
+            self.mismatch_lang = None;
+            self.mismatch_streak = 0;
+            return false;
+        };
+
+        if detected == prior {
+            self.mismatch_lang = None;
+            self.mismatch_streak = 0;
+            return false;
+        }
+
+        if self.mismatch_lang == Some(detected) {
+            self.mismatch_streak += 1;
+        } else {
+            self.mismatch_lang = Some(detected);
+            self.mismatch_streak = 1;
+        }
+
+        self.mismatch_streak >= MISMATCH_STREAK_THRESHOLD
+    }
+}
+
+/// Per-batch language trackers (one or two lanes).
+#[derive(Debug, Clone)]
+pub struct LanguageTracker {
+    lanes: Vec<LanguageLaneTracker>,
+}
+
+impl LanguageTracker {
+    pub fn new(batch_size: usize, setting_prior: MeetingTranscriptionLanguage) -> Self {
+        Self {
+            lanes: (0..batch_size)
+                .map(|_| LanguageLaneTracker::new(setting_prior))
+                .collect(),
+        }
+    }
+
+    pub fn resize(&mut self, batch_size: usize, setting_prior: MeetingTranscriptionLanguage) {
+        if self.lanes.len() == batch_size {
+            for lane in &mut self.lanes {
+                lane.setting_prior = setting_prior;
+            }
+            return;
+        }
+        *self = Self::new(batch_size, setting_prior);
+    }
+
+    pub fn reset_lane(&mut self, batch_idx: usize) {
+        if let Some(lane) = self.lanes.get_mut(batch_idx) {
+            lane.reset();
+        }
+    }
+
+    pub fn reset_all(&mut self) {
+        for lane in &mut self.lanes {
+            lane.reset();
+        }
+    }
+
+    /// Returns true when this lane needs a forced reset due to language mismatch.
+    pub fn on_word(&mut self, text: &str, batch_idx: usize) -> bool {
+        self.lanes
+            .get_mut(batch_idx)
+            .is_some_and(|lane| lane.on_word(text))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::MeetingTranscriptionLanguage;
+
+    #[test]
+    fn detect_french_accents_and_stopwords() {
+        assert_eq!(detect_word("réunion"), Some(LanguageCode::Fr));
+        assert_eq!(detect_word("bonjour"), Some(LanguageCode::Fr));
+        assert_eq!(detect_text("le projet est très bien"), Some(LanguageCode::Fr));
+    }
+
+    #[test]
+    fn detect_english_stopwords() {
+        assert_eq!(detect_word("the"), Some(LanguageCode::En));
+        assert_eq!(detect_text("the meeting is about planning"), Some(LanguageCode::En));
+    }
+
+    #[test]
+    fn ambiguous_short_tokens_return_none() {
+        assert_eq!(detect_word("ok"), None);
+        assert_eq!(detect_word("12"), None);
+    }
+
+    #[test]
+    fn mismatch_streak_triggers_after_threshold() {
+        let mut lane = LanguageLaneTracker::new(MeetingTranscriptionLanguage::En);
+        assert!(!lane.on_word("bonjour"));
+        assert!(!lane.on_word("merci"));
+        assert!(lane.on_word("réunion"));
+    }
+
+    #[test]
+    fn mismatch_streak_clears_on_agreement() {
+        let mut lane = LanguageLaneTracker::new(MeetingTranscriptionLanguage::En);
+        assert!(!lane.on_word("bonjour"));
+        assert!(!lane.on_word("merci"));
+        assert!(!lane.on_word("the"));
+        assert!(!lane.on_word("réunion"));
+        assert!(!lane.on_word("encore"));
+    }
+
+    #[test]
+    fn auto_prior_inferred_from_majority() {
+        let mut lane = LanguageLaneTracker::new(MeetingTranscriptionLanguage::Auto);
+        for _ in 0..4 {
+            assert!(!lane.on_word("the"));
+        }
+        for _ in 0..2 {
+            assert!(!lane.on_word("bonjour"));
+        }
+        assert_eq!(lane.effective_prior(), Some(LanguageCode::En));
+    }
+
+}

--- a/src-tauri/src/pipeline/actor.rs
+++ b/src-tauri/src/pipeline/actor.rs
@@ -69,6 +69,8 @@ pub struct SessionConfig {
     /// Meeting-only auto-stop detection (silence + max duration). `None` for
     /// dictation sessions, where "meeting is over" doesn't apply.
     pub idle_config: Option<MeetingIdleConfig>,
+    /// Heuristic prior for meeting language stability (LID + lane resets).
+    pub meeting_transcription_language: crate::settings::MeetingTranscriptionLanguage,
 }
 
 pub enum EngineCommand {
@@ -619,6 +621,7 @@ impl EngineActor {
         let diarize = config.diarize && engine.supports_diarization();
 
         engine.set_diarization(diarize);
+        engine.set_meeting_language_prior(config.meeting_transcription_language);
 
         // The idle pre-warm (see `prewarm_single_stream`) keeps the engine
         // state reset for dictation between sessions; skip the reset here
@@ -1452,6 +1455,7 @@ mod tests {
             session_terms: vec![],
             diarize: false,
             idle_config: None,
+            meeting_transcription_language: crate::settings::MeetingTranscriptionLanguage::Auto,
         }
     }
 
@@ -1548,6 +1552,7 @@ mod tests {
             session_terms: vec![],
             diarize: true,
             idle_config: None,
+            meeting_transcription_language: crate::settings::MeetingTranscriptionLanguage::Auto,
         };
         actor.start_session(1, cfg, cb).expect("start diarized");
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -46,6 +46,7 @@ const LOG_LEVEL_KEY: &str = "log_level";
 const PASTE_METHOD_KEY: &str = "paste_method";
 const LAST_SEEN_VERSION_KEY: &str = "last_seen_version";
 const MEETING_AUDIO_RETENTION_KEY: &str = "meeting_audio_retention";
+const MEETING_TRANSCRIPTION_LANGUAGE_KEY: &str = "meeting_transcription_language";
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default, specta::Type)]
 #[serde(rename_all = "snake_case")]
@@ -83,6 +84,17 @@ pub enum Theme {
 
 /// How long recorded meeting audio is kept on disk before the startup sweep
 /// deletes it. Opt-in: recording itself only happens when this is not `Off`.
+/// Heuristic prior for meeting language detection and mismatch resets.
+/// Never passed to the STT engine as a forced decode language.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default, specta::Type)]
+#[serde(rename_all = "snake_case")]
+pub enum MeetingTranscriptionLanguage {
+    #[default]
+    Auto,
+    En,
+    Fr,
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default, specta::Type)]
 #[serde(rename_all = "snake_case")]
 pub enum MeetingAudioRetention {
@@ -159,6 +171,9 @@ pub struct AppSettings {
     /// Opt-in recording of meeting audio to compressed files on disk, and
     /// for how long they're kept. Off by default.
     pub meeting_audio_retention: MeetingAudioRetention,
+    /// Heuristic prior for meeting language stability (LID + lane resets).
+    /// Does not force Kyutai/moshi decode language.
+    pub meeting_transcription_language: MeetingTranscriptionLanguage,
     /// Optional LLM post-processing applied to dictation before paste/history.
     pub dictation_polish_enabled: bool,
     /// Active polish template id (email, bullets, no_fillers).
@@ -215,6 +230,7 @@ impl Default for AppSettings {
             meeting_autostop_minutes: 10,
             meeting_max_duration_minutes: 240,
             meeting_audio_retention: MeetingAudioRetention::default(),
+            meeting_transcription_language: MeetingTranscriptionLanguage::default(),
             dictation_polish_enabled: false,
             dictation_polish_template_id: crate::summary::TEMPLATE_EMAIL.to_string(),
             dictation_polish_templates: crate::summary::default_polish_templates(),
@@ -370,6 +386,11 @@ impl AppSettings {
         {
             settings.meeting_audio_retention = meeting_audio_retention;
         }
+        if let Some(meeting_transcription_language) =
+            read_json_setting::<MeetingTranscriptionLanguage>(db, MEETING_TRANSCRIPTION_LANGUAGE_KEY)?
+        {
+            settings.meeting_transcription_language = meeting_transcription_language;
+        }
         if let Some(dictation_polish_enabled) =
             read_json_setting::<bool>(db, DICTATION_POLISH_ENABLED_KEY)?
         {
@@ -505,6 +526,16 @@ impl AppSettings {
         }
         if !MEETING_MAX_DURATION_MINUTES_RANGE.contains(&normalized.meeting_max_duration_minutes) {
             normalized.meeting_max_duration_minutes = Self::default().meeting_max_duration_minutes;
+        }
+
+        if !matches!(
+            normalized.meeting_transcription_language,
+            MeetingTranscriptionLanguage::Auto
+                | MeetingTranscriptionLanguage::En
+                | MeetingTranscriptionLanguage::Fr
+        ) {
+            normalized.meeting_transcription_language =
+                Self::default().meeting_transcription_language;
         }
 
         normalized.dictation_polish_template_id = normalized
@@ -656,6 +687,11 @@ impl AppSettings {
             db,
             MEETING_AUDIO_RETENTION_KEY,
             &normalized.meeting_audio_retention,
+        )?;
+        write_json_setting(
+            db,
+            MEETING_TRANSCRIPTION_LANGUAGE_KEY,
+            &normalized.meeting_transcription_language,
         )?;
         write_json_setting(
             db,
@@ -821,6 +857,7 @@ mod tests {
             meeting_autostop_minutes: 15,
             meeting_max_duration_minutes: 120,
             meeting_audio_retention: MeetingAudioRetention::Keep30d,
+            meeting_transcription_language: super::MeetingTranscriptionLanguage::Fr,
             dictation_polish_enabled: true,
             dictation_polish_template_id: "email".into(),
             dictation_polish_templates: crate::summary::default_polish_templates(),

--- a/src/lib/components/SettingsView.svelte
+++ b/src/lib/components/SettingsView.svelte
@@ -149,6 +149,7 @@
       meetingAutostopEnabled={controller.app.settings.meeting_autostop_enabled}
       meetingAutostopMinutes={controller.app.settings.meeting_autostop_minutes}
       meetingMaxDurationMinutes={controller.app.settings.meeting_max_duration_minutes}
+      meetingTranscriptionLanguage={controller.app.settings.meeting_transcription_language}
       onCaptureSystemAudioChange={controller.onCaptureSystemAudioChange}
       onClamshellDeviceChange={controller.onClamshellDeviceChange}
       onVadEnabledChange={controller.onVadEnabledChange}
@@ -158,6 +159,7 @@
       onMeetingAutostopEnabledChange={controller.onMeetingAutostopEnabledChange}
       onMeetingAutostopMinutesChange={controller.onMeetingAutostopMinutesChange}
       onMeetingMaxDurationMinutesChange={controller.onMeetingMaxDurationMinutesChange}
+      onMeetingTranscriptionLanguageChange={controller.onMeetingTranscriptionLanguageChange}
     />
 
     <IntelligenceSettingsSection

--- a/src/lib/features/settings/components/AudioSettingsSection.svelte
+++ b/src/lib/features/settings/components/AudioSettingsSection.svelte
@@ -18,6 +18,13 @@
     480: "settings_audio.meeting_max_duration_8h",
   };
 
+  const meetingLanguageOptions = ["auto", "en", "fr"] as const;
+  const meetingLanguageKeys: Record<(typeof meetingLanguageOptions)[number], string> = {
+    auto: "settings_audio.meeting_transcription_language_auto",
+    en: "settings_audio.meeting_transcription_language_en",
+    fr: "settings_audio.meeting_transcription_language_fr",
+  };
+
   let {
     audioDevices,
     captureSystemAudio,
@@ -31,6 +38,7 @@
     meetingAutostopEnabled,
     meetingAutostopMinutes,
     meetingMaxDurationMinutes,
+    meetingTranscriptionLanguage,
     onCaptureSystemAudioChange,
     onClamshellDeviceChange,
     onVadEnabledChange,
@@ -40,6 +48,7 @@
     onMeetingAutostopEnabledChange,
     onMeetingAutostopMinutesChange,
     onMeetingMaxDurationMinutesChange,
+    onMeetingTranscriptionLanguageChange,
   }: {
     audioDevices: AudioDeviceInfo[];
     captureSystemAudio: boolean;
@@ -53,6 +62,7 @@
     meetingAutostopEnabled: boolean;
     meetingAutostopMinutes: number;
     meetingMaxDurationMinutes: number;
+    meetingTranscriptionLanguage: (typeof meetingLanguageOptions)[number];
     onCaptureSystemAudioChange: (event: Event) => void | Promise<void>;
     onClamshellDeviceChange: (event: Event) => void | Promise<void>;
     onVadEnabledChange: (event: Event) => void | Promise<void>;
@@ -62,6 +72,7 @@
     onMeetingAutostopEnabledChange: (event: Event) => void | Promise<void>;
     onMeetingAutostopMinutesChange: (event: Event) => void | Promise<void>;
     onMeetingMaxDurationMinutesChange: (event: Event) => void | Promise<void>;
+    onMeetingTranscriptionLanguageChange: (event: Event) => void | Promise<void>;
   } = $props();
 </script>
 
@@ -100,6 +111,25 @@
       {/snippet}
     </SettingsField>
   {/if}
+
+  <SettingsField
+    label={$t("settings_audio.meeting_transcription_language")}
+    description={$t("settings_audio.meeting_transcription_language_desc")}
+    htmlFor="meeting-transcription-language"
+  >
+    {#snippet control()}
+      <select
+        id="meeting-transcription-language"
+        value={meetingTranscriptionLanguage}
+        onchange={onMeetingTranscriptionLanguageChange}
+        class="field-select max-w-48"
+      >
+        {#each meetingLanguageOptions as lang}
+          <option value={lang}>{$t(meetingLanguageKeys[lang])}</option>
+        {/each}
+      </select>
+    {/snippet}
+  </SettingsField>
 
   <SettingsField
     label={$t("settings_audio.meeting_autostop")}

--- a/src/lib/features/settings/controller.svelte.test.ts
+++ b/src/lib/features/settings/controller.svelte.test.ts
@@ -76,6 +76,7 @@ const defaultSettings: AppSettings = {
   meeting_autostop_minutes: 10,
   meeting_max_duration_minutes: 240,
   meeting_audio_retention: "off",
+  meeting_transcription_language: "auto",
   dictation_polish_enabled: false,
   dictation_polish_template_id: "email",
   dictation_polish_templates: [

--- a/src/lib/features/settings/controller.svelte.ts
+++ b/src/lib/features/settings/controller.svelte.ts
@@ -522,6 +522,14 @@ export function createSettingsController() {
     });
   }
 
+  function onMeetingTranscriptionLanguageChange(event: Event) {
+    const value = (event.target as HTMLSelectElement)
+      .value as AppSettings["meeting_transcription_language"];
+    void persistSettings((settings) => {
+      settings.meeting_transcription_language = value;
+    });
+  }
+
   function onMeetingAudioRetentionChange(event: Event) {
     const value = (event.target as HTMLSelectElement).value as AppSettings["meeting_audio_retention"];
     void persistSettings((settings) => {
@@ -784,6 +792,7 @@ export function createSettingsController() {
     onMeetingAutostopEnabledChange,
     onMeetingAutostopMinutesChange,
     onMeetingMaxDurationMinutesChange,
+    onMeetingTranscriptionLanguageChange,
     onMeetingAudioRetentionChange,
     onVadEnabledChange,
     onFillerRemovalChange,

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -34,7 +34,12 @@
     "meeting_max_duration_label": "Maximum meeting length",
     "meeting_max_duration_2h": "2 hours",
     "meeting_max_duration_4h": "4 hours",
-    "meeting_max_duration_8h": "8 hours"
+    "meeting_max_duration_8h": "8 hours",
+    "meeting_transcription_language": "Meeting language",
+    "meeting_transcription_language_desc": "Hint for language detection during meetings. Does not force the transcription model.",
+    "meeting_transcription_language_auto": "Auto-detect",
+    "meeting_transcription_language_en": "English",
+    "meeting_transcription_language_fr": "French"
   },
   "settings_dictionary": {
     "title": "Custom Dictionary",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -34,7 +34,12 @@
     "meeting_max_duration_label": "Durée maximale de la réunion",
     "meeting_max_duration_2h": "2 heures",
     "meeting_max_duration_4h": "4 heures",
-    "meeting_max_duration_8h": "8 heures"
+    "meeting_max_duration_8h": "8 heures",
+    "meeting_transcription_language": "Langue de la réunion",
+    "meeting_transcription_language_desc": "Indication pour la détection de langue pendant les réunions. N'impose pas la langue au modèle.",
+    "meeting_transcription_language_auto": "Détection automatique",
+    "meeting_transcription_language_en": "Anglais",
+    "meeting_transcription_language_fr": "Français"
   },
   "settings_dictionary": {
     "title": "Dictionnaire personnalisé",

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -81,6 +81,7 @@ let settings = $state<AppSettings>({
   meeting_autostop_minutes: 10,
   meeting_max_duration_minutes: 240,
   meeting_audio_retention: "off",
+  meeting_transcription_language: "auto",
   dictation_polish_enabled: false,
   dictation_polish_template_id: "email",
   dictation_polish_templates: [

--- a/src/lib/test-helpers/fixtures.ts
+++ b/src/lib/test-helpers/fixtures.ts
@@ -208,6 +208,7 @@ export const mockSettings: AppSettings = {
   meeting_autostop_minutes: 10,
   meeting_max_duration_minutes: 240,
   meeting_audio_retention: "off",
+  meeting_transcription_language: "auto",
   dictation_polish_enabled: false,
   dictation_polish_template_id: "email",
   dictation_polish_templates: [

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -905,6 +905,11 @@ meeting_max_duration_minutes: number;
  */
 meeting_audio_retention: MeetingAudioRetention; 
 /**
+ * Heuristic prior for meeting language stability (LID + lane resets).
+ * Does not force Kyutai/moshi decode language.
+ */
+meeting_transcription_language: MeetingTranscriptionLanguage; 
+/**
  * Optional LLM post-processing applied to dictation before paste/history.
  */
 dictation_polish_enabled: boolean; 
@@ -1046,10 +1051,6 @@ export type HealthStatus = "healthy" |
 "stalled"
 export type LogLevel = "error" | "warn" | "info" | "debug" | "trace"
 export type McpSetupInfo = { binary_path: string; exists: boolean; claude_desktop_snippet: string; claude_code_command: string }
-/**
- * How long recorded meeting audio is kept on disk before the startup sweep
- * deletes it. Opt-in: recording itself only happens when this is not `Off`.
- */
 export type MeetingAudioRetention = 
 /**
  * No recording at all; existing recordings from a previous, more
@@ -1142,6 +1143,13 @@ calendar_event_id: string | null;
  * into the summary prompt.
  */
 participants: MeetingParticipant[] }
+/**
+ * How long recorded meeting audio is kept on disk before the startup sweep
+ * deletes it. Opt-in: recording itself only happens when this is not `Off`.
+ * Heuristic prior for meeting language detection and mismatch resets.
+ * Never passed to the STT engine as a forced decode language.
+ */
+export type MeetingTranscriptionLanguage = "auto" | "en" | "fr"
 export type ModelArtifactDescriptor = { id: string; label: string; description: string; provider: string; repository: string; revision: string | null; file_format: string; download_size_bytes: number | null; required_files: string[] }
 export type Navigate = AppView
 export type PasteMethod = "clipboard" | "type"


### PR DESCRIPTION
## Summary
- Adds a **Meeting language** setting (`meeting_transcription_language`: auto / en / fr) as a heuristic prior for language detection during meetings — not a hard Kyutai/moshi language pin (upstream has no supported pin).
- Introduces word-level heuristic LID and a consecutive **mismatch streak** that triggers per-lane KV resets via `reset_batch_idx`, so one speaker lane can recover from a wrong-language decode without tearing down the other.
- Refactors proactive context refresh to per-lane VAD pause tracking; **#50 soft refresh** behavior is preserved for single-stream mode and when both lanes are idle (full refresh).

## Test plan
- [ ] Local: `cargo test --manifest-path src-tauri/Cargo.toml --workspace`, clippy, `npm test`, `npm run check` (already green on this branch)
- [ ] CI: contracts + Playwright
- [ ] Manual: bilingual meeting with diarization — verify language flips stabilize without full-session freeze; confirm setting persists; single-stream / both-idle still soft-refreshes as before