### PR TITLE
Fix speaker recognition never labeling Kyutai meetings

### DIFF
--- a/src-tauri/src/diarize/assign.rs
+++ b/src-tauri/src/diarize/assign.rs
@@ -17,18 +17,32 @@ pub struct SegmentSpan {
     pub has_speaker: bool,
 }
 
+/// How far (seconds) an instant span may sit outside every diarized range
+/// and still snap to the nearest one. Word onsets rarely line up exactly
+/// with VAD-derived range boundaries.
+const INSTANT_TOLERANCE_S: f64 = 0.75;
+
 /// For each entry in `segments`, the local cluster index (`DiarizedSegment.speaker`)
 /// with the greatest temporal overlap, or `None` if the segment already has a
-/// speaker, has zero/negative duration, or no diarized range overlaps it at
-/// all. Output is index-aligned with `segments`.
+/// speaker or no diarized range overlaps it at all. Output is index-aligned
+/// with `segments`.
+///
+/// Zero-duration spans are word-level segments (Kyutai stores each word with
+/// `end_time == start_time`); they are assigned to the diarized range that
+/// contains the instant, or the nearest range within
+/// [`INSTANT_TOLERANCE_S`].
 pub fn assign_by_overlap(diarized: &[DiarizedSegment], segments: &[SegmentSpan]) -> Vec<Option<usize>> {
     segments
         .iter()
         .map(|segment| {
-            if segment.has_speaker || segment.end_s <= segment.start_s {
+            if segment.has_speaker {
                 return None;
             }
-            best_overlap(diarized, segment)
+            if segment.end_s > segment.start_s {
+                best_overlap(diarized, segment)
+            } else {
+                best_containing(diarized, segment.start_s)
+            }
         })
         .collect()
 }
@@ -45,6 +59,31 @@ fn best_overlap(diarized: &[DiarizedSegment], segment: &SegmentSpan) -> Option<u
         match best {
             Some((_, best_overlap)) if best_overlap >= overlap => {}
             _ => best = Some((d.speaker, overlap)),
+        }
+    }
+    best.map(|(speaker, _)| speaker)
+}
+
+/// Cluster of the diarized range containing instant `t` (distance 0), or the
+/// nearest range within [`INSTANT_TOLERANCE_S`]. Ties keep the earlier range.
+fn best_containing(diarized: &[DiarizedSegment], t: f64) -> Option<usize> {
+    let mut best: Option<(usize, f64)> = None;
+    for d in diarized {
+        let d_start = d.start_ms as f64 / 1000.0;
+        let d_end = d.end_ms as f64 / 1000.0;
+        let distance = if t < d_start {
+            d_start - t
+        } else if t > d_end {
+            t - d_end
+        } else {
+            0.0
+        };
+        if distance > INSTANT_TOLERANCE_S {
+            continue;
+        }
+        match best {
+            Some((_, best_distance)) if best_distance <= distance => {}
+            _ => best = Some((d.speaker, distance)),
         }
     }
     best.map(|(speaker, _)| speaker)
@@ -110,11 +149,50 @@ mod tests {
         assert_eq!(assign_by_overlap(&diarized, &segments), vec![None]);
     }
 
+    /// Kyutai stores each word with `end_time == start_time`; those instants
+    /// must land in the diarized range containing them, not be dropped.
     #[test]
-    fn zero_or_negative_duration_segment_is_unassigned() {
+    fn word_instant_inside_a_range_gets_that_cluster() {
+        let diarized = vec![seg(0, 1000, 0), seg(1000, 2000, 1)];
+        let segments = vec![span(0.5, 0.5), span(1.5, 1.5)];
+        assert_eq!(assign_by_overlap(&diarized, &segments), vec![Some(0), Some(1)]);
+    }
+
+    #[test]
+    fn word_instant_in_a_gap_snaps_to_the_nearest_range_within_tolerance() {
+        // Gap between the ranges: 2.0..2.5s. An instant at 2.4 is 0.4s from
+        // cluster 0's end and 0.1s from cluster 1's start.
+        let diarized = vec![seg(0, 2000, 0), seg(2500, 4000, 1)];
+        let segments = vec![span(2.4, 2.4)];
+        assert_eq!(assign_by_overlap(&diarized, &segments), vec![Some(1)]);
+    }
+
+    #[test]
+    fn word_instant_beyond_tolerance_is_unassigned() {
         let diarized = vec![seg(0, 1000, 0)];
-        let segments = vec![span(0.5, 0.5), span(0.8, 0.3)];
-        assert_eq!(assign_by_overlap(&diarized, &segments), vec![None, None]);
+        let segments = vec![span(5.0, 5.0)];
+        assert_eq!(assign_by_overlap(&diarized, &segments), vec![None]);
+    }
+
+    #[test]
+    fn negative_duration_segment_is_treated_as_an_instant_at_its_start() {
+        let diarized = vec![seg(0, 1000, 0)];
+        let segments = vec![span(0.8, 0.3)];
+        assert_eq!(assign_by_overlap(&diarized, &segments), vec![Some(0)]);
+    }
+
+    #[test]
+    fn labeled_word_instant_is_never_reassigned() {
+        let diarized = vec![seg(0, 1000, 0)];
+        let segments = vec![SegmentSpan { start_s: 0.5, end_s: 0.5, has_speaker: true }];
+        assert_eq!(assign_by_overlap(&diarized, &segments), vec![None]);
+    }
+
+    #[test]
+    fn word_instant_contained_by_overlapping_ranges_keeps_the_earlier_one() {
+        let diarized = vec![seg(0, 2000, 0), seg(1000, 3000, 1)];
+        let segments = vec![span(1.5, 1.5)];
+        assert_eq!(assign_by_overlap(&diarized, &segments), vec![Some(0)]);
     }
 
     #[test]

--- a/src-tauri/src/pipeline/diarize_task.rs
+++ b/src-tauri/src/pipeline/diarize_task.rs
@@ -126,6 +126,11 @@ fn run(app: &tauri::AppHandle, meeting_id: &str) {
                     meeting_id: meeting_id.to_string(),
                 }
                 .emit(app);
+            } else {
+                info!(
+                    meeting_id = %meeting_id,
+                    "Speaker recognition finished without labeling any segments"
+                );
             }
         }
         Err(e) => {
@@ -260,6 +265,14 @@ fn diarize_meeting(
     let mic_changed = db.set_segment_speakers(meeting_id, &mic_assignments, Some(Speaker::Me))?;
     let system_changed =
         db.set_segment_speakers(meeting_id, &system_assignments, Some(Speaker::Them))?;
+    info!(
+        meeting_id = %meeting_id,
+        mic_assigned = mic_assignments.len(),
+        mic_changed,
+        system_assigned = system_assignments.len(),
+        system_changed,
+        "Speaker recognition assignments written"
+    );
     Ok(mic_changed + system_changed)
 }
 
@@ -293,6 +306,24 @@ fn diarize_session(
     let result = crate::diarize::diarize(&samples, crate::diarize::segmentation::SAMPLE_RATE, cfg)
         .map_err(|e| format!("Diarize inference: {e}"))?;
     if result.segments.is_empty() || result.speakers.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Segment times restart at zero for each recording session, and so does
+    // the tapped WAV, so session-local segment spans line up with diarized
+    // ranges directly. Mapped before any speaker-row write: a pass whose
+    // ranges match no segment at all must not create orphan "Speaker N"
+    // rows or fold their centroids.
+    let spans: Vec<SegmentSpan> = meeting.segments[start..end]
+        .iter()
+        .map(|seg| SegmentSpan {
+            start_s: seg.start_time,
+            end_s: seg.end_time,
+            has_speaker: speaker_label_is_locked(seg.speaker.as_ref(), pass),
+        })
+        .collect();
+    let cluster_per_span = assign_by_overlap(&result.segments, &spans);
+    if cluster_per_span.iter().all(Option::is_none) {
         return Ok(Vec::new());
     }
 
@@ -331,19 +362,6 @@ fn diarize_session(
         )?;
         cluster_to_speaker.insert(decision.cluster, speaker_id);
     }
-
-    // Segment times restart at zero for each recording session, and so does
-    // the tapped WAV, so session-local segment spans line up with diarized
-    // ranges directly.
-    let spans: Vec<SegmentSpan> = meeting.segments[start..end]
-        .iter()
-        .map(|seg| SegmentSpan {
-            start_s: seg.start_time,
-            end_s: seg.end_time,
-            has_speaker: speaker_label_is_locked(seg.speaker.as_ref(), pass),
-        })
-        .collect();
-    let cluster_per_span = assign_by_overlap(&result.segments, &spans);
 
     Ok(cluster_per_span
         .into_iter()


### PR DESCRIPTION
Root cause of the v0.6.2 test where the diarization step ran but nothing changed (diagnosed from the app logs and the DB).

## What actually happened in the test

The 17:00 UTC test meeting ran both passes: the mic pass created Speaker 1-2 at 17:02:21, the system pass created Speaker 3-9 at 17:02:23, temp WAVs were cleaned up, the task finished with no error. But zero segments were labeled, and querying the DB shows why: no meeting on this machine has ever had a single `spk:` label. Speaker recognition has never worked with Kyutai, including the mic-only feature from #64.

**Kyutai stores every word segment with `end_time == start_time`** (`kyutai.rs` builds segments from the word onset), and `assign_by_overlap` explicitly skipped any span with `end <= start`. 186 of 186 segments in the test meeting are zero-duration, so every span was skipped before the DB write that #70 fixed was even reached.

## Fix

- Zero-duration spans are treated as instants: they take the cluster of the diarized range containing the timestamp, or the nearest range within 0.75s (word onsets rarely line up exactly with VAD-derived boundaries). Ranged spans (Parakeet) keep the max-overlap rule. 6 new unit tests.
- A pass that assigns nothing no longer creates persistent speaker rows or folds centroids (each broken run was adding phantom "Speaker N" rows; the test machine now has 9 of them).
- Assignment counts are logged after the writes, and a recognition run that labels nothing logs an explicit line instead of finishing silently. Today's diagnosis required correlating DB timestamps with the log; next time one Diagnostics line will say it.

## Gates

- cargo test workspace: 668 passed (6 new)
- cargo clippy all-targets -D warnings: clean
- No frontend changes

## QA

Same scenario as v0.6.2: meeting with system audio + Diarize system audio, distinct voices, stop, wait for labeling. Expected: Them lines become named speakers, and Diagnostics shows "Speaker recognition assignments written" with non-zero counts. Also worth deleting the 9 phantom "Speaker N" entries created by the earlier runs before re-testing, so matching starts clean.