### PR TITLE
Let users fix live meeting phrases and reuse corrections for the session

### DIFF
--- a/src-tauri/src/commands/meetings.rs
+++ b/src-tauri/src/commands/meetings.rs
@@ -2,6 +2,7 @@ use tauri::State;
 use tauri::ipc::Channel;
 
 use crate::db::search::SearchResult;
+use crate::engine::TranscriptionSegment;
 use crate::export::{self, ExportFormat};
 use crate::settings::AppSettings;
 use crate::state::AppState;
@@ -137,6 +138,112 @@ pub fn save_edited_transcript(
     state
         .db
         .save_edited_transcript(&id, edited_transcript.as_deref())
+}
+
+/// Apply a live paragraph edit during an active meeting: patch the edited
+/// segments in the accumulator (and on disk when already flushed), and
+/// register session corrections so later STT output of the same misspelling
+/// is rewritten for the rest of this recording session.
+#[tauri::command]
+#[specta::specta]
+pub fn apply_live_paragraph_edit(
+    state: State<'_, AppState>,
+    meeting_id: String,
+    segment_start: u32,
+    segment_end: u32,
+    new_text: String,
+) -> Result<(), String> {
+    use crate::filter::session_terms::derive_corrections_from_edit;
+    use crate::lock_ext::MutexExt;
+
+    let segment_start = segment_start as usize;
+    let segment_end = segment_end as usize;
+    if segment_end <= segment_start {
+        return Err("Invalid segment range".into());
+    }
+
+    let new_text = new_text.trim().to_string();
+    if new_text.is_empty() {
+        return Err("Paragraph text cannot be empty".into());
+    }
+
+    let (original_text, db_updates, corrections) = {
+        let mut acc = state.meeting_accumulator.acquire()?;
+        let Some(meeting) = acc.as_mut() else {
+            return Err("No meeting is recording".into());
+        };
+        if meeting.id != meeting_id {
+            return Err("Meeting id mismatch".into());
+        }
+        if segment_end > meeting.new_segments.len() {
+            return Err("Segment range out of bounds".into());
+        }
+
+        let slice = &meeting.new_segments[segment_start..segment_end];
+        let original_text = slice
+            .iter()
+            .map(|segment| segment.text.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        let corrections = derive_corrections_from_edit(&original_text, &new_text);
+
+        redistribute_segment_texts(
+            &mut meeting.new_segments[segment_start..segment_end],
+            &new_text,
+        );
+
+        let global_base = meeting.existing_segments.len();
+        let db_updates: Vec<(i64, String)> = (segment_start..segment_end)
+            .filter(|index| *index < meeting.persisted_new_count)
+            .map(|index| {
+                (
+                    (global_base + index) as i64,
+                    meeting.new_segments[index].text.clone(),
+                )
+            })
+            .collect();
+
+        (original_text, db_updates, corrections)
+    };
+
+    if original_text == new_text {
+        return Ok(());
+    }
+
+    if !db_updates.is_empty() {
+        state.db.update_segment_texts(&meeting_id, &db_updates)?;
+    }
+
+    for correction in corrections {
+        state.engine_actor.add_session_correction(correction)?;
+    }
+
+    Ok(())
+}
+
+fn redistribute_segment_texts(segments: &mut [TranscriptionSegment], new_text: &str) {
+    let words: Vec<&str> = new_text.split_whitespace().collect();
+    if segments.is_empty() {
+        return;
+    }
+    if words.is_empty() {
+        for segment in segments.iter_mut() {
+            segment.text.clear();
+        }
+        return;
+    }
+    if segments.len() == 1 {
+        segments[0].text = new_text.to_string();
+        return;
+    }
+    let last_index = segments.len() - 1;
+    for (index, segment) in segments.iter_mut().enumerate() {
+        if index < last_index {
+            segment.text = words.get(index).copied().unwrap_or("").to_string();
+        } else {
+            segment.text = words.get(index..).unwrap_or(&[""]).join(" ");
+        }
+    }
 }
 
 /// Render a meeting export without writing to disk. Used by tests and, if

--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -287,6 +287,7 @@ fn start_pipeline_blocking(
         pipeline_config: settings.pipeline_config(),
         dictionary_entries: db.list_dictionary_entries()?,
         session_terms,
+        session_corrections: vec![],
         diarize,
         idle_config,
         meeting_transcription_language: settings.meeting_transcription_language,

--- a/src-tauri/src/db/meetings.rs
+++ b/src-tauri/src/db/meetings.rs
@@ -202,6 +202,31 @@ impl Database {
         Ok(())
     }
 
+    /// Patch segment text for segments already flushed during a live meeting.
+    /// `updates` pairs `(sort_order, new_text)`.
+    pub fn update_segment_texts(
+        &self,
+        meeting_id: &str,
+        updates: &[(i64, String)],
+    ) -> Result<(), String> {
+        if updates.is_empty() {
+            return Ok(());
+        }
+        let mut conn = self.conn.acquire()?;
+        let tx = conn
+            .transaction()
+            .map_err(|e| format!("Transaction: {e}"))?;
+        for (sort_order, text) in updates {
+            tx.execute(
+                "UPDATE segments SET text = ?3 WHERE meeting_id = ?1 AND sort_order = ?2",
+                params![meeting_id, sort_order, text],
+            )
+            .map_err(|e| format!("Update segment text: {e}"))?;
+        }
+        tx.commit().map_err(|e| format!("Commit: {e}"))?;
+        Ok(())
+    }
+
     /// Finalize meetings left with `ended_at IS NULL` by a crash mid-recording.
     /// Empty shells (a started meeting with no persisted segments) are deleted;
     /// the rest get `ended_at`/`duration`/`recording_sessions` synthesized from

--- a/src-tauri/src/filter/mod.rs
+++ b/src-tauri/src/filter/mod.rs
@@ -152,6 +152,7 @@ pub fn build_text_filters(
     config: &PipelineConfig,
     dictionary: Vec<DictionaryEntry>,
     session_terms: &[String],
+    session_corrections: &[session_terms::SessionCorrection],
 ) -> TextFilterChain {
     let mut filters: Vec<Box<dyn TextFilter>> = Vec::new();
     if config.filler_removal_enabled {
@@ -160,11 +161,21 @@ pub fn build_text_filters(
     if config.stutter_collapse_enabled {
         filters.push(Box::new(text_stutter::StutterCollapseFilter::new()));
     }
-    if config.dictionary_correction_enabled && (!dictionary.is_empty() || !session_terms.is_empty())
+    if config.dictionary_correction_enabled
+        && (!dictionary.is_empty()
+            || !session_terms.is_empty()
+            || !session_corrections.is_empty())
     {
-        filters.push(Box::new(
-            text_dictionary::DictionaryFilter::with_session_terms(dictionary, session_terms),
-        ));
+        let filter = if session_corrections.is_empty() {
+            text_dictionary::DictionaryFilter::with_session_terms(dictionary, session_terms)
+        } else {
+            text_dictionary::DictionaryFilter::with_session_hints(
+                dictionary,
+                session_terms,
+                session_corrections,
+            )
+        };
+        filters.push(Box::new(filter));
     }
     // Whitespace normalization always runs last to clean up artifacts from previous filters
     filters.push(Box::new(text_whitespace::WhitespaceNormFilter));
@@ -237,8 +248,52 @@ mod tests {
             stutter_collapse_enabled: false,
             dictionary_correction_enabled: false,
         };
-        let chain = build_text_filters(&config, vec![], &[]);
+        let chain = build_text_filters(&config, vec![], &[], &[]);
         // Whitespace normalization should still clean up
         assert_eq!(chain.apply("  hello   world  "), "hello world");
+    }
+
+    #[test]
+    fn session_corrections_apply_when_dictionary_correction_enabled() {
+        use crate::filter::session_terms::SessionCorrection;
+        let config = PipelineConfig {
+            vad_enabled: false,
+            vad_model_path: None,
+            filler_removal_enabled: false,
+            stutter_collapse_enabled: false,
+            dictionary_correction_enabled: true,
+        };
+        let chain = build_text_filters(
+            &config,
+            vec![],
+            &[],
+            &[SessionCorrection {
+                misspelling: "Kubernetis".to_string(),
+                term: "Kubernetes".to_string(),
+            }],
+        );
+        assert_eq!(chain.apply("Kubernetis cluster"), "Kubernetes cluster");
+    }
+
+    #[test]
+    fn session_corrections_skipped_when_dictionary_correction_disabled() {
+        use crate::filter::session_terms::SessionCorrection;
+        let config = PipelineConfig {
+            vad_enabled: false,
+            vad_model_path: None,
+            filler_removal_enabled: false,
+            stutter_collapse_enabled: false,
+            dictionary_correction_enabled: false,
+        };
+        let chain = build_text_filters(
+            &config,
+            vec![],
+            &[],
+            &[SessionCorrection {
+                misspelling: "Kubernetis".to_string(),
+                term: "Kubernetes".to_string(),
+            }],
+        );
+        assert_eq!(chain.apply("Kubernetis cluster"), "Kubernetis cluster");
     }
 }

--- a/src-tauri/src/filter/session_terms.rs
+++ b/src-tauri/src/filter/session_terms.rs
@@ -5,6 +5,8 @@
 
 use std::collections::HashSet;
 
+use serde::{Deserialize, Serialize};
+
 /// Upper bound on derived terms: invitation bodies can be huge
 /// (videoconference boilerplate), and every term costs a comparison per
 /// transcribed word.
@@ -12,6 +14,15 @@ const MAX_SESSION_TERMS: usize = 50;
 
 /// Minimum token length; shorter tokens collide with function words.
 const MIN_TOKEN_LEN: usize = 3;
+
+/// An explicit misspelling-to-term pair registered when the user edits live
+/// transcript text. Applied through the dictionary filter for the rest of the
+/// recording session only.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+pub struct SessionCorrection {
+    pub misspelling: String,
+    pub term: String,
+}
 
 /// Derive session terms from participant names plus free text (event title,
 /// invitation body). Names contribute every name token; free text only
@@ -41,6 +52,82 @@ pub fn derive_session_terms(names: &[String], free_texts: &[&str]) -> Vec<String
     }
 
     terms
+}
+
+/// Word-level alignment between the paragraph text before and after a live
+/// edit. Each changed word pair becomes a session correction so later STT
+/// output of the same misspelling is rewritten toward the user's fix.
+pub fn derive_corrections_from_edit(original: &str, corrected: &str) -> Vec<SessionCorrection> {
+    let orig_words = tokenize_words(original);
+    let corr_words = tokenize_words(corrected);
+    if orig_words.is_empty() || corr_words.is_empty() || orig_words == corr_words {
+        return Vec::new();
+    }
+
+    let mut corrections = Vec::new();
+    let mut seen: HashSet<(String, String)> = HashSet::new();
+    let mut i = 0usize;
+    let mut j = 0usize;
+
+    while i < orig_words.len() && j < corr_words.len() {
+        if orig_words[i].eq_ignore_ascii_case(&corr_words[j]) {
+            i += 1;
+            j += 1;
+            continue;
+        }
+
+        // Skip ahead on whichever side still has a matching token later in
+        // the other list (handles insertions/deletions without pairing noise).
+        if j + 1 < corr_words.len()
+            && orig_words[i].eq_ignore_ascii_case(&corr_words[j + 1])
+        {
+            j += 1;
+            continue;
+        }
+        if i + 1 < orig_words.len()
+            && orig_words[i + 1].eq_ignore_ascii_case(&corr_words[j])
+        {
+            i += 1;
+            continue;
+        }
+
+        push_correction(&mut corrections, &mut seen, &orig_words[i], &corr_words[j]);
+        i += 1;
+        j += 1;
+    }
+
+    corrections
+}
+
+fn tokenize_words(text: &str) -> Vec<String> {
+    text.split_whitespace()
+        .map(|token| token.trim_matches(|c: char| !c.is_alphanumeric()).to_string())
+        .filter(|token| !token.is_empty())
+        .collect()
+}
+
+fn push_correction(
+    corrections: &mut Vec<SessionCorrection>,
+    seen: &mut HashSet<(String, String)>,
+    from: &str,
+    to: &str,
+) {
+    if !is_correction_candidate(from, to) {
+        return;
+    }
+    let key = (from.to_lowercase(), to.to_lowercase());
+    if seen.insert(key) {
+        corrections.push(SessionCorrection {
+            misspelling: from.to_string(),
+            term: to.to_string(),
+        });
+    }
+}
+
+fn is_correction_candidate(from: &str, to: &str) -> bool {
+    from.chars().count() >= MIN_TOKEN_LEN
+        && to.chars().count() >= MIN_TOKEN_LEN
+        && !from.eq_ignore_ascii_case(to)
 }
 
 fn is_name_token(token: &str) -> bool {
@@ -98,6 +185,32 @@ mod tests {
     fn punctuation_is_trimmed() {
         let terms = derive_session_terms(&[], &["(FluidNC), API."]);
         assert_eq!(strs(&terms), vec!["FluidNC", "API"]);
+    }
+
+    #[test]
+    fn derive_corrections_pairs_changed_words() {
+        let corrections = derive_corrections_from_edit(
+            "We use Kubernetis for deploys",
+            "We use Kubernetes for deploys",
+        );
+        assert_eq!(corrections.len(), 1);
+        assert_eq!(corrections[0].misspelling, "Kubernetis");
+        assert_eq!(corrections[0].term, "Kubernetes");
+    }
+
+    #[test]
+    fn derive_corrections_skips_identical_and_short_tokens() {
+        assert!(derive_corrections_from_edit("hello world", "hello world").is_empty());
+        assert!(derive_corrections_from_edit("ok fine", "ok ok").is_empty());
+    }
+
+    #[test]
+    fn derive_corrections_dedupes_repeated_pairs() {
+        let corrections = derive_corrections_from_edit(
+            "Kubernetis and Kubernetis again",
+            "Kubernetes and Kubernetes again",
+        );
+        assert_eq!(corrections.len(), 1);
     }
 
     #[test]

--- a/src-tauri/src/filter/text_dictionary.rs
+++ b/src-tauri/src/filter/text_dictionary.rs
@@ -96,6 +96,15 @@ impl DictionaryFilter {
     /// `session_terms` are ephemeral additions for one recording session
     /// (participant names, meeting jargon); they match phonetically only.
     pub fn with_session_terms(entries: Vec<DictionaryEntry>, session_terms: &[String]) -> Self {
+        Self::with_session_hints(entries, session_terms, &[])
+    }
+
+    /// Session terms plus explicit misspelling-to-term pairs from live edits.
+    pub fn with_session_hints(
+        entries: Vec<DictionaryEntry>,
+        session_terms: &[String],
+        session_corrections: &[super::session_terms::SessionCorrection],
+    ) -> Self {
         let mut matches: Vec<DictionaryMatch> = entries
             .into_iter()
             .map(|e| {
@@ -123,6 +132,19 @@ impl DictionaryFilter {
                 phonetic_code: soundex(term),
                 phonetic_only: true,
                 explicit_pronunciation: false,
+            });
+        }
+        for correction in session_corrections {
+            let term_lower = correction.term.to_lowercase();
+            if matches.iter().any(|m| m.term_lower == term_lower) {
+                continue;
+            }
+            matches.push(DictionaryMatch {
+                term: correction.term.clone(),
+                term_lower,
+                phonetic_code: soundex(&correction.misspelling),
+                phonetic_only: false,
+                explicit_pronunciation: true,
             });
         }
         Self { entries: matches }
@@ -350,6 +372,20 @@ mod tests {
 
         let user = DictionaryFilter::with_session_terms(vec![entry("Martin")], &[]);
         assert_eq!(user.apply("le matin venu"), "le Martin venu");
+    }
+
+    #[test]
+    fn session_corrections_rewrite_live_misspellings() {
+        use crate::filter::session_terms::SessionCorrection;
+        let f = DictionaryFilter::with_session_hints(
+            vec![],
+            &[],
+            &[SessionCorrection {
+                misspelling: "Kubernetis".to_string(),
+                term: "Kubernetes".to_string(),
+            }],
+        );
+        assert_eq!(f.apply("Kubernetis cluster"), "Kubernetes cluster");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -102,6 +102,7 @@ fn specta_builder() -> Builder<tauri::Wry> {
             commands::rename_meeting,
             commands::save_meeting_notes,
             commands::save_edited_transcript,
+            commands::apply_live_paragraph_edit,
             commands::export_meeting_preview,
             commands::export_meeting_filename,
             commands::export_meeting_to_file,

--- a/src-tauri/src/pipeline/actor.rs
+++ b/src-tauri/src/pipeline/actor.rs
@@ -7,6 +7,8 @@
 //! the engine lifecycle across command and inference threads.
 
 use std::path::PathBuf;
+use std::rc::Rc;
+use std::cell::RefCell;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::AtomicU64;
@@ -26,7 +28,7 @@ use crate::engine::{
 };
 use crate::filter::{
     AudioFilterChain, DictionaryEntry, PipelineConfig, TextFilterChain, build_audio_filters,
-    build_text_filters,
+    build_text_filters, session_terms::SessionCorrection,
 };
 use crate::platform::with_autorelease_pool;
 
@@ -63,6 +65,8 @@ pub struct SessionConfig {
     /// Ephemeral correction terms for this session only (participant names,
     /// meeting jargon); never persisted to the user's dictionary.
     pub session_terms: Vec<String>,
+    /// Explicit misspelling-to-term pairs from live transcript edits.
+    pub session_corrections: Vec<SessionCorrection>,
     /// Diarized meeting: run a second engine so the mic (Me) and system audio
     /// (Them) legs are transcribed separately and segments are speaker-tagged.
     pub diarize: bool,
@@ -100,6 +104,12 @@ pub enum EngineCommand {
     },
     /// Reconfigure the idle-unload timeout. `None` disables it. Fire-and-forget.
     SetUnloadTimeout(Option<Duration>),
+    /// Register a live transcript correction for the active session's filter
+    /// chain. Replies once the dictionary filter has been rebuilt.
+    AddSessionCorrection {
+        correction: SessionCorrection,
+        reply: Sender<Result<(), String>>,
+    },
     Shutdown,
 }
 
@@ -246,6 +256,15 @@ impl EngineActorHandle {
         )
     }
 
+    /// Register a live transcript correction so later STT output of the same
+    /// misspelling is rewritten for the rest of this recording session.
+    pub fn add_session_correction(&self, correction: SessionCorrection) -> Result<(), String> {
+        self.request(
+            |reply| EngineCommand::AddSessionCorrection { correction, reply },
+            None,
+        )
+    }
+
     /// Shut down the actor thread: unloads and drops the engine on the actor
     /// thread, then joins. Idempotent.
     pub fn shutdown(&self) -> Result<(), String> {
@@ -300,6 +319,36 @@ struct EngineActor {
     /// session. Set by the idle pre-warm after a session ends and by the
     /// initial load; cleared as soon as a session starts consuming it.
     state_fresh_for: Option<bool>,
+}
+
+/// Mutable filter state for an active session; rebuilt when live corrections arrive.
+struct LiveFilterState {
+    pipeline_config: PipelineConfig,
+    dictionary_entries: Vec<DictionaryEntry>,
+    session_terms: Vec<String>,
+    session_corrections: Vec<SessionCorrection>,
+}
+
+impl LiveFilterState {
+    fn rebuild_chain(&self) -> TextFilterChain {
+        build_text_filters(
+            &self.pipeline_config,
+            self.dictionary_entries.clone(),
+            &self.session_terms,
+            &self.session_corrections,
+        )
+    }
+
+    fn register_correction(&mut self, correction: SessionCorrection) {
+        if self
+            .session_corrections
+            .iter()
+            .any(|existing| existing.misspelling.eq_ignore_ascii_case(&correction.misspelling))
+        {
+            return;
+        }
+        self.session_corrections.push(correction);
+    }
 }
 
 /// Outcome of an active session loop.
@@ -456,6 +505,9 @@ impl EngineActor {
                 }
                 EngineCommand::SetUnloadTimeout(duration) => {
                     self.unload_timeout = duration;
+                }
+                EngineCommand::AddSessionCorrection { reply, .. } => {
+                    let _ = reply.send(Err("No active recording session".into()));
                 }
                 EngineCommand::Shutdown => break,
             }
@@ -665,12 +717,18 @@ impl EngineActor {
         let sample_rate = info.audio.sample_rate_hz;
 
         // Filter chains are built on this thread so ONNX Runtime (Silero VAD)
-        // initialization shares the thread with engine Metal work.
-        let text_filters = build_text_filters(
-            &config.pipeline_config,
-            config.dictionary_entries,
-            &config.session_terms,
-        );
+        // initialization shares the thread with engine Metal work. The chain
+        // is shared behind an RwLock so live transcript edits can register
+        // session corrections mid-recording.
+        let filter_state = Rc::new(RefCell::new(LiveFilterState {
+            pipeline_config: config.pipeline_config.clone(),
+            dictionary_entries: config.dictionary_entries,
+            session_terms: config.session_terms,
+            session_corrections: config.session_corrections,
+        }));
+        let text_filters = Rc::new(RefCell::new(
+            filter_state.borrow().rebuild_chain(),
+        ));
 
         let mut health = SessionHealth::start(session_id, Arc::clone(&self.dropped_counter));
         let idle_monitor = config
@@ -715,6 +773,7 @@ impl EngineActor {
             &on_segment,
             session_id,
             &text_filters,
+            &filter_state,
             &mut health,
             self.app.as_ref(),
             mode.as_mut(),
@@ -992,7 +1051,8 @@ fn run_session_loop(
     engine: &mut dyn TranscriptionEngine,
     on_segment: &SegmentCallback,
     session_id: u64,
-    text_filters: &TextFilterChain,
+    text_filters: &Rc<RefCell<TextFilterChain>>,
+    filter_state: &Rc<RefCell<LiveFilterState>>,
     health: &mut SessionHealth,
     app: Option<&tauri::AppHandle>,
     mode: &mut dyn SessionMode,
@@ -1134,6 +1194,14 @@ fn run_session_loop(
             // rather than silently dropping the setting change.
             Ok(EngineCommand::SetUnloadTimeout(duration)) => {
                 *pending_unload_timeout = Some(duration);
+            }
+            Ok(EngineCommand::AddSessionCorrection { correction, reply }) => {
+                {
+                    let mut state = filter_state.borrow_mut();
+                    state.register_correction(correction);
+                    *text_filters.borrow_mut() = state.rebuild_chain();
+                }
+                let _ = reply.send(Ok(()));
             }
             Err(_) => {}
         }
@@ -1287,7 +1355,7 @@ fn finish_session(
     engine: &mut dyn TranscriptionEngine,
     on_segment: &SegmentCallback,
     session_id: u64,
-    text_filters: &TextFilterChain,
+    text_filters: &Rc<RefCell<TextFilterChain>>,
     mode: &mut dyn SessionMode,
     summary: &mut SessionSummary,
 ) {
@@ -1370,14 +1438,14 @@ fn catch_engine<T, E: std::string::ToString>(
 /// speech-activity signal.
 fn emit_filtered(
     engine: &dyn TranscriptionEngine,
-    text_filters: &TextFilterChain,
+    text_filters: &Rc<RefCell<TextFilterChain>>,
     mut segment: TranscriptionSegment,
     on_segment: &SegmentCallback,
 ) -> bool {
     // Step 1: engine-specific normalization (strip [_TT_], ▁, etc.)
     segment.text = engine.normalize_text(&segment.text);
     // Step 2: shared text filter chain (filler, stutter, dictionary, whitespace)
-    segment.text = text_filters.apply(&segment.text);
+    segment.text = text_filters.borrow().apply(&segment.text);
     if segment.text.is_empty() {
         return false;
     }
@@ -1453,6 +1521,7 @@ mod tests {
             pipeline_config: noop_filter_config(),
             dictionary_entries: vec![],
             session_terms: vec![],
+            session_corrections: vec![],
             diarize: false,
             idle_config: None,
             meeting_transcription_language: crate::settings::MeetingTranscriptionLanguage::Auto,
@@ -1550,6 +1619,7 @@ mod tests {
             pipeline_config: noop_filter_config(),
             dictionary_entries: vec![],
             session_terms: vec![],
+            session_corrections: vec![],
             diarize: true,
             idle_config: None,
             meeting_transcription_language: crate::settings::MeetingTranscriptionLanguage::Auto,

--- a/src/lib/api/meetings.ts
+++ b/src/lib/api/meetings.ts
@@ -87,6 +87,15 @@ export async function saveEditedTranscript(id: string, editedTranscript: string 
   await unwrap(commands.saveEditedTranscript(id, editedTranscript));
 }
 
+export async function applyLiveParagraphEdit(
+  meetingId: string,
+  segmentStart: number,
+  segmentEnd: number,
+  newText: string,
+): Promise<void> {
+  await unwrap(commands.applyLiveParagraphEdit(meetingId, segmentStart, segmentEnd, newText));
+}
+
 /** Suggested filename for a meeting export (e.g. "2026-07-09-weekly-sync.md"). */
 export async function exportMeetingFilename(id: string, format: ExportFormat): Promise<string> {
   return unwrap(commands.exportMeetingFilename(id, format));

--- a/src/lib/features/home/LiveSessionCard.svelte
+++ b/src/lib/features/home/LiveSessionCard.svelte
@@ -5,6 +5,7 @@
   import Waveform from "../../components/Waveform.svelte";
   import Spinner from "../../components/ui/Spinner.svelte";
   import MeetingNotesSection from "../meeting/components/MeetingNotesSection.svelte";
+  import type { LiveParagraph } from "../meeting/live-transcript.svelte";
   import type { createMeetingController } from "../meeting/controller.svelte";
   import type { createTranscriptionController } from "../transcription/controller.svelte";
 
@@ -26,15 +27,12 @@
 
   let elapsedSeconds = $state(0);
   let transcriptEl: HTMLDivElement | undefined = $state();
+  let editingParagraphId = $state<number | null>(null);
+  let editDraft = $state("");
+  let editSaving = $state(false);
 
   const liveText = $derived(mode === "dictation" ? transcription.transcript : "");
 
-  // Meetings render through the same paragraph grouping as the finished
-  // transcript, so diarized sessions show Me/Them live: segments are ordered
-  // by time and split on speaker changes instead of one undifferentiated blob.
-  // `committed` only grows by push and can hold hours of history, so slice it
-  // to the window first: slicing the last N elements is O(N), not O(meeting
-  // length), which keeps this derived cheap on every incoming segment.
   const liveParagraphs = $derived(
     mode === "meeting"
       ? [...meeting.liveTranscript.committed.slice(-LIVE_PARAGRAPH_WINDOW), ...meeting.liveTranscript.tail]
@@ -70,9 +68,49 @@
     }
   }
 
-  // Track whether the user is (still) parked near the bottom, independent of
-  // content changes, so a burst of new segments never fights a manual scroll
-  // up to read earlier text.
+  function paragraphEditable(paragraph: LiveParagraph, index: number): boolean {
+    if (stopping || editSaving) return false;
+    const isCommitted = meeting.liveTranscript.committed.some((item) => item.id === paragraph.id);
+    if (!isCommitted) return false;
+    const isLast = index === liveParagraphs.length - 1;
+    return !(isLast && Boolean(liveTentative));
+  }
+
+  function startParagraphEdit(paragraph: LiveParagraph) {
+    editingParagraphId = paragraph.id;
+    editDraft = paragraph.text;
+  }
+
+  function cancelParagraphEdit() {
+    editingParagraphId = null;
+    editDraft = "";
+  }
+
+  async function saveParagraphEdit() {
+    if (editingParagraphId == null || editSaving) return;
+    const trimmed = editDraft.trim();
+    if (!trimmed) return;
+    editSaving = true;
+    try {
+      await meeting.applyLiveParagraphEdit(editingParagraphId, trimmed);
+      cancelParagraphEdit();
+    } finally {
+      editSaving = false;
+    }
+  }
+
+  function handleParagraphKeydown(event: KeyboardEvent) {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      cancelParagraphEdit();
+      return;
+    }
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      void saveParagraphEdit();
+    }
+  }
+
   let isNearBottom = true;
   let scrollRafId: number | null = null;
 
@@ -90,8 +128,6 @@
     });
   }
 
-  // Keep the latest words in view as they stream in, coalesced to one scroll
-  // per frame instead of one per segment.
   $effect(() => {
     void liveText;
     void liveParagraphs;
@@ -139,7 +175,6 @@
   </div>
 
   {#if mode === "dictation"}
-    <!-- Dictation hero: the words are the whole surface. -->
     <div class="flex min-h-[340px] flex-col rounded-[18px] bg-surface-1 p-[30px] px-8 outline-1 outline-ghost-border">
       <p class="m-0 text-[19px] font-normal leading-[1.85] text-text-secondary">
         {liveText}<span
@@ -171,9 +206,8 @@
       </div>
     {/if}
 
-    <!-- Meeting hero: live transcript front and center. -->
     <div class="flex min-h-[300px] flex-col gap-[18px] rounded-[18px] bg-surface-1 px-6 py-[22px] outline-1 outline-ghost-border">
-      <div class="flex items-center justify-between">
+      <div class="flex items-center justify-between gap-3">
         <h3 class="text-sm font-semibold text-text-primary">{$t("home.live_transcript")}</h3>
         <span class="inline-flex items-center gap-1.5 text-[11.5px] text-text-muted">
           <span class={`h-1.5 w-1.5 rounded-full ${systemAudioActive ? "bg-accent" : "bg-surface-4"}`}></span>
@@ -182,6 +216,7 @@
             : $t("meeting_header.system_audio_unavailable")}
         </span>
       </div>
+      <p class="m-0 text-[11.5px] text-text-muted">{$t("home.live_edit_hint")}</p>
       <div
         bind:this={transcriptEl}
         onscroll={handleScroll}
@@ -202,12 +237,46 @@
                 {/if}
                 <span class="font-mono text-[10.5px] text-text-faint">{paragraph.timestamp}</span>
               </div>
-              <p class="m-0 text-[15px] leading-[1.75] text-text-secondary">
-                {paragraph.text}
-                {#if i === liveParagraphs.length - 1 && liveTentative}
-                  <span class="opacity-50">{paragraph.text ? " " : ""}{liveTentative}</span>
-                {/if}
-              </p>
+              {#if editingParagraphId === paragraph.id}
+                <div class="flex flex-col gap-2">
+                  <textarea
+                    bind:value={editDraft}
+                    onkeydown={handleParagraphKeydown}
+                    class="field-input min-h-[72px] resize-y text-[15px] leading-[1.75]"
+                    disabled={editSaving}
+                  ></textarea>
+                  <div class="flex gap-2">
+                    <button
+                      onclick={() => void saveParagraphEdit()}
+                      class="btn btn-sm"
+                      disabled={editSaving || !editDraft.trim()}
+                    >
+                      {$t("home.live_edit_save")}
+                    </button>
+                    <button onclick={cancelParagraphEdit} class="btn btn-ghost btn-sm" disabled={editSaving}>
+                      {$t("home.live_edit_cancel")}
+                    </button>
+                  </div>
+                </div>
+              {:else}
+                <p
+                  class="m-0 text-[15px] leading-[1.75] text-text-secondary"
+                  class:cursor-text={paragraphEditable(paragraph, i)}
+                  class:hover:outline-1={paragraphEditable(paragraph, i)}
+                  class:hover:outline-ghost-border={paragraphEditable(paragraph, i)}
+                  class:rounded-default={paragraphEditable(paragraph, i)}
+                  class:px-1={paragraphEditable(paragraph, i)}
+                  class:-mx-1={paragraphEditable(paragraph, i)}
+                  ondblclick={() => {
+                    if (paragraphEditable(paragraph, i)) startParagraphEdit(paragraph);
+                  }}
+                >
+                  {paragraph.text}
+                  {#if i === liveParagraphs.length - 1 && liveTentative}
+                    <span class="opacity-50">{paragraph.text ? " " : ""}{liveTentative}</span>
+                  {/if}
+                </p>
+              {/if}
             </div>
           {/each}
           {#if liveParagraphs.length === 0 && liveTentative}

--- a/src/lib/features/meeting/controller.svelte.ts
+++ b/src/lib/features/meeting/controller.svelte.ts
@@ -8,6 +8,7 @@ import {
   renameMeeting as applyMeetingRename,
   resumeMeetingRecording,
   saveEditedTranscript,
+  applyLiveParagraphEdit as submitLiveParagraphEdit,
   saveMeetingNotes,
   startMeetingRecording,
   stopMeetingRecording,
@@ -265,7 +266,8 @@ function createMeetingControllerInstance() {
         // Only skip empty finals; non-final (tentative) segments still flow
         // through so the live view can show them as a faded suffix.
         if (segment.is_final && !segment.text) return;
-        liveTranscript.append(segment);
+        const segmentIndex = liveMeetingSegments.length;
+        liveTranscript.append(segment, segmentIndex);
         if (segment.is_final && segment.text) liveMeetingSegments.push(segment);
         clearIdleState();
       });
@@ -310,7 +312,8 @@ function createMeetingControllerInstance() {
 
       await resumeMeetingRecording(meeting.id, (segment) => {
         if (segment.is_final && !segment.text) return;
-        liveTranscript.append(segment);
+        const segmentIndex = liveMeetingSegments.length;
+        liveTranscript.append(segment, segmentIndex);
         if (segment.is_final && segment.text) liveMeetingSegments.push(segment);
         clearIdleState();
       });
@@ -400,6 +403,51 @@ function createMeetingControllerInstance() {
   function dismissIdle() {
     idleDismissed = true;
     idleSignal = null;
+  }
+
+  function recordingMeetingId(): string {
+    const machineState = app.machineState;
+    if (machineState.state === "recording_meeting") return machineState.data.meeting_id;
+    return meeting?.id ?? "";
+  }
+
+  function redistributeSegmentTexts(segmentStart: number, segmentEnd: number, newText: string) {
+    const words = newText.trim().split(/\s+/).filter(Boolean);
+    const slice = liveMeetingSegments.slice(segmentStart, segmentEnd);
+    if (slice.length === 0) return;
+    if (slice.length === 1) {
+      slice[0].text = newText.trim();
+      return;
+    }
+    for (let i = 0; i < slice.length; i++) {
+      if (i + 1 < slice.length) {
+        slice[i].text = words[i] ?? "";
+      } else {
+        slice[i].text = words.slice(i).join(" ");
+      }
+    }
+  }
+
+  async function applyLiveParagraphEdit(paragraphId: number, newText: string) {
+    const trimmed = newText.trim();
+    if (!trimmed || !isRecordingMeeting) return;
+
+    const updated = liveTranscript.editParagraph(paragraphId, trimmed);
+    if (!updated) return;
+
+    const { start, end } = updated.segmentRange;
+    if (end <= start || end > liveMeetingSegments.length) return;
+
+    redistributeSegmentTexts(start, end, trimmed);
+
+    const meetingId = recordingMeetingId();
+    if (!meetingId) return;
+
+    try {
+      await submitLiveParagraphEdit(meetingId, start, end, trimmed);
+    } catch (e) {
+      statusMessage = errorMessage(e);
+    }
   }
 
   /** The system woke from sleep (or the webview visibility turned to
@@ -636,6 +684,7 @@ function createMeetingControllerInstance() {
     handleMeetingFinalized,
     handleMeetingIdle,
     dismissIdle,
+    applyLiveParagraphEdit,
     resumeAfterSystemWake,
   };
 }

--- a/src/lib/features/meeting/live-transcript.svelte.test.ts
+++ b/src/lib/features/meeting/live-transcript.svelte.test.ts
@@ -25,12 +25,21 @@ function dseg(text: string, start: number, speaker: Speaker): TranscriptionSegme
 
 const PAUSE_THRESHOLD = 1.5;
 
+/** Feed finalized segments one-by-one, mirroring the controller's index assignment. */
+function feedSegments(live: ReturnType<typeof createLiveTranscript>, segments: TranscriptionSegment[]) {
+  let segmentIndex = 0;
+  for (const s of segments) {
+    live.append(s, segmentIndex);
+    if (s.is_final !== false) segmentIndex++;
+  }
+}
+
 /** Feed segments one-by-one into a fresh grouper and return the final
- * flattened committed+tail paragraphs (stripped of the live-only `id`). */
+ * flattened committed+tail paragraphs (stripped of live-only fields). */
 function runStream(segments: TranscriptionSegment[]) {
   const live = createLiveTranscript(PAUSE_THRESHOLD);
-  for (const s of segments) live.append(s);
-  const all = [...live.committed, ...live.tail].map(({ id: _id, ...rest }) => rest);
+  feedSegments(live, segments);
+  const all = [...live.committed, ...live.tail].map(({ id: _id, segmentRange: _range, ...rest }) => rest);
   return { live, all };
 }
 
@@ -82,7 +91,7 @@ describe("createLiveTranscript equivalence", () => {
       seg("Fourth paragraph.", 6.0),
     ];
     const live = createLiveTranscript(PAUSE_THRESHOLD);
-    for (const s of segments) live.append(s);
+    feedSegments(live, segments);
 
     expect(live.tail.length).toBeLessThanOrEqual(2);
     expect(live.committed.length + live.tail.length).toBe(4);
@@ -100,14 +109,16 @@ describe("createLiveTranscript committed immutability", () => {
       seg("Fifth paragraph.", 8.0),
     ];
     const live = createLiveTranscript(PAUSE_THRESHOLD);
-    for (const s of segments) live.append(s);
+    feedSegments(live, segments);
 
     expect(live.committed.length).toBeGreaterThan(0);
     const snapshot = live.committed.map((p) => ({ ref: p, copy: { ...p } }));
 
     // Append more segments; already-committed paragraphs must stay identical.
-    live.append(seg("Sixth paragraph.", 10.0));
-    live.append(seg("Seventh paragraph.", 12.0));
+    feedSegments(live, [
+      seg("Sixth paragraph.", 10.0),
+      seg("Seventh paragraph.", 12.0),
+    ]);
 
     for (const { ref, copy } of snapshot) {
       expect(ref).toEqual(copy);
@@ -118,12 +129,12 @@ describe("createLiveTranscript committed immutability", () => {
 describe("createLiveTranscript tentative text", () => {
   it("sets tentative on a non-final segment and clears it on the next final", () => {
     const live = createLiveTranscript(PAUSE_THRESHOLD);
-    live.append(seg("Hello wor", 0, { is_final: false }));
+    live.append(seg("Hello wor", 0, { is_final: false }), 0);
     expect(live.tentative).toBe("Hello wor");
     expect(live.committed).toEqual([]);
     expect(live.tail).toEqual([]);
 
-    live.append(seg("Hello world.", 0));
+    live.append(seg("Hello world.", 0), 0);
     expect(live.tentative).toBe("");
     expect(live.tail).toHaveLength(1);
     expect(live.tail[0].text).toBe("Hello world.");
@@ -131,9 +142,9 @@ describe("createLiveTranscript tentative text", () => {
 
   it("does not increment segmentCount for non-final segments", () => {
     const live = createLiveTranscript(PAUSE_THRESHOLD);
-    live.append(seg("partial", 0, { is_final: false }));
+    live.append(seg("partial", 0, { is_final: false }), 0);
     expect(live.segmentCount).toBe(0);
-    live.append(seg("partial done.", 0));
+    live.append(seg("partial done.", 0), 0);
     expect(live.segmentCount).toBe(1);
   });
 });
@@ -141,11 +152,13 @@ describe("createLiveTranscript tentative text", () => {
 describe("createLiveTranscript reset", () => {
   it("clears committed, tail, tentative, and segmentCount", () => {
     const live = createLiveTranscript(PAUSE_THRESHOLD);
-    live.append(seg("First paragraph.", 0));
-    live.append(seg("Second paragraph.", 2.0));
-    live.append(seg("Third paragraph.", 4.0));
-    live.append(seg("Fourth paragraph.", 6.0));
-    live.append(seg("partial", 8.0, { is_final: false }));
+    feedSegments(live, [
+      seg("First paragraph.", 0),
+      seg("Second paragraph.", 2.0),
+      seg("Third paragraph.", 4.0),
+      seg("Fourth paragraph.", 6.0),
+    ]);
+    live.append(seg("partial", 8.0, { is_final: false }), 4);
 
     expect(live.committed.length + live.tail.length).toBeGreaterThan(0);
     expect(live.tentative).toBe("partial");
@@ -158,7 +171,7 @@ describe("createLiveTranscript reset", () => {
     expect(live.segmentCount).toBe(0);
 
     // Grouper is fully usable again after reset.
-    live.append(seg("Fresh start.", 0));
+    live.append(seg("Fresh start.", 0), 0);
     expect(live.tail).toHaveLength(1);
     expect(live.tail[0].text).toBe("Fresh start.");
   });
@@ -168,7 +181,7 @@ describe("createLiveTranscript paragraph ids", () => {
   it("assigns strictly increasing ids across committed and tail paragraphs", () => {
     const segments = Array.from({ length: 10 }, (_, i) => seg(`Sentence ${i}.`, i * 2.0));
     const live = createLiveTranscript(PAUSE_THRESHOLD);
-    for (const s of segments) live.append(s);
+    feedSegments(live, segments);
 
     const ids = [...live.committed, ...live.tail].map((p) => p.id);
     expect(ids.length).toBeGreaterThan(1);
@@ -179,14 +192,47 @@ describe("createLiveTranscript paragraph ids", () => {
 
   it("keeps the same id for a growing tail paragraph across appends", () => {
     const live = createLiveTranscript(PAUSE_THRESHOLD);
-    live.append(seg("Hello", 0));
+    live.append(seg("Hello", 0), 0);
     expect(live.tail).toHaveLength(1);
     const firstId = live.tail[0].id;
 
     // No pause, no sentence end yet: still the same open paragraph.
-    live.append(seg("world", 0.5));
+    live.append(seg("world", 0.5), 1);
     expect(live.tail).toHaveLength(1);
     expect(live.tail[0].id).toBe(firstId);
     expect(live.tail[0].text).toBe("Hello world");
+  });
+});
+
+describe("createLiveTranscript segment ranges and live edits", () => {
+  it("tracks segment ranges on committed paragraphs", () => {
+    const live = createLiveTranscript(PAUSE_THRESHOLD);
+    feedSegments(live, [
+      seg("hello", 0),
+      seg("world", 1),
+      seg("again", 3),
+    ]);
+
+    const paragraphs = [...live.committed, ...live.tail];
+    expect(paragraphs.length).toBeGreaterThan(0);
+    expect(paragraphs[0].segmentRange.start).toBe(0);
+    expect(paragraphs[0].segmentRange.end).toBeGreaterThan(0);
+  });
+
+  it("editParagraph updates committed text without resetting the stream", () => {
+    const live = createLiveTranscript(PAUSE_THRESHOLD);
+    feedSegments(live, [
+      seg("hello", 0),
+      seg("world", 1),
+      seg("First paragraph.", 2.0),
+      seg("Second paragraph.", 4.0),
+      seg("Third paragraph.", 6.0),
+    ]);
+
+    expect(live.committed.length).toBeGreaterThan(0);
+    const target = live.committed[0];
+    const updated = live.editParagraph(target.id, "hello universe");
+    expect(updated?.text).toBe("hello universe");
+    expect(live.committed[0].text).toBe("hello universe");
   });
 });

--- a/src/lib/features/meeting/live-transcript.svelte.ts
+++ b/src/lib/features/meeting/live-transcript.svelte.ts
@@ -1,4 +1,4 @@
-import type { Paragraph } from "../../utils/paragraphs";
+import type { Paragraph, ParagraphRange } from "../../utils/paragraphs";
 import { groupIntoParagraphsWithRanges } from "../../utils/paragraphs";
 import type { TranscriptionSegment } from "../../types";
 
@@ -6,7 +6,13 @@ import type { TranscriptionSegment } from "../../types";
  * once, when a paragraph first comes into existence (either at commit time,
  * or the first time it appears in the tail), and never reassigned while the
  * paragraph keeps growing. */
-export type LiveParagraph = Paragraph & { id: number };
+export type LiveParagraph = Paragraph & {
+  id: number;
+  /** Half-open range into the finalized segment list for this paragraph. */
+  segmentRange: ParagraphRange;
+};
+
+type IndexedSegment = { segment: TranscriptionSegment; index: number };
 
 /**
  * Incremental paragraph grouper for a live transcript stream.
@@ -43,54 +49,72 @@ export function createLiveTranscript(pauseThreshold: number) {
   // Not reactive state on purpose: only the derived paragraphs need to drive
   // rendering, and re-sorting/regrouping this buffer never touches anything
   // outside the (bounded) tail.
-  let tailSegments: TranscriptionSegment[] = [];
+  let tailSegments: IndexedSegment[] = [];
   let nextParagraphId = 0;
 
-  function insertByStartTime(seg: TranscriptionSegment) {
-    // Fast path: in-order arrival, the overwhelming common case.
-    if (tailSegments.length === 0 || seg.start_time >= tailSegments[tailSegments.length - 1].start_time) {
-      tailSegments.push(seg);
+  function insertByStartTime(entry: IndexedSegment) {
+    const seg = entry.segment;
+    if (
+      tailSegments.length === 0
+      || seg.start_time >= tailSegments[tailSegments.length - 1].segment.start_time
+    ) {
+      tailSegments.push(entry);
       return;
     }
     let lo = 0;
     let hi = tailSegments.length;
     while (lo < hi) {
       const mid = (lo + hi) >>> 1;
-      if (tailSegments[mid].start_time <= seg.start_time) lo = mid + 1;
+      if (tailSegments[mid].segment.start_time <= seg.start_time) lo = mid + 1;
       else hi = mid;
     }
-    tailSegments.splice(lo, 0, seg);
+    tailSegments.splice(lo, 0, entry);
+  }
+
+  function globalRange(range: ParagraphRange): ParagraphRange {
+    const startIndex = tailSegments[range.start]?.index;
+    const endIndex = tailSegments[range.end - 1]?.index;
+    return {
+      start: startIndex ?? range.start,
+      end: endIndex == null ? range.end : endIndex + 1,
+    };
   }
 
   function regroupTail() {
-    const { paragraphs, ranges, ordered } = groupIntoParagraphsWithRanges(tailSegments, pauseThreshold);
+    const ordered = tailSegments.map((entry) => entry.segment);
+    const { paragraphs, ranges } = groupIntoParagraphsWithRanges(ordered, pauseThreshold);
     const prevTail = tail;
     const numToCommit = Math.max(0, paragraphs.length - MAX_TAIL_PARAGRAPHS);
 
-    // A committed paragraph is always a prefix of the previous tail (new
-    // paragraphs only ever appear at the end), so it keeps the id it was
-    // already assigned while still open rather than getting a new one now.
-    let cutIndex = 0;
     for (let i = 0; i < numToCommit; i++) {
       const id = i < prevTail.length ? prevTail[i].id : nextParagraphId++;
-      committed.push({ ...paragraphs[i], id });
-      cutIndex = ranges[i].end;
+      committed.push({
+        ...paragraphs[i],
+        id,
+        segmentRange: globalRange(ranges[i]),
+      });
     }
-    if (numToCommit > 0) tailSegments = ordered.slice(cutIndex);
+    if (numToCommit > 0) {
+      const cutIndex = ranges[numToCommit - 1].end;
+      tailSegments = tailSegments.slice(cutIndex);
+    }
 
-    // Reassign ids: a paragraph that already existed in the previous tail
-    // keeps its id (so keyed rendering treats it as the same, growing node);
-    // only a genuinely new trailing paragraph gets a fresh id.
     const remaining = paragraphs.slice(numToCommit);
+    const remainingRanges = ranges.slice(numToCommit);
     const survivingOldCount = Math.max(0, prevTail.length - numToCommit);
-    tail = remaining.map((paragraph, i) =>
-      i < survivingOldCount
-        ? { ...paragraph, id: prevTail[numToCommit + i].id }
-        : { ...paragraph, id: nextParagraphId++ },
-    );
+    tail = remaining.map((paragraph, i) => {
+      const id = i < survivingOldCount
+        ? prevTail[numToCommit + i].id
+        : nextParagraphId++;
+      return {
+        ...paragraph,
+        id,
+        segmentRange: globalRange(remainingRanges[i]),
+      };
+    });
   }
 
-  function append(segment: TranscriptionSegment) {
+  function append(segment: TranscriptionSegment, segmentIndex: number) {
     if (!segment.is_final) {
       tentative = segment.text;
       return;
@@ -98,11 +122,29 @@ export function createLiveTranscript(pauseThreshold: number) {
     tentative = "";
     segmentCount++;
 
-    const diarizedSoFar = segment.speaker != null || tailSegments.some((s) => s.speaker != null);
-    if (diarizedSoFar) insertByStartTime(segment);
-    else tailSegments.push(segment);
+    const entry = { segment, index: segmentIndex };
+    const diarizedSoFar =
+      segment.speaker != null || tailSegments.some((item) => item.segment.speaker != null);
+    if (diarizedSoFar) insertByStartTime(entry);
+    else tailSegments.push(entry);
 
     regroupTail();
+  }
+
+  /** Update a paragraph's displayed text after a live edit without reopening
+   * the incremental grouper. */
+  function editParagraph(id: number, newText: string): LiveParagraph | null {
+    const committedIndex = committed.findIndex((paragraph) => paragraph.id === id);
+    if (committedIndex !== -1) {
+      committed[committedIndex] = { ...committed[committedIndex], text: newText };
+      return committed[committedIndex];
+    }
+    const tailIndex = tail.findIndex((paragraph) => paragraph.id === id);
+    if (tailIndex !== -1) {
+      tail[tailIndex] = { ...tail[tailIndex], text: newText };
+      return tail[tailIndex];
+    }
+    return null;
   }
 
   function reset() {
@@ -116,6 +158,7 @@ export function createLiveTranscript(pauseThreshold: number) {
 
   return {
     append,
+    editParagraph,
     reset,
     get committed() { return committed; },
     get tail() { return tail; },

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -380,7 +380,10 @@
     "system_audio_active": "System audio active",
     "idle_silence_banner": "No speech detected for {minutes} min. Recording will stop soon.",
     "idle_stop_now": "Stop now",
-    "idle_keep_recording": "Keep recording"
+    "idle_keep_recording": "Keep recording",
+    "live_edit_hint": "Double-click a paragraph to fix a misheard word. Later occurrences are corrected automatically.",
+    "live_edit_save": "Save",
+    "live_edit_cancel": "Cancel"
   },
   "permissions": {
     "title": "Grant permissions",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -380,7 +380,10 @@
     "system_audio_active": "Audio système actif",
     "idle_silence_banner": "Aucune parole détectée depuis {minutes} min. L'enregistrement va bientôt s'arrêter.",
     "idle_stop_now": "Arrêter maintenant",
-    "idle_keep_recording": "Continuer l'enregistrement"
+    "idle_keep_recording": "Continuer l'enregistrement",
+    "live_edit_hint": "Double-cliquez sur un paragraphe pour corriger un mot mal entendu. Les occurrences suivantes seront corrigées automatiquement.",
+    "live_edit_save": "Enregistrer",
+    "live_edit_cancel": "Annuler"
   },
   "permissions": {
     "title": "Autoriser les permissions",

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -273,6 +273,20 @@ async saveEditedTranscript(id: string, editedTranscript: string | null) : Promis
 }
 },
 /**
+ * Apply a live paragraph edit during an active meeting: patch the edited
+ * segments in the accumulator (and on disk when already flushed), and
+ * register session corrections so later STT output of the same misspelling
+ * is rewritten for the rest of this recording session.
+ */
+async applyLiveParagraphEdit(meetingId: string, segmentStart: number, segmentEnd: number, newText: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("apply_live_paragraph_edit", { meetingId, segmentStart, segmentEnd, newText }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Render a meeting export without writing to disk. Used by tests and, if
  * ever needed, a clipboard-copy affordance.
  */


### PR DESCRIPTION
## Summary

- Live meeting transcript: edit **committed paragraphs only** (not in-flight partial text); changes update stored segments and the UI.
- User corrections are stored as **SessionCorrection** entries and folded into the **dictionary filter** so the same fix applies to the rest of the session.
- **Mid-session filter rebuild** when corrections change, so recognition picks up new terms without restarting the meeting.

## Test plan

- [ ] Start a live meeting; wait for a paragraph to commit; edit a phrase and confirm the transcript and persistence update.
- [ ] Dictate again with the mistaken phrase; confirm the corrected form (or session term) is preferred.
- [ ] Add multiple corrections; confirm filter rebuild does not drop the session.
- [ ] `npm test` — live-transcript suite (13 tests in that file).
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml --workspace` for filter/session command paths.