### PR TITLE
Identify microphones by stable CoreAudio UID

### DIFF
--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -12,6 +12,7 @@ use tracing::{debug, error, info, warn};
 use super::mixer::MeetingMixer;
 use super::recorder::MeetingRecorder;
 use super::resampler::Resampler;
+use crate::audio::device::{AudioInputDevice, resolve_device_name};
 use crate::state::AudioCommand;
 
 /// Tell the frontend whether the system-audio leg of a meeting is live.
@@ -291,16 +292,9 @@ pub enum AudioMessage {
     },
 }
 
-/// Info about an available audio input device, sent to frontend
-#[derive(Debug, Clone, serde::Serialize, specta::Type)]
-pub struct AudioDeviceInfo {
-    pub name: String,
-    pub is_default: bool,
-}
-
 /// List all available input devices. Logged at info level (device count) so
 /// enumeration events show up in the Diagnostics live log.
-pub fn list_input_devices() -> Vec<AudioDeviceInfo> {
+pub fn list_input_devices() -> Vec<AudioInputDevice> {
     let devices = list_input_devices_impl();
     info!("Enumerated {} input device(s)", devices.len());
     devices
@@ -315,15 +309,14 @@ pub fn list_input_devices() -> Vec<AudioDeviceInfo> {
 /// enough to do that with no recording active. `device_watch::list_devices`
 /// does the same enumeration with only cheap property reads.
 #[cfg(target_os = "macos")]
-fn list_input_devices_impl() -> Vec<AudioDeviceInfo> {
+fn list_input_devices_impl() -> Vec<AudioInputDevice> {
     super::device_watch::list_devices()
-        .into_iter()
-        .map(|(name, is_default)| AudioDeviceInfo { name, is_default })
-        .collect()
 }
 
 #[cfg(not(target_os = "macos"))]
-fn list_input_devices_impl() -> Vec<AudioDeviceInfo> {
+fn list_input_devices_impl() -> Vec<AudioInputDevice> {
+    use crate::audio::device::TransportType;
+
     let host = cpal::default_host();
     let default_name = host
         .default_input_device()
@@ -341,9 +334,11 @@ fn list_input_devices_impl() -> Vec<AudioDeviceInfo> {
     devices
         .filter_map(|d| {
             let name = d.name().ok()?;
-            Some(AudioDeviceInfo {
-                is_default: name == default_name,
+            Some(AudioInputDevice {
+                uid: name.clone(),
                 name,
+                transport: TransportType::Unknown,
+                is_default: name == default_name,
             })
         })
         .collect()
@@ -356,8 +351,9 @@ fn list_input_devices_impl() -> Vec<AudioDeviceInfo> {
 pub struct AudioCapture {
     stream: Option<Stream>,
     audio_sender: Sender<AudioMessage>,
+    /// Pinned input device UID (or legacy name during migration).
     selected_device: Option<String>,
-    /// Preferred microphone while the lid is closed with an external display
+    /// Preferred microphone UID while the lid is closed with an external display
     /// attached (clamshell mode); `None` disables the override entirely, so
     /// `find_device` never pays for the `is_clamshell()` probe.
     clamshell_device: Option<String>,
@@ -520,17 +516,17 @@ impl AudioCapture {
                         AudioCommand::Stop => {
                             capture.stop();
                         }
-                        AudioCommand::SelectDevice(name) => {
-                            info!("Selected input device: {name}");
-                            capture.selected_device = Some(name);
+                        AudioCommand::SelectDevice(uid) => {
+                            info!("Selected input device UID: {uid}");
+                            capture.selected_device = Some(uid);
                         }
-                        AudioCommand::SetClamshellDevice(name) => {
-                            if let Some(ref name) = name {
-                                info!("Clamshell-mode microphone preference: {name}");
+                        AudioCommand::SetClamshellDevice(uid) => {
+                            if let Some(ref uid) = uid {
+                                info!("Clamshell-mode microphone preference UID: {uid}");
                             } else {
                                 info!("Clamshell-mode microphone preference cleared");
                             }
-                            capture.clamshell_device = name;
+                            capture.clamshell_device = uid;
                         }
                         AudioCommand::AttachApp(app) => {
                             capture.app = Some(app);
@@ -545,11 +541,11 @@ impl AudioCapture {
         Ok((cmd_tx, audio_rx))
     }
 
-    /// Which device name (if any) `find_device` should target, given the
+    /// Which device UID (if any) `find_device` should target, given the
     /// user's explicit pin, the configured clamshell-mode preference, and
     /// whether clamshell mode is currently active *and* a preference is
     /// configured. Returns `None` to mean "follow whatever the OS reports as
-    /// the default input" — presence of the named device is checked by the
+    /// the default input" — presence of the device is checked by the
     /// caller, not here, so this stays a pure decision with no I/O.
     fn effective_device<'a>(
         selected: Option<&'a str>,
@@ -572,31 +568,40 @@ impl AudioCapture {
             && self.clamshell_device.is_some()
             && crate::power::is_clamshell();
 
-        if let Some(name) = Self::effective_device(
+        if let Some(stored) = Self::effective_device(
             self.selected_device.as_deref(),
             self.clamshell_device.as_deref(),
             clamshell_active,
         ) {
-            // Unfiltered `devices()`, not `input_devices()`: the latter's
-            // default filter probes every device's supported input configs
-            // (opens an AudioUnit per device on coreaudio) just to enumerate
-            // them, which can flip a Bluetooth headset into HFP mono. This
-            // runs on every session start and every mic health check
-            // (MIC_CHECK_INTERVAL), so the unfiltered form matters even when
-            // no device is pinned by name below the fallback. `Device::name`
-            // itself is a cheap property read, safe to call on every device.
-            let devices = host
-                .devices()
-                .map_err(|e| format!("Failed to list devices: {e}"))?;
+            let known_devices = list_input_devices_impl();
+            let target_name = resolve_device_name(&known_devices, stored).or({
+                // Disconnected UID or legacy name not in the current snapshot:
+                // try the stored value as a cpal device name directly.
+                Some(stored)
+            });
 
-            for device in devices {
-                if let Ok(n) = device.name()
-                    && n == name
-                {
-                    return Ok(device);
+            if let Some(name) = target_name {
+                // Unfiltered `devices()`, not `input_devices()`: the latter's
+                // default filter probes every device's supported input configs
+                // (opens an AudioUnit per device on coreaudio) just to enumerate
+                // them, which can flip a Bluetooth headset into HFP mono. This
+                // runs on every session start and every mic health check
+                // (MIC_CHECK_INTERVAL), so the unfiltered form matters even when
+                // no device is pinned below the fallback. `Device::name`
+                // itself is a cheap property read, safe to call on every device.
+                let devices = host
+                    .devices()
+                    .map_err(|e| format!("Failed to list devices: {e}"))?;
+
+                for device in devices {
+                    if let Ok(n) = device.name()
+                        && n == name
+                    {
+                        return Ok(device);
+                    }
                 }
+                warn!("Input device '{name}' not found, falling back to default");
             }
-            warn!("Input device '{name}' not found, falling back to default");
         }
 
         host.default_input_device()
@@ -1303,30 +1308,33 @@ mod effective_device_tests {
     #[test]
     fn explicit_pin_wins_over_clamshell_preference() {
         assert_eq!(
-            AudioCapture::effective_device(Some("Pinned Mic"), Some("USB Mic"), true),
-            Some("Pinned Mic"),
+            AudioCapture::effective_device(Some("pinned-uid"), Some("clamshell-uid"), true),
+            Some("pinned-uid"),
         );
     }
 
     #[test]
     fn explicit_pin_wins_even_without_clamshell_active() {
         assert_eq!(
-            AudioCapture::effective_device(Some("Pinned Mic"), Some("USB Mic"), false),
-            Some("Pinned Mic"),
+            AudioCapture::effective_device(Some("pinned-uid"), Some("clamshell-uid"), false),
+            Some("pinned-uid"),
         );
     }
 
     #[test]
     fn clamshell_preference_applies_when_no_pin_and_active() {
         assert_eq!(
-            AudioCapture::effective_device(None, Some("USB Mic"), true),
-            Some("USB Mic"),
+            AudioCapture::effective_device(None, Some("clamshell-uid"), true),
+            Some("clamshell-uid"),
         );
     }
 
     #[test]
     fn clamshell_preference_ignored_when_not_active() {
-        assert_eq!(AudioCapture::effective_device(None, Some("USB Mic"), false), None);
+        assert_eq!(
+            AudioCapture::effective_device(None, Some("clamshell-uid"), false),
+            None
+        );
     }
 
     #[test]

--- a/src-tauri/src/audio/device.rs
+++ b/src-tauri/src/audio/device.rs
@@ -1,0 +1,133 @@
+//! Stable CoreAudio input-device identity and preference helpers.
+
+/// Human-facing transport label for an input device.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, specta::Type)]
+#[serde(rename_all = "snake_case")]
+pub enum TransportType {
+    BuiltIn,
+    Usb,
+    Bluetooth,
+    BluetoothLe,
+    Virtual,
+    Aggregate,
+    Unknown,
+}
+
+/// An input-capable audio device as reported to the frontend.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, specta::Type)]
+pub struct AudioInputDevice {
+    /// Stable CoreAudio device UID (`kAudioDevicePropertyDeviceUID`).
+    pub uid: String,
+    pub name: String,
+    pub transport: TransportType,
+    pub is_default: bool,
+}
+
+/// Name of the private aggregate device created for system-audio capture.
+pub const SOUFFLE_TAP_DEVICE_NAME: &str = "Souffle system audio tap";
+
+/// Whether `name` refers to Souffle's own system-audio tap aggregate device.
+pub fn is_souffle_tap_device(name: &str) -> bool {
+    name.contains(SOUFFLE_TAP_DEVICE_NAME)
+}
+
+/// Convert a stored preference (`uid` or legacy `name`) to the device name cpal
+/// can match. Returns `None` when nothing in `devices` matches.
+pub fn resolve_device_name<'a>(devices: &'a [AudioInputDevice], stored: &str) -> Option<&'a str> {
+    devices
+        .iter()
+        .find(|device| device.uid == stored)
+        .map(|device| device.name.as_str())
+        .or_else(|| {
+            devices
+                .iter()
+                .find(|device| device.name == stored)
+                .map(|device| device.name.as_str())
+        })
+}
+
+/// On upgrade, map a legacy name pin to the matching connected device's UID.
+/// Returns `(value, changed)`.
+pub fn migrate_stored_device_id(stored: &str, devices: &[AudioInputDevice]) -> (String, bool) {
+    if devices.iter().any(|device| device.uid == stored) {
+        return (stored.to_string(), false);
+    }
+    if let Some(device) = devices.iter().find(|device| device.name == stored) {
+        return (device.uid.clone(), true);
+    }
+    (stored.to_string(), false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn device(uid: &str, name: &str) -> AudioInputDevice {
+        AudioInputDevice {
+            uid: uid.into(),
+            name: name.into(),
+            transport: TransportType::BuiltIn,
+            is_default: false,
+        }
+    }
+
+    #[test]
+    fn migrate_keeps_existing_uid() {
+        let devices = vec![device("BuiltInMic", "MacBook Pro Microphone")];
+        assert_eq!(
+            migrate_stored_device_id("BuiltInMic", &devices),
+            ("BuiltInMic".into(), false)
+        );
+    }
+
+    #[test]
+    fn migrate_maps_legacy_name_to_uid() {
+        let devices = vec![device("UsbMicUid", "USB Microphone")];
+        assert_eq!(
+            migrate_stored_device_id("USB Microphone", &devices),
+            ("UsbMicUid".into(), true)
+        );
+    }
+
+    #[test]
+    fn migrate_leaves_unknown_value_unchanged() {
+        let devices = vec![device("BuiltInMic", "MacBook Pro Microphone")];
+        assert_eq!(
+            migrate_stored_device_id("Ghost Mic", &devices),
+            ("Ghost Mic".into(), false)
+        );
+    }
+
+    #[test]
+    fn resolve_prefers_uid_match() {
+        let devices = vec![
+            device("uid-a", "Duplicate Name"),
+            device("uid-b", "Duplicate Name"),
+        ];
+        assert_eq!(
+            resolve_device_name(&devices, "uid-b"),
+            Some("Duplicate Name")
+        );
+    }
+
+    #[test]
+    fn resolve_falls_back_to_legacy_name() {
+        let devices = vec![device("uid-a", "USB Microphone")];
+        assert_eq!(
+            resolve_device_name(&devices, "USB Microphone"),
+            Some("USB Microphone")
+        );
+    }
+
+    #[test]
+    fn resolve_returns_none_for_unknown_value() {
+        let devices = vec![device("uid-a", "USB Microphone")];
+        assert_eq!(resolve_device_name(&devices, "Missing"), None);
+    }
+
+    #[test]
+    fn souffle_tap_name_is_detected() {
+        assert!(is_souffle_tap_device("Souffle system audio tap"));
+        assert!(!is_souffle_tap_device("MacBook Pro Microphone"));
+    }
+}

--- a/src-tauri/src/audio/device_watch.rs
+++ b/src-tauri/src/audio/device_watch.rs
@@ -27,17 +27,19 @@ use dispatch2::{DispatchQueue, DispatchRetained};
 use objc2_core_audio::{
     AudioObjectAddPropertyListenerBlock, AudioObjectGetPropertyData,
     AudioObjectGetPropertyDataSize, AudioObjectID, AudioObjectPropertyAddress,
-    kAudioDevicePropertyStreams, kAudioDevicePropertyTransportType,
-    kAudioDeviceTransportTypeAggregate, kAudioDeviceTransportTypeBluetooth,
-    kAudioDeviceTransportTypeBluetoothLE, kAudioDeviceTransportTypeBuiltIn,
-    kAudioDeviceTransportTypeUSB, kAudioDeviceTransportTypeVirtual,
-    kAudioHardwarePropertyDefaultInputDevice, kAudioHardwarePropertyDefaultOutputDevice,
-    kAudioHardwarePropertyDevices, kAudioObjectPropertyElementMain, kAudioObjectPropertyName,
-    kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyScopeInput, kAudioObjectSystemObject,
+    kAudioDevicePropertyDeviceUID, kAudioDevicePropertyStreams,
+    kAudioDevicePropertyTransportType, kAudioDeviceTransportTypeAggregate,
+    kAudioDeviceTransportTypeBluetooth, kAudioDeviceTransportTypeBluetoothLE,
+    kAudioDeviceTransportTypeBuiltIn, kAudioDeviceTransportTypeUSB,
+    kAudioDeviceTransportTypeVirtual, kAudioHardwarePropertyDefaultInputDevice,
+    kAudioHardwarePropertyDefaultOutputDevice, kAudioHardwarePropertyDevices,
+    kAudioObjectPropertyElementMain, kAudioObjectPropertyName, kAudioObjectPropertyScopeGlobal,
+    kAudioObjectPropertyScopeInput, kAudioObjectSystemObject,
 };
 use objc2_core_foundation::{CFRetained, CFString};
 use tracing::{info, warn};
 
+use crate::audio::device::{AudioInputDevice, TransportType, is_souffle_tap_device};
 use crate::power::is_clamshell;
 
 type ListenerBlock = RcBlock<dyn Fn(u32, NonNull<AudioObjectPropertyAddress>)>;
@@ -263,18 +265,29 @@ fn diff_devices(
     DeviceDiff { arrived, removed }
 }
 
+fn map_transport(transport: u32) -> TransportType {
+    match transport {
+        t if t == kAudioDeviceTransportTypeBuiltIn => TransportType::BuiltIn,
+        t if t == kAudioDeviceTransportTypeBluetooth => TransportType::Bluetooth,
+        t if t == kAudioDeviceTransportTypeBluetoothLE => TransportType::BluetoothLe,
+        t if t == kAudioDeviceTransportTypeUSB => TransportType::Usb,
+        t if t == kAudioDeviceTransportTypeVirtual => TransportType::Virtual,
+        t if t == kAudioDeviceTransportTypeAggregate => TransportType::Aggregate,
+        _ => TransportType::Unknown,
+    }
+}
+
 /// Human transport label for logging. Falls back to the raw four-char-code
 /// hex value for transports not worth naming individually.
-fn transport_name(transport: u32) -> String {
+fn transport_name(transport: TransportType) -> String {
     match transport {
-        t if t == kAudioDeviceTransportTypeBuiltIn => "built-in".into(),
-        t if t == kAudioDeviceTransportTypeBluetooth => "bluetooth".into(),
-        t if t == kAudioDeviceTransportTypeBluetoothLE => "bluetooth-le".into(),
-        t if t == kAudioDeviceTransportTypeUSB => "usb".into(),
-        t if t == kAudioDeviceTransportTypeVirtual => "virtual".into(),
-        t if t == kAudioDeviceTransportTypeAggregate => "aggregate".into(),
-        0 => "unknown".into(),
-        other => format!("{other:#x}"),
+        TransportType::BuiltIn => "built-in".into(),
+        TransportType::Bluetooth => "bluetooth".into(),
+        TransportType::BluetoothLe => "bluetooth-le".into(),
+        TransportType::Usb => "usb".into(),
+        TransportType::Virtual => "virtual".into(),
+        TransportType::Aggregate => "aggregate".into(),
+        TransportType::Unknown => "unknown".into(),
     }
 }
 
@@ -366,10 +379,25 @@ fn device_name(device: AudioObjectID) -> String {
     }
 }
 
-fn device_transport(device: AudioObjectID) -> u32 {
+fn device_uid(device: AudioObjectID) -> String {
+    let mut uid_ptr: *const CFString = std::ptr::null();
+    if !get_property(device, global_address(kAudioDevicePropertyDeviceUID), &mut uid_ptr) {
+        return format!("device#{device}");
+    }
+    match NonNull::new(uid_ptr.cast_mut()) {
+        Some(ptr) => unsafe { CFRetained::from_raw(ptr) }.to_string(),
+        None => format!("device#{device}"),
+    }
+}
+
+fn device_transport(device: AudioObjectID) -> TransportType {
     let mut transport: u32 = 0;
-    get_property(device, global_address(kAudioDevicePropertyTransportType), &mut transport);
-    transport
+    get_property(
+        device,
+        global_address(kAudioDevicePropertyTransportType),
+        &mut transport,
+    );
+    map_transport(transport)
 }
 
 /// Input-capable = has at least one stream in the input scope.
@@ -381,6 +409,15 @@ fn device_info(device: AudioObjectID) -> DeviceInfo {
     DeviceInfo {
         name: device_name(device),
         transport: transport_name(device_transport(device)),
+    }
+}
+
+fn input_device(device: AudioObjectID, is_default: bool) -> AudioInputDevice {
+    AudioInputDevice {
+        uid: device_uid(device),
+        name: device_name(device),
+        transport: device_transport(device),
+        is_default,
     }
 }
 
@@ -412,12 +449,12 @@ pub(crate) fn default_input_device_id() -> Option<AudioObjectID> {
     default_device_id(kAudioHardwarePropertyDefaultInputDevice)
 }
 
-/// `(name, is_default)` for every input-capable device. Pure CoreAudio
-/// property queries only (device list, stream count, name, transport-free) —
+/// Every input-capable device with stable UID and transport. Pure CoreAudio
+/// property queries only (device list, stream count, name, uid, transport) —
 /// unlike cpal's `Host::input_devices()`, this never queries a device's
 /// supported stream formats, so it can't open an AudioUnit on a device and
 /// force a Bluetooth headset out of A2DP. Used for the Settings device list.
-pub(crate) fn list_devices() -> Vec<(String, bool)> {
+pub(crate) fn list_devices() -> Vec<AudioInputDevice> {
     let default = default_input_device_id();
     device_ids(
         kAudioObjectSystemObject as AudioObjectID,
@@ -425,7 +462,8 @@ pub(crate) fn list_devices() -> Vec<(String, bool)> {
     )
     .into_iter()
     .filter(|&id| is_input_capable(id))
-    .map(|id| (device_name(id), Some(id) == default))
+    .map(|id| input_device(id, Some(id) == default))
+    .filter(|device| !is_souffle_tap_device(&device.name))
     .collect()
 }
 
@@ -493,18 +531,23 @@ mod tests {
 
     #[test]
     fn transport_maps_known_types() {
-        assert_eq!(transport_name(kAudioDeviceTransportTypeBuiltIn), "built-in");
-        assert_eq!(transport_name(kAudioDeviceTransportTypeBluetooth), "bluetooth");
-        assert_eq!(transport_name(kAudioDeviceTransportTypeBluetoothLE), "bluetooth-le");
-        assert_eq!(transport_name(kAudioDeviceTransportTypeUSB), "usb");
-        assert_eq!(transport_name(kAudioDeviceTransportTypeVirtual), "virtual");
-        assert_eq!(transport_name(kAudioDeviceTransportTypeAggregate), "aggregate");
+        assert_eq!(transport_name(TransportType::BuiltIn), "built-in");
+        assert_eq!(transport_name(TransportType::Bluetooth), "bluetooth");
+        assert_eq!(transport_name(TransportType::BluetoothLe), "bluetooth-le");
+        assert_eq!(transport_name(TransportType::Usb), "usb");
+        assert_eq!(transport_name(TransportType::Virtual), "virtual");
+        assert_eq!(transport_name(TransportType::Aggregate), "aggregate");
+        assert_eq!(transport_name(TransportType::Unknown), "unknown");
     }
 
     #[test]
-    fn transport_unknown_falls_back_to_hex() {
-        assert_eq!(transport_name(0), "unknown");
-        assert_eq!(transport_name(0xdead_beef), "0xdeadbeef");
+    fn map_transport_covers_coreaudio_codes() {
+        assert_eq!(map_transport(kAudioDeviceTransportTypeBuiltIn), TransportType::BuiltIn);
+        assert_eq!(
+            map_transport(kAudioDeviceTransportTypeBluetooth),
+            TransportType::Bluetooth
+        );
+        assert_eq!(map_transport(0xdead_beef), TransportType::Unknown);
     }
 
     #[test]

--- a/src-tauri/src/audio/mod.rs
+++ b/src-tauri/src/audio/mod.rs
@@ -1,5 +1,6 @@
 pub mod aec;
 pub mod capture;
+pub mod device;
 pub mod device_watch;
 pub mod feedback;
 pub mod mixer;
@@ -11,4 +12,5 @@ pub mod system_activity;
 pub mod system_tap;
 
 pub use capture::{AudioCapture, AudioChunk, AudioMessage};
+pub use device::{AudioInputDevice, TransportType};
 pub use resampler::Resampler;

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -1,22 +1,23 @@
 use tauri::State;
 
-use crate::audio::capture::{AudioDeviceInfo, list_input_devices};
+use crate::audio::capture::list_input_devices;
+use crate::audio::AudioInputDevice;
 use crate::state::{AppState, AudioCommand};
 
 /// List available audio input devices
 #[tauri::command]
 #[specta::specta]
-pub fn list_audio_devices() -> Result<Vec<AudioDeviceInfo>, String> {
+pub fn list_audio_devices() -> Result<Vec<AudioInputDevice>, String> {
     Ok(list_input_devices())
 }
 
-/// Select an audio input device by name
+/// Select an audio input device by stable CoreAudio UID.
 #[tauri::command]
 #[specta::specta]
-pub fn select_audio_device(state: State<'_, AppState>, device_name: String) -> Result<(), String> {
+pub fn select_audio_device(state: State<'_, AppState>, device_uid: String) -> Result<(), String> {
     state
         .audio_cmd_sender
-        .send(AudioCommand::SelectDevice(device_name))
+        .send(AudioCommand::SelectDevice(device_uid))
         .map_err(|e| format!("Failed to send device selection: {e}"))
 }
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -126,8 +126,9 @@ pub struct AppSettings {
     pub debug_transcription: bool,
     /// Global tracing verbosity for the `souffle` crate.
     pub log_level: LogLevel,
+    /// Pinned input device UID (`kAudioDevicePropertyDeviceUID`).
     pub audio_device: Option<String>,
-    /// Preferred microphone while the lid is closed with an external display
+    /// Preferred microphone UID while the lid is closed with an external display
     /// attached (clamshell mode). `None` means just follow whatever macOS
     /// reports as the default input, the previous behavior.
     pub clamshell_audio_device: Option<String>,
@@ -421,7 +422,50 @@ impl AppSettings {
             settings.last_seen_version = last_seen_version;
         }
 
-        Ok(settings.sanitized())
+        let mut settings = settings.sanitized();
+        Self::migrate_audio_device_preferences(&mut settings, db)?;
+
+        Ok(settings)
+    }
+
+    /// Best-effort upgrade from legacy name pins to stable CoreAudio UIDs.
+    fn migrate_audio_device_preferences(
+        settings: &mut AppSettings,
+        db: &Database,
+    ) -> Result<(), String> {
+        #[cfg(target_os = "macos")]
+        {
+            use crate::audio::device::migrate_stored_device_id;
+            use crate::audio::device_watch::list_devices;
+
+            let devices = list_devices();
+            let mut changed = false;
+
+            if let Some(stored) = settings.audio_device.as_ref() {
+                let (migrated, did_change) = migrate_stored_device_id(stored, &devices);
+                if did_change {
+                    settings.audio_device = Some(migrated);
+                    changed = true;
+                }
+            }
+            if let Some(stored) = settings.clamshell_audio_device.as_ref() {
+                let (migrated, did_change) = migrate_stored_device_id(stored, &devices);
+                if did_change {
+                    settings.clamshell_audio_device = Some(migrated);
+                    changed = true;
+                }
+            }
+
+            if changed {
+                if let Some(audio_device) = settings.audio_device.as_ref() {
+                    write_json_setting(db, AUDIO_DEVICE_KEY, audio_device)?;
+                }
+                if let Some(clamshell_audio_device) = settings.clamshell_audio_device.as_ref() {
+                    write_json_setting(db, CLAMSHELL_AUDIO_DEVICE_KEY, clamshell_audio_device)?;
+                }
+            }
+        }
+        Ok(())
     }
 
     pub fn sanitize_for_save(&self) -> Result<Self, String> {

--- a/src/lib/api/settings.test.ts
+++ b/src/lib/api/settings.test.ts
@@ -65,7 +65,12 @@ describe('settings API', () => {
   });
 
   it('listAudioDevices calls correct command', async () => {
-    const devices = [{ name: 'MacBook Pro Microphone', is_default: true }];
+    const devices = [{
+      uid: 'BuiltInMic',
+      name: 'MacBook Pro Microphone',
+      transport: 'built_in',
+      is_default: true,
+    }];
     mockInvoke.mockResolvedValue(devices);
 
     const result = await listAudioDevices();
@@ -74,11 +79,11 @@ describe('settings API', () => {
     expect(result).toEqual(devices);
   });
 
-  it('selectAudioDevice passes device name', async () => {
+  it('selectAudioDevice passes device UID', async () => {
     mockInvoke.mockResolvedValue(null);
 
-    await selectAudioDevice('External Mic');
+    await selectAudioDevice('ExternalMicUid');
 
-    expect(mockInvoke).toHaveBeenCalledWith('select_audio_device', expect.objectContaining({ deviceName: 'External Mic' }), undefined);
+    expect(mockInvoke).toHaveBeenCalledWith('select_audio_device', expect.objectContaining({ deviceUid: 'ExternalMicUid' }), undefined);
   });
 });

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -1,5 +1,5 @@
 import { commands, unwrap } from "./generated";
-import type { AppSettings, AudioDeviceInfo, ShortcutSettings } from "../types";
+import type { AppSettings, AudioInputDevice, ShortcutSettings } from "../types";
 
 export async function getSettings(): Promise<AppSettings> {
   return unwrap(commands.getSettings());
@@ -17,12 +17,12 @@ export async function saveShortcuts(shortcuts: ShortcutSettings): Promise<void> 
   await unwrap(commands.saveShortcuts(shortcuts));
 }
 
-export async function listAudioDevices(): Promise<AudioDeviceInfo[]> {
+export async function listAudioDevices(): Promise<AudioInputDevice[]> {
   return unwrap(commands.listAudioDevices());
 }
 
-export async function selectAudioDevice(deviceName: string): Promise<void> {
-  await unwrap(commands.selectAudioDevice(deviceName));
+export async function selectAudioDevice(deviceUid: string): Promise<void> {
+  await unwrap(commands.selectAudioDevice(deviceUid));
 }
 
 export async function getSystemAudioSupport(): Promise<boolean> {

--- a/src/lib/features/settings/components/AudioSettingsSection.svelte
+++ b/src/lib/features/settings/components/AudioSettingsSection.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { t } from "svelte-i18n";
   import SettingsField from "../../../components/ui/SettingsField.svelte";
-  import type { AudioDeviceInfo } from "../../../types";
+  import type { AudioInputDevice } from "../../../types";
 
   const autostopMinutesOptions = [5, 10, 15, 30] as const;
   const autostopMinutesKeys: Record<(typeof autostopMinutesOptions)[number], string> = {
@@ -50,7 +50,7 @@
     onMeetingMaxDurationMinutesChange,
     onMeetingTranscriptionLanguageChange,
   }: {
-    audioDevices: AudioDeviceInfo[];
+    audioDevices: AudioInputDevice[];
     captureSystemAudio: boolean;
     systemAudioSupported: boolean;
     isLaptop: boolean;
@@ -94,7 +94,7 @@
         >
           <option value="">{$t("settings_audio.clamshell_device_follow_default")}</option>
           {#each audioDevices as device}
-            <option value={device.name}>{device.name}</option>
+            <option value={device.uid}>{device.name}</option>
           {/each}
         </select>
       {/snippet}

--- a/src/lib/features/settings/components/MicrophoneSettingsSection.svelte
+++ b/src/lib/features/settings/components/MicrophoneSettingsSection.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { RefreshCw } from "@lucide/svelte";
   import { t } from "svelte-i18n";
-  import type { AudioDeviceInfo } from "../../../types";
+  import type { AudioInputDevice } from "../../../types";
 
   let {
     audioDevices,
@@ -9,7 +9,7 @@
     onDeviceChange,
     onRefreshDevices,
   }: {
-    audioDevices: AudioDeviceInfo[];
+    audioDevices: AudioInputDevice[];
     selectedDevice: string;
     onDeviceChange: (event: Event) => void | Promise<void>;
     onRefreshDevices: () => void | Promise<void>;
@@ -27,7 +27,7 @@
       <div class="flex shrink-0 gap-1.5 items-center">
         <select id="input-device" value={selectedDevice} onchange={onDeviceChange} class="field-select max-w-52">
           {#each audioDevices as device}
-            <option value={device.name}>
+            <option value={device.uid}>
               {device.name}{device.is_default ? ` ${$t("settings_audio.device_default_suffix")}` : ""}
             </option>
           {/each}

--- a/src/lib/features/settings/controller.svelte.test.ts
+++ b/src/lib/features/settings/controller.svelte.test.ts
@@ -37,7 +37,7 @@ import { createSettingsController } from "./controller.svelte";
 import { getAppState } from "../../stores/app.svelte";
 import type {
   AppSettings,
-  AudioDeviceInfo,
+  AudioInputDevice,
   ShortcutSettings,
   TranscriptionCatalog,
   TranscriptionRuntimeStatus,
@@ -93,9 +93,9 @@ const defaultSettings: AppSettings = {
   last_seen_version: "",
 }
 
-const fakeDevices: AudioDeviceInfo[] = [
-  { name: "Built-in Microphone", is_default: true },
-  { name: "USB Microphone", is_default: false },
+const fakeDevices: AudioInputDevice[] = [
+  { uid: "builtin-mic", name: "Built-in Microphone", transport: "built_in", is_default: true },
+  { uid: "usb-mic", name: "USB Microphone", transport: "usb", is_default: false },
 ];
 
 const fakeShortcuts: ShortcutSettings = {
@@ -292,14 +292,14 @@ describe("settings controller", () => {
     await ctrl.mount();
 
     const fakeEvent = {
-      target: { value: "USB Microphone" },
+      target: { value: "usb-mic" },
     } as unknown as Event;
 
     await ctrl.onDeviceChange(fakeEvent);
 
-    expect(mockInvoke).toHaveBeenCalledWith("select_audio_device", { deviceName: "USB Microphone" });
+    expect(mockInvoke).toHaveBeenCalledWith("select_audio_device", { deviceUid: "usb-mic" });
     expect(mockInvoke).toHaveBeenCalledWith("save_settings", expect.objectContaining({
-      settings: expect.objectContaining({ audio_device: "USB Microphone" }),
+      settings: expect.objectContaining({ audio_device: "usb-mic" }),
     }));
   });
 

--- a/src/lib/features/settings/controller.svelte.ts
+++ b/src/lib/features/settings/controller.svelte.ts
@@ -21,7 +21,7 @@ import { setLocale } from "../../i18n";
 import { getAppState } from "../../stores/app.svelte";
 import type {
   AppSettings,
-  AudioDeviceInfo,
+  AudioInputDevice,
   CalendarInfo,
   DictionaryEntry,
   PermState,
@@ -48,7 +48,7 @@ import {
 export function createSettingsController() {
   const app = getAppState();
 
-  let audioDevices = $state<AudioDeviceInfo[]>([]);
+  let audioDevices = $state<AudioInputDevice[]>([]);
   let systemAudioSupported = $state(false);
   // Gates the "microphone when lid is closed" picker: meaningless on a
   // desktop Mac, so it's hidden entirely rather than shown disabled.
@@ -164,7 +164,7 @@ export function createSettingsController() {
     try {
       audioDevices = await listAudioDevices();
       if (app.selectedDevice) {
-        const exists = audioDevices.some((device) => device.name === app.selectedDevice);
+        const exists = audioDevices.some((device) => device.uid === app.selectedDevice);
         if (exists) {
           await selectAudioDevice(app.selectedDevice);
           return;
@@ -172,8 +172,8 @@ export function createSettingsController() {
       }
       const defaultDevice = audioDevices.find((device) => device.is_default);
       if (defaultDevice) {
-        app.selectedDevice = defaultDevice.name;
-        await selectAudioDevice(defaultDevice.name);
+        app.selectedDevice = defaultDevice.uid;
+        await selectAudioDevice(defaultDevice.uid);
       }
     } catch (e) {
       statusMessage = errorMessage(e);

--- a/src/lib/test-helpers/tauri-mock.ts
+++ b/src/lib/test-helpers/tauri-mock.ts
@@ -13,7 +13,7 @@
 import { vi } from "vitest";
 import type {
   AppSettings,
-  AudioDeviceInfo,
+  AudioInputDevice,
   DictationEntry,
   MeetingListItem,
   MeetingTranscript,
@@ -110,8 +110,8 @@ export interface SettingsApiMock {
   saveSettings: ReturnType<typeof vi.fn<(settings: AppSettings) => Promise<void>>>;
   getShortcuts: ReturnType<typeof vi.fn<() => Promise<ShortcutSettings>>>;
   saveShortcuts: ReturnType<typeof vi.fn<(shortcuts: ShortcutSettings) => Promise<void>>>;
-  listAudioDevices: ReturnType<typeof vi.fn<() => Promise<AudioDeviceInfo[]>>>;
-  selectAudioDevice: ReturnType<typeof vi.fn<(deviceName: string) => Promise<void>>>;
+  listAudioDevices: ReturnType<typeof vi.fn<() => Promise<AudioInputDevice[]>>>;
+  selectAudioDevice: ReturnType<typeof vi.fn<(deviceUid: string) => Promise<void>>>;
 }
 
 export function createSettingsApiMock(
@@ -122,11 +122,11 @@ export function createSettingsApiMock(
     saveSettings: vi.fn<(settings: AppSettings) => Promise<void>>().mockResolvedValue(undefined),
     getShortcuts: vi.fn<() => Promise<ShortcutSettings>>().mockResolvedValue(mockShortcuts),
     saveShortcuts: vi.fn<(shortcuts: ShortcutSettings) => Promise<void>>().mockResolvedValue(undefined),
-    listAudioDevices: vi.fn<() => Promise<AudioDeviceInfo[]>>().mockResolvedValue([
-      { name: "Built-in Microphone", is_default: true },
-      { name: "External USB Mic", is_default: false },
+    listAudioDevices: vi.fn<() => Promise<AudioInputDevice[]>>().mockResolvedValue([
+      { uid: "builtin-mic", name: "Built-in Microphone", transport: "built_in", is_default: true },
+      { uid: "usb-mic", name: "External USB Mic", transport: "usb", is_default: false },
     ]),
-    selectAudioDevice: vi.fn<(deviceName: string) => Promise<void>>().mockResolvedValue(undefined),
+    selectAudioDevice: vi.fn<(deviceUid: string) => Promise<void>>().mockResolvedValue(undefined),
     ...overrides,
   };
 }

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -95,7 +95,7 @@ async stopTranscription() : Promise<Result<null, string>> {
 /**
  * List available audio input devices
  */
-async listAudioDevices() : Promise<Result<AudioDeviceInfo[], string>> {
+async listAudioDevices() : Promise<Result<AudioInputDevice[], string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("list_audio_devices") };
 } catch (e) {
@@ -104,11 +104,11 @@ async listAudioDevices() : Promise<Result<AudioDeviceInfo[], string>> {
 }
 },
 /**
- * Select an audio input device by name
+ * Select an audio input device by stable CoreAudio UID.
  */
-async selectAudioDevice(deviceName: string) : Promise<Result<null, string>> {
+async selectAudioDevice(deviceUid: string) : Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("select_audio_device", { deviceName }) };
+    return { status: "ok", data: await TAURI_INVOKE("select_audio_device", { deviceUid }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -866,9 +866,13 @@ paste_method: PasteMethod; ollama_url: string; ollama_model: string; debug_trans
 /**
  * Global tracing verbosity for the `souffle` crate.
  */
-log_level: LogLevel; audio_device: string | null; 
+log_level: LogLevel; 
 /**
- * Preferred microphone while the lid is closed with an external display
+ * Pinned input device UID (`kAudioDevicePropertyDeviceUID`).
+ */
+audio_device: string | null; 
+/**
+ * Preferred microphone UID while the lid is closed with an external display
  * attached (clamshell mode). `None` means just follow whatever macOS
  * reports as the default input, the previous behavior.
  */
@@ -978,9 +982,13 @@ export type AppView = "home" | "settings"
  */
 export type ArchiveExportProgress = { done: number; total: number; finished: boolean; error: string | null }
 /**
- * Info about an available audio input device, sent to frontend
+ * An input-capable audio device as reported to the frontend.
  */
-export type AudioDeviceInfo = { name: string; is_default: boolean }
+export type AudioInputDevice = { 
+/**
+ * Stable CoreAudio device UID (`kAudioDevicePropertyDeviceUID`).
+ */
+uid: string; name: string; transport: TransportType; is_default: boolean }
 export type AudioInputRequirements = { sample_rate_hz: number; channels: number; chunk_size_samples: number }
 /**
  * Current microphone/meeting input level (RMS, 0.0-1.0), pushed by the audio
@@ -1350,6 +1358,10 @@ export type TranscriptionSegment = { text: string; start_time: number; end_time:
  * Set by the pipeline for diarized meetings; `None` otherwise.
  */
 speaker?: Speaker | null }
+/**
+ * Human-facing transport label for an input device.
+ */
+export type TransportType = "built_in" | "usb" | "bluetooth" | "bluetooth_le" | "virtual" | "aggregate" | "unknown"
 /**
  * Emitted by the calendar reminder scheduler shortly before a calendar
  * event starts, so the frontend can offer a one-click transcription start.

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -3,7 +3,7 @@ export type {
   AppStateMachine,
   AppView,
   ArchiveExportProgress,
-  AudioDeviceInfo,
+  AudioInputDevice,
   AudioInputRequirements,
   CalendarEvent,
   CalendarInfo,


### PR DESCRIPTION
## Summary

- List and select input devices by stable CoreAudio UID (`kAudioDevicePropertyDeviceUID`), exposing `uid`, display `name`, and `transport` to the frontend.
- Migrate persisted `audio_device` / clamshell preference from legacy display names to UIDs on settings load when a unique name match exists.
- Exclude the system-audio tap device from the mic picker via UID; device watch compares UIDs for hot-plug changes.
- Settings and capture paths still read legacy name fields where needed for backward compatibility during migration.
- **Known caveat:** cpal still opens streams by resolved display name after UID lookup (unchanged cpal limitation).

## Test plan

- [ ] Open Settings → Audio: mic list shows expected devices; selection persists across app restart.
- [ ] Rename a virtual/USB device in macOS (or reconnect BT): pinned mic stays correct when matched by UID.
- [ ] Load settings file with old name-only `audio_device`: migrates to UID on first load when name is unique.
- [ ] System-audio tap device does not appear as a selectable microphone.
- [ ] Clamshell mic preference uses UID and applies when lid closed + external display.
- [ ] `npm test`, `npm run check`, `cargo test --manifest-path src-tauri/Cargo.toml --workspace` (already green locally).