### PR TITLE
Fix speaker recognition for system audio and declutter Settings

### DIFF
--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -224,11 +224,14 @@ struct StartParams {
     /// not `off`. `None` for dictation sessions and for meetings recorded
     /// with retention off.
     record_path: Option<PathBuf>,
-    /// File to tee this session's mic audio to for offline speaker
-    /// diarization, if the feature is on and this is a mic-only meeting.
-    /// `None` for dictation, for meetings with a system-audio lane, and
-    /// whenever the feature is off or its models aren't downloaded.
-    diarize_capture_path: Option<PathBuf>,
+    /// File to tee this session's mic (Me-lane) audio to for offline speaker
+    /// diarization, when enabled. `None` for dictation and whenever the
+    /// feature is off or its models aren't downloaded.
+    diarize_mic_capture_path: Option<PathBuf>,
+    /// File to tee this session's system-audio (Them-lane) capture to for
+    /// offline speaker diarization, when enabled. `None` unless system
+    /// capture and system-audio diarization are both on.
+    diarize_system_capture_path: Option<PathBuf>,
 }
 
 /// Per-session state for meeting mode (mic + system audio).
@@ -382,10 +385,13 @@ pub struct AudioCapture {
     /// a mic rebuild mid-session must keep recording to the same file —
     /// only a genuinely new `session_id` (or no `record_path`) replaces it.
     recorder: Option<MeetingRecorder>,
-    /// Tees this session's mic audio to a temporary 16kHz mono WAV for
-    /// offline speaker diarization, when enabled. Same lifecycle rule as
+    /// Tees this session's mic (Me-lane) audio to a temporary 16kHz mono WAV
+    /// for offline speaker diarization, when enabled. Same lifecycle rule as
     /// `recorder`: survives a mid-session mic rebuild by session id.
     diarize_tap: Option<super::diarize_tap::DiarizeTapWriter>,
+    /// Tees this session's system-audio (Them-lane) capture to a temporary
+    /// 16kHz mono WAV for offline speaker diarization, when enabled.
+    diarize_system_tap: Option<super::diarize_tap::DiarizeTapWriter>,
     /// For emitting SystemAudioStatus events (set during app setup).
     app: Option<tauri::AppHandle>,
     /// Parameters of the running session, kept for mid-session rebuilds.
@@ -450,6 +456,7 @@ impl AudioCapture {
                     meeting: None,
                     recorder: None,
                     diarize_tap: None,
+                    diarize_system_tap: None,
                     app: None,
                     active_params: None,
                     mic_device_name: None,
@@ -521,7 +528,8 @@ impl AudioCapture {
                             capture_system_audio,
                             diarize,
                             record_path,
-                            diarize_capture_path,
+                            diarize_mic_capture_path,
+                            diarize_system_capture_path,
                         } => {
                             if let Err(e) = capture.start(
                                 session_id,
@@ -530,7 +538,8 @@ impl AudioCapture {
                                 capture_system_audio,
                                 diarize,
                                 record_path,
-                                diarize_capture_path,
+                                diarize_mic_capture_path,
+                                diarize_system_capture_path,
                             ) {
                                 warn!("Failed to start audio capture: {e}");
                             }
@@ -648,18 +657,24 @@ impl AudioCapture {
         capture_system_audio: bool,
         diarize: bool,
         record_path: Option<PathBuf>,
-        diarize_capture_path: Option<PathBuf>,
+        diarize_mic_capture_path: Option<PathBuf>,
+        diarize_system_capture_path: Option<PathBuf>,
     ) -> Result<(), String> {
         // Ensure any previous callback stops emitting immediately, and tear
         // down any leftover meeting state (tap included). The recorder and
-        // diarize tap are NOT torn down here; see `sync_recorder` /
+        // diarize taps are NOT torn down here; see `sync_recorder` /
         // `sync_diarize_tap`, so a mid-session mic rebuild (same
         // session_id) keeps recording to the same file(s).
         self.active_session_id.store(0, Ordering::Release);
         self.stream.take();
         self.meeting.take();
         self.sync_recorder(session_id, record_path.as_deref(), target_sample_rate);
-        self.sync_diarize_tap(session_id, diarize_capture_path.as_deref(), target_sample_rate);
+        self.sync_diarize_tap(session_id, diarize_mic_capture_path.as_deref(), target_sample_rate);
+        self.sync_diarize_system_tap(
+            session_id,
+            diarize_system_capture_path.as_deref(),
+            target_sample_rate,
+        );
 
         // Stored before any fallible step so a failed (re)build is retried
         // by the next mic health check instead of killing the session.
@@ -670,7 +685,8 @@ impl AudioCapture {
             capture_system_audio,
             diarize,
             record_path,
-            diarize_capture_path,
+            diarize_mic_capture_path,
+            diarize_system_capture_path,
         });
         self.stream_failed
             .store(false, std::sync::atomic::Ordering::Relaxed);
@@ -887,6 +903,56 @@ impl AudioCapture {
         }
     }
 
+    /// Reconcile `self.diarize_system_tap` with what this `start()` call
+    /// wants, mirroring `sync_diarize_tap`.
+    fn sync_diarize_system_tap(
+        &mut self,
+        session_id: u64,
+        path: Option<&std::path::Path>,
+        sample_rate: u32,
+    ) {
+        let same_session = self
+            .diarize_system_tap
+            .as_ref()
+            .is_some_and(|t| t.session_id() == session_id);
+        match path {
+            Some(_) if same_session => {}
+            Some(path) => {
+                self.finish_diarize_system_tap();
+                match super::diarize_tap::DiarizeTapWriter::start(path.to_path_buf(), sample_rate, session_id)
+                {
+                    Ok(tap) => self.diarize_system_tap = Some(tap),
+                    Err(e) => warn!("Failed to start system diarization audio tap: {e}"),
+                }
+            }
+            None => self.finish_diarize_system_tap(),
+        }
+    }
+
+    /// Finalize and drop the active system diarize tap, if any.
+    fn finish_diarize_system_tap(&mut self) {
+        if let Some(tap) = self.diarize_system_tap.take() {
+            let dropped = tap.dropped_chunks();
+            if dropped > 0 {
+                warn!("System diarization audio tap dropped {dropped} audio chunks this session");
+            }
+        }
+    }
+
+    /// Feed one mono chunk to the mic diarization tap, if any.
+    fn push_diarize_mic(&self, samples: &[f32]) {
+        if let Some(tap) = &self.diarize_tap {
+            tap.push(samples);
+        }
+    }
+
+    /// Feed one mono chunk to the system-audio diarization tap, if any.
+    fn push_diarize_system(&self, samples: &[f32]) {
+        if let Some(tap) = &self.diarize_system_tap {
+            tap.push(samples);
+        }
+    }
+
     /// Feed one diarized meeting-audio tick to the active recorder, if any:
     /// the two legs are summed with soft clipping into the single mixed
     /// stream the recording represents (diarization only affects
@@ -1067,7 +1133,8 @@ impl AudioCapture {
             params.capture_system_audio,
             params.diarize,
             params.record_path.clone(),
-            params.diarize_capture_path.clone(),
+            params.diarize_mic_capture_path.clone(),
+            params.diarize_system_capture_path.clone(),
         ) {
             Ok(()) => {
                 self.mic_rebuild_failures = 0;
@@ -1142,6 +1209,8 @@ impl AudioCapture {
         use crate::engine::Speaker;
         if diarize {
             self.push_recording_diarized(&me, &them);
+            self.push_diarize_mic(&me);
+            self.push_diarize_system(&them);
             self.store_meeting_rms(&me, &them);
             self.send_meeting_chunk(session_id, me, Some(Speaker::Me));
             self.send_meeting_chunk(session_id, them, Some(Speaker::Them));
@@ -1258,6 +1327,7 @@ impl AudioCapture {
         // but structurally valid Ogg file is acceptable here.
         self.finish_recording();
         self.finish_diarize_tap();
+        self.finish_diarize_system_tap();
         self.emit_audio_level(0.0);
         self.level_throttle.reset();
     }
@@ -1312,6 +1382,8 @@ impl AudioCapture {
                 if meeting.diarize {
                     let (me, them) = meeting.mixer.flush_split();
                     self.push_recording_diarized(&me, &them);
+                    self.push_diarize_mic(&me);
+                    self.push_diarize_system(&them);
                     self.send_meeting_chunk(session_id, me, Some(crate::engine::Speaker::Me));
                     self.send_meeting_chunk(session_id, them, Some(crate::engine::Speaker::Them));
                 } else {
@@ -1327,6 +1399,7 @@ impl AudioCapture {
             }
             self.finish_recording();
             self.finish_diarize_tap();
+            self.finish_diarize_system_tap();
 
             if had_stream {
                 info!("Meeting audio capture stopped");
@@ -1343,9 +1416,7 @@ impl AudioCapture {
             {
                 let tail = r.flush();
                 if !tail.is_empty() {
-                    if let Some(tap) = &self.diarize_tap {
-                        tap.push(&tail);
-                    }
+                    self.push_diarize_mic(&tail);
                     let _ = self.audio_sender.send(AudioMessage::Chunk(AudioChunk {
                         session_id,
                         samples: tail,
@@ -1362,9 +1433,11 @@ impl AudioCapture {
             // header is written by then. Not a realtime path (the cpal
             // stream is already dropped).
             self.finish_diarize_tap();
+            self.finish_diarize_system_tap();
             self.send_end_of_stream(session_id);
         }
         self.finish_diarize_tap();
+        self.finish_diarize_system_tap();
 
         if had_stream {
             info!("Audio capture stopped");

--- a/src-tauri/src/audio/diarize_tap.rs
+++ b/src-tauri/src/audio/diarize_tap.rs
@@ -1,10 +1,11 @@
-//! Temporary 16kHz mono WAV capture of mic-only meeting audio, so a
-//! background task can run offline speaker diarization on it once the
-//! recording stops. Same shape as `recorder.rs`'s `MeetingRecorder`: a
-//! dedicated writer thread fed by a bounded channel, so the realtime
-//! audio-capture callback never blocks on resampling or disk I/O:
-//! `DiarizeTapWriter::push`/`DiarizeTapHandle::push` are `try_send`, and a
-//! full channel just drops the chunk (counted, logged at session end).
+//! Temporary 16kHz mono WAV capture of meeting audio for offline speaker
+//! diarization once the recording stops. Mic and system-audio lanes can each
+//! have their own tap (`{index}-mic.wav` and `{index}-system.wav`). Same
+//! shape as `recorder.rs`'s `MeetingRecorder`: a dedicated writer thread fed
+//! by a bounded channel, so the realtime audio-capture callback never blocks
+//! on resampling or disk I/O: `DiarizeTapWriter::push`/`DiarizeTapHandle::push`
+//! are `try_send`, and a full channel just drops the chunk (counted, logged at
+//! session end).
 //!
 //! Unlike the opus recorder, this tap is meeting-and-mic-only, opt-in via
 //! `AppSettings::diarize_enabled`, and its output is always transient: every
@@ -39,10 +40,22 @@ pub fn meeting_diarize_tmp_dir(meeting_id: &str) -> PathBuf {
     diarize_tmp_root().join(meeting_id)
 }
 
-/// WAV path for one recording session's tapped mic audio, at 16kHz mono.
-/// `session_index` matches the corresponding `MeetingRecordingSession`'s
-/// position in the meeting's `recording_sessions`.
-pub fn session_wav_path(meeting_id: &str, session_index: usize) -> PathBuf {
+/// WAV path for one recording session's tapped microphone (Me-lane) audio,
+/// at 16kHz mono. `session_index` matches the corresponding
+/// `MeetingRecordingSession`'s position in the meeting's `recording_sessions`.
+pub fn session_mic_wav_path(meeting_id: &str, session_index: usize) -> PathBuf {
+    meeting_diarize_tmp_dir(meeting_id).join(format!("{session_index}-mic.wav"))
+}
+
+/// WAV path for one recording session's tapped system-audio (Them-lane)
+/// capture, at 16kHz mono.
+pub fn session_system_wav_path(meeting_id: &str, session_index: usize) -> PathBuf {
+    meeting_diarize_tmp_dir(meeting_id).join(format!("{session_index}-system.wav"))
+}
+
+/// Legacy mic WAV path (`{index}.wav`) kept for pending files from older
+/// builds. New recordings use `session_mic_wav_path`.
+pub fn legacy_session_mic_wav_path(meeting_id: &str, session_index: usize) -> PathBuf {
     meeting_diarize_tmp_dir(meeting_id).join(format!("{session_index}.wav"))
 }
 
@@ -282,13 +295,17 @@ mod tests {
     }
 
     #[test]
-    fn session_wav_path_is_scoped_by_meeting_and_index() {
-        let a = session_wav_path("meeting-1", 0);
-        let b = session_wav_path("meeting-1", 1);
-        let c = session_wav_path("meeting-2", 0);
-        assert_ne!(a, b);
-        assert_ne!(a, c);
-        assert!(a.ends_with("meeting-1/0.wav") || a.to_string_lossy().replace('\\', "/").ends_with("meeting-1/0.wav"));
+    fn session_mic_and_system_wav_paths_are_scoped_by_meeting_and_index() {
+        let mic0 = session_mic_wav_path("meeting-1", 0);
+        let mic1 = session_mic_wav_path("meeting-1", 1);
+        let sys0 = session_system_wav_path("meeting-1", 0);
+        let legacy = legacy_session_mic_wav_path("meeting-1", 0);
+        assert_ne!(mic0, mic1);
+        assert_ne!(mic0, sys0);
+        assert_ne!(mic0, legacy);
+        assert!(mic0.to_string_lossy().ends_with("0-mic.wav"));
+        assert!(sys0.to_string_lossy().ends_with("0-system.wav"));
+        assert!(legacy.to_string_lossy().ends_with("0.wav"));
     }
 
     #[test]

--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -311,20 +311,32 @@ fn start_pipeline_blocking(
         None
     };
 
-    // Offline speaker recognition only applies to mic-only meetings: a
-    // system-audio lane already gives authoritative Me/Them attribution, so
-    // tapping audio for diarization would be pointless work. Silently skips
-    // (no tap, no capture, no inference) whenever the feature is off or its
-    // models aren't downloaded yet. The Settings UI is where downloading
-    // happens, this path never triggers it.
-    let diarize_capture_path = if mode == PipelineMode::Meeting
-        && !capture_system_audio
+    // Offline speaker recognition: tap mic and/or system WAVs when enabled
+    // and models are present. Each pass labels only its target lane (Me or
+    // Them); persistent speakers stay locked on both passes.
+    let models_ready = crate::diarize::models::models_downloaded();
+    let diarize_mic_capture_path = if mode == PipelineMode::Meeting
         && settings.diarize_enabled
-        && crate::diarize::models::models_downloaded()
+        && settings.diarize_mic
+        && models_ready
     {
         recording_target
             .as_ref()
-            .map(|target| crate::audio::diarize_tap::session_wav_path(&target.meeting_id, target.session_index))
+            .map(|target| crate::audio::diarize_tap::session_mic_wav_path(&target.meeting_id, target.session_index))
+    } else {
+        None
+    };
+    let diarize_system_capture_path = if mode == PipelineMode::Meeting
+        && settings.diarize_enabled
+        && settings.diarize_system_audio
+        && capture_system_audio
+        && models_ready
+    {
+        recording_target
+            .as_ref()
+            .map(|target| {
+                crate::audio::diarize_tap::session_system_wav_path(&target.meeting_id, target.session_index)
+            })
     } else {
         None
     };
@@ -337,7 +349,8 @@ fn start_pipeline_blocking(
             capture_system_audio,
             diarize,
             record_path,
-            diarize_capture_path,
+            diarize_mic_capture_path,
+            diarize_system_capture_path,
         })
         .map_err(|e| format!("Audio start: {e}"))?;
 

--- a/src-tauri/src/diarize/assign.rs
+++ b/src-tauri/src/diarize/assign.rs
@@ -5,11 +5,11 @@
 
 use super::DiarizedSegment;
 
-/// One transcript segment's time span, local to a single recording session
+/// one transcript segment's time span, local to a single recording session
 /// (matching the per-session zero-based clock `TranscriptionSegment.start_time`
-/// / `end_time` already use). `has_speaker` marks a segment that already
-/// carries a label (Me/Them, or a previous diarization pass). Such segments
-/// are always left untouched, whatever the overlap.
+/// / `end_time` already use). `has_speaker` marks a segment whose label must
+/// not be overwritten for this pass: mic pass locks Them and persistent
+/// speakers; system pass locks Me and persistent speakers.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SegmentSpan {
     pub start_s: f64,

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -459,20 +459,17 @@ mod paragraphs {
     /// speakers (not just Me/Them).
     ///
     /// Without a pause, a monologue would otherwise absorb everything
-    /// indefinitely, so a second speaker's interjection would render far
-    /// below the point in the monologue it actually responded to. To keep
-    /// interjections anchored near their moment: opening a new turn marks
-    /// every other speaker's currently open turn as interrupted. An
-    /// interrupted turn still keeps absorbing segments (crosstalk should
-    /// stay readable), but closes as soon as one of them ends a sentence, so
-    /// the speaker's next segment opens a fresh turn that sorts after the
-    /// interjection instead of the interjection trailing behind an
-    /// ever-growing paragraph. A turn that never hits a sentence end (no
-    /// punctuation) still only closes on pause, same as before.
+    /// indefinitely. Opening a new turn for speaker B:
+    /// - If B starts clearly after A's last end (>= 350ms handoff), A's turn
+    ///   closes immediately so A's later speech opens a fresh line below.
+    /// - If B overlaps A or starts within 350ms (crosstalk / tight
+    ///   interjection), A is marked interrupted and keeps absorbing until a
+    ///   sentence end.
     fn cluster_into_turns<'a>(
         sorted: Vec<&'a TranscriptionSegment>,
         pause_threshold: f64,
     ) -> Vec<&'a TranscriptionSegment> {
+        const HANDOFF_GAP_S: f64 = 0.35;
         struct Turn<'a> {
             start: f64,
             last_end: f64,
@@ -509,8 +506,15 @@ mod paragraphs {
                 turns.push(Turn { start: seg.start_time, last_end: end, segments: vec![seg], interrupted: false });
                 let new_idx = turns.len() - 1;
                 open_turns.insert(speaker, new_idx);
-                for (&other_speaker, &idx) in open_turns.iter() {
-                    if other_speaker != speaker {
+                let handoffs: Vec<(Speaker, usize)> = open_turns
+                    .iter()
+                    .filter(|(other, _)| **other != speaker)
+                    .map(|(&other, &idx)| (other, idx))
+                    .collect();
+                for (other_speaker, idx) in handoffs {
+                    if turns[new_idx].start >= turns[idx].last_end + HANDOFF_GAP_S {
+                        open_turns.remove(&other_speaker);
+                    } else {
                         turns[idx].interrupted = true;
                     }
                 }
@@ -1114,16 +1118,16 @@ mod tests {
     }
 
     #[test]
-    fn unpunctuated_monologue_absorbing_an_interjection_is_unchanged() {
-        // Me never produces sentence-final punctuation, so the interrupted
-        // flag never finds a sentence end to close on: behavior is
-        // unchanged, the turn keeps growing until a real pause.
+    fn unpunctuated_sequential_handoff_opens_a_new_line() {
+        // Me never produces sentence-final punctuation. Them starts clearly
+        // after Me's last end (>= 350ms handoff), so Me closes immediately
+        // and later Me speech opens a fresh turn below.
         let segments = vec![
             diarized_segment("so basically", 0.0, 0.5, Speaker::Me),
             diarized_segment("we were thinking", 0.6, 1.1, Speaker::Me),
-            diarized_segment("right", 1.2, 1.7, Speaker::Them),
-            diarized_segment("about moving the launch date", 1.8, 2.3, Speaker::Me),
-            diarized_segment("to next quarter", 2.4, 2.9, Speaker::Me),
+            diarized_segment("right", 1.6, 2.1, Speaker::Them),
+            diarized_segment("about moving the launch date", 2.2, 2.7, Speaker::Me),
+            diarized_segment("to next quarter", 2.8, 3.3, Speaker::Me),
         ];
         let result = paragraphs::group_into_paragraphs(&segments, 1.5);
         let texts: Vec<(Option<Speaker>, &str)> =
@@ -1131,8 +1135,9 @@ mod tests {
         assert_eq!(
             texts,
             vec![
-                (Some(Speaker::Me), "so basically we were thinking about moving the launch date to next quarter"),
+                (Some(Speaker::Me), "so basically we were thinking"),
                 (Some(Speaker::Them), "right"),
+                (Some(Speaker::Me), "about moving the launch date to next quarter"),
             ]
         );
     }

--- a/src-tauri/src/pipeline/diarize_task.rs
+++ b/src-tauri/src/pipeline/diarize_task.rs
@@ -1,11 +1,16 @@
-//! Post-stop offline speaker diarization for mic-only meetings. Spawned by
+//! Post-stop offline speaker diarization. Spawned by
 //! `stop_meeting_recording` right after the transcript is saved and
 //! `MeetingFinalized` is emitted (never delaying either): for each recording
-//! session whose mic audio was tapped to a temporary WAV
+//! session whose mic and/or system audio was tapped to temporary WAVs
 //! (`audio::diarize_tap`), run the offline diarization engine, match the
 //! detected voice clusters against persistent speakers (`diarize::persist`),
 //! map the diarized time ranges onto that session's transcript segments
 //! (`diarize::assign`), and write the labels back in one transaction.
+//!
+//! Mic and system-audio passes are independent: the mic WAV rewrites Me-lane
+//! segments (Them and persistent labels stay locked); the system WAV rewrites
+//! Them-lane segments (Me and persistent labels stay locked). Live Me/Them
+//! lanes during recording are unchanged.
 //!
 //! Everything here is best-effort: any failure just leaves the meeting
 //! unlabeled (logged, surfaced via `DiarizationProgress.error`), and the
@@ -26,11 +31,27 @@ use crate::diarize::{DiarizeConfig, models};
 use crate::engine::Speaker;
 use crate::state::AppState;
 
+/// Which transcript lane a diarization pass may rewrite.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DiarizationPass {
+    /// Mic WAV: assign onto Me-lane (or unlabeled mic-only) segments.
+    Mic,
+    /// System WAV: assign onto Them-lane segments.
+    System,
+}
+
+/// Pending diarization WAVs for one recording session.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SessionDiarizeFiles {
+    session_index: usize,
+    mic_wav: Option<std::path::PathBuf>,
+    system_wav: Option<std::path::PathBuf>,
+}
+
 /// Kick off the background diarization pass for `meeting_id`. Returns
 /// immediately; all work happens on a dedicated thread. A meeting with no
-/// pending diarization WAVs (system-audio meeting, feature off, models
-/// missing at record time) is a silent no-op: no events, no logs beyond
-/// trace level.
+/// pending diarization WAVs (feature off, models missing at record time) is
+/// a silent no-op: no events, no logs beyond trace level.
 pub fn spawn_post_meeting_diarization(app: tauri::AppHandle, meeting_id: String) {
     let spawned = std::thread::Builder::new()
         .name("diarize-task".into())
@@ -57,10 +78,11 @@ pub fn spawn_post_meeting_diarization(app: tauri::AppHandle, meeting_id: String)
 }
 
 fn run(app: &tauri::AppHandle, meeting_id: &str) {
-    // Pending WAVs are the trigger: they only exist if this was a mic-only
-    // meeting recorded with the feature enabled and models present.
-    let session_wavs = pending_session_wavs(meeting_id);
-    if session_wavs.is_empty() {
+    // Pending WAVs are the trigger: they only exist if this meeting was
+    // recorded with speaker recognition enabled and models present.
+    let session_files = pending_session_diarize_files(meeting_id);
+    let total_passes = session_files.iter().map(SessionDiarizeFiles::pass_count).sum::<usize>();
+    if total_passes == 0 {
         return;
     }
 
@@ -74,7 +96,7 @@ fn run(app: &tauri::AppHandle, meeting_id: &str) {
 
     let state = app.state::<AppState>();
     let db = &state.db;
-    let total_sessions = session_wavs.len() as u32;
+    let total_sessions = total_passes as u32;
 
     let emit_progress = |done: u32, finished: bool, error: Option<String>| {
         let _ = DiarizationProgress {
@@ -88,7 +110,7 @@ fn run(app: &tauri::AppHandle, meeting_id: &str) {
     };
     emit_progress(0, false, None);
 
-    let outcome = diarize_meeting(db, meeting_id, &session_wavs, |done| {
+    let outcome = diarize_meeting(db, meeting_id, &session_files, |done| {
         emit_progress(done, false, None);
     });
 
@@ -113,39 +135,71 @@ fn run(app: &tauri::AppHandle, meeting_id: &str) {
     }
 }
 
-/// The tapped WAVs waiting for this meeting, as (session_index, path) pairs
-/// sorted by session index. Non-WAV or non-numeric entries are ignored.
-fn pending_session_wavs(meeting_id: &str) -> Vec<(usize, std::path::PathBuf)> {
+impl SessionDiarizeFiles {
+    fn pass_count(&self) -> usize {
+        usize::from(self.mic_wav.is_some()) + usize::from(self.system_wav.is_some())
+    }
+}
+
+/// Discover mic and/or system WAVs waiting for this meeting, grouped by
+/// session index and sorted. Recognizes `{index}-mic.wav`, `{index}-system.wav`,
+/// and legacy `{index}.wav` (mic-only from older builds).
+fn pending_session_diarize_files(meeting_id: &str) -> Vec<SessionDiarizeFiles> {
     let dir = diarize_tap::meeting_diarize_tmp_dir(meeting_id);
     let Ok(entries) = std::fs::read_dir(&dir) else {
         return Vec::new();
     };
-    let mut wavs: Vec<(usize, std::path::PathBuf)> = entries
-        .flatten()
-        .filter_map(|entry| {
-            let path = entry.path();
-            let index = path
-                .file_stem()?
-                .to_str()?
-                .parse::<usize>()
-                .ok()?;
-            (path.extension()?.to_str()? == "wav").then_some((index, path))
-        })
-        .collect();
-    wavs.sort_by_key(|(index, _)| *index);
-    wavs
+
+    let mut by_session: std::collections::BTreeMap<usize, SessionDiarizeFiles> =
+        std::collections::BTreeMap::new();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("wav") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let (session_index, lane) = match parse_diarize_wav_stem(stem) {
+            Some(parsed) => parsed,
+            None => continue,
+        };
+        let slot = by_session.entry(session_index).or_insert_with(|| SessionDiarizeFiles {
+            session_index,
+            mic_wav: None,
+            system_wav: None,
+        });
+        match lane {
+            DiarizationPass::Mic => slot.mic_wav = Some(path),
+            DiarizationPass::System => slot.system_wav = Some(path),
+        }
+    }
+
+    by_session.into_values().collect()
+}
+
+/// Parse a diarization WAV stem into `(session_index, lane)`.
+fn parse_diarize_wav_stem(stem: &str) -> Option<(usize, DiarizationPass)> {
+    if let Some(index_str) = stem.strip_suffix("-mic") {
+        return Some((index_str.parse().ok()?, DiarizationPass::Mic));
+    }
+    if let Some(index_str) = stem.strip_suffix("-system") {
+        return Some((index_str.parse().ok()?, DiarizationPass::System));
+    }
+    stem.parse::<usize>().ok().map(|index| (index, DiarizationPass::Mic))
 }
 
 /// Diarize every tapped session of one meeting and write the resulting
-/// speaker labels back. Sessions are processed in order and independently:
-/// a failed session is logged and skipped (its segments stay unlabeled), it
-/// does not abort the rest. All segment updates land in one transaction at
+/// speaker labels back. Each session may run a mic pass, a system pass, or
+/// both; a failed pass is logged and skipped (its segments stay unlabeled),
+/// it does not abort the rest. All segment updates land in one transaction at
 /// the end. Returns how many segments were relabeled.
 fn diarize_meeting(
     db: &Database,
     meeting_id: &str,
-    session_wavs: &[(usize, std::path::PathBuf)],
-    mut on_session_done: impl FnMut(u32),
+    session_files: &[SessionDiarizeFiles],
+    mut on_pass_done: impl FnMut(u32),
 ) -> Result<usize, String> {
     let settings = crate::settings::AppSettings::load(db)?;
     let meeting = db.load_meeting(meeting_id)?;
@@ -154,16 +208,48 @@ fn diarize_meeting(
     cfg.max_speakers = settings.diarize_max_speakers.map(|n| n as usize);
 
     let mut assignments: Vec<(u64, Speaker)> = Vec::new();
-    for (done, (session_index, wav_path)) in session_wavs.iter().enumerate() {
-        match diarize_session(db, &meeting, *session_index, wav_path, &cfg) {
-            Ok(mut session_assignments) => assignments.append(&mut session_assignments),
-            Err(e) => warn!(
-                meeting_id = %meeting_id,
-                session = session_index,
-                "Diarization failed for one session (its segments stay unlabeled): {e}"
-            ),
+    let mut done_passes = 0u32;
+    for session in session_files {
+        if let Some(wav_path) = &session.mic_wav {
+            match diarize_session(
+                db,
+                &meeting,
+                session.session_index,
+                wav_path,
+                &cfg,
+                DiarizationPass::Mic,
+            ) {
+                Ok(mut session_assignments) => assignments.append(&mut session_assignments),
+                Err(e) => warn!(
+                    meeting_id = %meeting_id,
+                    session = session.session_index,
+                    pass = "mic",
+                    "Diarization failed for one session (its segments stay unlabeled): {e}"
+                ),
+            }
+            done_passes += 1;
+            on_pass_done(done_passes);
         }
-        on_session_done(done as u32 + 1);
+        if let Some(wav_path) = &session.system_wav {
+            match diarize_session(
+                db,
+                &meeting,
+                session.session_index,
+                wav_path,
+                &cfg,
+                DiarizationPass::System,
+            ) {
+                Ok(mut session_assignments) => assignments.append(&mut session_assignments),
+                Err(e) => warn!(
+                    meeting_id = %meeting_id,
+                    session = session.session_index,
+                    pass = "system",
+                    "Diarization failed for one session (its segments stay unlabeled): {e}"
+                ),
+            }
+            done_passes += 1;
+            on_pass_done(done_passes);
+        }
     }
 
     db.set_segment_speakers(meeting_id, &assignments)
@@ -179,6 +265,7 @@ fn diarize_session(
     session_index: usize,
     wav_path: &std::path::Path,
     cfg: &DiarizeConfig,
+    pass: DiarizationPass,
 ) -> Result<Vec<(u64, Speaker)>, String> {
     let session = meeting
         .recording_sessions
@@ -240,17 +327,12 @@ fn diarize_session(
     // Segment times restart at zero for each recording session, and so does
     // the tapped WAV, so session-local segment spans line up with diarized
     // ranges directly.
-    let start = session.start_segment_index as usize;
-    let end = (session.end_segment_index as usize).min(meeting.segments.len());
-    if start >= end {
-        return Ok(Vec::new());
-    }
     let spans: Vec<SegmentSpan> = meeting.segments[start..end]
         .iter()
         .map(|seg| SegmentSpan {
             start_s: seg.start_time,
             end_s: seg.end_time,
-            has_speaker: seg.speaker.is_some(),
+            has_speaker: speaker_label_is_locked(seg.speaker.as_ref(), pass),
         })
         .collect();
     let cluster_per_span = assign_by_overlap(&result.segments, &spans);
@@ -265,14 +347,57 @@ fn diarize_session(
         .collect())
 }
 
+/// Mic pass locks Them and persistent speakers; system pass locks Me and
+/// persistent speakers. Unlabeled segments on the target lane are fair game.
+fn speaker_label_is_locked(speaker: Option<&Speaker>, pass: DiarizationPass) -> bool {
+    match pass {
+        DiarizationPass::Mic => {
+            matches!(speaker, Some(Speaker::Them) | Some(Speaker::Persistent(_)))
+        }
+        DiarizationPass::System => {
+            matches!(speaker, Some(Speaker::Me) | Some(Speaker::Persistent(_)))
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::test_helpers::fixtures::{sample_meeting, test_db};
 
     #[test]
-    fn pending_session_wavs_on_missing_dir_is_empty() {
-        assert!(pending_session_wavs("no-such-meeting-id-for-tests").is_empty());
+    fn pending_session_diarize_files_on_missing_dir_is_empty() {
+        assert!(pending_session_diarize_files("no-such-meeting-id-for-tests").is_empty());
+    }
+
+    #[test]
+    fn parse_diarize_wav_stem_recognizes_mic_system_and_legacy() {
+        assert_eq!(
+            parse_diarize_wav_stem("2-mic"),
+            Some((2, DiarizationPass::Mic))
+        );
+        assert_eq!(
+            parse_diarize_wav_stem("2-system"),
+            Some((2, DiarizationPass::System))
+        );
+        assert_eq!(parse_diarize_wav_stem("2"), Some((2, DiarizationPass::Mic)));
+        assert_eq!(parse_diarize_wav_stem("2-other"), None);
+    }
+
+    #[test]
+    fn speaker_label_lock_respects_pass() {
+        assert!(speaker_label_is_locked(Some(&Speaker::Them), DiarizationPass::Mic));
+        assert!(!speaker_label_is_locked(Some(&Speaker::Me), DiarizationPass::Mic));
+        assert!(speaker_label_is_locked(Some(&Speaker::Me), DiarizationPass::System));
+        assert!(!speaker_label_is_locked(Some(&Speaker::Them), DiarizationPass::System));
+        assert!(speaker_label_is_locked(
+            Some(&Speaker::Persistent(1)),
+            DiarizationPass::Mic
+        ));
+        assert!(speaker_label_is_locked(
+            Some(&Speaker::Persistent(1)),
+            DiarizationPass::System
+        ));
     }
 
     /// End-to-end match-then-assign against the real downloaded models and a
@@ -327,6 +452,7 @@ mod tests {
             0,
             std::path::Path::new("/tmp/diarize_test.wav"),
             &cfg,
+            DiarizationPass::Mic,
         )
         .expect("diarize session");
         assert!(!assignments.is_empty(), "expected at least one labeled segment");
@@ -358,6 +484,7 @@ mod tests {
             0,
             std::path::Path::new("/tmp/diarize_test.wav"),
             &cfg,
+            DiarizationPass::Mic,
         )
         .expect("second diarize session");
         let speakers_after = db.list_speakers().unwrap().len();

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -51,6 +51,8 @@ const LAST_SEEN_VERSION_KEY: &str = "last_seen_version";
 const MEETING_AUDIO_RETENTION_KEY: &str = "meeting_audio_retention";
 const MEETING_TRANSCRIPTION_LANGUAGE_KEY: &str = "meeting_transcription_language";
 const DIARIZE_ENABLED_KEY: &str = "diarize_enabled";
+const DIARIZE_MIC_KEY: &str = "diarize_mic";
+const DIARIZE_SYSTEM_AUDIO_KEY: &str = "diarize_system_audio";
 const DIARIZE_MAX_SPEAKERS_KEY: &str = "diarize_max_speakers";
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default, specta::Type)]
@@ -199,12 +201,17 @@ pub struct AppSettings {
     pub summary_templates: Vec<SummaryTemplate>,
     /// App version the user has acknowledged (What's New / post-update dialog).
     pub last_seen_version: String,
-    /// Offline speaker recognition for mic-only meetings: after a mic-only
-    /// meeting stops, label its segments with a persistent, cross-meeting
-    /// speaker identity. Off by default (extra local inference + on-disk
-    /// model download); meetings with a system-audio lane are unaffected
-    /// regardless of this setting (Me/Them attribution stays authoritative).
+    /// Offline speaker recognition after a meeting stops. Off by default
+    /// (extra local inference + on-disk model download). When on, at least
+    /// one of `diarize_mic` / `diarize_system_audio` must be enabled.
     pub diarize_enabled: bool,
+    /// Run speaker recognition on microphone (Me-lane) audio after a meeting
+    /// stops. On by default when speaker recognition is enabled.
+    pub diarize_mic: bool,
+    /// Run speaker recognition on system-audio (Them-lane) capture after a
+    /// meeting stops. Only meaningful when `capture_system_audio` is on.
+    /// Off by default.
+    pub diarize_system_audio: bool,
     /// Optional upper bound on how many distinct speakers a single meeting
     /// can be split into. `None` means unbounded (the clustering stage
     /// decides on its own).
@@ -262,6 +269,8 @@ impl Default for AppSettings {
             summary_templates: crate::summary::default_summary_templates(),
             last_seen_version: String::new(),
             diarize_enabled: false,
+            diarize_mic: true,
+            diarize_system_audio: false,
             diarize_max_speakers: None,
         }
     }
@@ -457,6 +466,14 @@ impl AppSettings {
         if let Some(diarize_enabled) = read_json_setting::<bool>(db, DIARIZE_ENABLED_KEY)? {
             settings.diarize_enabled = diarize_enabled;
         }
+        if let Some(diarize_mic) = read_json_setting::<bool>(db, DIARIZE_MIC_KEY)? {
+            settings.diarize_mic = diarize_mic;
+        }
+        if let Some(diarize_system_audio) =
+            read_json_setting::<bool>(db, DIARIZE_SYSTEM_AUDIO_KEY)?
+        {
+            settings.diarize_system_audio = diarize_system_audio;
+        }
         if let Some(diarize_max_speakers) =
             read_json_setting::<Option<u32>>(db, DIARIZE_MAX_SPEAKERS_KEY)?
         {
@@ -648,6 +665,16 @@ impl AppSettings {
             && !DIARIZE_MAX_SPEAKERS_RANGE.contains(&max_speakers)
         {
             normalized.diarize_max_speakers = None;
+        }
+
+        if !normalized.capture_system_audio {
+            normalized.diarize_system_audio = false;
+        }
+        if normalized.diarize_enabled
+            && !normalized.diarize_mic
+            && !normalized.diarize_system_audio
+        {
+            normalized.diarize_mic = true;
         }
 
         normalized.dictation_polish_template_id = normalized
@@ -852,6 +879,8 @@ impl AppSettings {
         write_json_setting(db, SUMMARY_TEMPLATES_KEY, &normalized.summary_templates)?;
         write_json_setting(db, LAST_SEEN_VERSION_KEY, &normalized.last_seen_version)?;
         write_json_setting(db, DIARIZE_ENABLED_KEY, &normalized.diarize_enabled)?;
+        write_json_setting(db, DIARIZE_MIC_KEY, &normalized.diarize_mic)?;
+        write_json_setting(db, DIARIZE_SYSTEM_AUDIO_KEY, &normalized.diarize_system_audio)?;
         write_json_setting(db, DIARIZE_MAX_SPEAKERS_KEY, &normalized.diarize_max_speakers)?;
 
         if let Some(audio_device) = normalized.audio_device.as_ref() {
@@ -1024,6 +1053,8 @@ mod tests {
             summary_templates: crate::summary::default_summary_templates(),
             last_seen_version: "0.0.9".into(),
             diarize_enabled: true,
+            diarize_mic: true,
+            diarize_system_audio: false,
             diarize_max_speakers: Some(4),
         };
 
@@ -1233,7 +1264,31 @@ mod tests {
     #[test]
     fn diarize_enabled_defaults_false() {
         assert!(!AppSettings::default().diarize_enabled);
+        assert!(AppSettings::default().diarize_mic);
+        assert!(!AppSettings::default().diarize_system_audio);
         assert_eq!(AppSettings::default().diarize_max_speakers, None);
+    }
+
+    #[test]
+    fn diarize_sub_options_force_mic_when_both_off() {
+        let s = AppSettings {
+            diarize_enabled: true,
+            diarize_mic: false,
+            diarize_system_audio: false,
+            ..AppSettings::default()
+        };
+        assert!(s.sanitize_for_save().unwrap().diarize_mic);
+    }
+
+    #[test]
+    fn diarize_system_audio_cleared_without_system_capture() {
+        let s = AppSettings {
+            diarize_enabled: true,
+            diarize_system_audio: true,
+            capture_system_audio: false,
+            ..AppSettings::default()
+        };
+        assert!(!s.sanitize_for_save().unwrap().diarize_system_audio);
     }
 
     #[test]
@@ -1262,12 +1317,16 @@ mod tests {
         let (db, _dir) = test_db();
         let settings = AppSettings {
             diarize_enabled: true,
+            diarize_mic: true,
+            diarize_system_audio: true,
             diarize_max_speakers: Some(3),
             ..AppSettings::default()
         };
         settings.save(&db).expect("save settings");
         let loaded = AppSettings::load(&db).expect("load settings");
         assert!(loaded.diarize_enabled);
+        assert!(loaded.diarize_mic);
+        assert!(loaded.diarize_system_audio);
         assert_eq!(loaded.diarize_max_speakers, Some(3));
     }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -32,10 +32,15 @@ pub enum AudioCommand {
         /// setting is not off. `None` for dictation and for meetings
         /// recorded with retention off.
         record_path: Option<std::path::PathBuf>,
-        /// Where to tee this session's mic audio for offline speaker
-        /// diarization. `None` unless this is a mic-only meeting with the
-        /// feature enabled and its models downloaded.
-        diarize_capture_path: Option<std::path::PathBuf>,
+        /// Where to tee this session's mic (Me-lane) audio for offline speaker
+        /// diarization. `None` unless speaker recognition on the microphone
+        /// is enabled and its models are downloaded.
+        diarize_mic_capture_path: Option<std::path::PathBuf>,
+        /// Where to tee this session's system-audio (Them-lane) capture for
+        /// offline speaker diarization. `None` unless speaker recognition on
+        /// system audio is enabled, system capture is on, and models are
+        /// downloaded.
+        diarize_system_capture_path: Option<std::path::PathBuf>,
     },
     Stop,
     SelectDevice(String),

--- a/src/app.css
+++ b/src/app.css
@@ -495,6 +495,46 @@ img {
   flex-shrink: 0;
 }
 
+/* ─── Settings tabs ─── */
+.settings-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  background: color-mix(in srgb, var(--color-surface-1) 94%, transparent);
+  border-radius: var(--radius-card);
+  outline: 1px solid var(--color-ghost-border);
+}
+
+.settings-tab {
+  cursor: pointer;
+  border: 0;
+  background: transparent;
+  color: var(--color-text-muted);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  line-height: 1.2;
+  padding: 0.5rem 0.75rem;
+  border-radius: calc(var(--radius-card) - 2px);
+  transition: color 120ms ease, background-color 120ms ease;
+}
+
+.settings-tab:hover {
+  color: var(--color-text-secondary);
+  background: color-mix(in srgb, var(--color-surface-2) 70%, transparent);
+}
+
+.settings-tab-active {
+  color: var(--color-text-primary);
+  background: var(--color-surface-2);
+  box-shadow: var(--shadow-card);
+}
+
+.settings-tab-active:hover {
+  color: var(--color-text-primary);
+  background: var(--color-surface-2);
+}
+
 /* ─── Settings groups: uppercase label above a card of divided rows ─── */
 .settings-group {
   display: flex;

--- a/src/lib/components/SettingsView.svelte
+++ b/src/lib/components/SettingsView.svelte
@@ -2,7 +2,6 @@
   import { onMount } from "svelte";
   import { t } from "svelte-i18n";
   import AboutSettingsSection from "../features/settings/components/AboutSettingsSection.svelte";
-  import AdvancedSettingsSection from "../features/settings/components/AdvancedSettingsSection.svelte";
   import AudioSettingsSection from "../features/settings/components/AudioSettingsSection.svelte";
   import CalendarSettingsSection from "../features/settings/components/CalendarSettingsSection.svelte";
   import DataSettingsSection from "../features/settings/components/DataSettingsSection.svelte";
@@ -22,7 +21,18 @@
   import ConfirmAction from "./ui/ConfirmAction.svelte";
   import StatusBanner from "./ui/StatusBanner.svelte";
 
+  type SettingsTab = "transcription" | "audio" | "interface" | "meetings" | "system";
+
+  const TABS: { id: SettingsTab; labelKey: string }[] = [
+    { id: "transcription", labelKey: "settings.tab_transcription" },
+    { id: "audio", labelKey: "settings.tab_audio" },
+    { id: "interface", labelKey: "settings.tab_interface" },
+    { id: "meetings", labelKey: "settings.tab_meetings" },
+    { id: "system", labelKey: "settings.tab_system" },
+  ];
+
   const controller = createSettingsController();
+  let activeTab = $state<SettingsTab>("transcription");
 
   let selectedTranscriptionLabel = $derived(
     formatSelectedTranscriptionLabel(
@@ -91,179 +101,211 @@
     <StatusBanner message={controller.statusMessage} />
   {/if}
 
-  <ModelSettingsSection
-    catalog={controller.catalog}
-    selectedEngineId={controller.app.settings.transcription_engine_id}
-    selectedModelId={controller.app.settings.transcription_model_id}
-    runtimePhase={controller.runtimePhase}
-    operationState={controller.modelOperationState}
-    downloadedBytes={controller.downloadedBytes}
-    downloadTotalBytes={controller.downloadTotalBytes}
-    downloadFile={controller.downloadFile}
-    unloadTimeoutMinutes={controller.app.settings.model_unload_timeout_minutes}
-    onSelectModel={controller.selectModelOption}
-    onUnloadTimeoutChange={controller.onModelUnloadTimeoutChange}
-  />
+  <div
+    class="settings-tabs"
+    role="tablist"
+    aria-label={$t("settings.title")}
+  >
+    {#each TABS as tab}
+      <button
+        type="button"
+        role="tab"
+        id={`settings-tab-${tab.id}`}
+        aria-selected={activeTab === tab.id}
+        aria-controls={`settings-panel-${tab.id}`}
+        class="settings-tab"
+        class:settings-tab-active={activeTab === tab.id}
+        onclick={() => { activeTab = tab.id; }}
+      >
+        {$t(tab.labelKey)}
+      </button>
+    {/each}
+  </div>
 
-  <MicrophoneSettingsSection
-    audioDevices={controller.audioDevices}
-    inputPriority={controller.app.settings.input_priority}
-    selectedDevice={controller.app.selectedDevice}
-    pinUnavailable={controller.pinUnavailable}
-    allowBluetoothMic={controller.app.settings.allow_bluetooth_mic}
-    onDeviceChange={controller.onDeviceChange}
-    onAllowBluetoothMicChange={controller.onAllowBluetoothMicChange}
-    onRefreshDevices={controller.refreshDevices}
-    onMoveDevice={controller.onMoveDevice}
-    onToggleHidden={controller.onToggleHidden}
-  />
+  <div
+    role="tabpanel"
+    id={`settings-panel-${activeTab}`}
+    aria-labelledby={`settings-tab-${activeTab}`}
+    class="flex flex-col gap-[22px]"
+  >
+    {#if activeTab === "transcription"}
+      <ModelSettingsSection
+        catalog={controller.catalog}
+        selectedEngineId={controller.app.settings.transcription_engine_id}
+        selectedModelId={controller.app.settings.transcription_model_id}
+        runtimePhase={controller.runtimePhase}
+        operationState={controller.modelOperationState}
+        downloadedBytes={controller.downloadedBytes}
+        downloadTotalBytes={controller.downloadTotalBytes}
+        downloadFile={controller.downloadFile}
+        unloadTimeoutMinutes={controller.app.settings.model_unload_timeout_minutes}
+        onSelectModel={controller.selectModelOption}
+        onUnloadTimeoutChange={controller.onModelUnloadTimeoutChange}
+      />
 
-  <InterfaceSettingsSection
-    theme={controller.app.settings.theme}
-    locale={controller.app.settings.locale}
-    autoPaste={controller.app.settings.auto_paste}
-    pasteDelayMs={controller.app.settings.paste_delay_ms}
-    pasteMethod={controller.app.settings.paste_method}
-    toggleShortcut={controller.toggleShortcut}
-    pttShortcut={controller.pttShortcut}
-    recordingField={controller.recordingField}
-    shortcutError={controller.shortcutError}
-    onThemeChange={controller.onThemeChange}
-    onLocaleChange={controller.onLocaleChange}
-    onAutoPasteChange={controller.onAutoPasteChange}
-    onPasteDelayChange={controller.onPasteDelayChange}
-    onPasteMethodChange={controller.onPasteMethodChange}
-    onStartRecording={controller.startRecording}
-    onClearShortcut={controller.clearShortcut}
-    formatShortcut={controller.formatShortcut}
-  />
+      <DictationPolishSettingsSection
+        enabled={controller.app.settings.dictation_polish_enabled}
+        templateId={controller.app.settings.dictation_polish_template_id}
+        templates={controller.app.settings.dictation_polish_templates}
+        providerAvailable={controller.summaryProviderAvailable}
+        onEnabledChange={controller.onDictationPolishEnabledChange}
+        onTemplateChange={controller.onDictationPolishTemplateChange}
+        onPromptChange={controller.onDictationPolishPromptChange}
+      />
 
-  <DictationPolishSettingsSection
-    enabled={controller.app.settings.dictation_polish_enabled}
-    templateId={controller.app.settings.dictation_polish_template_id}
-    templates={controller.app.settings.dictation_polish_templates}
-    providerAvailable={controller.summaryProviderAvailable}
-    onEnabledChange={controller.onDictationPolishEnabledChange}
-    onTemplateChange={controller.onDictationPolishTemplateChange}
-    onPromptChange={controller.onDictationPolishPromptChange}
-  />
+      <DictionarySettingsSection
+        entries={controller.dictionaryEntries}
+        onAdd={controller.handleAddDictionaryEntry}
+        onDelete={controller.handleDeleteDictionaryEntry}
+      />
+    {:else if activeTab === "audio"}
+      <MicrophoneSettingsSection
+        audioDevices={controller.audioDevices}
+        inputPriority={controller.app.settings.input_priority}
+        selectedDevice={controller.app.selectedDevice}
+        pinUnavailable={controller.pinUnavailable}
+        allowBluetoothMic={controller.app.settings.allow_bluetooth_mic}
+        onDeviceChange={controller.onDeviceChange}
+        onAllowBluetoothMicChange={controller.onAllowBluetoothMicChange}
+        onRefreshDevices={controller.refreshDevices}
+        onMoveDevice={controller.onMoveDevice}
+        onToggleHidden={controller.onToggleHidden}
+      />
 
-  <FeedbackSoundsSettingsSection
-    enabled={controller.app.settings.feedback_sounds_enabled}
-    volume={controller.app.settings.feedback_sounds_volume}
-    onEnabledChange={controller.onFeedbackSoundsEnabledChange}
-    onVolumeChange={controller.onFeedbackSoundsVolumeChange}
-  />
-
-  <DictionarySettingsSection
-    entries={controller.dictionaryEntries}
-    onAdd={controller.handleAddDictionaryEntry}
-    onDelete={controller.handleDeleteDictionaryEntry}
-  />
-
-  <CalendarSettingsSection
-    enabled={controller.app.settings.calendar_integration_enabled}
-    permission={controller.calendarPermission}
-    calendars={controller.calendars}
-    selectedIds={controller.app.settings.calendar_selected_ids}
-    reminderMinutes={controller.app.settings.calendar_reminder_minutes}
-    autostartEnabled={controller.app.settings.calendar_autostart_enabled}
-    onEnabledChange={controller.onCalendarEnabledChange}
-    onToggleCalendar={controller.toggleCalendarSelected}
-    onReminderMinutesChange={controller.onCalendarReminderMinutesChange}
-    onAutostartEnabledChange={controller.onCalendarAutostartEnabledChange}
-  />
-
-  <AdvancedSettingsSection>
-    <AudioSettingsSection
-      audioDevices={controller.audioDevices}
-      captureSystemAudio={controller.app.settings.capture_system_audio}
-      systemAudioSupported={controller.systemAudioSupported}
-      isLaptop={controller.isLaptop}
-      clamshellAudioDevice={controller.app.settings.clamshell_audio_device}
-      vadEnabled={controller.app.settings.vad_enabled}
-      fillerRemoval={controller.app.settings.filler_removal}
-      stutterCollapse={controller.app.settings.stutter_collapse}
-      dictionaryCorrection={controller.app.settings.dictionary_correction}
-      meetingAutostopEnabled={controller.app.settings.meeting_autostop_enabled}
-      meetingAutostopMinutes={controller.app.settings.meeting_autostop_minutes}
-      meetingMaxDurationMinutes={controller.app.settings.meeting_max_duration_minutes}
-      meetingTranscriptionLanguage={controller.app.settings.meeting_transcription_language}
+      <AudioSettingsSection
+        audioDevices={controller.audioDevices}
+        captureSystemAudio={controller.app.settings.capture_system_audio}
+        systemAudioSupported={controller.systemAudioSupported}
+        isLaptop={controller.isLaptop}
+        clamshellAudioDevice={controller.app.settings.clamshell_audio_device}
+        vadEnabled={controller.app.settings.vad_enabled}
+        fillerRemoval={controller.app.settings.filler_removal}
+        stutterCollapse={controller.app.settings.stutter_collapse}
+        dictionaryCorrection={controller.app.settings.dictionary_correction}
+        meetingAutostopEnabled={controller.app.settings.meeting_autostop_enabled}
+        meetingAutostopMinutes={controller.app.settings.meeting_autostop_minutes}
+        meetingMaxDurationMinutes={controller.app.settings.meeting_max_duration_minutes}
+        meetingTranscriptionLanguage={controller.app.settings.meeting_transcription_language}
       diarizeEnabled={controller.app.settings.diarize_enabled}
+      diarizeMic={controller.app.settings.diarize_mic}
+      diarizeSystemAudio={controller.app.settings.diarize_system_audio}
       diarizeMaxSpeakers={controller.app.settings.diarize_max_speakers}
-      diarizeDownloadState={controller.diarizeDownloadState}
-      diarizeDownloadedBytes={controller.diarizeDownloadedBytes}
-      diarizeDownloadTotalBytes={controller.diarizeDownloadTotalBytes}
-      onCaptureSystemAudioChange={controller.onCaptureSystemAudioChange}
-      onClamshellDeviceChange={controller.onClamshellDeviceChange}
-      onVadEnabledChange={controller.onVadEnabledChange}
-      onFillerRemovalChange={controller.onFillerRemovalChange}
-      onStutterCollapseChange={controller.onStutterCollapseChange}
-      onDictionaryCorrectionChange={controller.onDictionaryCorrectionChange}
-      onMeetingAutostopEnabledChange={controller.onMeetingAutostopEnabledChange}
-      onMeetingAutostopMinutesChange={controller.onMeetingAutostopMinutesChange}
-      onMeetingMaxDurationMinutesChange={controller.onMeetingMaxDurationMinutesChange}
-      onMeetingTranscriptionLanguageChange={controller.onMeetingTranscriptionLanguageChange}
+        diarizeDownloadState={controller.diarizeDownloadState}
+        diarizeDownloadedBytes={controller.diarizeDownloadedBytes}
+        diarizeDownloadTotalBytes={controller.diarizeDownloadTotalBytes}
+        onCaptureSystemAudioChange={controller.onCaptureSystemAudioChange}
+        onClamshellDeviceChange={controller.onClamshellDeviceChange}
+        onVadEnabledChange={controller.onVadEnabledChange}
+        onFillerRemovalChange={controller.onFillerRemovalChange}
+        onStutterCollapseChange={controller.onStutterCollapseChange}
+        onDictionaryCorrectionChange={controller.onDictionaryCorrectionChange}
+        onMeetingAutostopEnabledChange={controller.onMeetingAutostopEnabledChange}
+        onMeetingAutostopMinutesChange={controller.onMeetingAutostopMinutesChange}
+        onMeetingMaxDurationMinutesChange={controller.onMeetingMaxDurationMinutesChange}
+        onMeetingTranscriptionLanguageChange={controller.onMeetingTranscriptionLanguageChange}
       onDiarizeEnabledChange={controller.onDiarizeEnabledChange}
+      onDiarizeMicChange={controller.onDiarizeMicChange}
+      onDiarizeSystemAudioChange={controller.onDiarizeSystemAudioChange}
       onDiarizeMaxSpeakersChange={controller.onDiarizeMaxSpeakersChange}
-    />
+      />
+    {:else if activeTab === "interface"}
+      <InterfaceSettingsSection
+        theme={controller.app.settings.theme}
+        locale={controller.app.settings.locale}
+        autoPaste={controller.app.settings.auto_paste}
+        pasteDelayMs={controller.app.settings.paste_delay_ms}
+        pasteMethod={controller.app.settings.paste_method}
+        toggleShortcut={controller.toggleShortcut}
+        pttShortcut={controller.pttShortcut}
+        recordingField={controller.recordingField}
+        shortcutError={controller.shortcutError}
+        onThemeChange={controller.onThemeChange}
+        onLocaleChange={controller.onLocaleChange}
+        onAutoPasteChange={controller.onAutoPasteChange}
+        onPasteDelayChange={controller.onPasteDelayChange}
+        onPasteMethodChange={controller.onPasteMethodChange}
+        onStartRecording={controller.startRecording}
+        onClearShortcut={controller.clearShortcut}
+        formatShortcut={controller.formatShortcut}
+      />
 
-    <IntelligenceSettingsSection
-      ollamaUrl={controller.app.settings.ollama_url}
-      ollamaAvailable={controller.ollamaAvailable}
-      appleIntelligenceAvailable={controller.appleIntelligenceAvailable}
-      appleIntelligenceUnavailableReason={controller.appleIntelligenceUnavailableReason}
-      ollamaModels={controller.ollamaModels}
-      summaryModels={controller.summaryModels}
-      selectedOllamaModel={controller.app.settings.ollama_model}
-      onOllamaUrlChange={controller.onOllamaUrlChange}
-      onOllamaModelChange={controller.onOllamaModelChange}
-      onRetrySummaryProviders={controller.refreshSummaryProviders}
-    />
+      <FeedbackSoundsSettingsSection
+        enabled={controller.app.settings.feedback_sounds_enabled}
+        volume={controller.app.settings.feedback_sounds_volume}
+        onEnabledChange={controller.onFeedbackSoundsEnabledChange}
+        onVolumeChange={controller.onFeedbackSoundsVolumeChange}
+      />
+    {:else if activeTab === "meetings"}
+      <CalendarSettingsSection
+        enabled={controller.app.settings.calendar_integration_enabled}
+        permission={controller.calendarPermission}
+        calendars={controller.calendars}
+        selectedIds={controller.app.settings.calendar_selected_ids}
+        reminderMinutes={controller.app.settings.calendar_reminder_minutes}
+        autostartEnabled={controller.app.settings.calendar_autostart_enabled}
+        onEnabledChange={controller.onCalendarEnabledChange}
+        onToggleCalendar={controller.toggleCalendarSelected}
+        onReminderMinutesChange={controller.onCalendarReminderMinutesChange}
+        onAutostartEnabledChange={controller.onCalendarAutostartEnabledChange}
+      />
 
-    <SummaryTemplatesSettingsSection
-      templates={controller.app.settings.summary_templates}
-      defaultTemplateId={controller.app.settings.default_summary_template_id}
-      onDefaultChange={controller.onDefaultSummaryTemplateChange}
-      onNameChange={controller.onSummaryTemplateNameChange}
-      onPromptChange={controller.onSummaryTemplatePromptChange}
-      onAdd={controller.addSummaryTemplate}
-      onDelete={controller.deleteSummaryTemplate}
-    />
+      <IntelligenceSettingsSection
+        ollamaUrl={controller.app.settings.ollama_url}
+        ollamaAvailable={controller.ollamaAvailable}
+        appleIntelligenceAvailable={controller.appleIntelligenceAvailable}
+        appleIntelligenceUnavailableReason={controller.appleIntelligenceUnavailableReason}
+        ollamaModels={controller.ollamaModels}
+        summaryModels={controller.summaryModels}
+        selectedOllamaModel={controller.app.settings.ollama_model}
+        onOllamaUrlChange={controller.onOllamaUrlChange}
+        onOllamaModelChange={controller.onOllamaModelChange}
+        onRetrySummaryProviders={controller.refreshSummaryProviders}
+      />
 
-    <PermissionsSettingsSection />
+      <SummaryTemplatesSettingsSection
+        templates={controller.app.settings.summary_templates}
+        defaultTemplateId={controller.app.settings.default_summary_template_id}
+        onDefaultChange={controller.onDefaultSummaryTemplateChange}
+        onNameChange={controller.onSummaryTemplateNameChange}
+        onPromptChange={controller.onSummaryTemplatePromptChange}
+        onAdd={controller.addSummaryTemplate}
+        onDelete={controller.deleteSummaryTemplate}
+      />
+    {:else}
+      <PermissionsSettingsSection />
 
-    <DiagnosticsSettingsSection
-      debugTranscription={controller.app.settings.debug_transcription}
-      logLevel={controller.app.settings.log_level}
-      onDebugTranscriptionChange={controller.onDebugTranscriptionChange}
-      onLogLevelChange={controller.onLogLevelChange}
-    />
+      <DiagnosticsSettingsSection
+        debugTranscription={controller.app.settings.debug_transcription}
+        logLevel={controller.app.settings.log_level}
+        onDebugTranscriptionChange={controller.onDebugTranscriptionChange}
+        onLogLevelChange={controller.onLogLevelChange}
+      />
 
-    <DataSettingsSection
-      retention={controller.app.settings.meeting_audio_retention}
-      onRetentionChange={controller.onMeetingAudioRetentionChange}
-    />
+      <DataSettingsSection
+        retention={controller.app.settings.meeting_audio_retention}
+        onRetentionChange={controller.onMeetingAudioRetentionChange}
+      />
 
-    <section class="settings-group">
-      <h3>{$t("settings_advanced.model_storage")}</h3>
-      <div class="settings-rows">
-        <div class="flex items-center justify-between gap-4">
-          <span class="setting-desc min-w-0 flex-1">{$t("settings_advanced.model_storage_desc")}</span>
-          <ConfirmAction
-            label={$t("settings_advanced.delete_model")}
-            confirmLabel={$t("settings_advanced.delete_model_confirm")}
-            confirmMessage={$t("settings_advanced.delete_model_msg")}
-            variant="danger"
-            onConfirm={controller.handleDeleteModel}
-          />
+      <section class="settings-group">
+        <h3>{$t("settings_advanced.model_storage")}</h3>
+        <div class="settings-rows">
+          <div class="flex items-center justify-between gap-4">
+            <span class="setting-desc min-w-0 flex-1">{$t("settings_advanced.model_storage_desc")}</span>
+            <ConfirmAction
+              label={$t("settings_advanced.delete_model")}
+              confirmLabel={$t("settings_advanced.delete_model_confirm")}
+              confirmMessage={$t("settings_advanced.delete_model_msg")}
+              variant="danger"
+              onConfirm={controller.handleDeleteModel}
+            />
+          </div>
         </div>
-      </div>
-    </section>
-  </AdvancedSettingsSection>
+      </section>
 
-  <AboutSettingsSection
-    selectedTranscriptionLabel={selectedTranscriptionLabel}
-    selectedOllamaModelLabel={selectedOllamaModelLabel}
-  />
+      <AboutSettingsSection
+        selectedTranscriptionLabel={selectedTranscriptionLabel}
+        selectedOllamaModelLabel={selectedOllamaModelLabel}
+      />
+    {/if}
+  </div>
 </div>

--- a/src/lib/features/meeting/components/DictionaryAliasPopover.svelte
+++ b/src/lib/features/meeting/components/DictionaryAliasPopover.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
   import { t } from "svelte-i18n";
+  import { fixedPopoverStyle, portal, type AnchorRect } from "../../../utils";
 
   let {
     heardAs,
+    anchorRect,
     onClose,
     onSave,
   }: {
     heardAs: string;
+    anchorRect: AnchorRect;
     onClose: () => void;
     onSave: (term: string, pronunciation: string | null) => void | Promise<void>;
   } = $props();
@@ -15,6 +18,10 @@
   let pronunciationDraft = $state("");
   let isSaving = $state(false);
   let saveError = $state("");
+
+  const panelStyle = $derived(
+    fixedPopoverStyle(anchorRect, { width: 288, estimatedHeight: 280 }),
+  );
 
   $effect(() => {
     termDraft = "";
@@ -39,59 +46,64 @@
   }
 </script>
 
-<button
-  type="button"
-  class="fixed inset-0 z-10 cursor-default"
-  aria-label={$t("ui.cancel")}
-  onclick={onClose}
-></button>
-
-<div class="absolute left-0 top-full z-20 mt-1.5 w-72 rounded-[11px] bg-surface-1 p-3 shadow-lg outline-1 outline-ghost-border">
-  <p class="m-0 mb-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">
-    {$t("dictionary_alias.title")}
-  </p>
-  <p class="m-0 mb-3 text-[12px] leading-relaxed text-text-muted">
-    {$t("dictionary_alias.description")}
-  </p>
-
-  <div class="mb-2 flex flex-col gap-1">
-    <label for="dict-alias-term" class="field-label">{$t("dictionary_alias.term")}</label>
-    <input
-      id="dict-alias-term"
-      bind:value={termDraft}
-      class="field-input text-[13px]"
-      placeholder={$t("dictionary_alias.term_placeholder")}
-      onkeydown={(e) => {
-        if (e.key === "Enter") void save();
-        if (e.key === "Escape") onClose();
-      }}
-    />
-  </div>
-
-  <div class="mb-3 flex flex-col gap-1">
-    <label for="dict-alias-pronunciation" class="field-label">{$t("dictionary_alias.pronunciation")}</label>
-    <input
-      id="dict-alias-pronunciation"
-      bind:value={pronunciationDraft}
-      class="field-input text-[13px]"
-      placeholder={$t("dictionary_alias.pronunciation_placeholder")}
-      title={$t("dictionary_alias.pronunciation_desc")}
-      onkeydown={(e) => {
-        if (e.key === "Enter") void save();
-        if (e.key === "Escape") onClose();
-      }}
-    />
-  </div>
-
-  {#if saveError}
-    <p class="mb-2 text-xs text-danger-soft">{saveError}</p>
-  {/if}
-
+<div use:portal>
   <button
-    class="btn btn-primary w-full text-[12.5px]"
-    disabled={isSaving || !termDraft.trim()}
-    onclick={() => void save()}
+    type="button"
+    class="fixed inset-0 z-40 cursor-default"
+    aria-label={$t("ui.cancel")}
+    onclick={onClose}
+  ></button>
+
+  <div
+    class="fixed z-50 rounded-[11px] bg-surface-1 p-3 shadow-lg outline-1 outline-ghost-border"
+    style={panelStyle}
   >
-    {$t("dictionary_alias.save")}
-  </button>
+    <p class="m-0 mb-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">
+      {$t("dictionary_alias.title")}
+    </p>
+    <p class="m-0 mb-3 text-[12px] leading-relaxed text-text-muted">
+      {$t("dictionary_alias.description")}
+    </p>
+
+    <div class="mb-2 flex flex-col gap-1">
+      <label for="dict-alias-term" class="field-label">{$t("dictionary_alias.term")}</label>
+      <input
+        id="dict-alias-term"
+        bind:value={termDraft}
+        class="field-input text-[13px]"
+        placeholder={$t("dictionary_alias.term_placeholder")}
+        onkeydown={(e) => {
+          if (e.key === "Enter") void save();
+          if (e.key === "Escape") onClose();
+        }}
+      />
+    </div>
+
+    <div class="mb-3 flex flex-col gap-1">
+      <label for="dict-alias-pronunciation" class="field-label">{$t("dictionary_alias.pronunciation")}</label>
+      <input
+        id="dict-alias-pronunciation"
+        bind:value={pronunciationDraft}
+        class="field-input text-[13px]"
+        placeholder={$t("dictionary_alias.pronunciation_placeholder")}
+        title={$t("dictionary_alias.pronunciation_desc")}
+        onkeydown={(e) => {
+          if (e.key === "Enter") void save();
+          if (e.key === "Escape") onClose();
+        }}
+      />
+    </div>
+
+    {#if saveError}
+      <p class="mb-2 text-xs text-danger-soft">{saveError}</p>
+    {/if}
+
+    <button
+      class="btn btn-primary w-full text-[12.5px]"
+      disabled={isSaving || !termDraft.trim()}
+      onclick={() => void save()}
+    >
+      {$t("dictionary_alias.save")}
+    </button>
+  </div>
 </div>

--- a/src/lib/features/meeting/components/MeetingTranscriptSection.svelte
+++ b/src/lib/features/meeting/components/MeetingTranscriptSection.svelte
@@ -10,6 +10,7 @@
     resolveSpeakerLabel,
     speakerPillClass,
     speakerPlainLabel,
+    type AnchorRect,
   } from "../../../utils";
   import TranscriptWordLine from "./TranscriptWordLine.svelte";
 
@@ -73,6 +74,7 @@
     speakerId: number;
     speakerName: string;
     segmentSortOrders: number[];
+    anchorRect: AnchorRect;
   };
 
   const pauseThreshold = 1.5;
@@ -114,12 +116,15 @@
     speakerId: number,
     speakerName: string,
     segmentRange: { start: number; end: number },
+    event: MouseEvent,
   ) {
     if (!canManageSpeakers) return;
+    const target = event.currentTarget as HTMLElement;
     openSpeakerPopover = {
       speakerId,
       speakerName,
       segmentSortOrders: segmentSortOrdersForRange(segmentRange.start, segmentRange.end),
+      anchorRect: target.getBoundingClientRect(),
     };
   }
 
@@ -215,7 +220,7 @@
                           type="button"
                           class="speaker-pill cursor-pointer transition-opacity hover:opacity-85 {speakerPillClass(speakerId)}"
                           aria-label={$t("speaker_manage.edit_aria", { values: { name: speakerDisplayText(label) } })}
-                          onclick={() => openSpeakerManage(speakerId, speakerDisplayText(label), block.segmentRange)}
+                          onclick={(event) => openSpeakerManage(speakerId, speakerDisplayText(label), block.segmentRange, event)}
                         >{speakerDisplayText(label)}</button>
                       {:else}
                         <span class="speaker-pill {speakerPillClass(speakerId)}">
@@ -228,6 +233,7 @@
                           speakerName={openSpeakerPopover.speakerName}
                           meetingSpeakers={speakers}
                           allSpeakers={allSpeakers}
+                          anchorRect={openSpeakerPopover.anchorRect}
                           onClose={() => { openSpeakerPopover = null; }}
                           onRename={(name) => onRenameSpeaker?.(openSpeakerPopover!.speakerId, name)}
                           onRetag={(options) => onRetagSpeaker?.({

--- a/src/lib/features/meeting/components/SpeakerManagePopover.svelte
+++ b/src/lib/features/meeting/components/SpeakerManagePopover.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
   import { t } from "svelte-i18n";
   import type { MeetingSpeaker } from "../../../types";
+  import { fixedPopoverStyle, portal, type AnchorRect } from "../../../utils";
 
   let {
     speakerId,
     speakerName,
     meetingSpeakers,
     allSpeakers,
+    anchorRect,
     onClose,
     onRename,
     onRetag,
@@ -15,6 +17,7 @@
     speakerName: string;
     meetingSpeakers: MeetingSpeaker[];
     allSpeakers: MeetingSpeaker[];
+    anchorRect: AnchorRect;
     onClose: () => void;
     onRename: (name: string) => void | Promise<void>;
     onRetag: (options: {
@@ -30,6 +33,10 @@
   let targetSpeakerId = $state<number | null>(null);
   let newSpeakerName = $state("");
   let isSaving = $state(false);
+
+  const panelStyle = $derived(
+    fixedPopoverStyle(anchorRect, { width: 288, estimatedHeight: 360 }),
+  );
 
   $effect(() => {
     nameDraft = speakerName;
@@ -97,85 +104,90 @@
   }
 </script>
 
-<button
-  type="button"
-  class="fixed inset-0 z-10 cursor-default"
-  aria-label={$t("ui.cancel")}
-  onclick={onClose}
-></button>
+<div use:portal>
+  <button
+    type="button"
+    class="fixed inset-0 z-40 cursor-default"
+    aria-label={$t("ui.cancel")}
+    onclick={onClose}
+  ></button>
 
-<div class="absolute left-0 top-full z-20 mt-1.5 w-72 rounded-[11px] bg-surface-1 p-3 shadow-lg outline-1 outline-ghost-border">
-  <p class="m-0 mb-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">
-    {$t("speaker_manage.rename_heading")}
-  </p>
-  <div class="flex gap-2">
-    <input
-      bind:value={nameDraft}
-      class="field-input flex-1 text-[13px]"
-      aria-label={$t("speaker_manage.rename_label")}
-      onkeydown={(e) => {
-        if (e.key === "Enter") void saveRename();
-        if (e.key === "Escape") onClose();
-      }}
-    />
-    <button class="btn px-2.5 py-1 text-[12.5px]" disabled={isSaving} onclick={() => void saveRename()}>
-      {$t("speaker_manage.save_name")}
+  <div
+    class="fixed z-50 rounded-[11px] bg-surface-1 p-3 shadow-lg outline-1 outline-ghost-border"
+    style={panelStyle}
+  >
+    <p class="m-0 mb-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">
+      {$t("speaker_manage.rename_heading")}
+    </p>
+    <div class="flex gap-2">
+      <input
+        bind:value={nameDraft}
+        class="field-input flex-1 text-[13px]"
+        aria-label={$t("speaker_manage.rename_label")}
+        onkeydown={(e) => {
+          if (e.key === "Enter") void saveRename();
+          if (e.key === "Escape") onClose();
+        }}
+      />
+      <button class="btn px-2.5 py-1 text-[12.5px]" disabled={isSaving} onclick={() => void saveRename()}>
+        {$t("speaker_manage.save_name")}
+      </button>
+    </div>
+
+    <div class="my-3 h-px bg-ghost-border"></div>
+
+    <p class="m-0 mb-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">
+      {$t("speaker_manage.retag_heading")}
+    </p>
+
+    <fieldset class="m-0 mb-2 flex flex-col gap-1.5 border-0 p-0">
+      <label class="flex items-center gap-2 text-[12.5px] text-text-secondary">
+        <input type="radio" bind:group={retagScope} value="turn" />
+        {$t("speaker_manage.scope_turn")}
+      </label>
+      <label class="flex items-center gap-2 text-[12.5px] text-text-secondary">
+        <input type="radio" bind:group={retagScope} value="meeting" />
+        {$t("speaker_manage.scope_meeting")}
+      </label>
+    </fieldset>
+
+    <div class="mb-2 flex flex-col gap-1.5">
+      <label class="flex items-center gap-2 text-[12.5px] text-text-secondary">
+        <input type="radio" bind:group={targetMode} value="existing" />
+        {$t("speaker_manage.pick_existing")}
+      </label>
+      {#if targetMode === "existing"}
+        <select bind:value={targetSpeakerId} class="field-select text-[12.5px]" disabled={pickerSpeakers.length === 0}>
+          {#if pickerSpeakers.length === 0}
+            <option value={null}>{$t("speaker_manage.no_other_speakers")}</option>
+          {:else}
+            {#each pickerSpeakers as speaker (speaker.id)}
+              <option value={speaker.id}>{speaker.name}</option>
+            {/each}
+          {/if}
+        </select>
+      {/if}
+
+      <label class="flex items-center gap-2 text-[12.5px] text-text-secondary">
+        <input type="radio" bind:group={targetMode} value="new" />
+        {$t("speaker_manage.new_speaker")}
+      </label>
+      {#if targetMode === "new"}
+        <input
+          bind:value={newSpeakerName}
+          class="field-input text-[13px]"
+          placeholder={$t("speaker_manage.new_speaker_placeholder")}
+          aria-label={$t("speaker_manage.new_speaker_placeholder")}
+        />
+      {/if}
+    </div>
+
+    <button
+      class="btn btn-primary w-full text-[12.5px]"
+      disabled={isSaving || (targetMode === "existing" && pickerSpeakers.length === 0)}
+      onclick={() => void applyRetag()}
+    >
+      {$t("speaker_manage.apply_retag")}
     </button>
   </div>
-
-  <div class="my-3 h-px bg-ghost-border"></div>
-
-  <p class="m-0 mb-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-text-muted">
-    {$t("speaker_manage.retag_heading")}
-  </p>
-
-  <fieldset class="m-0 mb-2 flex flex-col gap-1.5 border-0 p-0">
-    <label class="flex items-center gap-2 text-[12.5px] text-text-secondary">
-      <input type="radio" bind:group={retagScope} value="turn" />
-      {$t("speaker_manage.scope_turn")}
-    </label>
-    <label class="flex items-center gap-2 text-[12.5px] text-text-secondary">
-      <input type="radio" bind:group={retagScope} value="meeting" />
-      {$t("speaker_manage.scope_meeting")}
-    </label>
-  </fieldset>
-
-  <div class="mb-2 flex flex-col gap-1.5">
-    <label class="flex items-center gap-2 text-[12.5px] text-text-secondary">
-      <input type="radio" bind:group={targetMode} value="existing" />
-      {$t("speaker_manage.pick_existing")}
-    </label>
-    {#if targetMode === "existing"}
-      <select bind:value={targetSpeakerId} class="field-select text-[12.5px]" disabled={pickerSpeakers.length === 0}>
-        {#if pickerSpeakers.length === 0}
-          <option value={null}>{$t("speaker_manage.no_other_speakers")}</option>
-        {:else}
-          {#each pickerSpeakers as speaker (speaker.id)}
-            <option value={speaker.id}>{speaker.name}</option>
-          {/each}
-        {/if}
-      </select>
-    {/if}
-
-    <label class="flex items-center gap-2 text-[12.5px] text-text-secondary">
-      <input type="radio" bind:group={targetMode} value="new" />
-      {$t("speaker_manage.new_speaker")}
-    </label>
-    {#if targetMode === "new"}
-      <input
-        bind:value={newSpeakerName}
-        class="field-input text-[13px]"
-        placeholder={$t("speaker_manage.new_speaker_placeholder")}
-        aria-label={$t("speaker_manage.new_speaker_placeholder")}
-      />
-    {/if}
-  </div>
-
-  <button
-    class="btn btn-primary w-full text-[12.5px]"
-    disabled={isSaving || (targetMode === "existing" && pickerSpeakers.length === 0)}
-    onclick={() => void applyRetag()}
-  >
-    {$t("speaker_manage.apply_retag")}
-  </button>
 </div>

--- a/src/lib/features/meeting/components/TranscriptWordLine.svelte
+++ b/src/lib/features/meeting/components/TranscriptWordLine.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  import { isClickableTranscriptWord, tokenizeTranscriptWords } from "../../../utils/transcript-words";
+  import {
+    isClickableTranscriptWord,
+    tokenizeTranscriptWords,
+    type AnchorRect,
+  } from "../../../utils";
   import DictionaryAliasPopover from "./DictionaryAliasPopover.svelte";
 
   let {
@@ -15,6 +19,7 @@
   /** Index into `tokens`, not the word text: duplicate spellings share text but
    * must not all open the popover together. */
   let openTokenIndex = $state<number | null>(null);
+  let openAnchorRect = $state<AnchorRect | null>(null);
   let tokens = $derived(tokenizeTranscriptWords(text));
 
   function swallowPointerEvent(event: MouseEvent) {
@@ -23,7 +28,14 @@
 
   function openAlias(tokenIndex: number, event: MouseEvent) {
     event.stopPropagation();
+    const target = event.currentTarget as HTMLElement;
+    openAnchorRect = target.getBoundingClientRect();
     openTokenIndex = tokenIndex;
+  }
+
+  function closeAlias() {
+    openTokenIndex = null;
+    openAnchorRect = null;
   }
 </script>
 
@@ -32,24 +44,23 @@
     {#if token.kind === "gap"}
       {token.text}
     {:else if isClickableTranscriptWord(token.text)}
-      <span class="relative inline">
-        <button
-          type="button"
-          class="cursor-pointer rounded-[3px] border-0 bg-transparent p-0 font-inherit text-inherit hover:bg-accent/10 hover:text-accent"
-          onmousedown={swallowPointerEvent}
-          onclick={(event) => openAlias(i, event)}
-          ondblclick={swallowPointerEvent}
-        >
-          {token.text}
-        </button>
-        {#if openTokenIndex === i}
-          <DictionaryAliasPopover
-            heardAs={token.text}
-            onClose={() => { openTokenIndex = null; }}
-            onSave={onAddAlias}
-          />
-        {/if}
-      </span>
+      <button
+        type="button"
+        class="cursor-pointer rounded-[3px] border-0 bg-transparent p-0 font-inherit text-inherit hover:bg-accent/10 hover:text-accent"
+        onmousedown={swallowPointerEvent}
+        onclick={(event) => openAlias(i, event)}
+        ondblclick={swallowPointerEvent}
+      >
+        {token.text}
+      </button>
+      {#if openTokenIndex === i && openAnchorRect}
+        <DictionaryAliasPopover
+          heardAs={token.text}
+          anchorRect={openAnchorRect}
+          onClose={closeAlias}
+          onSave={onAddAlias}
+        />
+      {/if}
     {:else}
       {token.text}
     {/if}

--- a/src/lib/features/settings/components/AudioSettingsSection.svelte
+++ b/src/lib/features/settings/components/AudioSettingsSection.svelte
@@ -43,6 +43,8 @@
     meetingMaxDurationMinutes,
     meetingTranscriptionLanguage,
     diarizeEnabled,
+    diarizeMic,
+    diarizeSystemAudio,
     diarizeMaxSpeakers,
     diarizeDownloadState,
     diarizeDownloadedBytes,
@@ -58,6 +60,8 @@
     onMeetingMaxDurationMinutesChange,
     onMeetingTranscriptionLanguageChange,
     onDiarizeEnabledChange,
+    onDiarizeMicChange,
+    onDiarizeSystemAudioChange,
     onDiarizeMaxSpeakersChange,
   }: {
     audioDevices: AudioInputDevice[];
@@ -74,6 +78,8 @@
     meetingMaxDurationMinutes: number;
     meetingTranscriptionLanguage: (typeof meetingLanguageOptions)[number];
     diarizeEnabled: boolean;
+    diarizeMic: boolean;
+    diarizeSystemAudio: boolean;
     diarizeMaxSpeakers: number | null;
     diarizeDownloadState: "idle" | "downloading" | "error";
     diarizeDownloadedBytes: number;
@@ -89,6 +95,8 @@
     onMeetingMaxDurationMinutesChange: (event: Event) => void | Promise<void>;
     onMeetingTranscriptionLanguageChange: (event: Event) => void | Promise<void>;
     onDiarizeEnabledChange: (event: Event) => void | Promise<void>;
+    onDiarizeMicChange: (event: Event) => void | Promise<void>;
+    onDiarizeSystemAudioChange: (event: Event) => void | Promise<void>;
     onDiarizeMaxSpeakersChange: (event: Event) => void | Promise<void>;
   } = $props();
 </script>
@@ -175,6 +183,40 @@
   {/if}
 
   {#if diarizeEnabled}
+    <SettingsField
+      label={$t("settings_audio.diarize_mic")}
+      description={$t("settings_audio.diarize_mic_desc")}
+    >
+      {#snippet control()}
+        <input
+          type="checkbox"
+          checked={diarizeMic}
+          disabled={diarizeDownloadState === "downloading"}
+          onchange={onDiarizeMicChange}
+          class="switch"
+          aria-label={$t("settings_audio.diarize_mic")}
+        />
+      {/snippet}
+    </SettingsField>
+
+    <SettingsField
+      label={$t("settings_audio.diarize_system_audio")}
+      description={captureSystemAudio
+        ? $t("settings_audio.diarize_system_audio_desc")
+        : $t("settings_audio.diarize_system_audio_requires_capture")}
+    >
+      {#snippet control()}
+        <input
+          type="checkbox"
+          checked={diarizeSystemAudio}
+          disabled={!captureSystemAudio || diarizeDownloadState === "downloading"}
+          onchange={onDiarizeSystemAudioChange}
+          class="switch"
+          aria-label={$t("settings_audio.diarize_system_audio")}
+        />
+      {/snippet}
+    </SettingsField>
+
     <SettingsField
       label={$t("settings_audio.diarize_max_speakers_label")}
       description={$t("settings_audio.diarize_max_speakers_desc")}

--- a/src/lib/features/settings/controller.svelte.test.ts
+++ b/src/lib/features/settings/controller.svelte.test.ts
@@ -94,6 +94,8 @@ const defaultSettings: AppSettings = {
   ],
   last_seen_version: "",
   diarize_enabled: false,
+  diarize_mic: true,
+  diarize_system_audio: false,
   diarize_max_speakers: null,
 }
 

--- a/src/lib/features/settings/controller.svelte.ts
+++ b/src/lib/features/settings/controller.svelte.ts
@@ -597,6 +597,29 @@ export function createSettingsController() {
     });
   }
 
+  function onDiarizeMicChange(event: Event) {
+    const checked = (event.target as HTMLInputElement).checked;
+    void persistSettings((settings) => {
+      if (!checked && !settings.diarize_system_audio) {
+        settings.diarize_mic = true;
+        return;
+      }
+      settings.diarize_mic = checked;
+    });
+  }
+
+  function onDiarizeSystemAudioChange(event: Event) {
+    const checked = (event.target as HTMLInputElement).checked;
+    if (checked && !app.settings.capture_system_audio) return;
+    void persistSettings((settings) => {
+      if (!checked && !settings.diarize_mic) {
+        settings.diarize_mic = true;
+        return;
+      }
+      settings.diarize_system_audio = checked;
+    });
+  }
+
   function onDiarizeMaxSpeakersChange(event: Event) {
     const raw = (event.target as HTMLSelectElement).value;
     const value = raw === "" ? null : parseInt(raw, 10);
@@ -924,6 +947,8 @@ export function createSettingsController() {
     get diarizeDownloadedBytes() { return diarizeDownloadedBytes; },
     get diarizeDownloadTotalBytes() { return diarizeDownloadTotalBytes; },
     onDiarizeEnabledChange,
+    onDiarizeMicChange,
+    onDiarizeSystemAudioChange,
     onDiarizeMaxSpeakersChange,
     onVadEnabledChange,
     onFillerRemovalChange,

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -2,7 +2,12 @@
   "settings": {
     "title": "Settings",
     "no_model_selected": "No transcription model selected",
-    "done": "Done"
+    "done": "Done",
+    "tab_transcription": "Transcription",
+    "tab_audio": "Audio",
+    "tab_interface": "Interface",
+    "tab_meetings": "Meetings",
+    "tab_system": "System"
   },
   "settings_audio": {
     "title": "Audio",
@@ -44,7 +49,12 @@
     "capture_system_audio": "System Audio Capture",
     "capture_system_audio_desc": "During meetings, capture the computer's audio output (Teams, Zoom…) alongside the microphone. No configuration needed.",
     "diarize_enabled": "Speaker recognition",
-    "diarize_enabled_desc": "For in-person meetings recorded from the microphone only, recognize who is speaking and label the transcript afterwards. Runs entirely on this Mac; nothing leaves your computer.",
+    "diarize_enabled_desc": "After a meeting stops, recognize who spoke and label those turns with named speakers. Runs entirely on this Mac.",
+    "diarize_mic": "Diarize microphone",
+    "diarize_mic_desc": "Recognize voices on the microphone (Me) after the meeting stops.",
+    "diarize_system_audio": "Diarize system audio",
+    "diarize_system_audio_desc": "Recognize voices on captured system audio (Them) after the meeting stops. Requires system audio capture.",
+    "diarize_system_audio_requires_capture": "Turn on system audio capture above to use this.",
     "diarize_downloading": "Downloading speaker recognition models…",
     "diarize_max_speakers_label": "Maximum speakers",
     "diarize_max_speakers_desc": "Optional cap on how many distinct voices to detect in one meeting. Auto leaves the limit to the diarization engine.",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -2,7 +2,12 @@
   "settings": {
     "title": "Paramètres",
     "no_model_selected": "Aucun modèle de transcription sélectionné",
-    "done": "Terminé"
+    "done": "Terminé",
+    "tab_transcription": "Transcription",
+    "tab_audio": "Audio",
+    "tab_interface": "Interface",
+    "tab_meetings": "Réunions",
+    "tab_system": "Système"
   },
   "settings_audio": {
     "title": "Audio",
@@ -44,7 +49,12 @@
     "capture_system_audio": "Capture de l'audio système",
     "capture_system_audio_desc": "Pendant les meetings, capture la sortie audio de l'ordinateur (Teams, Zoom…) en plus du micro. Aucune configuration requise.",
     "diarize_enabled": "Reconnaissance des interlocuteurs",
-    "diarize_enabled_desc": "Pour les réunions en personne enregistrées uniquement au micro, identifie qui parle et annote la transcription après coup. Tout se passe sur ce Mac ; rien ne quitte votre ordinateur.",
+    "diarize_enabled_desc": "À la fin d'une réunion, reconnaît qui a parlé et annote ces tours avec des interlocuteurs nommés. Tout se passe sur ce Mac.",
+    "diarize_mic": "Diariser le micro",
+    "diarize_mic_desc": "Reconnaît les voix au micro (Moi) après la réunion.",
+    "diarize_system_audio": "Diariser l'audio système",
+    "diarize_system_audio_desc": "Reconnaît les voix sur l'audio système capturé (Eux) après la réunion. Nécessite la capture audio système.",
+    "diarize_system_audio_requires_capture": "Activez la capture audio système ci-dessus pour utiliser cette option.",
     "diarize_downloading": "Téléchargement des modèles de reconnaissance des interlocuteurs…",
     "diarize_max_speakers_label": "Nombre max. d'interlocuteurs",
     "diarize_max_speakers_desc": "Limite optionnelle du nombre de voix distinctes détectées dans une réunion. Auto laisse le moteur décider.",

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -99,6 +99,8 @@ let settings = $state<AppSettings>({
   ],
   last_seen_version: "",
   diarize_enabled: false,
+  diarize_mic: true,
+  diarize_system_audio: false,
   diarize_max_speakers: null,
 });
 

--- a/src/lib/test-helpers/fixtures.ts
+++ b/src/lib/test-helpers/fixtures.ts
@@ -227,6 +227,8 @@ export const mockSettings: AppSettings = {
   ],
   last_seen_version: "",
   diarize_enabled: false,
+  diarize_mic: true,
+  diarize_system_audio: false,
   diarize_max_speakers: null,
 }
 

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -1045,13 +1045,22 @@ summary_templates: SummaryTemplate[];
  */
 last_seen_version: string; 
 /**
- * Offline speaker recognition for mic-only meetings: after a mic-only
- * meeting stops, label its segments with a persistent, cross-meeting
- * speaker identity. Off by default (extra local inference + on-disk
- * model download); meetings with a system-audio lane are unaffected
- * regardless of this setting (Me/Them attribution stays authoritative).
+ * Offline speaker recognition after a meeting stops. Off by default
+ * (extra local inference + on-disk model download). When on, at least
+ * one of `diarize_mic` / `diarize_system_audio` must be enabled.
  */
 diarize_enabled: boolean; 
+/**
+ * Run speaker recognition on microphone (Me-lane) audio after a meeting
+ * stops. On by default when speaker recognition is enabled.
+ */
+diarize_mic: boolean; 
+/**
+ * Run speaker recognition on system-audio (Them-lane) capture after a
+ * meeting stops. Only meaningful when `capture_system_audio` is on.
+ * Off by default.
+ */
+diarize_system_audio: boolean; 
 /**
  * Optional upper bound on how many distinct speakers a single meeting
  * can be split into. `None` means unbounded (the clustering stage

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -11,3 +11,5 @@ export type { DebouncedSearch } from "./search.svelte";
 export { resolveSpeakerLabel, speakerPlainLabel } from "./speaker-label";
 export type { SpeakerLabel } from "./speaker-label";
 export { speakerPaletteIndex, speakerPillClass, persistentSpeakerId, SPEAKER_PALETTE_SIZE } from "./speaker-color";
+export { portal, fixedPopoverStyle } from "./portal";
+export type { AnchorRect } from "./portal";

--- a/src/lib/utils/paragraphs.test.ts
+++ b/src/lib/utils/paragraphs.test.ts
@@ -118,21 +118,22 @@ describe('groupIntoParagraphs diarization', () => {
     ]);
   });
 
-  it('leaves an unpunctuated monologue absorbing an interjection unchanged (closes on pause only)', () => {
-    // Me never produces sentence-final punctuation, so the interrupted flag
-    // never finds a sentence end to close on: behavior is unchanged, the
-    // turn keeps growing until a real pause.
+  it('closes an unpunctuated turn on sequential handoff so later speech opens a new line', () => {
+    // Me never produces sentence-final punctuation. Them starts clearly
+    // after Me's last end (>= 350ms handoff), so Me must close immediately:
+    // later Me speech opens a fresh turn below Them instead of editing the top.
     const segments = [
       dseg('so basically', 0, 'me'),
       dseg('we were thinking', 0.6, 'me'),
-      dseg('right', 1.2, 'them'),
-      dseg('about moving the launch date', 1.8, 'me'),
-      dseg('to next quarter', 2.4, 'me'),
+      dseg('right', 1.6, 'them'),
+      dseg('about moving the launch date', 2.2, 'me'),
+      dseg('to next quarter', 2.8, 'me'),
     ];
     const result = groupIntoParagraphs(segments, 1.5);
     expect(result.map((p) => ({ speaker: p.speaker, text: p.text }))).toEqual([
-      { speaker: 'me', text: 'so basically we were thinking about moving the launch date to next quarter' },
+      { speaker: 'me', text: 'so basically we were thinking' },
       { speaker: 'them', text: 'right' },
+      { speaker: 'me', text: 'about moving the launch date to next quarter' },
     ]);
   });
 

--- a/src/lib/utils/paragraphs.ts
+++ b/src/lib/utils/paragraphs.ts
@@ -55,16 +55,18 @@ export type ParagraphRange = { start: number; end: number };
  *
  * Without a pause, a monologue would otherwise absorb everything indefinitely,
  * so a second speaker's interjection would render far below the point in the
- * monologue it actually responded to. To keep interjections anchored near
- * their moment: opening a new turn marks every other speaker's currently open
- * turn as interrupted. An interrupted turn still keeps absorbing segments
- * (crosstalk should stay readable), but closes as soon as one of them ends a
- * sentence, so the speaker's next segment opens a fresh turn that sorts after
- * the interjection instead of the interjection trailing behind an
- * ever-growing paragraph. A turn that never hits a sentence end (no
- * punctuation) still only closes on pause, same as before.
+ * monologue it actually responded to. Opening a new turn for speaker B:
+ * - If B starts clearly after A's last end (sequential handoff, >= 350ms),
+ *   A's turn closes immediately so A's later speech opens a fresh line below.
+ *   This matters for unpunctuated word streams (Kyutai) that never hit a
+ *   sentence end.
+ * - If B overlaps A or starts within 350ms (true crosstalk / tight
+ *   interjection), A is marked interrupted and keeps absorbing until a
+ *   sentence end, so word-level interleaving stays readable as two phrases.
  */
 function clusterIntoTurns(sorted: TranscriptionSegment[], pauseThreshold: number): TranscriptionSegment[] {
+  /** Gap after which a new speaker is treated as a handoff, not crosstalk. */
+  const HANDOFF_GAP_S = 0.35;
   type Turn = { start: number; lastEnd: number; segments: TranscriptionSegment[]; interrupted: boolean };
   const openTurns = new Map<Speaker, Turn>();
   const turns: Turn[] = [];
@@ -90,8 +92,15 @@ function clusterIntoTurns(sorted: TranscriptionSegment[], pauseThreshold: number
       const turn: Turn = { start: seg.start_time, lastEnd: seg.end_time || seg.start_time, segments: [seg], interrupted: false };
       turns.push(turn);
       openTurns.set(speaker, turn);
-      for (const [otherSpeaker, otherTurn] of openTurns) {
-        if (otherSpeaker !== speaker) otherTurn.interrupted = true;
+      for (const [otherSpeaker, otherTurn] of [...openTurns.entries()]) {
+        if (otherSpeaker === speaker) continue;
+        if (turn.start >= otherTurn.lastEnd + HANDOFF_GAP_S) {
+          // Sequential handoff: close now so later speech from that speaker
+          // opens a new line below instead of editing the earlier monologue.
+          openTurns.delete(otherSpeaker);
+        } else {
+          otherTurn.interrupted = true;
+        }
       }
     }
   }

--- a/src/lib/utils/portal.test.ts
+++ b/src/lib/utils/portal.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+import { fixedPopoverStyle } from "./portal";
+
+describe("fixedPopoverStyle", () => {
+  it("places the panel below the anchor when there is room", () => {
+    vi.stubGlobal("innerHeight", 800);
+    vi.stubGlobal("innerWidth", 1200);
+    expect(
+      fixedPopoverStyle(
+        { top: 100, left: 40, bottom: 120, right: 80, width: 40, height: 20 },
+        { width: 288, estimatedHeight: 280 },
+      ),
+    ).toBe("top:126px;left:40px;width:288px");
+  });
+
+  it("flips above the anchor when the viewport bottom is tight", () => {
+    vi.stubGlobal("innerHeight", 400);
+    vi.stubGlobal("innerWidth", 1200);
+    expect(
+      fixedPopoverStyle(
+        { top: 350, left: 40, bottom: 370, right: 80, width: 40, height: 20 },
+        { width: 288, estimatedHeight: 280 },
+      ),
+    ).toBe("top:64px;left:40px;width:288px");
+  });
+
+  it("clamps left so the panel stays on screen", () => {
+    vi.stubGlobal("innerHeight", 800);
+    vi.stubGlobal("innerWidth", 300);
+    expect(
+      fixedPopoverStyle(
+        { top: 100, left: 200, bottom: 120, right: 240, width: 40, height: 20 },
+        { width: 288, estimatedHeight: 280 },
+      ),
+    ).toBe("top:126px;left:8px;width:288px");
+  });
+});

--- a/src/lib/utils/portal.ts
+++ b/src/lib/utils/portal.ts
@@ -1,0 +1,33 @@
+/** Move a node under `document.body` so `position: fixed` escapes overflow clipping. */
+export function portal(node: HTMLElement) {
+  document.body.appendChild(node);
+  return {
+    destroy() {
+      node.remove();
+    },
+  };
+}
+
+export type AnchorRect = Pick<DOMRect, "top" | "left" | "bottom" | "right" | "width" | "height">;
+
+/** Place a fixed popover under (or above) an anchor, keeping it in the viewport. */
+export function fixedPopoverStyle(
+  anchor: AnchorRect,
+  options: { width: number; estimatedHeight: number; gap?: number } = {
+    width: 288,
+    estimatedHeight: 280,
+  },
+): string {
+  const gap = options.gap ?? 6;
+  const preferBelow = anchor.bottom + gap;
+  const spaceBelow = window.innerHeight - preferBelow;
+  const top =
+    spaceBelow < options.estimatedHeight && anchor.top > options.estimatedHeight
+      ? Math.max(8, anchor.top - options.estimatedHeight - gap)
+      : preferBelow;
+  let left = anchor.left;
+  if (left + options.width > window.innerWidth - 8) {
+    left = Math.max(8, window.innerWidth - options.width - 8);
+  }
+  return `top:${top}px;left:${left}px;width:${options.width}px`;
+}


### PR DESCRIPTION
## Summary
- Offline speaker recognition can run on the microphone, system audio, or both (separate taps; Me/Them lanes assigned independently after stop)
- Sequential speaker handoffs open a new transcript line instead of rewriting earlier Me/Them monologues
- Dictionary and speaker popovers portal above the transcript overflow
- Settings split into Transcription / Audio / Interface / Meetings / System tabs

## Test plan
- [ ] Settings tabs switch cleanly; Audio shows Diarize microphone + Diarize system audio under Speaker recognition
- [ ] Enable system audio capture + diarize system audio; play distinct YouTube speakers; stop meeting; wait for labeling; confirm colored speaker pills (not only Them)
- [ ] Mic-only meeting with diarize mic still labels in-room voices after stop
- [ ] Click a transcript word: dictionary popover fully visible (not clipped)
- [ ] Me then Them then Me again without punctuation: second Me turn appears below, not editing the top line