### PR TITLE
Add dictionary aliases from meeting transcript words

### DIFF
--- a/src-tauri/src/commands/meetings.rs
+++ b/src-tauri/src/commands/meetings.rs
@@ -221,6 +221,40 @@ pub fn apply_live_paragraph_edit(
     Ok(())
 }
 
+/// Register a misspelling-to-term pair for the active recording session so
+/// later STT output of the same form is rewritten immediately.
+#[tauri::command]
+#[specta::specta]
+pub fn add_session_correction(
+    state: State<'_, AppState>,
+    misspelling: String,
+    term: String,
+) -> Result<(), String> {
+    use crate::filter::session_terms::SessionCorrection;
+    use crate::lock_ext::MutexExt;
+
+    let misspelling = misspelling.trim().to_string();
+    let term = term.trim().to_string();
+    if misspelling.is_empty() || term.is_empty() {
+        return Err("Misspelling and term cannot be empty".into());
+    }
+    if misspelling == term {
+        return Ok(());
+    }
+
+    {
+        let acc = state.meeting_accumulator.acquire()?;
+        if acc.is_none() {
+            return Err("No meeting is recording".into());
+        }
+    }
+
+    state.engine_actor.add_session_correction(SessionCorrection {
+        misspelling,
+        term,
+    })
+}
+
 fn redistribute_segment_texts(segments: &mut [TranscriptionSegment], new_text: &str) {
     let words: Vec<&str> = new_text.split_whitespace().collect();
     if segments.is_empty() {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -103,6 +103,7 @@ fn specta_builder() -> Builder<tauri::Wry> {
             commands::save_meeting_notes,
             commands::save_edited_transcript,
             commands::apply_live_paragraph_edit,
+            commands::add_session_correction,
             commands::export_meeting_preview,
             commands::export_meeting_filename,
             commands::export_meeting_to_file,

--- a/src/lib/api/dictionary.ts
+++ b/src/lib/api/dictionary.ts
@@ -29,3 +29,10 @@ export async function deleteDictionaryEntry(id: number): Promise<void> {
 export async function clearDictionary(): Promise<void> {
   await unwrap(commands.clearDictionary());
 }
+
+export async function addSessionCorrection(
+  misspelling: string,
+  term: string,
+): Promise<void> {
+  await unwrap(commands.addSessionCorrection(misspelling, term));
+}

--- a/src/lib/features/home/LiveSessionCard.svelte
+++ b/src/lib/features/home/LiveSessionCard.svelte
@@ -5,6 +5,7 @@
   import Waveform from "../../components/Waveform.svelte";
   import Spinner from "../../components/ui/Spinner.svelte";
   import MeetingNotesSection from "../meeting/components/MeetingNotesSection.svelte";
+  import TranscriptWordLine from "../meeting/components/TranscriptWordLine.svelte";
   import type { LiveParagraph } from "../meeting/live-transcript.svelte";
   import type { createMeetingController } from "../meeting/controller.svelte";
   import type { createTranscriptionController } from "../transcription/controller.svelte";
@@ -271,7 +272,11 @@
                     if (paragraphEditable(paragraph, i)) startParagraphEdit(paragraph);
                   }}
                 >
-                  {paragraph.text}
+                  <TranscriptWordLine
+                    text={paragraph.text}
+                    onAddAlias={meeting.addDictionaryAlias}
+                    class="m-0 inline text-[15px] leading-[1.75] text-text-secondary"
+                  />
                   {#if i === liveParagraphs.length - 1 && liveTentative}
                     <span class="opacity-50">{paragraph.text ? " " : ""}{liveTentative}</span>
                   {/if}

--- a/src/lib/features/meeting/components/DictionaryAliasPopover.svelte
+++ b/src/lib/features/meeting/components/DictionaryAliasPopover.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+  import { t } from "svelte-i18n";
+
+  let {
+    heardAs,
+    onClose,
+    onSave,
+  }: {
+    heardAs: string;
+    onClose: () => void;
+    onSave: (term: string, pronunciation: string | null) => void | Promise<void>;
+  } = $props();
+
+  let termDraft = $state("");
+  let pronunciationDraft = $state("");
+  let isSaving = $state(false);
+  let saveError = $state("");
+
+  $effect(() => {
+    termDraft = "";
+    pronunciationDraft = heardAs;
+    saveError = "";
+  });
+
+  async function save() {
+    const term = termDraft.trim();
+    if (!term) return;
+    const pronunciation = pronunciationDraft.trim() || null;
+    isSaving = true;
+    saveError = "";
+    try {
+      await onSave(term, pronunciation);
+      onClose();
+    } catch (e) {
+      saveError = e instanceof Error ? e.message : String(e);
+    } finally {
+      isSaving = false;
+    }
+  }
+</script>
+
+<button
+  type="button"
+  class="fixed inset-0 z-10 cursor-default"
+  aria-label={$t("ui.cancel")}
+  onclick={onClose}
+></button>
+
+<div class="absolute left-0 top-full z-20 mt-1.5 w-72 rounded-[11px] bg-surface-1 p-3 shadow-lg outline-1 outline-ghost-border">
+  <p class="m-0 mb-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">
+    {$t("dictionary_alias.title")}
+  </p>
+  <p class="m-0 mb-3 text-[12px] leading-relaxed text-text-muted">
+    {$t("dictionary_alias.description")}
+  </p>
+
+  <div class="mb-2 flex flex-col gap-1">
+    <label for="dict-alias-term" class="field-label">{$t("dictionary_alias.term")}</label>
+    <input
+      id="dict-alias-term"
+      bind:value={termDraft}
+      class="field-input text-[13px]"
+      placeholder={$t("dictionary_alias.term_placeholder")}
+      onkeydown={(e) => {
+        if (e.key === "Enter") void save();
+        if (e.key === "Escape") onClose();
+      }}
+    />
+  </div>
+
+  <div class="mb-3 flex flex-col gap-1">
+    <label for="dict-alias-pronunciation" class="field-label">{$t("dictionary_alias.pronunciation")}</label>
+    <input
+      id="dict-alias-pronunciation"
+      bind:value={pronunciationDraft}
+      class="field-input text-[13px]"
+      placeholder={$t("dictionary_alias.pronunciation_placeholder")}
+      title={$t("dictionary_alias.pronunciation_desc")}
+      onkeydown={(e) => {
+        if (e.key === "Enter") void save();
+        if (e.key === "Escape") onClose();
+      }}
+    />
+  </div>
+
+  {#if saveError}
+    <p class="mb-2 text-xs text-danger-soft">{saveError}</p>
+  {/if}
+
+  <button
+    class="btn btn-primary w-full text-[12.5px]"
+    disabled={isSaving || !termDraft.trim()}
+    onclick={() => void save()}
+  >
+    {$t("dictionary_alias.save")}
+  </button>
+</div>

--- a/src/lib/features/meeting/components/MeetingDetail.svelte
+++ b/src/lib/features/meeting/components/MeetingDetail.svelte
@@ -93,6 +93,7 @@
       onResetEdited={controller.resetEditedTranscript}
       onEditDraftChange={(value) => { controller.editedTranscriptDraft = value; }}
       onParagraphClick={controller.audioSessions.length > 0 ? controller.requestAudioSeek : undefined}
+      onAddDictionaryAlias={controller.addDictionaryAlias}
     />
 
     <!-- AI summary, generated from notes + transcript. -->

--- a/src/lib/features/meeting/components/MeetingTranscriptSection.svelte
+++ b/src/lib/features/meeting/components/MeetingTranscriptSection.svelte
@@ -4,6 +4,7 @@
   import CopyButton from "../../../components/ui/CopyButton.svelte";
   import type { MeetingRecordingSession, TranscriptionSegment } from "../../../types";
   import { buildMeetingTranscriptBlocks } from "../../../utils";
+  import TranscriptWordLine from "./TranscriptWordLine.svelte";
 
   let {
     segments,
@@ -20,6 +21,7 @@
     onResetEdited,
     onEditDraftChange,
     onParagraphClick,
+    onAddDictionaryAlias,
   }: {
     segments: TranscriptionSegment[];
     recordingSessions: MeetingRecordingSession[];
@@ -37,6 +39,7 @@
     /** A paragraph's timestamp was clicked; seeks the audio player if that
      * paragraph maps to a recorded session (no-op otherwise). */
     onParagraphClick?: (recordingSessionIndex: number | null, startTime: number) => void;
+    onAddDictionaryAlias?: (term: string, pronunciation: string | null) => void | Promise<void>;
   } = $props();
 
   type TranscriptPhase = "has_content" | "recording_empty" | "empty";
@@ -144,7 +147,15 @@
                   <span class="font-mono text-[10.5px] text-text-faint">{block.timestamp}</span>
                 {/if}
               </div>
-              <p class="m-0 text-sm leading-[1.7] text-text-secondary">{block.text}</p>
+              {#if onAddDictionaryAlias}
+                <TranscriptWordLine
+                  text={block.text}
+                  onAddAlias={onAddDictionaryAlias}
+                  class="m-0 block text-sm leading-[1.7] text-text-secondary"
+                />
+              {:else}
+                <p class="m-0 text-sm leading-[1.7] text-text-secondary">{block.text}</p>
+              {/if}
             </div>
           {:else}
             <div class="my-1 flex items-center gap-3 text-text-muted/80">

--- a/src/lib/features/meeting/components/TranscriptWordLine.svelte
+++ b/src/lib/features/meeting/components/TranscriptWordLine.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { isClickableTranscriptWord, tokenizeTranscriptWords } from "../../../utils/transcript-words";
+  import DictionaryAliasPopover from "./DictionaryAliasPopover.svelte";
+
+  let {
+    text,
+    onAddAlias,
+    class: className = "",
+  }: {
+    text: string;
+    onAddAlias: (term: string, pronunciation: string | null) => void | Promise<void>;
+    class?: string;
+  } = $props();
+
+  /** Index into `tokens`, not the word text: duplicate spellings share text but
+   * must not all open the popover together. */
+  let openTokenIndex = $state<number | null>(null);
+  let tokens = $derived(tokenizeTranscriptWords(text));
+
+  function swallowPointerEvent(event: MouseEvent) {
+    event.stopPropagation();
+  }
+
+  function openAlias(tokenIndex: number, event: MouseEvent) {
+    event.stopPropagation();
+    openTokenIndex = tokenIndex;
+  }
+</script>
+
+<span class={className}>
+  {#each tokens as token, i (i)}
+    {#if token.kind === "gap"}
+      {token.text}
+    {:else if isClickableTranscriptWord(token.text)}
+      <span class="relative inline">
+        <button
+          type="button"
+          class="cursor-pointer rounded-[3px] border-0 bg-transparent p-0 font-inherit text-inherit hover:bg-accent/10 hover:text-accent"
+          onmousedown={swallowPointerEvent}
+          onclick={(event) => openAlias(i, event)}
+          ondblclick={swallowPointerEvent}
+        >
+          {token.text}
+        </button>
+        {#if openTokenIndex === i}
+          <DictionaryAliasPopover
+            heardAs={token.text}
+            onClose={() => { openTokenIndex = null; }}
+            onSave={onAddAlias}
+          />
+        {/if}
+      </span>
+    {:else}
+      {token.text}
+    {/if}
+  {/each}
+</span>

--- a/src/lib/features/meeting/controller.svelte.ts
+++ b/src/lib/features/meeting/controller.svelte.ts
@@ -1,4 +1,5 @@
 import { save as showSaveDialog } from "@tauri-apps/plugin-dialog";
+import { addDictionaryEntry, addSessionCorrection } from "../../api/dictionary";
 import {
   deleteMeeting as removeMeeting,
   exportMeetingFilename,
@@ -428,6 +429,30 @@ function createMeetingControllerInstance() {
     }
   }
 
+  async function addDictionaryAlias(term: string, pronunciation: string | null) {
+    const trimmedTerm = term.trim();
+    if (!trimmedTerm) return;
+
+    const trimmedPronunciation = pronunciation?.trim() || null;
+    try {
+      await addDictionaryEntry(trimmedTerm, trimmedPronunciation, null);
+      if (
+        isRecordingMeeting
+        && trimmedPronunciation
+        && trimmedPronunciation.toLowerCase() !== trimmedTerm.toLowerCase()
+      ) {
+        try {
+          await addSessionCorrection(trimmedPronunciation, trimmedTerm);
+        } catch {
+          // Session hint is best-effort; the dictionary entry still persists.
+        }
+      }
+    } catch (e) {
+      statusMessage = errorMessage(e);
+      throw e;
+    }
+  }
+
   async function applyLiveParagraphEdit(paragraphId: number, newText: string) {
     const trimmed = newText.trim();
     if (!trimmed || !isRecordingMeeting) return;
@@ -685,6 +710,7 @@ function createMeetingControllerInstance() {
     handleMeetingIdle,
     dismissIdle,
     applyLiveParagraphEdit,
+    addDictionaryAlias,
     resumeAfterSystemWake,
   };
 }

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -240,9 +240,9 @@
     "title": "Add to dictionary",
     "description": "Map how this word was heard to the spelling you want.",
     "term": "Correct term",
-    "term_placeholder": "e.g. J-F",
+    "term_placeholder": "e.g. Kubernetes",
     "pronunciation": "Heard as",
-    "pronunciation_placeholder": "e.g. jef",
+    "pronunciation_placeholder": "e.g. kubernetis",
     "pronunciation_desc": "Optional spelling of how the word sounds when misheard. Helps match future transcriptions.",
     "save": "Add entry"
   },

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -236,6 +236,16 @@
     "reset_to_original": "Reset to original",
     "segments_count": "{count} segments"
   },
+  "dictionary_alias": {
+    "title": "Add to dictionary",
+    "description": "Map how this word was heard to the spelling you want.",
+    "term": "Correct term",
+    "term_placeholder": "e.g. J-F",
+    "pronunciation": "Heard as",
+    "pronunciation_placeholder": "e.g. jef",
+    "pronunciation_desc": "Optional spelling of how the word sounds when misheard. Helps match future transcriptions.",
+    "save": "Add entry"
+  },
   "transcript": {
     "me": "Me",
     "them": "Them"

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -240,9 +240,9 @@
     "title": "Ajouter au dictionnaire",
     "description": "Associez la forme entendue à l'orthographe souhaitée.",
     "term": "Terme correct",
-    "term_placeholder": "ex. J-F",
+    "term_placeholder": "ex. Kubernetes",
     "pronunciation": "Entendu comme",
-    "pronunciation_placeholder": "ex. jef",
+    "pronunciation_placeholder": "ex. kubernetis",
     "pronunciation_desc": "Orthographe optionnelle de la forme mal entendue. Aide à reconnaître les prochaines transcriptions.",
     "save": "Ajouter l'entrée"
   },

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -236,6 +236,16 @@
     "reset_to_original": "Revenir à l'original",
     "segments_count": "{count} segments"
   },
+  "dictionary_alias": {
+    "title": "Ajouter au dictionnaire",
+    "description": "Associez la forme entendue à l'orthographe souhaitée.",
+    "term": "Terme correct",
+    "term_placeholder": "ex. J-F",
+    "pronunciation": "Entendu comme",
+    "pronunciation_placeholder": "ex. jef",
+    "pronunciation_desc": "Orthographe optionnelle de la forme mal entendue. Aide à reconnaître les prochaines transcriptions.",
+    "save": "Ajouter l'entrée"
+  },
   "transcript": {
     "me": "Moi",
     "them": "Eux"

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -287,6 +287,18 @@ async applyLiveParagraphEdit(meetingId: string, segmentStart: number, segmentEnd
 }
 },
 /**
+ * Register a misspelling-to-term pair for the active recording session so
+ * later STT output of the same form is rewritten immediately.
+ */
+async addSessionCorrection(misspelling: string, term: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("add_session_correction", { misspelling, term }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Render a meeting export without writing to disk. Used by tests and, if
  * ever needed, a clipboard-copy affordance.
  */

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -2,6 +2,8 @@ export { formatTimestamp, formatDate, formatDuration, formatShortcutLabel, forma
 export { applyTheme } from "./theme";
 export { buildMeetingTranscriptBlocks, groupIntoParagraphs } from "./paragraphs";
 export type { Paragraph, TranscriptBlock } from "./paragraphs";
+export { isClickableTranscriptWord, tokenizeTranscriptWords } from "./transcript-words";
+export type { TranscriptWordToken } from "./transcript-words";
 export { errorMessage } from "./errors";
 export { renderReleaseNotesMarkdown } from "./markdown";
 export { createDebouncedSearch, filterResultsByType, findSnippet, matchedIdsForType } from "./search.svelte";

--- a/src/lib/utils/transcript-words.test.ts
+++ b/src/lib/utils/transcript-words.test.ts
@@ -3,10 +3,10 @@ import { isClickableTranscriptWord, tokenizeTranscriptWords } from "./transcript
 
 describe("tokenizeTranscriptWords", () => {
   it("splits words and preserves gaps", () => {
-    expect(tokenizeTranscriptWords("Hello, Jean-François!")).toEqual([
+    expect(tokenizeTranscriptWords("Hello, café-théâtre!")).toEqual([
       { kind: "word", text: "Hello" },
       { kind: "gap", text: ", " },
-      { kind: "word", text: "Jean-François" },
+      { kind: "word", text: "café-théâtre" },
       { kind: "gap", text: "!" },
     ]);
   });
@@ -25,9 +25,9 @@ describe("tokenizeTranscriptWords", () => {
   });
 
   it("gives duplicate words distinct indices for popover targeting", () => {
-    const tokens = tokenizeTranscriptWords("Jean met Jean");
+    const tokens = tokenizeTranscriptWords("Alex met Alex");
     const jeanIndexes = tokens.flatMap((token, index) =>
-      token.kind === "word" && token.text === "Jean" ? [index] : [],
+      token.kind === "word" && token.text === "Alex" ? [index] : [],
     );
     expect(jeanIndexes).toEqual([0, 4]);
   });

--- a/src/lib/utils/transcript-words.test.ts
+++ b/src/lib/utils/transcript-words.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { isClickableTranscriptWord, tokenizeTranscriptWords } from "./transcript-words";
+
+describe("tokenizeTranscriptWords", () => {
+  it("splits words and preserves gaps", () => {
+    expect(tokenizeTranscriptWords("Hello, Jean-François!")).toEqual([
+      { kind: "word", text: "Hello" },
+      { kind: "gap", text: ", " },
+      { kind: "word", text: "Jean-François" },
+      { kind: "gap", text: "!" },
+    ]);
+  });
+
+  it("handles apostrophes inside words", () => {
+    expect(tokenizeTranscriptWords("c'est bien")).toEqual([
+      { kind: "word", text: "c'est" },
+      { kind: "gap", text: " " },
+      { kind: "word", text: "bien" },
+    ]);
+  });
+
+  it("returns an empty list for blank text", () => {
+    expect(tokenizeTranscriptWords("")).toEqual([]);
+    expect(tokenizeTranscriptWords("   ")).toEqual([{ kind: "gap", text: "   " }]);
+  });
+
+  it("gives duplicate words distinct indices for popover targeting", () => {
+    const tokens = tokenizeTranscriptWords("Jean met Jean");
+    const jeanIndexes = tokens.flatMap((token, index) =>
+      token.kind === "word" && token.text === "Jean" ? [index] : [],
+    );
+    expect(jeanIndexes).toEqual([0, 4]);
+  });
+});
+
+describe("isClickableTranscriptWord", () => {
+  it("accepts names and rejects one-letter tokens", () => {
+    expect(isClickableTranscriptWord("JF")).toBe(true);
+    expect(isClickableTranscriptWord("a")).toBe(false);
+    expect(isClickableTranscriptWord("42")).toBe(false);
+  });
+});

--- a/src/lib/utils/transcript-words.ts
+++ b/src/lib/utils/transcript-words.ts
@@ -1,0 +1,34 @@
+export type TranscriptWordToken =
+  | { kind: "word"; text: string }
+  | { kind: "gap"; text: string };
+
+const WORD_PATTERN = /[\p{L}\p{M}][\p{L}\p{M}\p{N}'-]*|[\p{L}\p{M}\p{N}'-]+/gu;
+
+/** Split transcript text into clickable words and non-word gaps (spaces, punctuation). */
+export function tokenizeTranscriptWords(text: string): TranscriptWordToken[] {
+  if (!text) return [];
+
+  const tokens: TranscriptWordToken[] = [];
+  let lastIndex = 0;
+
+  for (const match of text.matchAll(WORD_PATTERN)) {
+    const start = match.index ?? 0;
+    if (start > lastIndex) {
+      tokens.push({ kind: "gap", text: text.slice(lastIndex, start) });
+    }
+    tokens.push({ kind: "word", text: match[0] });
+    lastIndex = start + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    tokens.push({ kind: "gap", text: text.slice(lastIndex) });
+  }
+
+  return tokens;
+}
+
+/** Whether a token should open the dictionary-alias popover. */
+export function isClickableTranscriptWord(word: string): boolean {
+  if (word.length < 2) return false;
+  return /\p{L}/u.test(word);
+}


### PR DESCRIPTION
## Summary
- Click a word in a meeting transcript (live or saved) to open a dictionary alias popover with **Correct term** and optional **Heard as**; saves through existing dictionary CRUD.
- While a meeting is recording, a non-empty heard-as that differs from the term also registers a session correction so later STT output is rewritten immediately.
- Transcript words are index-keyed for popover placement; double-click and mousedown on words are stopped so live paragraph editing (D4) is unaffected.

## Test plan
- [ ] Open a saved meeting transcript, click a word, add term + heard-as, confirm entry appears in Settings → Dictionary.
- [ ] During an active recording, add an alias from the live transcript with heard-as; confirm subsequent mishearings are corrected in-session.
- [ ] Double-click a live paragraph to edit; confirm word clicks do not enter edit mode accidentally.
- [ ] `npm test`, `npm run check`, `cargo test --manifest-path src-tauri/Cargo.toml --workspace`