### PR TITLE
Fix speaker labels never landing on system-audio meetings and a mic rebuild loop

### DIFF
--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -400,6 +400,12 @@ pub struct AudioCapture {
     mic_device_name: Option<String>,
     /// UID resolved when the current stream was built (for route hot-swap).
     mic_device_uid: Option<String>,
+    /// Resolved target UID of the last route-change rebuild. When the opened
+    /// device cannot converge on that target (duplicate device names, or a
+    /// resolved device cpal cannot open), this stops the periodic health
+    /// check from tearing the stream down every interval; explicit route
+    /// events (`refresh_input_route`) clear it so a real change retries.
+    route_attempt_uid: Option<String>,
     /// Set by the cpal error callback when the stream dies (e.g. its device
     /// disappeared); the next mic health check rebuilds the capture leg.
     stream_failed: Arc<std::sync::atomic::AtomicBool>,
@@ -461,6 +467,7 @@ impl AudioCapture {
                     active_params: None,
                     mic_device_name: None,
                     mic_device_uid: None,
+                    route_attempt_uid: None,
                     stream_failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
                     last_mic_check: Instant::now(),
                     level_throttle: AudioLevelThrottle::new(),
@@ -609,12 +616,14 @@ impl AudioCapture {
         )
     }
 
-    fn find_device(&self) -> Result<Device, String> {
+    /// Open the cpal device for the resolved input route. `known_devices` is
+    /// the CoreAudio snapshot the caller already holds, so resolution and
+    /// UID mapping work from one consistent device list.
+    fn find_device(&self, known_devices: &[AudioInputDevice]) -> Result<Device, String> {
         let host = cpal::default_host();
-        let known_devices = list_input_devices_impl();
 
-        if let Some(uid) = self.resolved_input_uid(&known_devices) {
-            let target_name = resolve_device_name(&known_devices, &uid).or({
+        if let Some(uid) = self.resolved_input_uid(known_devices) {
+            let target_name = resolve_device_name(known_devices, &uid).or({
                 // Disconnected UID or legacy name not in the current snapshot:
                 // try the stored value as a cpal device name directly.
                 Some(uid.as_str())
@@ -644,6 +653,11 @@ impl AudioCapture {
             }
         }
 
+        // Also reached when `resolve_input` found no auto-eligible device
+        // (every connected mic hidden, or Bluetooth-only with the Bluetooth
+        // preference off): recording on the OS default, even an excluded
+        // one, beats not recording at all. The policy only steers the
+        // automatic choice among alternatives.
         host.default_input_device()
             .ok_or_else(|| "No input device available".to_string())
     }
@@ -694,11 +708,11 @@ impl AudioCapture {
         self.mic_device_uid = None;
 
         let known_devices = list_input_devices_impl();
-        let device = self.find_device()?;
+        let device = self.find_device(&known_devices)?;
 
         let device_name = device.name().unwrap_or_else(|_| "Unknown".into());
         // Track the UID of the device cpal actually opened, not just what
-        // resolve_input picked — find_device may fall back to the OS default
+        // resolve_input picked: find_device may fall back to the OS default
         // when the resolved name is missing from the cpal device list.
         self.mic_device_uid = uid_for_device_name(&known_devices, &device_name);
         info!("Using input device: {device_name}");
@@ -1113,17 +1127,28 @@ impl AudioCapture {
             .swap(false, std::sync::atomic::Ordering::Relaxed);
 
         // Rebuild when the resolved input UID changes (lid closed, headset
-        // plugged in, priority policy update…) or the stream died.
-        let resolved_changed = self.active_params.is_some()
-            && self.resolved_input_uid(&list_input_devices_impl()).as_deref()
-                != self.mic_device_uid.as_deref();
+        // plugged in, priority policy update) or the stream died. Two guards
+        // keep this from looping every MIC_CHECK_INTERVAL:
+        // - `None` (no auto-eligible device under the current policy) never
+        //   tears down a healthy stream; a dead one is caught by `failed`.
+        // - A target already attempted without converging (duplicate device
+        //   names, resolved device cpal cannot open) is parked in
+        //   `route_attempt_uid` until an explicit route event retries it.
+        let resolved = self.resolved_input_uid(&list_input_devices_impl());
+        let resolved_changed = resolved.is_some()
+            && resolved != self.mic_device_uid
+            && resolved != self.route_attempt_uid;
 
         if !failed && !resolved_changed {
             return false;
         }
 
+        if resolved_changed {
+            self.route_attempt_uid = resolved.clone();
+        }
+
         info!(
-            "Input device {} — rebuilding audio capture",
+            "Input device {}, rebuilding audio capture",
             if failed { "failed" } else { "changed" }
         );
         match self.start(
@@ -1139,6 +1164,14 @@ impl AudioCapture {
             Ok(()) => {
                 self.mic_rebuild_failures = 0;
                 self.mic_loss_warned = false;
+                if resolved_changed && resolved != self.mic_device_uid {
+                    warn!(
+                        "Input route did not converge on the resolved device \
+                         (target {:?}, opened {:?}); keeping the opened device \
+                         until the route changes",
+                        resolved, self.mic_device_uid
+                    );
+                }
                 false
             }
             Err(e) => {
@@ -1174,7 +1207,11 @@ impl AudioCapture {
     }
 
     /// Re-run input resolution and hot-swap the mic leg when recording.
+    /// Called on explicit route events (device pick, policy change, CoreAudio
+    /// device-list or default-input change), so a previously non-converged
+    /// target is fair game again.
     fn refresh_input_route(&mut self) {
+        self.route_attempt_uid = None;
         if self.active_params.is_some() {
             self.last_mic_check = Instant::now();
             if self.check_mic_health() {
@@ -1312,6 +1349,7 @@ impl AudioCapture {
         self.active_params = None;
         self.mic_device_name = None;
         self.mic_device_uid = None;
+        self.route_attempt_uid = None;
         self.stream.take();
         self.resampler.take();
         #[cfg(target_os = "macos")]
@@ -1366,6 +1404,7 @@ impl AudioCapture {
         self.active_params = None;
         self.mic_device_name = None;
         self.mic_device_uid = None;
+        self.route_attempt_uid = None;
         self.emit_audio_level(0.0);
         self.level_throttle.reset();
 

--- a/src-tauri/src/audio/priority.rs
+++ b/src-tauri/src/audio/priority.rs
@@ -82,6 +82,11 @@ pub fn touch_known(priority: &mut InputPriority, connected: &[AudioInputDevice])
 /// Order: explicit pin (if connected) -> clamshell preference (when active and
 /// connected) -> first connected non-hidden priority entry -> system default
 /// (with anti-Bluetooth preference when `allow_bluetooth_mic` is false).
+///
+/// `None` is also returned when devices are connected but none is
+/// auto-eligible (all hidden, or Bluetooth-only with Bluetooth disallowed).
+/// The caller decides that fallback: capture opens the OS default anyway so
+/// recording still works, and never rebuilds toward a `None` resolution.
 pub fn resolve_input(connected: &[AudioInputDevice], params: ResolveInputParams<'_>) -> Option<String> {
     if connected.is_empty() {
         return None;
@@ -343,6 +348,18 @@ mod tests {
     fn empty_connected_returns_none() {
         assert_eq!(
             resolve_input(&[], params(None, None, false, &empty_priority(), false)),
+            None,
+        );
+    }
+
+    #[test]
+    fn bluetooth_only_returns_none_for_caller_fallback() {
+        let connected = vec![device("bt", "AirPods", TransportType::Bluetooth, true)];
+        assert_eq!(
+            resolve_input(
+                &connected,
+                params(None, None, false, &empty_priority(), false),
+            ),
             None,
         );
     }

--- a/src-tauri/src/db/meetings.rs
+++ b/src-tauri/src/db/meetings.rs
@@ -228,30 +228,49 @@ impl Database {
     }
 
     /// Set the speaker label on specific segments of a meeting, identified
-    /// by their `sort_order`, in one transaction. Only segments whose
-    /// speaker is currently NULL are rewritten. Me/Them attribution and any
-    /// previous diarization pass are never overwritten. Segment text is
-    /// untouched, so the FTS index and any edited transcript stay valid
-    /// as-is. Returns how many rows actually changed.
+    /// by their `sort_order`, in one transaction. Segments whose speaker is
+    /// currently NULL are always writable. `replaceable` optionally names the
+    /// one live-attribution label (Me or Them) this write may also overwrite,
+    /// so an offline diarization pass can refine its own lane: the mic pass
+    /// replaces `me`, the system pass replaces `them`. Any other existing
+    /// label (the opposite lane, previous diarization passes) is never
+    /// touched. Segment text is untouched, so the FTS index and any edited
+    /// transcript stay valid as-is. Returns how many rows actually changed.
     pub fn set_segment_speakers(
         &self,
         meeting_id: &str,
         assignments: &[(u64, Speaker)],
+        replaceable: Option<Speaker>,
     ) -> Result<usize, String> {
         if assignments.is_empty() {
             return Ok(0);
         }
+        if matches!(replaceable, Some(Speaker::Persistent(_))) {
+            return Err(
+                "Persistent labels cannot be marked replaceable; use retag_persistent_speaker"
+                    .into(),
+            );
+        }
+        let replaceable_label = replaceable.map(Speaker::as_str);
         let mut conn = self.conn.acquire()?;
         let tx = conn
             .transaction()
             .map_err(|e| format!("Transaction: {e}"))?;
         let mut changed = 0usize;
         for (sort_order, speaker) in assignments {
+            // `speaker = NULL` is never true in SQL, so a `replaceable` of
+            // `None` reduces the predicate to `speaker IS NULL`.
             changed += tx
                 .execute(
                     "UPDATE segments SET speaker = ?1
-                     WHERE meeting_id = ?2 AND sort_order = ?3 AND speaker IS NULL",
-                    params![speaker.as_str(), meeting_id, *sort_order as i64],
+                     WHERE meeting_id = ?2 AND sort_order = ?3
+                       AND (speaker IS NULL OR speaker = ?4)",
+                    params![
+                        speaker.as_str(),
+                        meeting_id,
+                        *sort_order as i64,
+                        replaceable_label
+                    ],
                 )
                 .map_err(|e| format!("Set segment speaker: {e}"))?;
         }
@@ -1266,7 +1285,7 @@ mod tests {
     }
 
     #[test]
-    fn set_segment_speakers_only_rewrites_null_speakers() {
+    fn set_segment_speakers_without_replaceable_only_rewrites_null_speakers() {
         let (db, _dir) = test_db();
         let mut meeting = sample_meeting("m1");
         meeting.segments[0].speaker = Some(Speaker::Me);
@@ -1277,6 +1296,7 @@ mod tests {
             .set_segment_speakers(
                 "m1",
                 &[(0, Speaker::Persistent(7)), (1, Speaker::Persistent(7))],
+                None,
             )
             .unwrap();
         assert_eq!(changed, 1, "the Me segment must not be rewritten");
@@ -1286,11 +1306,64 @@ mod tests {
         assert_eq!(loaded.segments[1].speaker, Some(Speaker::Persistent(7)));
     }
 
+    /// Regression test for the system-audio diarization pass: segments in a
+    /// meeting with a system-audio lane are live-labeled Me/Them, and each
+    /// offline pass must be able to replace exactly its own lane.
+    #[test]
+    fn set_segment_speakers_replaces_only_the_allowed_lane() {
+        let (db, _dir) = test_db();
+        let mut meeting = sample_meeting("m1");
+        meeting.segments[0].speaker = Some(Speaker::Me);
+        meeting.segments[1].speaker = Some(Speaker::Them);
+        db.save_meeting(&meeting).unwrap();
+
+        // System pass: may replace Them, must not touch Me.
+        let changed = db
+            .set_segment_speakers(
+                "m1",
+                &[(0, Speaker::Persistent(7)), (1, Speaker::Persistent(7))],
+                Some(Speaker::Them),
+            )
+            .unwrap();
+        assert_eq!(changed, 1, "only the Them segment is replaceable");
+
+        let loaded = db.load_meeting("m1").unwrap();
+        assert_eq!(loaded.segments[0].speaker, Some(Speaker::Me));
+        assert_eq!(loaded.segments[1].speaker, Some(Speaker::Persistent(7)));
+
+        // Mic pass: may replace Me, must not touch the persistent label the
+        // system pass just wrote.
+        let changed = db
+            .set_segment_speakers(
+                "m1",
+                &[(0, Speaker::Persistent(9)), (1, Speaker::Persistent(9))],
+                Some(Speaker::Me),
+            )
+            .unwrap();
+        assert_eq!(changed, 1, "only the Me segment is replaceable");
+
+        let loaded = db.load_meeting("m1").unwrap();
+        assert_eq!(loaded.segments[0].speaker, Some(Speaker::Persistent(9)));
+        assert_eq!(loaded.segments[1].speaker, Some(Speaker::Persistent(7)));
+    }
+
+    #[test]
+    fn set_segment_speakers_rejects_persistent_replaceable() {
+        let (db, _dir) = test_db();
+        db.save_meeting(&sample_meeting("m1")).unwrap();
+        let result = db.set_segment_speakers(
+            "m1",
+            &[(0, Speaker::Persistent(1))],
+            Some(Speaker::Persistent(2)),
+        );
+        assert!(result.is_err());
+    }
+
     #[test]
     fn set_segment_speakers_empty_assignments_is_a_noop() {
         let (db, _dir) = test_db();
         db.save_meeting(&sample_meeting("m1")).unwrap();
-        assert_eq!(db.set_segment_speakers("m1", &[]).unwrap(), 0);
+        assert_eq!(db.set_segment_speakers("m1", &[], None).unwrap(), 0);
     }
 
     #[test]
@@ -1298,7 +1371,7 @@ mod tests {
         let (db, _dir) = test_db();
         db.save_meeting(&sample_meeting("m1")).unwrap();
         let changed = db
-            .set_segment_speakers("m1", &[(999, Speaker::Persistent(1))])
+            .set_segment_speakers("m1", &[(999, Speaker::Persistent(1))], None)
             .unwrap();
         assert_eq!(changed, 0);
     }
@@ -1307,7 +1380,7 @@ mod tests {
     fn set_segment_speakers_keeps_fts_search_working() {
         let (db, _dir) = test_db();
         db.save_meeting(&sample_meeting("m1")).unwrap();
-        db.set_segment_speakers("m1", &[(0, Speaker::Persistent(1))])
+        db.set_segment_speakers("m1", &[(0, Speaker::Persistent(1))], None)
             .unwrap();
         let hits = db.search_text("Hello", 10).unwrap();
         assert!(hits.iter().any(|hit| hit.source_id == "m1"));

--- a/src-tauri/src/diarize/assign.rs
+++ b/src-tauri/src/diarize/assign.rs
@@ -5,7 +5,7 @@
 
 use super::DiarizedSegment;
 
-/// one transcript segment's time span, local to a single recording session
+/// One transcript segment's time span, local to a single recording session
 /// (matching the per-session zero-based clock `TranscriptionSegment.start_time`
 /// / `end_time` already use). `has_speaker` marks a segment whose label must
 /// not be overwritten for this pass: mic pass locks Them and persistent

--- a/src-tauri/src/pipeline/diarize_task.rs
+++ b/src-tauri/src/pipeline/diarize_task.rs
@@ -193,8 +193,10 @@ fn parse_diarize_wav_stem(stem: &str) -> Option<(usize, DiarizationPass)> {
 /// Diarize every tapped session of one meeting and write the resulting
 /// speaker labels back. Each session may run a mic pass, a system pass, or
 /// both; a failed pass is logged and skipped (its segments stay unlabeled),
-/// it does not abort the rest. All segment updates land in one transaction at
-/// the end. Returns how many segments were relabeled.
+/// it does not abort the rest. Segment updates land at the end, one
+/// transaction per lane: the mic pass may replace live `me` labels, the
+/// system pass may replace live `them` labels, and either may fill NULL
+/// speakers (mic-only meetings). Returns how many segments were relabeled.
 fn diarize_meeting(
     db: &Database,
     meeting_id: &str,
@@ -207,7 +209,8 @@ fn diarize_meeting(
     let mut cfg = DiarizeConfig::new(models::segmentation_model_path(), models::embedding_model_path());
     cfg.max_speakers = settings.diarize_max_speakers.map(|n| n as usize);
 
-    let mut assignments: Vec<(u64, Speaker)> = Vec::new();
+    let mut mic_assignments: Vec<(u64, Speaker)> = Vec::new();
+    let mut system_assignments: Vec<(u64, Speaker)> = Vec::new();
     let mut done_passes = 0u32;
     for session in session_files {
         if let Some(wav_path) = &session.mic_wav {
@@ -219,7 +222,7 @@ fn diarize_meeting(
                 &cfg,
                 DiarizationPass::Mic,
             ) {
-                Ok(mut session_assignments) => assignments.append(&mut session_assignments),
+                Ok(mut session_assignments) => mic_assignments.append(&mut session_assignments),
                 Err(e) => warn!(
                     meeting_id = %meeting_id,
                     session = session.session_index,
@@ -239,7 +242,7 @@ fn diarize_meeting(
                 &cfg,
                 DiarizationPass::System,
             ) {
-                Ok(mut session_assignments) => assignments.append(&mut session_assignments),
+                Ok(mut session_assignments) => system_assignments.append(&mut session_assignments),
                 Err(e) => warn!(
                     meeting_id = %meeting_id,
                     session = session.session_index,
@@ -252,7 +255,12 @@ fn diarize_meeting(
         }
     }
 
-    db.set_segment_speakers(meeting_id, &assignments)
+    // The mic write runs first, so a NULL segment both passes claimed keeps
+    // the mic label (the system write only replaces NULL or `them`).
+    let mic_changed = db.set_segment_speakers(meeting_id, &mic_assignments, Some(Speaker::Me))?;
+    let system_changed =
+        db.set_segment_speakers(meeting_id, &system_assignments, Some(Speaker::Them))?;
+    Ok(mic_changed + system_changed)
 }
 
 /// Diarize one recording session's WAV and return the (sort_order, speaker)
@@ -457,7 +465,9 @@ mod tests {
         .expect("diarize session");
         assert!(!assignments.is_empty(), "expected at least one labeled segment");
 
-        let changed = db.set_segment_speakers("diarize-e2e", &assignments).unwrap();
+        let changed = db
+            .set_segment_speakers("diarize-e2e", &assignments, Some(Speaker::Me))
+            .unwrap();
         assert_eq!(changed, assignments.len());
 
         let relabeled = db.load_meeting("diarize-e2e").unwrap();


### PR DESCRIPTION
Two fixes for issues found reviewing #68 and #69.

## Speaker recognition on system-audio meetings wrote nothing

The mic and system diarization passes (#69) compute persistent-speaker assignments for segments live-labeled Me/Them, but `set_segment_speakers` only updated rows `WHERE speaker IS NULL`. On any meeting with a system-audio lane, every segment carries `me`/`them`, so the passes ran full inference, created persistent speaker rows, updated centroids, and then wrote zero labels.

`set_segment_speakers` now takes an optional replaceable label: the mic pass may replace `me`, the system pass may replace `them`, NULL stays writable by either, persistent labels and the opposite lane stay locked. The mic write runs first so a NULL segment claimed by both passes keeps the mic label. Regression tests cover the lane rules (a `them` segment relabeled by the system pass while `me` stays locked, and vice versa) and reject persistent labels as a replaceable target.

## Mic health check could rebuild capture every 2 seconds

`check_mic_health` (#68) rebuilt the capture leg whenever the resolved input UID differed from the opened device's UID. Two situations never converge: duplicate device names (cpal opens the first name match, which maps back to the other UID) and a resolved device missing from the cpal list (find_device falls back to the OS default). Both tore the stream down and rebuilt it every `MIC_CHECK_INTERVAL` for the rest of the session, the same failure class PR #21 fixed for the old name-based check.

The health check now parks a non-converged target in `route_attempt_uid` and keeps the opened stream until an explicit route event (device pick, policy change, CoreAudio device-list or default-input change) retries it, with a warning logged when a rebuild does not converge. A `None` resolution (no auto-eligible device, e.g. only a Bluetooth mic while Bluetooth input is disallowed) no longer tears down a healthy stream; capture falls back to the OS default so recording still works. Also threads one CoreAudio snapshot through `start`/`find_device` instead of enumerating twice per rebuild.

## Gates

- cargo test workspace: 663 passed
- cargo clippy all-targets -D warnings: clean
- npm test: 266 passed, npm run check: 0 errors

## QA suggested

- System-audio meeting with speaker recognition on both lanes: after stop, Them lines split into named speakers, Me lines intact (or relabeled by the mic pass where a second in-room voice exists).
- Two input devices with identical names: no capture teardown every 2s mid-recording (log shows one non-convergence warning instead).