### PR TITLE
Rebuild cross-meeting speaker recognition for reliability

### DIFF
--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -13,6 +13,7 @@
 use std::path::{Path, PathBuf};
 
 use clap::Parser;
+use rusqlite::{Connection, OpenFlags};
 
 use crate::constants::{SAMPLE_RATE_F64, SILENCE_SUFFIX_SAMPLES};
 use crate::engine::{
@@ -249,55 +250,119 @@ fn run_diarize(wav_path: &Path, json: bool) -> i32 {
 }
 
 /// One stored speaker's id, name, and decoded embeddings, loaded for the
-/// `--diarize-file` calibration report. Best-effort: a missing or unreadable
-/// `souffle.db` (e.g. the app has never been launched) degrades to an empty
-/// list rather than failing the whole run, since this flag is a calibration
-/// tool over whatever real speakers happen to be enrolled, not something
-/// that should require the app database to exist.
-fn load_stored_speakers_for_calibration() -> Vec<(i64, String, Vec<Vec<f32>>)> {
+/// `--diarize-file` calibration report.
+struct CalibrationSpeaker {
+    id: i64,
+    name: String,
+    embeddings: Vec<Vec<f32>>,
+}
+
+/// A `load_calibration_speakers` failure, distinguishing "this database
+/// predates the feature" (silent) from every other failure (reported).
+enum CalibrationLoadError {
+    /// `speakers` or `speaker_embeddings` doesn't exist: a pre-v13 (or
+    /// pre-v12) database that has simply never had persistent speakers.
+    MissingTable,
+    Other(rusqlite::Error),
+}
+
+impl From<rusqlite::Error> for CalibrationLoadError {
+    fn from(e: rusqlite::Error) -> Self {
+        let missing_table = matches!(
+            &e,
+            rusqlite::Error::SqliteFailure(_, Some(msg)) if msg.contains("no such table")
+        );
+        if missing_table {
+            CalibrationLoadError::MissingTable
+        } else {
+            CalibrationLoadError::Other(e)
+        }
+    }
+}
+
+/// Stored speakers for the `--diarize-file` calibration report, read
+/// straight from `souffle.db` in read-only mode: this is a diagnostic tool
+/// run against whatever database the app happens to have, not a codepath
+/// that should ever create, migrate, or lock one for writing. Three
+/// outcomes: no database file yet is a silent empty list (the app has never
+/// been launched); a database that predates the `speaker_embeddings` table
+/// (schema v13) is also a silent empty list (there's nothing to have
+/// migrated); any other failure (permissions, corruption, a locked file) is
+/// reported on stderr before falling back to an empty list, since silently
+/// swallowing those would make "No stored speakers" a misleading message.
+fn load_stored_speakers_for_calibration() -> Vec<CalibrationSpeaker> {
     let db_path = crate::constants::app_data_dir().join("souffle.db");
-    let Ok(db) = crate::db::Database::open(&db_path) else {
+    if !db_path.exists() {
         return Vec::new();
-    };
-    let Ok(speakers) = db.list_speakers_with_embeddings() else {
-        return Vec::new();
-    };
-    speakers
+    }
+    match load_calibration_speakers(&db_path) {
+        Ok(speakers) => speakers,
+        Err(CalibrationLoadError::MissingTable) => Vec::new(),
+        Err(CalibrationLoadError::Other(e)) => {
+            eprintln!(
+                "Warning: could not read stored speakers from '{}': {e}",
+                db_path.display()
+            );
+            Vec::new()
+        }
+    }
+}
+
+fn load_calibration_speakers(db_path: &Path) -> Result<Vec<CalibrationSpeaker>, CalibrationLoadError> {
+    let conn = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
+
+    let mut speakers_stmt = conn.prepare("SELECT id, name FROM speakers ORDER BY id")?;
+    let speakers: Vec<(i64, String)> = speakers_stmt
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut embeddings_stmt =
+        conn.prepare("SELECT speaker_id, embedding FROM speaker_embeddings ORDER BY speaker_id, id")?;
+    let embedding_rows: Vec<(i64, Vec<u8>)> = embeddings_stmt
+        .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+        .collect::<Result<Vec<_>, _>>()?;
+    drop(embeddings_stmt);
+
+    let mut by_speaker: std::collections::HashMap<i64, Vec<Vec<f32>>> = std::collections::HashMap::new();
+    for (speaker_id, blob) in embedding_rows {
+        if let Some(decoded) = crate::diarize::persist::decode_embedding(&blob) {
+            by_speaker.entry(speaker_id).or_default().push(decoded);
+        }
+    }
+
+    Ok(speakers
         .into_iter()
-        .map(|s| {
-            let embeddings = s
-                .embeddings
-                .iter()
-                .filter_map(|e| crate::diarize::persist::decode_embedding(e))
-                .collect();
-            (s.speaker.id, s.speaker.name, embeddings)
+        .map(|(id, name)| CalibrationSpeaker {
+            id,
+            name,
+            embeddings: by_speaker.remove(&id).unwrap_or_default(),
         })
-        .collect()
+        .collect())
 }
 
 /// Cosine similarity of `embedding` against the MAX-similarity embedding of
-/// each `(id, name, embeddings)` stored speaker, for calibrating
-/// `persist::MATCH_THRESHOLD`/`MATCH_MARGIN` against real recordings.
-/// `None` for a stored speaker with no embeddings recorded yet.
+/// each stored speaker, for calibrating `persist::MATCH_THRESHOLD`/
+/// `MATCH_MARGIN` against real recordings. `None` for a stored speaker with
+/// no embeddings recorded yet.
 fn max_similarity_per_speaker<'a>(
     embedding: &[f32],
-    stored: &'a [(i64, String, Vec<Vec<f32>>)],
+    stored: &'a [CalibrationSpeaker],
 ) -> Vec<(i64, &'a str, Option<f32>)> {
     stored
         .iter()
-        .map(|(id, name, embeddings)| {
-            let max_sim = embeddings
-                .iter()
-                .map(|e| crate::diarize::persist::cosine_similarity(embedding, e))
-                .max_by(f32::total_cmp);
-            (*id, name.as_str(), max_sim)
+        .map(|s| {
+            (
+                s.id,
+                s.name.as_str(),
+                crate::diarize::persist::max_similarity(embedding, &s.embeddings),
+            )
         })
         .collect()
 }
 
 fn print_diarization_result(
     result: &crate::diarize::DiarizationResult,
-    stored: &[(i64, String, Vec<Vec<f32>>)],
+    stored: &[CalibrationSpeaker],
     json: bool,
 ) {
     if json {

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -243,11 +243,63 @@ fn run_diarize(wav_path: &Path, json: bool) -> i32 {
         }
     };
 
-    print_diarization_result(&result, json);
+    let stored = load_stored_speakers_for_calibration();
+    print_diarization_result(&result, &stored, json);
     0
 }
 
-fn print_diarization_result(result: &crate::diarize::DiarizationResult, json: bool) {
+/// One stored speaker's id, name, and decoded embeddings, loaded for the
+/// `--diarize-file` calibration report. Best-effort: a missing or unreadable
+/// `souffle.db` (e.g. the app has never been launched) degrades to an empty
+/// list rather than failing the whole run, since this flag is a calibration
+/// tool over whatever real speakers happen to be enrolled, not something
+/// that should require the app database to exist.
+fn load_stored_speakers_for_calibration() -> Vec<(i64, String, Vec<Vec<f32>>)> {
+    let db_path = crate::constants::app_data_dir().join("souffle.db");
+    let Ok(db) = crate::db::Database::open(&db_path) else {
+        return Vec::new();
+    };
+    let Ok(speakers) = db.list_speakers_with_embeddings() else {
+        return Vec::new();
+    };
+    speakers
+        .into_iter()
+        .map(|s| {
+            let embeddings = s
+                .embeddings
+                .iter()
+                .filter_map(|e| crate::diarize::persist::decode_embedding(e))
+                .collect();
+            (s.speaker.id, s.speaker.name, embeddings)
+        })
+        .collect()
+}
+
+/// Cosine similarity of `embedding` against the MAX-similarity embedding of
+/// each `(id, name, embeddings)` stored speaker, for calibrating
+/// `persist::MATCH_THRESHOLD`/`MATCH_MARGIN` against real recordings.
+/// `None` for a stored speaker with no embeddings recorded yet.
+fn max_similarity_per_speaker<'a>(
+    embedding: &[f32],
+    stored: &'a [(i64, String, Vec<Vec<f32>>)],
+) -> Vec<(i64, &'a str, Option<f32>)> {
+    stored
+        .iter()
+        .map(|(id, name, embeddings)| {
+            let max_sim = embeddings
+                .iter()
+                .map(|e| crate::diarize::persist::cosine_similarity(embedding, e))
+                .max_by(f32::total_cmp);
+            (*id, name.as_str(), max_sim)
+        })
+        .collect()
+}
+
+fn print_diarization_result(
+    result: &crate::diarize::DiarizationResult,
+    stored: &[(i64, String, Vec<Vec<f32>>)],
+    json: bool,
+) {
     if json {
         let json_value = serde_json::json!({
             "speaker_count": result.speakers.len(),
@@ -255,6 +307,17 @@ fn print_diarization_result(result: &crate::diarize::DiarizationResult, json: bo
                 "start_ms": s.start_ms,
                 "end_ms": s.end_ms,
                 "speaker": s.speaker,
+            })).collect::<Vec<_>>(),
+            "clusters": result.speakers.iter().map(|c| serde_json::json!({
+                "speaker": c.speaker,
+                "speech_seconds": c.speech_seconds,
+                "similarities": max_similarity_per_speaker(&c.embedding, stored).into_iter()
+                    .map(|(id, name, sim)| serde_json::json!({
+                        "speaker_id": id,
+                        "name": name,
+                        "max_similarity": sim,
+                    }))
+                    .collect::<Vec<_>>(),
             })).collect::<Vec<_>>(),
         });
         println!("{}", serde_json::to_string(&json_value).unwrap_or_default());
@@ -269,6 +332,22 @@ fn print_diarization_result(result: &crate::diarize::DiarizationResult, json: bo
             seg.end_ms as f64 / 1000.0,
             seg.speaker
         );
+    }
+
+    println!();
+    if stored.is_empty() {
+        println!("No stored speakers in the database; nothing to calibrate against.");
+        return;
+    }
+    println!("Calibration: cluster similarity against stored speakers");
+    for cluster in &result.speakers {
+        println!("  Cluster {} ({:.1}s of speech):", cluster.speaker, cluster.speech_seconds);
+        for (id, name, sim) in max_similarity_per_speaker(&cluster.embedding, stored) {
+            match sim {
+                Some(sim) => println!("    vs speaker {id} '{name}': {sim:.3}"),
+                None => println!("    vs speaker {id} '{name}': no embeddings recorded"),
+            }
+        }
     }
 }
 

--- a/src-tauri/src/commands/speakers.rs
+++ b/src-tauri/src/commands/speakers.rs
@@ -36,6 +36,7 @@ pub struct SpeakerProfile {
     pub last_seen_at: String,
     pub meeting_count: u32,
     pub segment_count: u32,
+    pub is_me: bool,
 }
 
 /// All persistent speakers with usage counts, most recently seen first.
@@ -55,6 +56,7 @@ pub fn list_speaker_profiles(state: State<'_, AppState>) -> Result<Vec<SpeakerPr
                 last_seen_at: record.last_seen_at.to_rfc3339(),
                 meeting_count: counts.meeting_count.max(0) as u32,
                 segment_count: counts.segment_count.max(0) as u32,
+                is_me: record.is_me,
             }
         })
         .collect();
@@ -70,6 +72,21 @@ pub fn delete_speaker(state: State<'_, AppState>, id: i64) -> Result<(), String>
     state.db.delete_speaker(id)
 }
 
+/// Merge one persistent speaker into another: segments and voice embeddings
+/// move to the target, and the source is deleted.
+#[tauri::command]
+#[specta::specta]
+pub fn merge_speakers(state: State<'_, AppState>, source_id: i64, target_id: i64) -> Result<(), String> {
+    state.db.merge_speakers(source_id, target_id)
+}
+
+/// Flag (or unflag) a persistent speaker as the app's user.
+#[tauri::command]
+#[specta::specta]
+pub fn set_speaker_is_me(state: State<'_, AppState>, id: i64, is_me: bool) -> Result<(), String> {
+    state.db.set_speaker_is_me(id, is_me)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 pub struct RetagMeetingSpeakerRequest {
     pub meeting_id: String,
@@ -83,6 +100,11 @@ pub struct RetagMeetingSpeakerRequest {
     pub to_speaker_id: Option<i64>,
     /// Create a new persistent speaker with this name and assign to it.
     pub new_speaker_name: Option<String>,
+    /// When true, also move this meeting's voice embeddings for the source
+    /// speaker to the target, so future matching benefits from the
+    /// correction. When false, the retag only relabels this meeting.
+    #[serde(default)]
+    pub remember: bool,
 }
 
 /// Reassign persistent-speaker labels within one meeting. Me/Them segments
@@ -105,6 +127,7 @@ pub fn retag_meeting_speaker(
         request.to_speaker_id,
         request.new_speaker_name.as_deref(),
         scope,
+        request.remember,
     )?;
 
     state.db.load_meeting(&request.meeting_id)

--- a/src-tauri/src/db/meetings.rs
+++ b/src-tauri/src/db/meetings.rs
@@ -319,7 +319,9 @@ impl Database {
     /// embeddings this meeting recorded for `from_persistent_id` move to the
     /// resolved target too, so future matching benefits from the correction;
     /// when false, the retag only overrides the label shown for this meeting
-    /// and the embeddings stay where they are.
+    /// and the embeddings stay where they are. A remembered retag only moves
+    /// those embeddings once `from_persistent_id` has no segments left in
+    /// this meeting: see the invariant note at the embedding move below.
     pub fn retag_meeting_speaker_labels(
         &self,
         meeting_id: &str,
@@ -383,14 +385,31 @@ impl Database {
             sort_orders,
         )?;
 
+        // A meeting's voice embeddings for a speaker cover every turn that
+        // speaker took in it, not just the retagged ones: they are only
+        // attributable as a block. So a remembered retag may only move them
+        // once the source speaker has no segments left in this meeting
+        // (whole-meeting retags always satisfy this; a single-turn retag
+        // only does when that was the source's sole turn here). Otherwise
+        // the source genuinely spoke elsewhere in the meeting and moving its
+        // embeddings would mis-train the target's voice profile.
         if remember {
-            tx.execute(
-                "UPDATE speaker_embeddings SET speaker_id = ?1
-                 WHERE speaker_id = ?2 AND meeting_id = ?3",
-                params![resolved_to_id, from_persistent_id, meeting_id],
-            )
-            .map_err(|e| format!("Move retagged speaker embeddings: {e}"))?;
-            super::speakers::prune_speaker_embeddings(&tx, resolved_to_id)?;
+            let remaining_for_source: i64 = tx
+                .query_row(
+                    "SELECT COUNT(*) FROM segments WHERE meeting_id = ?1 AND speaker = ?2",
+                    params![meeting_id, &from_label],
+                    |row| row.get(0),
+                )
+                .map_err(|e| format!("Count remaining source segments: {e}"))?;
+            if remaining_for_source == 0 {
+                tx.execute(
+                    "UPDATE speaker_embeddings SET speaker_id = ?1
+                     WHERE speaker_id = ?2 AND meeting_id = ?3",
+                    params![resolved_to_id, from_persistent_id, meeting_id],
+                )
+                .map_err(|e| format!("Move retagged speaker embeddings: {e}"))?;
+                super::speakers::prune_speaker_embeddings(&tx, resolved_to_id)?;
+            }
         }
 
         tx.commit().map_err(|e| format!("Commit: {e}"))?;
@@ -1262,6 +1281,62 @@ mod tests {
 
         assert_eq!(db.speaker_embeddings(alice).unwrap(), vec![vec![1u8]]);
         assert!(db.speaker_embeddings(bob).unwrap().is_empty());
+    }
+
+    #[test]
+    fn retag_meeting_speaker_labels_remember_leaves_embeddings_when_source_keeps_other_turns() {
+        let (db, _dir) = test_db();
+        let alice = db.create_speaker("Alice").unwrap();
+        let bob = db.create_speaker("Bob").unwrap();
+
+        // Alice has two turns in this meeting; only one is retagged, so she
+        // still spoke in the meeting after the correction.
+        let mut meeting = sample_meeting("m1");
+        meeting.segments[0].speaker = Some(Speaker::Persistent(alice));
+        meeting.segments[1].speaker = Some(Speaker::Persistent(alice));
+        db.save_meeting(&meeting).unwrap();
+        db.append_speaker_embedding(alice, Some("m1"), &[1u8], 1.0, chrono::Utc::now())
+            .unwrap();
+
+        db.retag_meeting_speaker_labels("m1", alice, Some(bob), None, Some(&[0]), true)
+            .unwrap();
+
+        let loaded = db.load_meeting("m1").unwrap();
+        assert_eq!(loaded.segments[0].speaker, Some(Speaker::Persistent(bob)));
+        assert_eq!(loaded.segments[1].speaker, Some(Speaker::Persistent(alice)));
+
+        // Alice's meeting embeddings stay put: she is still attributable to
+        // segment 1, so moving them would mis-train Bob's voice profile.
+        assert_eq!(db.speaker_embeddings(alice).unwrap(), vec![vec![1u8]]);
+        assert!(db.speaker_embeddings(bob).unwrap().is_empty());
+    }
+
+    #[test]
+    fn retag_meeting_speaker_labels_remember_moves_embeddings_when_turn_retag_fully_delogs_source()
+    {
+        let (db, _dir) = test_db();
+        let alice = db.create_speaker("Alice").unwrap();
+        let bob = db.create_speaker("Bob").unwrap();
+
+        // Alice only has a single turn in this meeting (segment 0); segment 1
+        // belongs to Bob. Retagging Alice's sole turn fully delogs her from
+        // the meeting, so the turn-scoped retag behaves like a meeting-scoped
+        // one for embedding purposes.
+        let mut meeting = sample_meeting("m1");
+        meeting.segments[0].speaker = Some(Speaker::Persistent(alice));
+        meeting.segments[1].speaker = Some(Speaker::Persistent(bob));
+        db.save_meeting(&meeting).unwrap();
+        db.append_speaker_embedding(alice, Some("m1"), &[1u8], 1.0, chrono::Utc::now())
+            .unwrap();
+
+        db.retag_meeting_speaker_labels("m1", alice, Some(bob), None, Some(&[0]), true)
+            .unwrap();
+
+        let loaded = db.load_meeting("m1").unwrap();
+        assert_eq!(loaded.segments[0].speaker, Some(Speaker::Persistent(bob)));
+
+        assert!(db.speaker_embeddings(alice).unwrap().is_empty());
+        assert_eq!(db.speaker_embeddings(bob).unwrap(), vec![vec![1u8]]);
     }
 
     #[test]

--- a/src-tauri/src/db/meetings.rs
+++ b/src-tauri/src/db/meetings.rs
@@ -315,7 +315,11 @@ impl Database {
     /// Meeting-scoped retag used by the UI: optionally creates a new
     /// persistent speaker, but only after verifying matching segments exist.
     /// The create + segment rewrite run in one transaction so a failed retag
-    /// never leaves an orphan speaker row.
+    /// never leaves an orphan speaker row. When `remember` is true, the voice
+    /// embeddings this meeting recorded for `from_persistent_id` move to the
+    /// resolved target too, so future matching benefits from the correction;
+    /// when false, the retag only overrides the label shown for this meeting
+    /// and the embeddings stay where they are.
     pub fn retag_meeting_speaker_labels(
         &self,
         meeting_id: &str,
@@ -323,6 +327,7 @@ impl Database {
         to_speaker_id: Option<i64>,
         new_speaker_name: Option<&str>,
         sort_orders: Option<&[u64]>,
+        remember: bool,
     ) -> Result<usize, String> {
         match (to_speaker_id, new_speaker_name) {
             (Some(id), None) => {
@@ -377,6 +382,17 @@ impl Database {
             &to_label,
             sort_orders,
         )?;
+
+        if remember {
+            tx.execute(
+                "UPDATE speaker_embeddings SET speaker_id = ?1
+                 WHERE speaker_id = ?2 AND meeting_id = ?3",
+                params![resolved_to_id, from_persistent_id, meeting_id],
+            )
+            .map_err(|e| format!("Move retagged speaker embeddings: {e}"))?;
+            super::speakers::prune_speaker_embeddings(&tx, resolved_to_id)?;
+        }
+
         tx.commit().map_err(|e| format!("Commit: {e}"))?;
         Ok(changed)
     }
@@ -1160,7 +1176,7 @@ mod tests {
         db.save_meeting(&meeting).unwrap();
 
         assert_eq!(
-            db.retag_meeting_speaker_labels("m1", alice, None, Some("  "), None)
+            db.retag_meeting_speaker_labels("m1", alice, None, Some("  "), None, false)
                 .unwrap_err(),
             "Speaker name cannot be empty"
         );
@@ -1173,7 +1189,7 @@ mod tests {
         db.save_meeting(&sample_meeting("m1")).unwrap();
 
         assert_eq!(
-            db.retag_meeting_speaker_labels("m1", alice, None, Some("Carol"), None)
+            db.retag_meeting_speaker_labels("m1", alice, None, Some("Carol"), None, false)
                 .unwrap_err(),
             "No matching segments were retagged"
         );
@@ -1190,7 +1206,7 @@ mod tests {
         db.save_meeting(&meeting).unwrap();
 
         let changed = db
-            .retag_meeting_speaker_labels("m1", alice, None, Some("Carol"), None)
+            .retag_meeting_speaker_labels("m1", alice, None, Some("Carol"), None, false)
             .unwrap();
         assert_eq!(changed, 1);
 
@@ -1203,6 +1219,78 @@ mod tests {
             loaded.segments[0].speaker,
             Some(Speaker::Persistent(carol.id))
         );
+    }
+
+    #[test]
+    fn retag_meeting_speaker_labels_remember_moves_meeting_embeddings_to_target() {
+        let (db, _dir) = test_db();
+        let alice = db.create_speaker("Alice").unwrap();
+        let bob = db.create_speaker("Bob").unwrap();
+
+        let mut meeting = sample_meeting("m1");
+        meeting.segments[0].speaker = Some(Speaker::Persistent(alice));
+        db.save_meeting(&meeting).unwrap();
+
+        // One embedding from this meeting, one from another: only the one
+        // tied to this meeting should move on a remembered retag.
+        db.append_speaker_embedding(alice, Some("m1"), &[1u8], 1.0, chrono::Utc::now())
+            .unwrap();
+        db.append_speaker_embedding(alice, Some("m2"), &[2u8], 1.0, chrono::Utc::now())
+            .unwrap();
+
+        db.retag_meeting_speaker_labels("m1", alice, Some(bob), None, None, true)
+            .unwrap();
+
+        assert_eq!(db.speaker_embeddings(alice).unwrap(), vec![vec![2u8]]);
+        assert_eq!(db.speaker_embeddings(bob).unwrap(), vec![vec![1u8]]);
+    }
+
+    #[test]
+    fn retag_meeting_speaker_labels_without_remember_leaves_embeddings_in_place() {
+        let (db, _dir) = test_db();
+        let alice = db.create_speaker("Alice").unwrap();
+        let bob = db.create_speaker("Bob").unwrap();
+
+        let mut meeting = sample_meeting("m1");
+        meeting.segments[0].speaker = Some(Speaker::Persistent(alice));
+        db.save_meeting(&meeting).unwrap();
+        db.append_speaker_embedding(alice, Some("m1"), &[1u8], 1.0, chrono::Utc::now())
+            .unwrap();
+
+        db.retag_meeting_speaker_labels("m1", alice, Some(bob), None, None, false)
+            .unwrap();
+
+        assert_eq!(db.speaker_embeddings(alice).unwrap(), vec![vec![1u8]]);
+        assert!(db.speaker_embeddings(bob).unwrap().is_empty());
+    }
+
+    #[test]
+    fn retag_meeting_speaker_labels_remember_only_moves_this_meetings_rows_for_new_speaker() {
+        let (db, _dir) = test_db();
+        let alice = db.create_speaker("Alice").unwrap();
+
+        let mut meeting = sample_meeting("m1");
+        meeting.segments[0].speaker = Some(Speaker::Persistent(alice));
+        db.save_meeting(&meeting).unwrap();
+        db.append_speaker_embedding(alice, Some("m1"), &[1u8], 1.0, chrono::Utc::now())
+            .unwrap();
+        db.append_speaker_embedding(alice, Some("m2"), &[2u8], 1.0, chrono::Utc::now())
+            .unwrap();
+
+        let changed = db
+            .retag_meeting_speaker_labels("m1", alice, None, Some("Carol"), None, true)
+            .unwrap();
+        assert_eq!(changed, 1);
+
+        let carol = db
+            .list_speakers()
+            .unwrap()
+            .into_iter()
+            .find(|speaker| speaker.name == "Carol")
+            .unwrap();
+
+        assert_eq!(db.speaker_embeddings(alice).unwrap(), vec![vec![2u8]]);
+        assert_eq!(db.speaker_embeddings(carol.id).unwrap(), vec![vec![1u8]]);
     }
 
     #[test]

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -185,6 +185,12 @@ impl Database {
                     .map_err(|e| format!("Update schema version v12: {e}"))?;
             }
 
+            if current_version < 13 {
+                schema::migrate_speaker_embeddings_to_v13(&conn)?;
+                conn.execute("UPDATE schema_version SET version = 13", [])
+                    .map_err(|e| format!("Update schema version v13: {e}"))?;
+            }
+
             info!("Schema migration complete");
         }
 

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -4,9 +4,9 @@ use rusqlite::{Connection, params};
 use crate::engine::TranscriptionProfile;
 use crate::transcript::{legacy_recording_session, resolve_legacy_transcription_profile};
 
-/// Schema version 12: `speakers` table for persistent, cross-meeting speaker
-/// identities resolved by offline diarization.
-pub const SCHEMA_VERSION: i64 = 12;
+/// Schema version 13: `speaker_embeddings` table for multi-embedding speaker
+/// matching, replacing the single running-mean centroid on `speakers`.
+pub const SCHEMA_VERSION: i64 = 13;
 
 pub const CREATE_SCHEMA_VERSION: &str = "
     CREATE TABLE IF NOT EXISTS schema_version (
@@ -122,8 +122,10 @@ pub const CREATE_DICTIONARY: &str = "
 ";
 
 /// Persistent, cross-meeting speaker identities resolved by offline
-/// diarization. `centroid` is an opaque BLOB from the DB layer's point of
-/// view: the diarization crate encodes it as 256 little-endian f32s.
+/// diarization. `centroid`/`embedding_count` are kept for schema stability
+/// (the MCP sidecar reads this table independently) but are no longer read
+/// or written by the matcher as of v13: matching uses the multi-embedding
+/// `speaker_embeddings` table instead of a single running-mean centroid.
 pub const CREATE_SPEAKERS: &str = "
     CREATE TABLE IF NOT EXISTS speakers (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -133,6 +135,28 @@ pub const CREATE_SPEAKERS: &str = "
         created_at TEXT NOT NULL,
         last_seen_at TEXT NOT NULL
     );
+";
+
+/// Up to `db::speakers::MAX_EMBEDDINGS_PER_SPEAKER` recent voice embeddings
+/// per persistent speaker, used to match future clusters by MAX cosine
+/// similarity across the bag rather than a single running-mean centroid.
+/// `embedding` is an opaque BLOB from this layer's point of view: the
+/// diarization crate encodes it as little-endian f32s. No FK cascade (the
+/// `PRAGMA foreign_keys` setting is not guaranteed active on every
+/// connection): `delete_speaker` removes matching rows explicitly.
+pub const CREATE_SPEAKER_EMBEDDINGS: &str = "
+    CREATE TABLE IF NOT EXISTS speaker_embeddings (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        speaker_id INTEGER NOT NULL,
+        meeting_id TEXT,
+        embedding BLOB NOT NULL,
+        speech_seconds REAL NOT NULL,
+        created_at TEXT NOT NULL
+    );
+";
+
+pub const CREATE_SPEAKER_EMBEDDINGS_INDEX: &str = "
+    CREATE INDEX IF NOT EXISTS idx_speaker_embeddings_speaker ON speaker_embeddings(speaker_id);
 ";
 
 /// All schema creation statements in order
@@ -429,6 +453,40 @@ pub fn migrate_add_speakers_to_v12(conn: &Connection) -> Result<(), String> {
     Ok(())
 }
 
+/// v13: multi-embedding speaker matching replaces the single running-mean
+/// centroid. Every historical match attempt under the old thresholds
+/// (0.65 similarity floor, 0.03 margin) failed in practice, so `speakers`
+/// rows that no segment ever ended up referencing are purged first: they
+/// are pure duplicate-name clutter, not identities worth carrying forward.
+/// Surviving speakers with a centroid get it seeded as their first
+/// `speaker_embeddings` row, so an existing enrollment isn't lost outright
+/// even though the matcher will accumulate fresher, more representative
+/// embeddings over time.
+pub fn migrate_speaker_embeddings_to_v13(conn: &Connection) -> Result<(), String> {
+    conn.execute(
+        "DELETE FROM speakers WHERE id NOT IN (
+            SELECT DISTINCT CAST(substr(speaker, 5) AS INTEGER)
+            FROM segments WHERE speaker LIKE 'spk:%'
+        )",
+        [],
+    )
+    .map_err(|e| format!("Purge orphaned speakers: {e}"))?;
+
+    conn.execute_batch(CREATE_SPEAKER_EMBEDDINGS)
+        .map_err(|e| format!("Create speaker_embeddings table: {e}"))?;
+    conn.execute_batch(CREATE_SPEAKER_EMBEDDINGS_INDEX)
+        .map_err(|e| format!("Create speaker_embeddings index: {e}"))?;
+
+    conn.execute(
+        "INSERT INTO speaker_embeddings (speaker_id, meeting_id, embedding, speech_seconds, created_at)
+         SELECT id, NULL, centroid, 0.0, last_seen_at FROM speakers WHERE centroid IS NOT NULL",
+        [],
+    )
+    .map_err(|e| format!("Seed speaker_embeddings from centroids: {e}"))?;
+
+    Ok(())
+}
+
 fn parse_datetime(value: &str) -> Result<DateTime<Utc>, String> {
     DateTime::parse_from_rfc3339(value)
         .map(|dt| dt.with_timezone(&Utc))
@@ -512,6 +570,9 @@ mod tests {
         conn.execute_batch(super::CREATE_MEETINGS_V3).unwrap();
         conn.execute_batch(CREATE_SEGMENTS).unwrap();
         conn.execute_batch(CREATE_SEGMENTS_INDEX).unwrap();
+        // A real v9 database has already been through the v7 migration.
+        conn.execute("ALTER TABLE segments ADD COLUMN speaker TEXT", [])
+            .unwrap();
         conn.execute_batch(CREATE_DICTATION_ENTRIES).unwrap();
         conn.execute_batch(CREATE_SETTINGS).unwrap();
         conn.execute_batch(super::CREATE_TEXT_SEARCH).unwrap();
@@ -603,6 +664,9 @@ mod tests {
         conn.execute_batch(super::CREATE_MEETINGS_V3).unwrap();
         conn.execute_batch(CREATE_SEGMENTS).unwrap();
         conn.execute_batch(CREATE_SEGMENTS_INDEX).unwrap();
+        // A real v10 database has already been through the v7 migration.
+        conn.execute("ALTER TABLE segments ADD COLUMN speaker TEXT", [])
+            .unwrap();
         conn.execute_batch(CREATE_DICTATION_ENTRIES).unwrap();
         conn.execute_batch(CREATE_SETTINGS).unwrap();
         conn.execute_batch(super::CREATE_TEXT_SEARCH).unwrap();
@@ -642,6 +706,9 @@ mod tests {
         .unwrap();
         conn.execute_batch(CREATE_SEGMENTS).unwrap();
         conn.execute_batch(CREATE_SEGMENTS_INDEX).unwrap();
+        // A real v11 database has already been through the v7 migration.
+        conn.execute("ALTER TABLE segments ADD COLUMN speaker TEXT", [])
+            .unwrap();
         conn.execute_batch(CREATE_DICTATION_ENTRIES).unwrap();
         conn.execute_batch(CREATE_SETTINGS).unwrap();
         conn.execute_batch(super::CREATE_TEXT_SEARCH).unwrap();
@@ -684,6 +751,114 @@ mod tests {
                 "speakers table should have column {expected}"
             );
         }
+    }
+
+    #[test]
+    fn v12_migrate_to_v13_purges_orphans_and_seeds_embeddings() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        // Minimal v12-era fixture: meetings v3 shape with structured_summary,
+        // segments referencing one of two speakers, and the v12 speakers
+        // table (with a centroid) but no speaker_embeddings table yet.
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(CREATE_SCHEMA_VERSION).unwrap();
+        conn.execute_batch(super::CREATE_MEETINGS_V3).unwrap();
+        conn.execute(
+            "ALTER TABLE meetings ADD COLUMN structured_summary TEXT",
+            [],
+        )
+        .unwrap();
+        conn.execute_batch(CREATE_SEGMENTS).unwrap();
+        conn.execute_batch(CREATE_SEGMENTS_INDEX).unwrap();
+        // A real v12 database has already been through the v7 migration.
+        conn.execute("ALTER TABLE segments ADD COLUMN speaker TEXT", [])
+            .unwrap();
+        conn.execute_batch(CREATE_DICTATION_ENTRIES).unwrap();
+        conn.execute_batch(CREATE_SETTINGS).unwrap();
+        conn.execute_batch(super::CREATE_TEXT_SEARCH).unwrap();
+        conn.execute_batch(super::CREATE_SPEAKERS).unwrap();
+        conn.execute("INSERT INTO schema_version (version) VALUES (12)", [])
+            .unwrap();
+
+        conn.execute(
+            "INSERT INTO meetings (id, title, started_at, ended_at, duration_seconds, transcription_profile, recording_sessions, summary, summary_is_stale, summary_model, summary_generated_at, edited_transcript)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            params![
+                "m1",
+                "Meeting",
+                "2026-03-01T10:00:00Z",
+                "2026-03-01T10:10:00Z",
+                600.0,
+                r#"{"engine_id":"parakeet","engine_label":"Parakeet","model_id":"parakeet-tdt-0.6b-v2","model_label":"Parakeet TDT 0.6B v2","backend_id":"ort","backend_label":"ONNX Runtime"}"#,
+                "[]",
+                None::<String>,
+                0,
+                None::<String>,
+                None::<String>,
+                None::<String>,
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO segments (meeting_id, text, start_time, end_time, is_final, language, confidence, sort_order, speaker)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params!["m1", "Hello", 0.0, 1.0, 1, Some("en"), None::<f32>, 0, "spk:1"],
+        )
+        .unwrap();
+
+        let now = "2026-03-01T10:00:00Z";
+        // Speaker 1 is referenced by a segment and has a centroid: it must
+        // survive and get that centroid seeded as an embedding.
+        conn.execute(
+            "INSERT INTO speakers (id, name, centroid, embedding_count, created_at, last_seen_at) VALUES (1, 'Alice', ?1, 3, ?2, ?2)",
+            params![vec![0u8; 1024], now],
+        )
+        .unwrap();
+        // Speaker 2 has no segment referencing it: orphaned, must be purged.
+        conn.execute(
+            "INSERT INTO speakers (id, name, centroid, embedding_count, created_at, last_seen_at) VALUES (2, 'Orphan', NULL, 0, ?1, ?1)",
+            params![now],
+        )
+        .unwrap();
+        drop(conn);
+
+        let db = Database::open(&db_path).unwrap();
+        let conn = db.conn.lock().unwrap();
+
+        let speaker_ids: Vec<i64> = {
+            let mut stmt = conn.prepare("SELECT id FROM speakers ORDER BY id").unwrap();
+            stmt.query_map([], |row| row.get(0))
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+        };
+        assert_eq!(
+            speaker_ids,
+            vec![1],
+            "orphaned speaker 2 must be purged, referenced speaker 1 kept"
+        );
+
+        let table_exists: bool = conn
+            .query_row(
+                "SELECT COUNT(*) > 0 FROM sqlite_master WHERE type='table' AND name='speaker_embeddings'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert!(table_exists, "v13 migration should create speaker_embeddings");
+
+        let seeded_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM speaker_embeddings WHERE speaker_id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            seeded_count, 1,
+            "surviving speaker with a centroid should get one seeded embedding"
+        );
     }
 
     #[test]

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -126,6 +126,8 @@ pub const CREATE_DICTIONARY: &str = "
 /// (the MCP sidecar reads this table independently) but are no longer read
 /// or written by the matcher as of v13: matching uses the multi-embedding
 /// `speaker_embeddings` table instead of a single running-mean centroid.
+/// `is_me` flags the speaker who is the app's user; at most one row has it
+/// set (enforced by `Database::set_speaker_is_me`, not by the schema).
 pub const CREATE_SPEAKERS: &str = "
     CREATE TABLE IF NOT EXISTS speakers (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -133,7 +135,8 @@ pub const CREATE_SPEAKERS: &str = "
         centroid BLOB,
         embedding_count INTEGER NOT NULL DEFAULT 0,
         created_at TEXT NOT NULL,
-        last_seen_at TEXT NOT NULL
+        last_seen_at TEXT NOT NULL,
+        is_me INTEGER NOT NULL DEFAULT 0
     );
 ";
 
@@ -461,7 +464,10 @@ pub fn migrate_add_speakers_to_v12(conn: &Connection) -> Result<(), String> {
 /// Surviving speakers with a centroid get it seeded as their first
 /// `speaker_embeddings` row, so an existing enrollment isn't lost outright
 /// even though the matcher will accumulate fresher, more representative
-/// embeddings over time.
+/// embeddings over time. Also adds `speakers.is_me`, guarded by a column
+/// check: a database that just went through the v12 step above already has
+/// it (`CREATE_SPEAKERS` includes it), so the `ALTER TABLE` only fires for
+/// databases that were already at v12 before this column existed.
 pub fn migrate_speaker_embeddings_to_v13(conn: &Connection) -> Result<(), String> {
     conn.execute(
         "DELETE FROM speakers WHERE id NOT IN (
@@ -471,6 +477,11 @@ pub fn migrate_speaker_embeddings_to_v13(conn: &Connection) -> Result<(), String
         [],
     )
     .map_err(|e| format!("Purge orphaned speakers: {e}"))?;
+
+    if !speakers_has_is_me_column(conn)? {
+        conn.execute("ALTER TABLE speakers ADD COLUMN is_me INTEGER NOT NULL DEFAULT 0", [])
+            .map_err(|e| format!("Add is_me column: {e}"))?;
+    }
 
     conn.execute_batch(CREATE_SPEAKER_EMBEDDINGS)
         .map_err(|e| format!("Create speaker_embeddings table: {e}"))?;
@@ -485,6 +496,20 @@ pub fn migrate_speaker_embeddings_to_v13(conn: &Connection) -> Result<(), String
     .map_err(|e| format!("Seed speaker_embeddings from centroids: {e}"))?;
 
     Ok(())
+}
+
+fn speakers_has_is_me_column(conn: &Connection) -> Result<bool, String> {
+    let mut stmt = conn
+        .prepare("PRAGMA table_info(speakers)")
+        .map_err(|e| format!("Prepare speakers table_info: {e}"))?;
+    let has_column = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|e| format!("Query speakers table_info: {e}"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("Collect speakers table_info: {e}"))?
+        .iter()
+        .any(|name| name == "is_me");
+    Ok(has_column)
 }
 
 fn parse_datetime(value: &str) -> Result<DateTime<Utc>, String> {
@@ -859,6 +884,102 @@ mod tests {
             seeded_count, 1,
             "surviving speaker with a centroid should get one seeded embedding"
         );
+
+        let is_me: i64 = conn
+            .query_row("SELECT is_me FROM speakers WHERE id = 1", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(is_me, 0, "is_me should default to 0");
+    }
+
+    #[test]
+    fn v12_speakers_without_is_me_column_migrate_to_v13_add_it() {
+        let dir = TempDir::new().unwrap();
+        let db_path = dir.path().join("test.db");
+
+        // A real v12 database predating this column: the speakers table has
+        // the pre-v13 shape (no is_me), unlike super::CREATE_SPEAKERS which
+        // already includes it.
+        let conn = Connection::open(&db_path).unwrap();
+        conn.execute_batch(CREATE_SCHEMA_VERSION).unwrap();
+        conn.execute_batch(super::CREATE_MEETINGS_V3).unwrap();
+        conn.execute(
+            "ALTER TABLE meetings ADD COLUMN structured_summary TEXT",
+            [],
+        )
+        .unwrap();
+        conn.execute_batch(CREATE_SEGMENTS).unwrap();
+        conn.execute_batch(CREATE_SEGMENTS_INDEX).unwrap();
+        conn.execute("ALTER TABLE segments ADD COLUMN speaker TEXT", [])
+            .unwrap();
+        conn.execute_batch(CREATE_DICTATION_ENTRIES).unwrap();
+        conn.execute_batch(CREATE_SETTINGS).unwrap();
+        conn.execute_batch(super::CREATE_TEXT_SEARCH).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS speakers (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                centroid BLOB,
+                embedding_count INTEGER NOT NULL DEFAULT 0,
+                created_at TEXT NOT NULL,
+                last_seen_at TEXT NOT NULL
+            );",
+        )
+        .unwrap();
+        conn.execute("INSERT INTO schema_version (version) VALUES (12)", [])
+            .unwrap();
+
+        let now = "2026-03-01T10:00:00Z";
+        conn.execute(
+            "INSERT INTO speakers (id, name, centroid, embedding_count, created_at, last_seen_at) VALUES (1, 'Alice', NULL, 0, ?1, ?1)",
+            params![now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO meetings (id, title, started_at, ended_at, duration_seconds, transcription_profile, recording_sessions, summary, summary_is_stale, summary_model, summary_generated_at, edited_transcript)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            params![
+                "m1",
+                "Meeting",
+                now,
+                now,
+                600.0,
+                r#"{"engine_id":"parakeet","engine_label":"Parakeet","model_id":"parakeet-tdt-0.6b-v2","model_label":"Parakeet TDT 0.6B v2","backend_id":"ort","backend_label":"ONNX Runtime"}"#,
+                "[]",
+                None::<String>,
+                0,
+                None::<String>,
+                None::<String>,
+                None::<String>,
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO segments (meeting_id, text, start_time, end_time, is_final, language, confidence, sort_order, speaker)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params!["m1", "Hello", 0.0, 1.0, 1, Some("en"), None::<f32>, 0, "spk:1"],
+        )
+        .unwrap();
+        drop(conn);
+
+        let db = Database::open(&db_path).unwrap();
+        let conn = db.conn.lock().unwrap();
+
+        let columns: Vec<String> = {
+            let mut stmt = conn.prepare("PRAGMA table_info(speakers)").unwrap();
+            stmt.query_map([], |row| row.get(1))
+                .unwrap()
+                .collect::<Result<Vec<_>, _>>()
+                .unwrap()
+        };
+        assert!(
+            columns.iter().any(|column| column == "is_me"),
+            "v13 migration should add is_me to a v12 speakers table missing it"
+        );
+
+        let is_me: i64 = conn
+            .query_row("SELECT is_me FROM speakers WHERE id = 1", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(is_me, 0, "is_me should default to 0 for existing rows");
     }
 
     #[test]

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -122,12 +122,15 @@ pub const CREATE_DICTIONARY: &str = "
 ";
 
 /// Persistent, cross-meeting speaker identities resolved by offline
-/// diarization. `centroid`/`embedding_count` are kept for schema stability
-/// (the MCP sidecar reads this table independently) but are no longer read
-/// or written by the matcher as of v13: matching uses the multi-embedding
-/// `speaker_embeddings` table instead of a single running-mean centroid.
-/// `is_me` flags the speaker who is the app's user; at most one row has it
-/// set (enforced by `Database::set_speaker_is_me`, not by the schema).
+/// diarization. `centroid`/`embedding_count` are no longer populated by
+/// `create_speaker` or read by the matcher as of v13 (matching uses the
+/// multi-embedding `speaker_embeddings` table instead of a single
+/// running-mean centroid), and `db::speakers::SpeakerRecord` doesn't expose
+/// them either. The columns stay in the schema anyway, purely to avoid an
+/// ALTER-driven table rebuild: the MCP sidecar (`souffle-mcp`) only reads
+/// `name` from this table, so it is not a reason to keep them. `is_me` flags
+/// the speaker who is the app's user; at most one row has it set (enforced
+/// by `Database::set_speaker_is_me`, not by the schema).
 pub const CREATE_SPEAKERS: &str = "
     CREATE TABLE IF NOT EXISTS speakers (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -160,6 +163,17 @@ pub const CREATE_SPEAKER_EMBEDDINGS: &str = "
 
 pub const CREATE_SPEAKER_EMBEDDINGS_INDEX: &str = "
     CREATE INDEX IF NOT EXISTS idx_speaker_embeddings_speaker ON speaker_embeddings(speaker_id);
+";
+
+/// Enforces at most one speaker flagged `is_me` at a time at the schema
+/// level, not just by application code (`Database::set_speaker_is_me`
+/// already maintains it transactionally, and `Database::merge_speakers`
+/// orders its statements to avoid a transient double-`is_me` mid-merge, but
+/// the invariant is cheap enough to also guarantee here). A partial index
+/// (`WHERE is_me = 1`) only constrains rows where the flag is set, so any
+/// number of `is_me = 0` rows coexist freely.
+pub const CREATE_SPEAKERS_IS_ME_INDEX: &str = "
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_speakers_is_me ON speakers(is_me) WHERE is_me = 1;
 ";
 
 /// All schema creation statements in order
@@ -467,7 +481,10 @@ pub fn migrate_add_speakers_to_v12(conn: &Connection) -> Result<(), String> {
 /// embeddings over time. Also adds `speakers.is_me`, guarded by a column
 /// check: a database that just went through the v12 step above already has
 /// it (`CREATE_SPEAKERS` includes it), so the `ALTER TABLE` only fires for
-/// databases that were already at v12 before this column existed.
+/// databases that were already at v12 before this column existed. Finally
+/// creates `CREATE_SPEAKERS_IS_ME_INDEX`: this is also where a fresh
+/// database picks it up, since `ensure_schema` runs every versioned step in
+/// order starting from 0 rather than jumping straight to the latest schema.
 pub fn migrate_speaker_embeddings_to_v13(conn: &Connection) -> Result<(), String> {
     conn.execute(
         "DELETE FROM speakers WHERE id NOT IN (
@@ -487,6 +504,8 @@ pub fn migrate_speaker_embeddings_to_v13(conn: &Connection) -> Result<(), String
         .map_err(|e| format!("Create speaker_embeddings table: {e}"))?;
     conn.execute_batch(CREATE_SPEAKER_EMBEDDINGS_INDEX)
         .map_err(|e| format!("Create speaker_embeddings index: {e}"))?;
+    conn.execute_batch(CREATE_SPEAKERS_IS_ME_INDEX)
+        .map_err(|e| format!("Create speakers is_me unique index: {e}"))?;
 
     conn.execute(
         "INSERT INTO speaker_embeddings (speaker_id, meeting_id, embedding, speech_seconds, created_at)

--- a/src-tauri/src/db/speakers.rs
+++ b/src-tauri/src/db/speakers.rs
@@ -27,10 +27,28 @@ pub struct SpeakerUsage {
     pub meeting_count: i64,
 }
 
+/// A stored speaker together with its recent voice embeddings (raw BLOBs,
+/// undecoded), for the offline diarization matcher.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpeakerWithEmbeddings {
+    pub speaker: SpeakerRecord,
+    pub embeddings: Vec<Vec<u8>>,
+}
+
+/// How many recent embeddings `append_speaker_embedding` keeps per speaker.
+/// A bag of embeddings (matched by MAX cosine similarity) tolerates
+/// variation across sessions, mics, and vocal tone far better than a single
+/// running-mean centroid, but an unbounded bag would grow forever and slow
+/// matching down; 20 is enough recent samples to cover that variation
+/// without a meaningful cost per match.
+pub const MAX_EMBEDDINGS_PER_SPEAKER: usize = 20;
+
 impl Database {
     /// Create a new persistent speaker with the given display name. Returns
-    /// the new row's id. `centroid`/`embedding_count` start empty; call
-    /// `update_speaker_centroid` once diarization has a centroid for it.
+    /// the new row's id. `centroid`/`embedding_count` are unused legacy
+    /// columns (kept for schema stability, see `schema::CREATE_SPEAKERS`)
+    /// and stay at their empty defaults; call `append_speaker_embedding`
+    /// once diarization has an embedding for it.
     pub fn create_speaker(&self, name: &str) -> Result<i64, String> {
         let conn = self.conn.acquire()?;
         let now = Utc::now().to_rfc3339();
@@ -100,22 +118,95 @@ impl Database {
         Ok(())
     }
 
-    /// Overwrite a speaker's centroid, embedding count, and `last_seen_at`
-    /// (typically after re-clustering embeddings into a fresh centroid).
-    pub fn update_speaker_centroid(
+    /// Record one new voice embedding for a speaker (from a matched or
+    /// freshly enrolled diarization cluster), touch its `last_seen_at`, and
+    /// prune down to `MAX_EMBEDDINGS_PER_SPEAKER` by dropping the oldest
+    /// rows (by `created_at`, then `id` to break ties deterministically).
+    /// One transaction, so a crash mid-append never leaves the speaker with
+    /// more than the cap or a stale `last_seen_at`.
+    pub fn append_speaker_embedding(
         &self,
-        id: i64,
-        centroid: &[u8],
-        embedding_count: i64,
-        last_seen_at: DateTime<Utc>,
+        speaker_id: i64,
+        meeting_id: Option<&str>,
+        embedding: &[u8],
+        speech_seconds: f64,
+        now: DateTime<Utc>,
     ) -> Result<(), String> {
-        let conn = self.conn.acquire()?;
-        conn.execute(
-            "UPDATE speakers SET centroid = ?1, embedding_count = ?2, last_seen_at = ?3 WHERE id = ?4",
-            params![centroid, embedding_count, last_seen_at.to_rfc3339(), id],
+        let now = now.to_rfc3339();
+        let mut conn = self.conn.acquire()?;
+        let tx = conn
+            .transaction()
+            .map_err(|e| format!("Transaction: {e}"))?;
+
+        tx.execute(
+            "INSERT INTO speaker_embeddings (speaker_id, meeting_id, embedding, speech_seconds, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![speaker_id, meeting_id, embedding, speech_seconds, now],
         )
-        .map_err(|e| format!("Update speaker centroid: {e}"))?;
+        .map_err(|e| format!("Insert speaker embedding: {e}"))?;
+
+        tx.execute(
+            "DELETE FROM speaker_embeddings WHERE speaker_id = ?1 AND id NOT IN (
+                SELECT id FROM speaker_embeddings WHERE speaker_id = ?1
+                ORDER BY created_at DESC, id DESC LIMIT ?2
+             )",
+            params![speaker_id, MAX_EMBEDDINGS_PER_SPEAKER as i64],
+        )
+        .map_err(|e| format!("Prune speaker embeddings: {e}"))?;
+
+        tx.execute(
+            "UPDATE speakers SET last_seen_at = ?1 WHERE id = ?2",
+            params![now, speaker_id],
+        )
+        .map_err(|e| format!("Update speaker last_seen_at: {e}"))?;
+
+        tx.commit().map_err(|e| format!("Commit: {e}"))?;
         Ok(())
+    }
+
+    /// Raw embedding BLOBs for one speaker, oldest first. Callers decode
+    /// with `diarize::persist::decode_embedding`.
+    pub fn speaker_embeddings(&self, speaker_id: i64) -> Result<Vec<Vec<u8>>, String> {
+        let conn = self.conn.acquire()?;
+        let mut stmt = conn
+            .prepare("SELECT embedding FROM speaker_embeddings WHERE speaker_id = ?1 ORDER BY id")
+            .map_err(|e| format!("Prepare speaker embeddings: {e}"))?;
+        stmt.query_map(params![speaker_id], |row| row.get::<_, Vec<u8>>(0))
+            .map_err(|e| format!("Query speaker embeddings: {e}"))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| format!("Collect speaker embeddings: {e}"))
+    }
+
+    /// Every persistent speaker with its embedding BLOBs, for the offline
+    /// diarization matcher. One query for all embeddings (grouped in Rust)
+    /// rather than N+1 per-speaker queries.
+    pub fn list_speakers_with_embeddings(&self) -> Result<Vec<SpeakerWithEmbeddings>, String> {
+        let speakers = self.list_speakers()?;
+
+        let mut by_speaker: std::collections::HashMap<i64, Vec<Vec<u8>>> =
+            std::collections::HashMap::new();
+        {
+            let conn = self.conn.acquire()?;
+            let mut stmt = conn
+                .prepare("SELECT speaker_id, embedding FROM speaker_embeddings ORDER BY speaker_id, id")
+                .map_err(|e| format!("Prepare list embeddings: {e}"))?;
+            let rows = stmt
+                .query_map([], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, Vec<u8>>(1)?)))
+                .map_err(|e| format!("Query list embeddings: {e}"))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| format!("Collect list embeddings: {e}"))?;
+            for (speaker_id, embedding) in rows {
+                by_speaker.entry(speaker_id).or_default().push(embedding);
+            }
+        }
+
+        Ok(speakers
+            .into_iter()
+            .map(|speaker| {
+                let embeddings = by_speaker.remove(&speaker.id).unwrap_or_default();
+                SpeakerWithEmbeddings { speaker, embeddings }
+            })
+            .collect())
     }
 
     /// Usage counts for every persistent speaker, keyed by speaker id.
@@ -146,10 +237,12 @@ impl Database {
         Ok(rows.into_iter().collect())
     }
 
-    /// Delete a persistent speaker and unlabel every segment that referenced
-    /// it (their speaker returns to NULL, so the lines render as plain
-    /// unattributed text). One transaction, so a failure never leaves
-    /// segments pointing at a missing speaker row.
+    /// Delete a persistent speaker, its recorded embeddings, and unlabel
+    /// every segment that referenced it (their speaker returns to NULL, so
+    /// the lines render as plain unattributed text). One transaction, so a
+    /// failure never leaves segments pointing at a missing speaker row or
+    /// orphaned `speaker_embeddings` rows behind (no FK cascade covers this;
+    /// see `schema::CREATE_SPEAKER_EMBEDDINGS`).
     pub fn delete_speaker(&self, id: i64) -> Result<(), String> {
         let label = crate::engine::Speaker::Persistent(id).as_str();
         let mut conn = self.conn.acquire()?;
@@ -161,6 +254,11 @@ impl Database {
             params![label],
         )
         .map_err(|e| format!("Unlabel speaker segments: {e}"))?;
+        tx.execute(
+            "DELETE FROM speaker_embeddings WHERE speaker_id = ?1",
+            params![id],
+        )
+        .map_err(|e| format!("Delete speaker embeddings: {e}"))?;
         let deleted = tx
             .execute("DELETE FROM speakers WHERE id = ?1", params![id])
             .map_err(|e| format!("Delete speaker: {e}"))?;
@@ -250,6 +348,8 @@ fn parse_datetime(value: &str) -> Result<DateTime<Utc>, String> {
 
 #[cfg(test)]
 mod tests {
+    use rusqlite::params;
+
     use crate::engine::Speaker;
     use crate::test_helpers::fixtures::{sample_meeting, test_db};
 
@@ -306,20 +406,84 @@ mod tests {
     }
 
     #[test]
-    fn update_speaker_centroid_overwrites_fields() {
+    fn append_speaker_embedding_round_trips_and_touches_last_seen_at() {
         let (db, _dir) = test_db();
         let id = db.create_speaker("Alice").unwrap();
-        let centroid = vec![0u8; 1024]; // 256 f32s
+        let embedding = vec![0u8; 1024]; // 256 f32s
         let now = chrono::Utc::now();
 
-        db.update_speaker_centroid(id, &centroid, 5, now).unwrap();
+        db.append_speaker_embedding(id, Some("m1"), &embedding, 6.5, now)
+            .unwrap();
+
+        let stored = db.speaker_embeddings(id).unwrap();
+        assert_eq!(stored, vec![embedding]);
 
         let record = db.get_speaker(id).unwrap().unwrap();
-        assert_eq!(record.centroid, Some(centroid));
-        assert_eq!(record.embedding_count, 5);
         // Sub-second precision may be lost in the RFC3339 round trip; compare
         // at second resolution.
         assert_eq!(record.last_seen_at.timestamp(), now.timestamp());
+    }
+
+    #[test]
+    fn append_speaker_embedding_caps_at_max_dropping_oldest() {
+        let (db, _dir) = test_db();
+        let id = db.create_speaker("Alice").unwrap();
+        let base = chrono::Utc::now();
+
+        // One more than the cap; each embedding is a distinguishable single
+        // byte so we can tell which ones survived.
+        for i in 0..(super::MAX_EMBEDDINGS_PER_SPEAKER + 1) {
+            let embedding = vec![i as u8];
+            let now = base + chrono::Duration::seconds(i as i64);
+            db.append_speaker_embedding(id, None, &embedding, 1.0, now)
+                .unwrap();
+        }
+
+        let stored = db.speaker_embeddings(id).unwrap();
+        assert_eq!(stored.len(), super::MAX_EMBEDDINGS_PER_SPEAKER);
+        // The oldest (embedding 0) must have been pruned; the newest
+        // (embedding MAX_EMBEDDINGS_PER_SPEAKER) must remain.
+        assert!(!stored.contains(&vec![0u8]));
+        assert!(stored.contains(&vec![super::MAX_EMBEDDINGS_PER_SPEAKER as u8]));
+    }
+
+    #[test]
+    fn list_speakers_with_embeddings_groups_by_speaker() {
+        let (db, _dir) = test_db();
+        let alice = db.create_speaker("Alice").unwrap();
+        let bob = db.create_speaker("Bob").unwrap();
+        let now = chrono::Utc::now();
+
+        db.append_speaker_embedding(alice, None, &[1u8], 1.0, now)
+            .unwrap();
+        db.append_speaker_embedding(alice, None, &[2u8], 1.0, now)
+            .unwrap();
+
+        let all = db.list_speakers_with_embeddings().unwrap();
+        let alice_entry = all.iter().find(|s| s.speaker.id == alice).unwrap();
+        let bob_entry = all.iter().find(|s| s.speaker.id == bob).unwrap();
+        assert_eq!(alice_entry.embeddings, vec![vec![1u8], vec![2u8]]);
+        assert!(bob_entry.embeddings.is_empty());
+    }
+
+    #[test]
+    fn delete_speaker_removes_its_embeddings() {
+        let (db, _dir) = test_db();
+        let id = db.create_speaker("Alice").unwrap();
+        db.append_speaker_embedding(id, None, &[1u8], 1.0, chrono::Utc::now())
+            .unwrap();
+
+        db.delete_speaker(id).unwrap();
+
+        let conn = db.conn.lock().unwrap();
+        let remaining: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM speaker_embeddings WHERE speaker_id = ?1",
+                params![id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(remaining, 0, "deleting a speaker must remove its embedding rows");
     }
 
     #[test]

--- a/src-tauri/src/db/speakers.rs
+++ b/src-tauri/src/db/speakers.rs
@@ -17,6 +17,9 @@ pub struct SpeakerRecord {
     pub embedding_count: i64,
     pub created_at: DateTime<Utc>,
     pub last_seen_at: DateTime<Utc>,
+    /// Whether this speaker is flagged as the app's user. At most one
+    /// speaker has this set; see `Database::set_speaker_is_me`.
+    pub is_me: bool,
 }
 
 /// How many transcript segments and distinct meetings reference a speaker,
@@ -65,19 +68,9 @@ impl Database {
     /// was deleted after a meeting's segments referenced it).
     pub fn get_speaker(&self, id: i64) -> Result<Option<SpeakerRecord>, String> {
         let conn = self.conn.acquire()?;
-        let row = conn
-            .query_row(
-                "SELECT id, name, centroid, embedding_count, created_at, last_seen_at
-                 FROM speakers WHERE id = ?1",
-                params![id],
-                map_speaker_row,
-            )
-            .map(Some)
-            .or_else(|e| match e {
-                rusqlite::Error::QueryReturnedNoRows => Ok(None),
-                other => Err(format!("Query speaker: {other}")),
-            })?;
-        row.map(SpeakerRow::into_record).transpose()
+        fetch_speaker_row(&conn, id)?
+            .map(SpeakerRow::into_record)
+            .transpose()
     }
 
     /// All persistent speakers, ordered by id.
@@ -85,7 +78,7 @@ impl Database {
         let conn = self.conn.acquire()?;
         let mut stmt = conn
             .prepare(
-                "SELECT id, name, centroid, embedding_count, created_at, last_seen_at
+                "SELECT id, name, centroid, embedding_count, created_at, last_seen_at, is_me
                  FROM speakers ORDER BY id",
             )
             .map_err(|e| format!("Prepare list speakers: {e}"))?;
@@ -145,14 +138,7 @@ impl Database {
         )
         .map_err(|e| format!("Insert speaker embedding: {e}"))?;
 
-        tx.execute(
-            "DELETE FROM speaker_embeddings WHERE speaker_id = ?1 AND id NOT IN (
-                SELECT id FROM speaker_embeddings WHERE speaker_id = ?1
-                ORDER BY created_at DESC, id DESC LIMIT ?2
-             )",
-            params![speaker_id, MAX_EMBEDDINGS_PER_SPEAKER as i64],
-        )
-        .map_err(|e| format!("Prune speaker embeddings: {e}"))?;
+        prune_speaker_embeddings(&tx, speaker_id)?;
 
         tx.execute(
             "UPDATE speakers SET last_seen_at = ?1 WHERE id = ?2",
@@ -269,6 +255,87 @@ impl Database {
         Ok(())
     }
 
+    /// Flag (or unflag) a persistent speaker as the app's user. At most one
+    /// speaker can be `is_me` at a time, so setting it first clears the flag
+    /// everywhere else. One transaction, so a crash mid-update never leaves
+    /// two speakers flagged.
+    pub fn set_speaker_is_me(&self, id: i64, is_me: bool) -> Result<(), String> {
+        let mut conn = self.conn.acquire()?;
+        let tx = conn
+            .transaction()
+            .map_err(|e| format!("Transaction: {e}"))?;
+
+        if is_me {
+            tx.execute("UPDATE speakers SET is_me = 0", [])
+                .map_err(|e| format!("Clear is_me flag: {e}"))?;
+        }
+        let changed = tx
+            .execute(
+                "UPDATE speakers SET is_me = ?1 WHERE id = ?2",
+                params![i32::from(is_me), id],
+            )
+            .map_err(|e| format!("Set is_me: {e}"))?;
+        if changed == 0 {
+            return Err(format!("Speaker not found: {id}"));
+        }
+
+        tx.commit().map_err(|e| format!("Commit: {e}"))?;
+        Ok(())
+    }
+
+    /// Merge `source_id` into `target_id`: every segment and voice embedding
+    /// referencing the source now points to the target, which keeps its own
+    /// id, name, and `is_me` flag (except that it inherits `is_me` from the
+    /// source if the source had it and the target didn't). The source row is
+    /// deleted. Used to fix the diarizer creating two speakers for the same
+    /// person. One transaction; errors if the two ids are equal or either
+    /// speaker doesn't exist.
+    pub fn merge_speakers(&self, source_id: i64, target_id: i64) -> Result<(), String> {
+        if source_id == target_id {
+            return Err("Cannot merge a speaker into itself".into());
+        }
+        let mut conn = self.conn.acquire()?;
+        let tx = conn
+            .transaction()
+            .map_err(|e| format!("Transaction: {e}"))?;
+
+        let source = fetch_speaker_row(&tx, source_id)?
+            .ok_or_else(|| format!("Speaker not found: {source_id}"))?
+            .into_record()?;
+        let target = fetch_speaker_row(&tx, target_id)?
+            .ok_or_else(|| format!("Speaker not found: {target_id}"))?
+            .into_record()?;
+
+        let source_label = crate::engine::Speaker::Persistent(source_id).as_str();
+        let target_label = crate::engine::Speaker::Persistent(target_id).as_str();
+        tx.execute(
+            "UPDATE segments SET speaker = ?1 WHERE speaker = ?2",
+            params![target_label, source_label],
+        )
+        .map_err(|e| format!("Reassign merged speaker segments: {e}"))?;
+
+        tx.execute(
+            "UPDATE speaker_embeddings SET speaker_id = ?1 WHERE speaker_id = ?2",
+            params![target_id, source_id],
+        )
+        .map_err(|e| format!("Move merged speaker embeddings: {e}"))?;
+        prune_speaker_embeddings(&tx, target_id)?;
+
+        let is_me = source.is_me || target.is_me;
+        let last_seen_at = source.last_seen_at.max(target.last_seen_at);
+        tx.execute(
+            "UPDATE speakers SET is_me = ?1, last_seen_at = ?2 WHERE id = ?3",
+            params![i32::from(is_me), last_seen_at.to_rfc3339(), target_id],
+        )
+        .map_err(|e| format!("Update merged speaker: {e}"))?;
+
+        tx.execute("DELETE FROM speakers WHERE id = ?1", params![source_id])
+            .map_err(|e| format!("Delete merged speaker: {e}"))?;
+
+        tx.commit().map_err(|e| format!("Commit: {e}"))?;
+        Ok(())
+    }
+
     /// Persistent speakers referenced by any segment of `meeting_id`
     /// (`speaker` column values of the form `spk:<id>`), ordered by id. A
     /// referenced id that no longer has a `speakers` row (deleted) is
@@ -314,6 +381,7 @@ struct SpeakerRow {
     embedding_count: i64,
     created_at: String,
     last_seen_at: String,
+    is_me: bool,
 }
 
 impl SpeakerRow {
@@ -325,6 +393,7 @@ impl SpeakerRow {
             embedding_count: self.embedding_count,
             created_at: parse_datetime(&self.created_at)?,
             last_seen_at: parse_datetime(&self.last_seen_at)?,
+            is_me: self.is_me,
         })
     }
 }
@@ -337,7 +406,47 @@ fn map_speaker_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SpeakerRow> {
         embedding_count: row.get(3)?,
         created_at: row.get(4)?,
         last_seen_at: row.get(5)?,
+        is_me: row.get::<_, i64>(6)? != 0,
     })
+}
+
+/// Look up one raw speaker row by id against any connection-like handle
+/// (a plain connection or an open transaction), so callers already inside a
+/// transaction don't need a second `Mutex` lock to read a speaker.
+fn fetch_speaker_row(
+    conn: &rusqlite::Connection,
+    id: i64,
+) -> Result<Option<SpeakerRow>, String> {
+    conn.query_row(
+        "SELECT id, name, centroid, embedding_count, created_at, last_seen_at, is_me
+         FROM speakers WHERE id = ?1",
+        params![id],
+        map_speaker_row,
+    )
+    .map(Some)
+    .or_else(|e| match e {
+        rusqlite::Error::QueryReturnedNoRows => Ok(None),
+        other => Err(format!("Query speaker: {other}")),
+    })
+}
+
+/// Keep only the newest `MAX_EMBEDDINGS_PER_SPEAKER` embedding rows for a
+/// speaker (by `created_at`, then `id` to break ties), dropping the rest.
+/// `pub(super)` so `meetings::retag_meeting_speaker_labels` can reuse it
+/// when moving embeddings onto a retag target.
+pub(super) fn prune_speaker_embeddings(
+    tx: &rusqlite::Transaction<'_>,
+    speaker_id: i64,
+) -> Result<(), String> {
+    tx.execute(
+        "DELETE FROM speaker_embeddings WHERE speaker_id = ?1 AND id NOT IN (
+            SELECT id FROM speaker_embeddings WHERE speaker_id = ?1
+            ORDER BY created_at DESC, id DESC LIMIT ?2
+         )",
+        params![speaker_id, MAX_EMBEDDINGS_PER_SPEAKER as i64],
+    )
+    .map_err(|e| format!("Prune speaker embeddings: {e}"))?;
+    Ok(())
 }
 
 fn parse_datetime(value: &str) -> Result<DateTime<Utc>, String> {
@@ -363,6 +472,7 @@ mod tests {
         assert_eq!(record.embedding_count, 0);
         assert!(record.centroid.is_none());
         assert_eq!(record.created_at, record.last_seen_at);
+        assert!(!record.is_me);
     }
 
     #[test]
@@ -585,5 +695,136 @@ mod tests {
     fn delete_speaker_missing_id_errors() {
         let (db, _dir) = test_db();
         assert!(db.delete_speaker(999).is_err());
+    }
+
+    #[test]
+    fn set_speaker_is_me_flags_exactly_one_speaker() {
+        let (db, _dir) = test_db();
+        let alice = db.create_speaker("Alice").unwrap();
+        let bob = db.create_speaker("Bob").unwrap();
+
+        db.set_speaker_is_me(alice, true).unwrap();
+        assert!(db.get_speaker(alice).unwrap().unwrap().is_me);
+        assert!(!db.get_speaker(bob).unwrap().unwrap().is_me);
+
+        db.set_speaker_is_me(bob, true).unwrap();
+        assert!(
+            !db.get_speaker(alice).unwrap().unwrap().is_me,
+            "flagging bob should clear alice's flag"
+        );
+        assert!(db.get_speaker(bob).unwrap().unwrap().is_me);
+
+        db.set_speaker_is_me(bob, false).unwrap();
+        assert!(!db.get_speaker(bob).unwrap().unwrap().is_me);
+    }
+
+    #[test]
+    fn set_speaker_is_me_missing_id_errors() {
+        let (db, _dir) = test_db();
+        assert!(db.set_speaker_is_me(999, true).is_err());
+    }
+
+    #[test]
+    fn merge_speakers_rejects_same_id() {
+        let (db, _dir) = test_db();
+        let alice = db.create_speaker("Alice").unwrap();
+        assert!(db.merge_speakers(alice, alice).is_err());
+    }
+
+    #[test]
+    fn merge_speakers_missing_id_errors() {
+        let (db, _dir) = test_db();
+        let alice = db.create_speaker("Alice").unwrap();
+        assert!(db.merge_speakers(999, alice).is_err());
+        assert!(db.merge_speakers(alice, 999).is_err());
+    }
+
+    #[test]
+    fn merge_speakers_relabels_segments_across_meetings_and_removes_source() {
+        let (db, _dir) = test_db();
+        let alice = db.create_speaker("Alice").unwrap();
+        let bob = db.create_speaker("Bob").unwrap();
+
+        let mut m1 = sample_meeting("m1");
+        m1.segments[0].speaker = Some(Speaker::Persistent(alice));
+        m1.segments[1].speaker = Some(Speaker::Persistent(bob));
+        db.save_meeting(&m1).unwrap();
+        let mut m2 = sample_meeting("m2");
+        m2.segments[0].speaker = Some(Speaker::Persistent(alice));
+        db.save_meeting(&m2).unwrap();
+
+        db.merge_speakers(alice, bob).unwrap();
+
+        assert!(db.get_speaker(alice).unwrap().is_none());
+        let loaded1 = db.load_meeting("m1").unwrap();
+        assert_eq!(loaded1.segments[0].speaker, Some(Speaker::Persistent(bob)));
+        assert_eq!(loaded1.segments[1].speaker, Some(Speaker::Persistent(bob)));
+        let loaded2 = db.load_meeting("m2").unwrap();
+        assert_eq!(loaded2.segments[0].speaker, Some(Speaker::Persistent(bob)));
+    }
+
+    #[test]
+    fn merge_speakers_moves_and_prunes_embeddings() {
+        let (db, _dir) = test_db();
+        let alice = db.create_speaker("Alice").unwrap();
+        let bob = db.create_speaker("Bob").unwrap();
+        let base = chrono::Utc::now();
+
+        // Bob already has 15 embeddings, Alice has 10; merging must keep only
+        // the newest MAX_EMBEDDINGS_PER_SPEAKER across the combined bag.
+        for i in 0..15u8 {
+            db.append_speaker_embedding(bob, None, &[i], 1.0, base + chrono::Duration::seconds(i as i64))
+                .unwrap();
+        }
+        for i in 0..10u8 {
+            let embedding = vec![100 + i];
+            db.append_speaker_embedding(
+                alice,
+                None,
+                &embedding,
+                1.0,
+                base + chrono::Duration::seconds(100 + i as i64),
+            )
+            .unwrap();
+        }
+
+        db.merge_speakers(alice, bob).unwrap();
+
+        let stored = db.speaker_embeddings(bob).unwrap();
+        assert_eq!(stored.len(), super::MAX_EMBEDDINGS_PER_SPEAKER);
+        // Alice's embeddings are all newer (higher timestamps), so all 10
+        // must survive, plus the 10 newest of Bob's original 15.
+        for i in 0..10u8 {
+            assert!(stored.contains(&vec![100 + i]));
+        }
+        assert!(db.speaker_embeddings(alice).unwrap().is_empty());
+    }
+
+    #[test]
+    fn merge_speakers_source_is_me_transfers_to_target() {
+        let (db, _dir) = test_db();
+        let alice = db.create_speaker("Alice").unwrap();
+        let bob = db.create_speaker("Bob").unwrap();
+        db.set_speaker_is_me(alice, true).unwrap();
+
+        db.merge_speakers(alice, bob).unwrap();
+
+        assert!(db.get_speaker(bob).unwrap().unwrap().is_me);
+    }
+
+    #[test]
+    fn merge_speakers_target_last_seen_at_is_the_max_of_both() {
+        let (db, _dir) = test_db();
+        let alice = db.create_speaker("Alice").unwrap();
+        let bob = db.create_speaker("Bob").unwrap();
+
+        let later = chrono::Utc::now() + chrono::Duration::seconds(3600);
+        db.append_speaker_embedding(alice, None, &[1u8], 1.0, later)
+            .unwrap();
+
+        db.merge_speakers(alice, bob).unwrap();
+
+        let merged = db.get_speaker(bob).unwrap().unwrap();
+        assert_eq!(merged.last_seen_at.timestamp(), later.timestamp());
     }
 }

--- a/src-tauri/src/db/speakers.rs
+++ b/src-tauri/src/db/speakers.rs
@@ -5,16 +5,11 @@ use crate::lock_ext::MutexExt;
 
 use super::Database;
 
-/// A persistent, cross-meeting speaker identity row. `centroid` is an opaque
-/// BLOB from this layer's point of view (the diarization crate encodes it as
-/// 256 little-endian f32s); it is `None` until at least one embedding has
-/// been recorded for this speaker.
+/// A persistent, cross-meeting speaker identity row.
 #[derive(Debug, Clone, PartialEq)]
 pub struct SpeakerRecord {
     pub id: i64,
     pub name: String,
-    pub centroid: Option<Vec<u8>>,
-    pub embedding_count: i64,
     pub created_at: DateTime<Utc>,
     pub last_seen_at: DateTime<Utc>,
     /// Whether this speaker is flagged as the app's user. At most one
@@ -48,16 +43,16 @@ pub const MAX_EMBEDDINGS_PER_SPEAKER: usize = 20;
 
 impl Database {
     /// Create a new persistent speaker with the given display name. Returns
-    /// the new row's id. `centroid`/`embedding_count` are unused legacy
-    /// columns (kept for schema stability, see `schema::CREATE_SPEAKERS`)
-    /// and stay at their empty defaults; call `append_speaker_embedding`
-    /// once diarization has an embedding for it.
+    /// the new row's id. `centroid`/`embedding_count` are no longer
+    /// populated; see `schema::CREATE_SPEAKERS` for why the columns stay.
+    /// Call `append_speaker_embedding` once diarization has an embedding for
+    /// it.
     pub fn create_speaker(&self, name: &str) -> Result<i64, String> {
         let conn = self.conn.acquire()?;
         let now = Utc::now().to_rfc3339();
         conn.execute(
-            "INSERT INTO speakers (name, centroid, embedding_count, created_at, last_seen_at)
-             VALUES (?1, NULL, 0, ?2, ?2)",
+            "INSERT INTO speakers (name, created_at, last_seen_at)
+             VALUES (?1, ?2, ?2)",
             params![name, now],
         )
         .map_err(|e| format!("Insert speaker: {e}"))?;
@@ -78,7 +73,7 @@ impl Database {
         let conn = self.conn.acquire()?;
         let mut stmt = conn
             .prepare(
-                "SELECT id, name, centroid, embedding_count, created_at, last_seen_at, is_me
+                "SELECT id, name, created_at, last_seen_at, is_me
                  FROM speakers ORDER BY id",
             )
             .map_err(|e| format!("Prepare list speakers: {e}"))?;
@@ -290,6 +285,14 @@ impl Database {
     /// deleted. Used to fix the diarizer creating two speakers for the same
     /// person. One transaction; errors if the two ids are equal or either
     /// speaker doesn't exist.
+    ///
+    /// The source row is deleted BEFORE the target's `is_me` is set, not
+    /// after: SQLite checks a UNIQUE index per statement, not at commit, and
+    /// `idx_speakers_is_me` (see `schema::CREATE_SPEAKERS_IS_ME_INDEX`)
+    /// allows at most one `is_me = 1` row at any point in the transaction,
+    /// not just at the end. Setting the target's flag first would, for a
+    /// moment, leave both the not-yet-deleted source and the freshly-flagged
+    /// target at `is_me = 1` and violate the index mid-transaction.
     pub fn merge_speakers(&self, source_id: i64, target_id: i64) -> Result<(), String> {
         if source_id == target_id {
             return Err("Cannot merge a speaker into itself".into());
@@ -321,6 +324,9 @@ impl Database {
         .map_err(|e| format!("Move merged speaker embeddings: {e}"))?;
         prune_speaker_embeddings(&tx, target_id)?;
 
+        tx.execute("DELETE FROM speakers WHERE id = ?1", params![source_id])
+            .map_err(|e| format!("Delete merged speaker: {e}"))?;
+
         let is_me = source.is_me || target.is_me;
         let last_seen_at = source.last_seen_at.max(target.last_seen_at);
         tx.execute(
@@ -328,9 +334,6 @@ impl Database {
             params![i32::from(is_me), last_seen_at.to_rfc3339(), target_id],
         )
         .map_err(|e| format!("Update merged speaker: {e}"))?;
-
-        tx.execute("DELETE FROM speakers WHERE id = ?1", params![source_id])
-            .map_err(|e| format!("Delete merged speaker: {e}"))?;
 
         tx.commit().map_err(|e| format!("Commit: {e}"))?;
         Ok(())
@@ -377,8 +380,6 @@ impl Database {
 struct SpeakerRow {
     id: i64,
     name: String,
-    centroid: Option<Vec<u8>>,
-    embedding_count: i64,
     created_at: String,
     last_seen_at: String,
     is_me: bool,
@@ -389,8 +390,6 @@ impl SpeakerRow {
         Ok(SpeakerRecord {
             id: self.id,
             name: self.name,
-            centroid: self.centroid,
-            embedding_count: self.embedding_count,
             created_at: parse_datetime(&self.created_at)?,
             last_seen_at: parse_datetime(&self.last_seen_at)?,
             is_me: self.is_me,
@@ -402,11 +401,9 @@ fn map_speaker_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<SpeakerRow> {
     Ok(SpeakerRow {
         id: row.get(0)?,
         name: row.get(1)?,
-        centroid: row.get(2)?,
-        embedding_count: row.get(3)?,
-        created_at: row.get(4)?,
-        last_seen_at: row.get(5)?,
-        is_me: row.get::<_, i64>(6)? != 0,
+        created_at: row.get(2)?,
+        last_seen_at: row.get(3)?,
+        is_me: row.get::<_, i64>(4)? != 0,
     })
 }
 
@@ -418,7 +415,7 @@ fn fetch_speaker_row(
     id: i64,
 ) -> Result<Option<SpeakerRow>, String> {
     conn.query_row(
-        "SELECT id, name, centroid, embedding_count, created_at, last_seen_at, is_me
+        "SELECT id, name, created_at, last_seen_at, is_me
          FROM speakers WHERE id = ?1",
         params![id],
         map_speaker_row,
@@ -469,8 +466,6 @@ mod tests {
 
         let record = db.get_speaker(id).unwrap().expect("speaker exists");
         assert_eq!(record.name, "Alice");
-        assert_eq!(record.embedding_count, 0);
-        assert!(record.centroid.is_none());
         assert_eq!(record.created_at, record.last_seen_at);
         assert!(!record.is_me);
     }
@@ -725,6 +720,25 @@ mod tests {
     }
 
     #[test]
+    fn speakers_is_me_unique_index_rejects_a_second_true_row() {
+        let (db, _dir) = test_db();
+        let alice = db.create_speaker("Alice").unwrap();
+        let bob = db.create_speaker("Bob").unwrap();
+        db.set_speaker_is_me(alice, true).unwrap();
+
+        // Bypass the app-level guard in `set_speaker_is_me` entirely: a raw
+        // UPDATE flagging a second row must still be rejected by the schema
+        // itself (`schema::CREATE_SPEAKERS_IS_ME_INDEX`), not just by
+        // application code remembering to clear the flag first.
+        let conn = db.conn.lock().unwrap();
+        let result = conn.execute("UPDATE speakers SET is_me = 1 WHERE id = ?1", params![bob]);
+        assert!(
+            result.is_err(),
+            "a second is_me = 1 row must violate the partial unique index"
+        );
+    }
+
+    #[test]
     fn merge_speakers_rejects_same_id() {
         let (db, _dir) = test_db();
         let alice = db.create_speaker("Alice").unwrap();
@@ -807,9 +821,19 @@ mod tests {
         let bob = db.create_speaker("Bob").unwrap();
         db.set_speaker_is_me(alice, true).unwrap();
 
+        // Regression guard for the statement order inside `merge_speakers`:
+        // both rows already exist (source is_me = 1, target is_me = 0)
+        // before the merge starts, which is exactly the shape that would
+        // trip `idx_speakers_is_me` mid-transaction if the target's flag
+        // were set before the source row is deleted.
         db.merge_speakers(alice, bob).unwrap();
 
         assert!(db.get_speaker(bob).unwrap().unwrap().is_me);
+        let conn = db.conn.lock().unwrap();
+        let is_me_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM speakers WHERE is_me = 1", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(is_me_count, 1, "exactly one speaker must be flagged is_me after the merge");
     }
 
     #[test]

--- a/src-tauri/src/diarize/clustering.rs
+++ b/src-tauri/src/diarize/clustering.rs
@@ -6,6 +6,14 @@
 //! similarity drops below `threshold` or `min_speakers` is reached. If
 //! `max_speakers` is set, merging continues past the threshold until the
 //! cluster count is at most `max_speakers`.
+//!
+//! `cluster()` maintains a full pairwise similarity matrix instead of
+//! recomputing cosines from scratch every merge: building it is O(n^2), and
+//! each of the (up to n-1) merges only needs to refresh the merged cluster's
+//! row/column against the survivors, an O(n) cosine cost, with the scan for
+//! the next best pair a flat compare over the matrix. That keeps the whole
+//! run at O(n^2) instead of O(n^3), which matters once a long meeting's
+//! 10s chunking produces hundreds of candidate points.
 
 /// L2-normalize a vector in place. A zero vector is left unchanged (cosine
 /// similarity against it is defined as 0 by `cosine_similarity` below).
@@ -68,6 +76,14 @@ pub fn cluster(
         })
         .collect();
 
+    // Pairwise similarity matrix over the current clusters, indexed the same
+    // way as `members`/`centroids` and kept in lockstep with them: built
+    // once up front (n^2 cosines), then patched incrementally on each merge
+    // instead of rescanned from scratch every iteration.
+    let mut sim: Vec<Vec<f32>> = (0..n)
+        .map(|i| (0..n).map(|j| normalized_similarity(&centroids[i], &centroids[j])).collect())
+        .collect();
+
     let min_k = min_speakers.unwrap_or(1).max(1);
     let max_k = max_speakers.unwrap_or(n).max(min_k);
 
@@ -77,26 +93,43 @@ pub fn cluster(
             break;
         }
 
+        // Pure float compares over the cached matrix: no cosine recompute.
         let mut best = (0usize, 0usize, f32::MIN);
-        for i in 0..k {
-            for j in (i + 1)..k {
-                let sim = cosine_similarity(&centroids[i], &centroids[j]);
-                if sim > best.2 {
-                    best = (i, j, sim);
+        for (i, row) in sim.iter().enumerate() {
+            for (j, &s) in row.iter().enumerate().skip(i + 1) {
+                if s > best.2 {
+                    best = (i, j, s);
                 }
             }
         }
-        let (i, j, sim) = best;
+        let (i, j, s) = best;
 
         let must_reduce = k > max_k;
-        if !must_reduce && sim < threshold {
+        if !must_reduce && s < threshold {
             break;
         }
 
         let absorbed = members.remove(j);
         members[i].extend(absorbed);
         centroids[i] = centroid_of(embeddings, &members[i], dim);
+
+        // Only the merged cluster's row/column changed; refresh it against
+        // every surviving cluster (O(k) cosines) rather than rebuilding the
+        // whole matrix.
+        for other in 0..k {
+            if other == i || other == j {
+                continue;
+            }
+            let s = normalized_similarity(&centroids[i], &centroids[other]);
+            sim[i][other] = s;
+            sim[other][i] = s;
+        }
+
         centroids.remove(j);
+        sim.remove(j);
+        for row in &mut sim {
+            row.remove(j);
+        }
     }
 
     let mut labels = vec![0usize; n];
@@ -107,6 +140,24 @@ pub fn cluster(
     }
 
     ClusterResult { labels, centroids }
+}
+
+/// Similarity between two cluster centroids for the pairwise matrix.
+/// Centroids here are always L2-normalized already (`l2_normalize` /
+/// `centroid_of`), or left as the exact zero vector when normalization
+/// guarded against a near-zero source, so the dot product alone equals
+/// cosine similarity: no per-call norm/sqrt work like `cosine_similarity`
+/// does for arbitrary vectors. The zero-vector case is still guarded
+/// explicitly, not left to fall out of the dot product incidentally, so this
+/// stays correct if a caller ever passes in a centroid that skipped
+/// normalization. `all()` short-circuits on the first nonzero component, so
+/// the guard is effectively free for the common non-degenerate case.
+fn normalized_similarity(a: &[f32], b: &[f32]) -> f32 {
+    let is_zero = |v: &[f32]| v.iter().all(|&x| x == 0.0);
+    if is_zero(a) || is_zero(b) {
+        return 0.0;
+    }
+    a.iter().zip(b).map(|(x, y)| x * y).sum()
 }
 
 /// Mean of the L2-normalized member embeddings, re-normalized. Matches the
@@ -219,6 +270,106 @@ mod tests {
         let result = cluster(&embeddings, 0.99, None, Some(1));
         assert_eq!(result.centroids.len(), 1);
         assert!(result.labels.iter().all(|&l| l == result.labels[0]));
+    }
+
+    /// Reference implementation mirroring the pre-optimization algorithm:
+    /// recomputes cosine similarity from scratch over every pair on every
+    /// iteration instead of maintaining the incremental matrix `cluster()`
+    /// now uses. Exists only so `cluster_matches_the_unoptimized_reference_algorithm`
+    /// can prove the optimization changed performance, not behavior.
+    fn cluster_reference(
+        embeddings: &[Vec<f32>],
+        threshold: f32,
+        min_speakers: Option<usize>,
+        max_speakers: Option<usize>,
+    ) -> ClusterResult {
+        let n = embeddings.len();
+        if n == 0 {
+            return ClusterResult {
+                labels: Vec::new(),
+                centroids: Vec::new(),
+            };
+        }
+        let dim = embeddings[0].len();
+        let mut members: Vec<Vec<usize>> = (0..n).map(|i| vec![i]).collect();
+        let mut centroids: Vec<Vec<f32>> = embeddings
+            .iter()
+            .map(|e| {
+                let mut v = e.clone();
+                l2_normalize(&mut v);
+                v
+            })
+            .collect();
+
+        let min_k = min_speakers.unwrap_or(1).max(1);
+        let max_k = max_speakers.unwrap_or(n).max(min_k);
+
+        loop {
+            let k = members.len();
+            if k <= min_k {
+                break;
+            }
+            let mut best = (0usize, 0usize, f32::MIN);
+            for i in 0..k {
+                for j in (i + 1)..k {
+                    let sim = cosine_similarity(&centroids[i], &centroids[j]);
+                    if sim > best.2 {
+                        best = (i, j, sim);
+                    }
+                }
+            }
+            let (i, j, sim) = best;
+            let must_reduce = k > max_k;
+            if !must_reduce && sim < threshold {
+                break;
+            }
+            let absorbed = members.remove(j);
+            members[i].extend(absorbed);
+            centroids[i] = centroid_of(embeddings, &members[i], dim);
+            centroids.remove(j);
+        }
+
+        let mut labels = vec![0usize; n];
+        for (cluster_id, member_indexes) in members.iter().enumerate() {
+            for &idx in member_indexes {
+                labels[idx] = cluster_id;
+            }
+        }
+        ClusterResult { labels, centroids }
+    }
+
+    #[test]
+    fn cluster_matches_the_unoptimized_reference_algorithm() {
+        // Fixed, deterministic embeddings mixing near-ties, well-separated
+        // clusters, and a point requiring several merges, run at several
+        // thresholds, to exercise the incremental matrix maintenance against
+        // the reference algorithm it must stay semantically identical to.
+        let embeddings = vec![
+            vec![1.0, 0.0, 0.0, 0.0],
+            vec![0.95, 0.05, 0.0, 0.0],
+            vec![0.9, 0.1, 0.0, 0.0],
+            vec![0.0, 1.0, 0.0, 0.0],
+            vec![0.05, 0.95, 0.0, 0.0],
+            vec![0.0, 0.0, 1.0, 0.0],
+            vec![0.0, 0.0, 0.95, 0.05],
+            vec![0.3, 0.3, 0.3, 0.3],
+        ];
+
+        for threshold in [0.3, 0.5, 0.7, 0.9] {
+            let optimized = cluster(&embeddings, threshold, None, None);
+            let reference = cluster_reference(&embeddings, threshold, None, None);
+            assert_eq!(optimized.labels, reference.labels, "threshold {threshold}");
+            assert_eq!(
+                optimized.centroids.len(),
+                reference.centroids.len(),
+                "threshold {threshold}"
+            );
+            for (a, b) in optimized.centroids.iter().zip(reference.centroids.iter()) {
+                for (x, y) in a.iter().zip(b.iter()) {
+                    assert!((x - y).abs() < 1e-5, "threshold {threshold}: centroid mismatch");
+                }
+            }
+        }
     }
 
     #[test]

--- a/src-tauri/src/diarize/mod.rs
+++ b/src-tauri/src/diarize/mod.rs
@@ -61,7 +61,11 @@ pub struct DiarizeConfig {
     /// Gaps shorter than this between same-slot segments are merged.
     pub min_duration_off_s: f64,
     /// Cosine similarity above which two speaker embeddings are merged into
-    /// the same cluster.
+    /// the same cluster. 0.5 matches the sherpa-onnx reference implementation
+    /// (`fast-clustering.cc`), which merges up to a cosine distance of 0.5,
+    /// i.e. an equivalent similarity of 0.5. A higher threshold over-splits
+    /// the same voice into several per-meeting clusters, which then compete
+    /// with each other against persistent speaker matching.
     pub cluster_threshold: f32,
     pub min_speakers: Option<usize>,
     pub max_speakers: Option<usize>,
@@ -76,7 +80,7 @@ impl DiarizeConfig {
             offset: 0.5,
             min_duration_on_s: 0.1,
             min_duration_off_s: 0.5,
-            cluster_threshold: 0.7,
+            cluster_threshold: 0.5,
             min_speakers: None,
             max_speakers: None,
         }
@@ -92,13 +96,17 @@ pub struct DiarizedSegment {
 
 /// A detected speaker's embedding centroid (mean of its member segments'
 /// L2-normalized embeddings, re-normalized). Kept in the result (rather than
-/// discarded once clustering is done) so a follow-up feature can persist
-/// speaker identity across meetings by comparing centroids, without
-/// re-running inference on old recordings.
+/// discarded once clustering is done) so persistent speaker matching
+/// (`persist::match_speakers`) can compare it against stored speakers
+/// without re-running inference on old recordings. `speech_seconds` is the
+/// total duration of this cluster's member segments, used as an enrollment
+/// guard: a cluster with only a fraction of a second of speech is not
+/// trustworthy enough to become a permanent identity.
 #[derive(Debug, Clone)]
 pub struct SpeakerCentroid {
     pub speaker: usize,
     pub embedding: Vec<f32>,
+    pub speech_seconds: f64,
 }
 
 /// `diarize()`'s output. Deviates from a bare `Vec<DiarizedSegment>` on
@@ -115,6 +123,40 @@ pub struct DiarizationResult {
 /// a stable speaker embedding, and too short to matter in a transcript.
 /// 0.25s at 16kHz, matching sherpa-onnx's own short-segment skip.
 const MIN_SEGMENT_SAMPLES_FOR_EMBEDDING: usize = 4_000;
+
+/// Longest single embedding window, in seconds. A raw segment longer than
+/// this is split into equal chunks at or under this length before embedding
+/// (`chunk_segment`): one embedding representing several minutes of
+/// continuous speech is a worse discriminator than several shorter ones, and
+/// `merge_adjacent_same_speaker` naturally reassembles chunks that cluster
+/// back into the same speaker.
+const MAX_EMBEDDING_WINDOW_S: f64 = 10.0;
+
+/// Split `(start_s, end_s)` into consecutive equal-length chunks of at most
+/// `max_window_s` seconds each. A span already at or under the limit is
+/// returned unchanged as a single-element result, so this is a safe no-op
+/// wrapper for the common case. `max_window_s <= 0.0` is treated as "no
+/// limit" (also a single-element result) rather than dividing by zero or
+/// looping forever.
+fn chunk_segment(start_s: f64, end_s: f64, max_window_s: f64) -> Vec<(f64, f64)> {
+    let duration = end_s - start_s;
+    if max_window_s <= 0.0 || duration <= max_window_s {
+        return vec![(start_s, end_s)];
+    }
+    let chunk_count = (duration / max_window_s).ceil() as usize;
+    let chunk_len = duration / chunk_count as f64;
+    (0..chunk_count)
+        .map(|i| {
+            let chunk_start = start_s + chunk_len * i as f64;
+            let chunk_end = if i + 1 == chunk_count {
+                end_s
+            } else {
+                start_s + chunk_len * (i + 1) as f64
+            };
+            (chunk_start, chunk_end)
+        })
+        .collect()
+}
 
 /// Run offline speaker diarization on a full, already-decoded recording.
 ///
@@ -161,19 +203,21 @@ pub fn diarize(samples: &[f32], sample_rate: u32, cfg: &DiarizeConfig) -> Result
         let mut kept_segments = Vec::with_capacity(raw_segments.len());
         let mut embeddings = Vec::with_capacity(raw_segments.len());
 
-        for (start_s, end_s) in raw_segments {
-            let start_sample = (start_s * sample_rate as f64).round().max(0.0) as usize;
-            let end_sample = ((end_s * sample_rate as f64).round() as usize).min(samples.len());
-            if end_sample <= start_sample || end_sample - start_sample < MIN_SEGMENT_SAMPLES_FOR_EMBEDDING {
-                continue;
+        for (raw_start_s, raw_end_s) in raw_segments {
+            for (start_s, end_s) in chunk_segment(raw_start_s, raw_end_s, MAX_EMBEDDING_WINDOW_S) {
+                let start_sample = (start_s * sample_rate as f64).round().max(0.0) as usize;
+                let end_sample = ((end_s * sample_rate as f64).round() as usize).min(samples.len());
+                if end_sample <= start_sample || end_sample - start_sample < MIN_SEGMENT_SAMPLES_FOR_EMBEDDING {
+                    continue;
+                }
+
+                let Some(embedding) = emb_model.embed(&samples[start_sample..end_sample])? else {
+                    continue;
+                };
+
+                kept_segments.push((start_s, end_s));
+                embeddings.push(embedding);
             }
-
-            let Some(embedding) = emb_model.embed(&samples[start_sample..end_sample])? else {
-                continue;
-            };
-
-            kept_segments.push((start_s, end_s));
-            embeddings.push(embedding);
         }
         (kept_segments, embeddings)
     };
@@ -201,11 +245,25 @@ pub fn diarize(samples: &[f32], sample_rate: u32, cfg: &DiarizeConfig) -> Result
     let max_gap_ms = (cfg.min_duration_off_s * 1000.0).round() as u64;
     let segments = merge_adjacent_same_speaker(segments, max_gap_ms);
 
+    // Sum of member segment durations per cluster, computed from the
+    // pre-merge (start_s, end_s) spans: chunking splits raw segments into
+    // non-overlapping pieces, so summing their durations per label gives the
+    // same total as the post-merge segments would, without needing to
+    // recover per-cluster spans from the merged, speaker-only output.
+    let mut speech_seconds_per_cluster = vec![0.0f64; cluster_result.centroids.len()];
+    for (&(start_s, end_s), &label) in kept_segments.iter().zip(cluster_result.labels.iter()) {
+        speech_seconds_per_cluster[label] += end_s - start_s;
+    }
+
     let speakers = cluster_result
         .centroids
         .into_iter()
         .enumerate()
-        .map(|(speaker, embedding)| SpeakerCentroid { speaker, embedding })
+        .map(|(speaker, embedding)| SpeakerCentroid {
+            speaker,
+            embedding,
+            speech_seconds: speech_seconds_per_cluster[speaker],
+        })
         .collect();
 
     Ok(DiarizationResult { segments, speakers })
@@ -265,6 +323,45 @@ mod tests {
     #[test]
     fn merge_adjacent_same_speaker_empty_input() {
         assert!(merge_adjacent_same_speaker(Vec::new(), 500).is_empty());
+    }
+
+    #[test]
+    fn chunk_segment_leaves_short_span_unchanged() {
+        assert_eq!(chunk_segment(0.0, 5.0, 10.0), vec![(0.0, 5.0)]);
+    }
+
+    #[test]
+    fn chunk_segment_leaves_span_at_exact_limit_unchanged() {
+        assert_eq!(chunk_segment(2.0, 12.0, 10.0), vec![(2.0, 12.0)]);
+    }
+
+    #[test]
+    fn chunk_segment_splits_long_span_into_equal_pieces() {
+        let chunks = chunk_segment(0.0, 25.0, 10.0);
+        // 25s / 10s -> 3 chunks of ~8.33s each, not 2 chunks of 10s + one
+        // short 5s tail: equal splitting avoids a degenerate final chunk.
+        assert_eq!(chunks.len(), 3);
+        for &(start, end) in &chunks {
+            assert!(end - start <= 10.0 + 1e-9);
+        }
+        assert!((chunks[0].0 - 0.0).abs() < 1e-9);
+        assert!((chunks.last().unwrap().1 - 25.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn chunk_segment_pieces_are_contiguous_and_preserve_total_duration() {
+        let chunks = chunk_segment(3.0, 37.0, 10.0);
+        for pair in chunks.windows(2) {
+            assert!((pair[0].1 - pair[1].0).abs() < 1e-9, "chunks must be contiguous");
+        }
+        let total: f64 = chunks.iter().map(|&(s, e)| e - s).sum();
+        assert!((total - 34.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn chunk_segment_non_positive_limit_is_a_no_op() {
+        assert_eq!(chunk_segment(0.0, 25.0, 0.0), vec![(0.0, 25.0)]);
+        assert_eq!(chunk_segment(0.0, 25.0, -1.0), vec![(0.0, 25.0)]);
     }
 
     #[test]

--- a/src-tauri/src/diarize/persist.rs
+++ b/src-tauri/src/diarize/persist.rs
@@ -3,48 +3,75 @@
 //! table, so the same voice resolves to the same speaker row across
 //! meetings. Pure decision logic only: no I/O, no database access. The
 //! caller (`pipeline::diarize_task`) is responsible for turning the returned
-//! `MatchDecision`s into `create_speaker`/`update_speaker_centroid` calls.
+//! `MatchDecision`s into `create_speaker`/`append_speaker_embedding` calls.
+//!
+//! Matching is against a bag of recent embeddings per speaker (up to
+//! `db::speakers::MAX_EMBEDDINGS_PER_SPEAKER`), not a single running-mean
+//! centroid: real inter-session cosine similarity for the same voice
+//! measures 0.48 to 0.66 in practice, so any one embedding can miss a match
+//! while another recorded on a different day, mic, or vocal tone hits.
+//! Similarity against a stored speaker is the MAX over its embeddings.
 
 use super::SpeakerCentroid;
 
 /// Cosine similarity above which a cluster is considered a candidate match
-/// for a stored speaker.
-pub const MATCH_THRESHOLD: f32 = 0.65;
+/// for a stored speaker. Calibrated from real inter-session measurements of
+/// the same voice (0.48 to 0.66), not from the clustering threshold: a
+/// plain 0.65 floor never matched anything in practice.
+pub const MATCH_THRESHOLD: f32 = 0.5;
 
 /// Minimum lead a cluster's best-matching stored speaker must have over the
-/// second-best, among all OTHER stored speakers, for the match to be
-/// accepted instead of treated as ambiguous (and so mapped to a new speaker).
-pub const MATCH_MARGIN: f32 = 0.03;
+/// second-best DISTINCT stored speaker for the match to be accepted instead
+/// of treated as ambiguous. An ambiguous cluster is left unlabeled rather
+/// than guessed at: creating a new speaker for it would spawn yet another
+/// duplicate of a voice that already has two candidate rows.
+pub const MATCH_MARGIN: f32 = 0.05;
 
-/// A stored, persistent speaker row as seen by the matcher. `centroid` is
-/// `None` for a speaker that has never had an embedding recorded (can't be
-/// matched against, only ever loses to every cluster).
+/// A cluster below `MATCH_THRESHOLD` only becomes a brand new stored speaker
+/// if it has at least this much speech. Guards against a stray fraction of a
+/// second of speech spawning a permanent identity that nothing will ever
+/// match against again.
+pub const MIN_ENROLL_SPEECH_S: f64 = 5.0;
+
+/// A stored, persistent speaker row as seen by the matcher: its recent
+/// embeddings (see `db::speakers::MAX_EMBEDDINGS_PER_SPEAKER`), decoded to
+/// f32s. Empty for a speaker that has never had an embedding recorded (can't
+/// be matched against, only ever loses to every cluster).
 #[derive(Debug, Clone, PartialEq)]
 pub struct StoredSpeaker {
     pub id: i64,
     pub name: String,
-    pub centroid: Option<Vec<f32>>,
-    pub embedding_count: i64,
+    pub embeddings: Vec<Vec<f32>>,
 }
 
 /// What to do with one cluster from a `diarize()` result, decided by
-/// `match_speakers`. Exactly one of `matched_speaker_id`/`new_name` is set.
+/// `match_speakers`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MatchOutcome {
+    /// This cluster resolved to an existing stored speaker.
+    Matched { speaker_id: i64 },
+    /// This cluster did not match anything, and had enough speech to be
+    /// worth enrolling as a brand new speaker with this name.
+    NewSpeaker { name: String },
+    /// This cluster is left without a persistent speaker: either its best
+    /// match was ambiguous against two distinct stored speakers, it lost a
+    /// same-target conflict to a higher-similarity cluster, or it was below
+    /// threshold with too little speech to enroll. Its spans stay unlabeled;
+    /// the meeting can still be retagged manually later.
+    Unlabeled,
+}
+
+/// A `match_speakers` decision for one cluster: which cluster
+/// (`DiarizedSegment.speaker` / `SpeakerCentroid.speaker`), what to do
+/// (`outcome`), and the embedding and speech duration the caller should
+/// persist for `Matched`/`NewSpeaker` (irrelevant for `Unlabeled`, but
+/// always populated so the caller doesn't need to special-case it).
 #[derive(Debug, Clone, PartialEq)]
 pub struct MatchDecision {
-    /// Index into the `DiarizationResult.speakers` slice this decision
-    /// covers (also the local speaker id used in `DiarizedSegment.speaker`).
     pub cluster: usize,
-    /// `Some(id)`: this cluster resolved to an existing stored speaker.
-    pub matched_speaker_id: Option<i64>,
-    /// `Some(name)`: this cluster did not match anything and should become a
-    /// brand new speaker with this name. Only set when `matched_speaker_id`
-    /// is `None`.
-    pub new_name: Option<String>,
-    /// The centroid to persist for the resolved speaker: a running mean of
-    /// the old centroid (if any) and this cluster's embedding, re-normalized.
-    pub updated_centroid: Vec<f32>,
-    /// The `embedding_count` to persist alongside `updated_centroid`.
-    pub updated_embedding_count: i64,
+    pub outcome: MatchOutcome,
+    pub embedding: Vec<f32>,
+    pub speech_seconds: f64,
 }
 
 /// Cosine similarity between two vectors. Returns 0.0 for a zero-length
@@ -63,10 +90,10 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     (dot / (norm_a * norm_b)).clamp(-1.0, 1.0)
 }
 
-/// Encode a centroid as the DB's opaque BLOB format: 256 little-endian f32s
-/// (or however many dimensions `v` has; the embedding model's output size
-/// is fixed, but nothing here hard-codes 256 beyond the doc comment).
-pub fn encode_centroid(v: &[f32]) -> Vec<u8> {
+/// Encode an embedding as the DB's opaque BLOB format: little-endian f32s,
+/// one per dimension (256 for the WeSpeaker model currently in use, but
+/// nothing here hard-codes that beyond this comment).
+pub fn encode_embedding(v: &[f32]) -> Vec<u8> {
     let mut out = Vec::with_capacity(v.len() * 4);
     for x in v {
         out.extend_from_slice(&x.to_le_bytes());
@@ -74,10 +101,10 @@ pub fn encode_centroid(v: &[f32]) -> Vec<u8> {
     out
 }
 
-/// Decode a centroid BLOB back into f32s. `None` if the byte length isn't a
-/// multiple of 4 (corrupt or foreign data). Callers treat that exactly like
-/// "no centroid yet", never as a hard error.
-pub fn decode_centroid(bytes: &[u8]) -> Option<Vec<f32>> {
+/// Decode an embedding BLOB back into f32s. `None` if the byte length isn't
+/// a multiple of 4 (corrupt or foreign data). Callers treat that exactly
+/// like "no embedding", never as a hard error.
+pub fn decode_embedding(bytes: &[u8]) -> Option<Vec<f32>> {
     if !bytes.len().is_multiple_of(4) {
         return None;
     }
@@ -87,40 +114,6 @@ pub fn decode_centroid(bytes: &[u8]) -> Option<Vec<f32>> {
             .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
             .collect(),
     )
-}
-
-/// Re-normalize `v` to unit length. A zero vector is returned unchanged
-/// (nothing sensible to normalize it to).
-fn l2_normalize(mut v: Vec<f32>) -> Vec<f32> {
-    let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
-    if norm > 0.0 {
-        for x in &mut v {
-            *x /= norm;
-        }
-    }
-    v
-}
-
-/// Running-mean centroid update: `old * old_count + new`, re-normalized.
-/// `old` is `None` for a brand new speaker, in which case the result is just
-/// `new` (already L2-normalized by the clustering stage) with count 1.
-fn update_centroid(old: Option<(&[f32], i64)>, new: &[f32]) -> (Vec<f32>, i64) {
-    match old {
-        None => (new.to_vec(), 1),
-        Some((old_centroid, old_count)) if old_centroid.len() == new.len() => {
-            let weight = old_count.max(0) as f32;
-            let combined: Vec<f32> = old_centroid
-                .iter()
-                .zip(new.iter())
-                .map(|(o, n)| o * weight + n)
-                .collect();
-            (l2_normalize(combined), old_count + 1)
-        }
-        // Dimension mismatch (shouldn't happen in practice; the embedding
-        // model's output size is fixed, but a corrupt/foreign BLOB must not
-        // panic): treat as if there were no prior centroid.
-        Some(_) => (new.to_vec(), 1),
-    }
 }
 
 /// The next unused "Speaker N" name, given every already-taken name (stored
@@ -137,17 +130,22 @@ fn next_speaker_name<'a>(taken_names: impl Iterator<Item = &'a str>) -> String {
 }
 
 /// Match every cluster in a `diarize()` result against `stored` speakers,
-/// deciding for each cluster whether it's an existing speaker (and its
-/// updated centroid) or a brand new one.
+/// deciding for each cluster whether it's an existing speaker, a brand new
+/// one, or left unlabeled.
 ///
-/// Matching rule: for a cluster, compute cosine similarity against every
-/// stored speaker that has a centroid. The best match is accepted only if
-/// `best >= MATCH_THRESHOLD` AND `best - second_best >= MATCH_MARGIN` (an
-/// ambiguous best match, or a match below the confidence floor, both fall
-/// back to "new speaker"). Because two different clusters can end up wanting
-/// the same stored speaker, candidates are resolved greedily by descending
-/// similarity: the higher-similarity cluster keeps the match, the loser
-/// becomes a new speaker instead.
+/// For a cluster, similarity against a stored speaker is the MAX cosine
+/// similarity over that speaker's embeddings. The best-matching stored
+/// speaker is accepted only if `best >= MATCH_THRESHOLD` AND there is no
+/// second DISTINCT stored speaker also `>= MATCH_THRESHOLD` within
+/// `MATCH_MARGIN` of it (an ambiguous best match never creates a duplicate:
+/// it's left unlabeled for the user to resolve). Below threshold, the
+/// cluster becomes a new speaker only if it has at least `MIN_ENROLL_SPEECH_S`
+/// of speech; otherwise it's left unlabeled. Because two different clusters
+/// can end up wanting the same stored speaker, accepted candidates are
+/// resolved greedily by descending similarity: the higher-similarity
+/// cluster keeps the match, the loser is left unlabeled (never demoted to a
+/// new speaker: that would still create a duplicate of a voice already
+/// matched this pass).
 pub fn match_speakers(clusters: &[SpeakerCentroid], stored: &[StoredSpeaker]) -> Vec<MatchDecision> {
     struct Candidate {
         cluster: usize,
@@ -155,31 +153,56 @@ pub fn match_speakers(clusters: &[SpeakerCentroid], stored: &[StoredSpeaker]) ->
         similarity: f32,
     }
 
-    let mut candidates: Vec<Candidate> = Vec::new();
-    for cluster in clusters {
-        let mut sims: Vec<(usize, f32)> = stored
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, s)| {
-                s.centroid
-                    .as_ref()
-                    .map(|c| (idx, cosine_similarity(&cluster.embedding, c)))
-            })
-            .collect();
-        sims.sort_by(|a, b| b.1.total_cmp(&a.1));
-
-        let Some(&(best_idx, best_sim)) = sims.first() else {
-            continue;
-        };
-        let second_sim = sims.get(1).map(|&(_, s)| s).unwrap_or(f32::MIN);
-        if best_sim >= MATCH_THRESHOLD && best_sim - second_sim >= MATCH_MARGIN {
-            candidates.push(Candidate {
-                cluster: cluster.speaker,
-                stored_idx: best_idx,
-                similarity: best_sim,
-            });
-        }
+    enum Prelim {
+        Candidate { stored_idx: usize, similarity: f32 },
+        Ambiguous,
+        BelowThreshold,
     }
+
+    let prelims: Vec<Prelim> = clusters
+        .iter()
+        .map(|cluster| {
+            let mut sims: Vec<(usize, f32)> = stored
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, s)| {
+                    s.embeddings
+                        .iter()
+                        .map(|e| cosine_similarity(&cluster.embedding, e))
+                        .max_by(f32::total_cmp)
+                        .map(|max_sim| (idx, max_sim))
+                })
+                .collect();
+            sims.sort_by(|a, b| b.1.total_cmp(&a.1));
+
+            match sims.first() {
+                Some(&(best_idx, best_sim)) if best_sim >= MATCH_THRESHOLD => {
+                    let ambiguous = sims.get(1).is_some_and(|&(_, second_sim)| {
+                        second_sim >= MATCH_THRESHOLD && best_sim - second_sim < MATCH_MARGIN
+                    });
+                    if ambiguous {
+                        Prelim::Ambiguous
+                    } else {
+                        Prelim::Candidate { stored_idx: best_idx, similarity: best_sim }
+                    }
+                }
+                _ => Prelim::BelowThreshold,
+            }
+        })
+        .collect();
+
+    let mut candidates: Vec<Candidate> = clusters
+        .iter()
+        .zip(prelims.iter())
+        .filter_map(|(cluster, prelim)| match prelim {
+            Prelim::Candidate { stored_idx, similarity } => Some(Candidate {
+                cluster: cluster.speaker,
+                stored_idx: *stored_idx,
+                similarity: *similarity,
+            }),
+            _ => None,
+        })
+        .collect();
     candidates.sort_by(|a, b| b.similarity.total_cmp(&a.similarity));
 
     let mut claimed_stored: std::collections::HashSet<usize> = std::collections::HashSet::new();
@@ -194,38 +217,28 @@ pub fn match_speakers(clusters: &[SpeakerCentroid], stored: &[StoredSpeaker]) ->
 
     let mut taken_names: Vec<String> = stored.iter().map(|s| s.name.clone()).collect();
     let mut decisions = Vec::with_capacity(clusters.len());
-    for cluster in clusters {
-        match cluster_match.get(&cluster.speaker) {
-            Some(&stored_idx) => {
-                let stored_speaker = &stored[stored_idx];
-                let (updated_centroid, updated_embedding_count) = update_centroid(
-                    stored_speaker
-                        .centroid
-                        .as_deref()
-                        .map(|c| (c, stored_speaker.embedding_count)),
-                    &cluster.embedding,
-                );
-                decisions.push(MatchDecision {
-                    cluster: cluster.speaker,
-                    matched_speaker_id: Some(stored_speaker.id),
-                    new_name: None,
-                    updated_centroid,
-                    updated_embedding_count,
-                });
+    for (cluster, prelim) in clusters.iter().zip(prelims.iter()) {
+        let outcome = if let Some(&stored_idx) = cluster_match.get(&cluster.speaker) {
+            MatchOutcome::Matched { speaker_id: stored[stored_idx].id }
+        } else {
+            match prelim {
+                Prelim::BelowThreshold if cluster.speech_seconds >= MIN_ENROLL_SPEECH_S => {
+                    let name = next_speaker_name(taken_names.iter().map(|s| s.as_str()));
+                    taken_names.push(name.clone());
+                    MatchOutcome::NewSpeaker { name }
+                }
+                // Ambiguous, below threshold with too little speech, or lost
+                // the greedy same-target conflict: none of these ever create
+                // a new speaker, only an already-matched cluster does.
+                _ => MatchOutcome::Unlabeled,
             }
-            None => {
-                let name = next_speaker_name(taken_names.iter().map(|s| s.as_str()));
-                taken_names.push(name.clone());
-                let (updated_centroid, updated_embedding_count) = update_centroid(None, &cluster.embedding);
-                decisions.push(MatchDecision {
-                    cluster: cluster.speaker,
-                    matched_speaker_id: None,
-                    new_name: Some(name),
-                    updated_centroid,
-                    updated_embedding_count,
-                });
-            }
-        }
+        };
+        decisions.push(MatchDecision {
+            cluster: cluster.speaker,
+            outcome,
+            embedding: cluster.embedding.clone(),
+            speech_seconds: cluster.speech_seconds,
+        });
     }
     decisions
 }
@@ -240,18 +253,26 @@ mod tests {
         v
     }
 
-    fn centroid(speaker: usize, embedding: Vec<f32>) -> SpeakerCentroid {
-        SpeakerCentroid { speaker, embedding }
+    fn normalize(mut v: Vec<f32>) -> Vec<f32> {
+        let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+        if norm > 0.0 {
+            for x in &mut v {
+                *x /= norm;
+            }
+        }
+        v
     }
 
-    fn stored(id: i64, name: &str, centroid: Option<Vec<f32>>, embedding_count: i64) -> StoredSpeaker {
-        StoredSpeaker {
-            id,
-            name: name.to_string(),
-            centroid,
-            embedding_count,
-        }
+    fn centroid(speaker: usize, embedding: Vec<f32>, speech_seconds: f64) -> SpeakerCentroid {
+        SpeakerCentroid { speaker, embedding, speech_seconds }
     }
+
+    fn stored(id: i64, name: &str, embeddings: Vec<Vec<f32>>) -> StoredSpeaker {
+        StoredSpeaker { id, name: name.to_string(), embeddings }
+    }
+
+    const LONG: f64 = 10.0; // well above MIN_ENROLL_SPEECH_S
+    const SHORT: f64 = 1.0; // well below MIN_ENROLL_SPEECH_S
 
     #[test]
     fn cosine_similarity_identical_vectors_is_one() {
@@ -287,19 +308,19 @@ mod tests {
     }
 
     #[test]
-    fn centroid_blob_round_trips() {
+    fn embedding_blob_round_trips() {
         let v = vec![0.1f32, -0.2, 0.3, 1.0, -1.0];
-        let bytes = encode_centroid(&v);
+        let bytes = encode_embedding(&v);
         assert_eq!(bytes.len(), v.len() * 4);
-        let decoded = decode_centroid(&bytes).expect("decode");
+        let decoded = decode_embedding(&bytes).expect("decode");
         for (a, b) in v.iter().zip(decoded.iter()) {
             assert!((a - b).abs() < 1e-9);
         }
     }
 
     #[test]
-    fn decode_centroid_rejects_truncated_bytes() {
-        assert!(decode_centroid(&[0, 1, 2]).is_none());
+    fn decode_embedding_rejects_truncated_bytes() {
+        assert!(decode_embedding(&[0, 1, 2]).is_none());
     }
 
     #[test]
@@ -335,117 +356,146 @@ mod tests {
 
     #[test]
     fn match_speakers_empty_stored_creates_new_speakers_for_every_cluster() {
-        let clusters = vec![centroid(0, unit(4, 0)), centroid(1, unit(4, 1))];
+        let clusters = vec![centroid(0, unit(4, 0), LONG), centroid(1, unit(4, 1), LONG)];
         let decisions = match_speakers(&clusters, &[]);
         assert_eq!(decisions.len(), 2);
-        assert!(decisions.iter().all(|d| d.matched_speaker_id.is_none()));
-        let names: Vec<&str> = decisions.iter().map(|d| d.new_name.as_deref().unwrap()).collect();
+        let names: Vec<&str> = decisions
+            .iter()
+            .map(|d| match &d.outcome {
+                MatchOutcome::NewSpeaker { name } => name.as_str(),
+                other => panic!("expected NewSpeaker, got {other:?}"),
+            })
+            .collect();
         assert_eq!(names, vec!["Speaker 1", "Speaker 2"]);
-        for d in &decisions {
-            assert_eq!(d.updated_embedding_count, 1);
-        }
     }
 
     #[test]
     fn match_speakers_above_threshold_and_margin_matches_existing_speaker() {
-        let clusters = vec![centroid(0, unit(4, 0))];
-        let stored_speakers = vec![
-            stored(10, "Alice", Some(unit(4, 0)), 3),
-            stored(11, "Bob", Some(unit(4, 1)), 3),
-        ];
+        let clusters = vec![centroid(0, unit(4, 0), SHORT)];
+        let stored_speakers = vec![stored(10, "Alice", vec![unit(4, 0)]), stored(11, "Bob", vec![unit(4, 1)])];
         let decisions = match_speakers(&clusters, &stored_speakers);
         assert_eq!(decisions.len(), 1);
-        assert_eq!(decisions[0].matched_speaker_id, Some(10));
-        assert_eq!(decisions[0].new_name, None);
-        assert_eq!(decisions[0].updated_embedding_count, 4);
+        assert_eq!(decisions[0].outcome, MatchOutcome::Matched { speaker_id: 10 });
     }
 
     #[test]
-    fn match_speakers_below_threshold_creates_new_speaker() {
-        // 45-degree vector is ~0.707 similar to each axis, comfortably above
-        // 0.65, so use something further off-axis to stay under threshold.
-        let low_sim = vec![0.5f32, 0.0, 0.0, (1.0f32 - 0.25).sqrt()];
-        let clusters = vec![centroid(0, low_sim)];
-        let stored_speakers = vec![stored(10, "Alice", Some(unit(4, 0)), 1)];
+    fn match_speakers_below_threshold_and_long_speech_creates_new_speaker() {
+        let clusters = vec![centroid(0, unit(4, 1), LONG)];
+        let stored_speakers = vec![stored(10, "Alice", vec![unit(4, 0)])]; // sim 0.0
         let decisions = match_speakers(&clusters, &stored_speakers);
-        assert_eq!(decisions[0].matched_speaker_id, None);
-        assert_eq!(decisions[0].new_name.as_deref(), Some("Speaker 1"));
+        assert_eq!(
+            decisions[0].outcome,
+            MatchOutcome::NewSpeaker { name: "Speaker 1".to_string() }
+        );
     }
 
     #[test]
-    fn match_speakers_ambiguous_margin_creates_new_speaker() {
-        // Two stored speakers whose centroids are both close to the cluster
+    fn match_speakers_below_threshold_and_short_speech_is_unlabeled() {
+        let clusters = vec![centroid(0, unit(4, 1), SHORT)];
+        let stored_speakers = vec![stored(10, "Alice", vec![unit(4, 0)])]; // sim 0.0
+        let decisions = match_speakers(&clusters, &stored_speakers);
+        assert_eq!(
+            decisions[0].outcome,
+            MatchOutcome::Unlabeled,
+            "too little speech below threshold must not enroll a new identity"
+        );
+    }
+
+    #[test]
+    fn match_speakers_ambiguous_margin_is_unlabeled_even_with_long_speech() {
+        // Two stored speakers whose embeddings are both close to the cluster
         // and close to each other: best and second-best land within the
-        // margin, so the match must be rejected as ambiguous.
-        let a = l2_normalize(vec![1.0, 0.05, 0.0, 0.0]);
-        let b = l2_normalize(vec![1.0, -0.05, 0.0, 0.0]);
-        let cluster_embedding = l2_normalize(vec![1.0, 0.0, 0.0, 0.0]);
-        let clusters = vec![centroid(0, cluster_embedding)];
-        let stored_speakers = vec![stored(10, "Alice", Some(a), 1), stored(11, "Bob", Some(b), 1)];
+        // margin, so the match must be rejected as ambiguous rather than
+        // spawning a third duplicate.
+        let a = normalize(vec![1.0, 0.05, 0.0, 0.0]);
+        let b = normalize(vec![1.0, -0.05, 0.0, 0.0]);
+        let cluster_embedding = normalize(vec![1.0, 0.0, 0.0, 0.0]);
+        let clusters = vec![centroid(0, cluster_embedding, LONG)];
+        let stored_speakers = vec![stored(10, "Alice", vec![a]), stored(11, "Bob", vec![b])];
         let decisions = match_speakers(&clusters, &stored_speakers);
-        assert_eq!(decisions[0].matched_speaker_id, None, "ambiguous match must fall back to new speaker");
+        assert_eq!(
+            decisions[0].outcome,
+            MatchOutcome::Unlabeled,
+            "ambiguous match must never fall back to creating a new speaker"
+        );
     }
 
     #[test]
-    fn match_speakers_speaker_without_centroid_is_never_matched() {
-        let clusters = vec![centroid(0, unit(4, 0))];
-        let stored_speakers = vec![stored(10, "Alice", None, 0)];
+    fn match_speakers_speaker_without_embeddings_never_matches() {
+        let clusters = vec![centroid(0, unit(4, 0), LONG)];
+        let stored_speakers = vec![stored(10, "Alice", Vec::new())];
         let decisions = match_speakers(&clusters, &stored_speakers);
-        assert_eq!(decisions[0].matched_speaker_id, None);
-        assert_eq!(decisions[0].new_name.as_deref(), Some("Speaker 1"));
+        assert_eq!(
+            decisions[0].outcome,
+            MatchOutcome::NewSpeaker { name: "Speaker 1".to_string() }
+        );
+    }
+
+    #[test]
+    fn match_speakers_max_similarity_across_multiple_embeddings_matches() {
+        // Alice has one far (orthogonal) embedding and one close (identical
+        // to the cluster) one. The match must succeed via the MAX, not fail
+        // because of the far one.
+        let far = unit(4, 1);
+        let close = unit(4, 0);
+        let clusters = vec![centroid(0, unit(4, 0), SHORT)];
+        let stored_speakers = vec![stored(10, "Alice", vec![far, close])];
+        let decisions = match_speakers(&clusters, &stored_speakers);
+        assert_eq!(decisions[0].outcome, MatchOutcome::Matched { speaker_id: 10 });
     }
 
     #[test]
     fn match_speakers_two_clusters_never_map_to_the_same_stored_speaker() {
         // Both clusters are near-identical to the single stored speaker; the
         // higher-similarity one (cluster 0, exact match) must win, the
-        // other must become a new speaker rather than double-mapping.
-        let stored_speakers = vec![stored(10, "Alice", Some(unit(4, 0)), 5)];
-        let almost = l2_normalize(vec![1.0, 0.2, 0.0, 0.0]);
-        let clusters = vec![centroid(0, unit(4, 0)), centroid(1, almost)];
+        // other must be left unlabeled rather than double-mapping or
+        // spawning a new speaker (even though it has plenty of speech).
+        let stored_speakers = vec![stored(10, "Alice", vec![unit(4, 0)])];
+        let almost = normalize(vec![1.0, 0.2, 0.0, 0.0]);
+        let clusters = vec![centroid(0, unit(4, 0), LONG), centroid(1, almost, LONG)];
         let decisions = match_speakers(&clusters, &stored_speakers);
 
         let d0 = decisions.iter().find(|d| d.cluster == 0).unwrap();
         let d1 = decisions.iter().find(|d| d.cluster == 1).unwrap();
-        assert_eq!(d0.matched_speaker_id, Some(10));
-        assert_eq!(d1.matched_speaker_id, None, "loser must not double-map to the same stored speaker");
-        assert_eq!(d1.new_name.as_deref(), Some("Speaker 1"));
+        assert_eq!(d0.outcome, MatchOutcome::Matched { speaker_id: 10 });
+        assert_eq!(
+            d1.outcome,
+            MatchOutcome::Unlabeled,
+            "loser of a same-target conflict must be left unlabeled, not double-mapped or re-enrolled"
+        );
     }
 
     #[test]
     fn match_speakers_multiple_new_speakers_get_sequential_distinct_names() {
         let clusters = vec![
-            centroid(0, unit(3, 0)),
-            centroid(1, unit(3, 1)),
-            centroid(2, unit(3, 2)),
+            centroid(0, unit(3, 0), LONG),
+            centroid(1, unit(3, 1), LONG),
+            centroid(2, unit(3, 2), LONG),
         ];
-        let stored_speakers = vec![stored(1, "Speaker 2", None, 0)];
+        let stored_speakers = vec![stored(1, "Speaker 2", Vec::new())];
         let decisions = match_speakers(&clusters, &stored_speakers);
-        let names: Vec<&str> = decisions.iter().map(|d| d.new_name.as_deref().unwrap()).collect();
+        let names: Vec<&str> = decisions
+            .iter()
+            .map(|d| match &d.outcome {
+                MatchOutcome::NewSpeaker { name } => name.as_str(),
+                other => panic!("expected NewSpeaker, got {other:?}"),
+            })
+            .collect();
         assert_eq!(names, vec!["Speaker 3", "Speaker 4", "Speaker 5"]);
     }
 
     #[test]
-    fn update_centroid_running_mean_matches_hand_computed_value() {
-        // old = [1, 0] with count 2, new = [0, 1] -> combined pre-normalize:
-        // [1*2 + 0, 0*2 + 1] = [2, 1], normalized = [2, 1] / sqrt(5).
-        let (result, count) = update_centroid(Some((&[1.0, 0.0], 2)), &[0.0, 1.0]);
-        let expected_norm = (5.0f32).sqrt();
-        assert!((result[0] - 2.0 / expected_norm).abs() < 1e-6);
-        assert!((result[1] - 1.0 / expected_norm).abs() < 1e-6);
-        assert_eq!(count, 3);
-    }
-
-    #[test]
-    fn update_centroid_with_no_prior_history_is_just_the_new_embedding() {
-        let (result, count) = update_centroid(None, &[0.6, 0.8]);
-        assert_eq!(result, vec![0.6, 0.8]);
-        assert_eq!(count, 1);
-    }
-
-    #[test]
     fn match_speakers_empty_clusters_returns_empty_decisions() {
-        let stored_speakers = vec![stored(10, "Alice", Some(unit(4, 0)), 1)];
+        let stored_speakers = vec![stored(10, "Alice", vec![unit(4, 0)])];
         assert!(match_speakers(&[], &stored_speakers).is_empty());
+    }
+
+    #[test]
+    fn match_speakers_carries_embedding_and_speech_seconds_on_every_decision() {
+        let embedding = unit(4, 0);
+        let clusters = vec![centroid(0, embedding.clone(), 7.5)];
+        let decisions = match_speakers(&clusters, &[]);
+        assert_eq!(decisions[0].embedding, embedding);
+        assert_eq!(decisions[0].speech_seconds, 7.5);
     }
 }

--- a/src-tauri/src/diarize/persist.rs
+++ b/src-tauri/src/diarize/persist.rs
@@ -22,8 +22,13 @@ pub const MATCH_THRESHOLD: f32 = 0.5;
 
 /// Minimum lead a cluster's best-matching stored speaker must have over the
 /// second-best DISTINCT stored speaker for the match to be accepted instead
-/// of treated as ambiguous. An ambiguous cluster is left unlabeled rather
-/// than guessed at: creating a new speaker for it would spawn yet another
+/// of treated as ambiguous. Applies whenever a second stored speaker exists
+/// at all, regardless of whether that second speaker's own similarity clears
+/// `MATCH_THRESHOLD`: intra-voice similarity varies 0.48 to 0.66 in practice,
+/// so a best match of 0.52 against a second-best of 0.47 is well inside that
+/// noise band and must not be silently accepted just because 0.47 falls
+/// under the threshold. An ambiguous cluster is left unlabeled rather than
+/// guessed at: creating a new speaker for it would spawn yet another
 /// duplicate of a voice that already has two candidate rows.
 pub const MATCH_MARGIN: f32 = 0.05;
 
@@ -90,6 +95,15 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     (dot / (norm_a * norm_b)).clamp(-1.0, 1.0)
 }
 
+/// MAX cosine similarity of `embedding` against every embedding in `bag`.
+/// `None` for an empty bag: a stored speaker that has never had an embedding
+/// recorded has nothing to compare against. Shared by `match_speakers` and
+/// the `--diarize-file` CLI calibration report, which both need "how close
+/// is this embedding to this speaker's bag of recent voice samples".
+pub fn max_similarity(embedding: &[f32], bag: &[Vec<f32>]) -> Option<f32> {
+    bag.iter().map(|e| cosine_similarity(embedding, e)).max_by(f32::total_cmp)
+}
+
 /// Encode an embedding as the DB's opaque BLOB format: little-endian f32s,
 /// one per dimension (256 for the WeSpeaker model currently in use, but
 /// nothing here hard-codes that beyond this comment).
@@ -136,9 +150,10 @@ fn next_speaker_name<'a>(taken_names: impl Iterator<Item = &'a str>) -> String {
 /// For a cluster, similarity against a stored speaker is the MAX cosine
 /// similarity over that speaker's embeddings. The best-matching stored
 /// speaker is accepted only if `best >= MATCH_THRESHOLD` AND there is no
-/// second DISTINCT stored speaker also `>= MATCH_THRESHOLD` within
-/// `MATCH_MARGIN` of it (an ambiguous best match never creates a duplicate:
-/// it's left unlabeled for the user to resolve). Below threshold, the
+/// second DISTINCT stored speaker within `MATCH_MARGIN` of it, whether or
+/// not that second speaker itself clears `MATCH_THRESHOLD` (an ambiguous
+/// best match never creates a duplicate: it's left unlabeled for the user to
+/// resolve). Below threshold, the
 /// cluster becomes a new speaker only if it has at least `MIN_ENROLL_SPEECH_S`
 /// of speech; otherwise it's left unlabeled. Because two different clusters
 /// can end up wanting the same stored speaker, accepted candidates are
@@ -166,20 +181,16 @@ pub fn match_speakers(clusters: &[SpeakerCentroid], stored: &[StoredSpeaker]) ->
                 .iter()
                 .enumerate()
                 .filter_map(|(idx, s)| {
-                    s.embeddings
-                        .iter()
-                        .map(|e| cosine_similarity(&cluster.embedding, e))
-                        .max_by(f32::total_cmp)
-                        .map(|max_sim| (idx, max_sim))
+                    max_similarity(&cluster.embedding, &s.embeddings).map(|max_sim| (idx, max_sim))
                 })
                 .collect();
             sims.sort_by(|a, b| b.1.total_cmp(&a.1));
 
             match sims.first() {
                 Some(&(best_idx, best_sim)) if best_sim >= MATCH_THRESHOLD => {
-                    let ambiguous = sims.get(1).is_some_and(|&(_, second_sim)| {
-                        second_sim >= MATCH_THRESHOLD && best_sim - second_sim < MATCH_MARGIN
-                    });
+                    let ambiguous = sims
+                        .get(1)
+                        .is_some_and(|&(_, second_sim)| best_sim - second_sim < MATCH_MARGIN);
                     if ambiguous {
                         Prelim::Ambiguous
                     } else {
@@ -254,12 +265,7 @@ mod tests {
     }
 
     fn normalize(mut v: Vec<f32>) -> Vec<f32> {
-        let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
-        if norm > 0.0 {
-            for x in &mut v {
-                *x /= norm;
-            }
-        }
+        crate::diarize::clustering::l2_normalize(&mut v);
         v
     }
 
@@ -305,6 +311,19 @@ mod tests {
     #[test]
     fn cosine_similarity_handles_empty_vectors() {
         assert_eq!(cosine_similarity(&[], &[]), 0.0);
+    }
+
+    #[test]
+    fn max_similarity_picks_the_best_of_the_bag() {
+        let far = unit(4, 1);
+        let close = unit(4, 0);
+        let sim = max_similarity(&unit(4, 0), &[far, close]).unwrap();
+        assert!((sim - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn max_similarity_empty_bag_is_none() {
+        assert!(max_similarity(&unit(4, 0), &[]).is_none());
     }
 
     #[test]
@@ -417,6 +436,25 @@ mod tests {
             decisions[0].outcome,
             MatchOutcome::Unlabeled,
             "ambiguous match must never fall back to creating a new speaker"
+        );
+    }
+
+    #[test]
+    fn match_speakers_ambiguous_when_second_is_below_threshold_but_within_margin() {
+        // Best match 0.52 against Alice, second-best 0.47 against Bob: 0.47
+        // is BELOW MATCH_THRESHOLD (0.5), but the 0.05 gap is inside the
+        // documented intra-voice variance (0.48-0.66), so this must still be
+        // ambiguous, not silently matched to Alice.
+        let cluster_embedding = vec![1.0, 0.0, 0.0, 0.0];
+        let a = vec![0.52, (1.0f32 - 0.52 * 0.52).sqrt(), 0.0, 0.0];
+        let b = vec![0.47, 0.0, (1.0f32 - 0.47 * 0.47).sqrt(), 0.0];
+        let clusters = vec![centroid(0, cluster_embedding, LONG)];
+        let stored_speakers = vec![stored(10, "Alice", vec![a]), stored(11, "Bob", vec![b])];
+        let decisions = match_speakers(&clusters, &stored_speakers);
+        assert_eq!(
+            decisions[0].outcome,
+            MatchOutcome::Unlabeled,
+            "a second-best within MATCH_MARGIN must be ambiguous even when itself below MATCH_THRESHOLD"
         );
     }
 

--- a/src-tauri/src/diarize/persist.rs
+++ b/src-tauri/src/diarize/persist.rs
@@ -11,6 +11,15 @@
 //! measures 0.48 to 0.66 in practice, so any one embedding can miss a match
 //! while another recorded on a different day, mic, or vocal tone hits.
 //! Similarity against a stored speaker is the MAX over its embeddings.
+//!
+//! `resolve_session` builds on `match_speakers` to coordinate a single
+//! recording session's mic and system-audio passes: it detects mic clusters
+//! that are just the system audio leaking into the microphone (see its doc
+//! comment for the physical invariant that makes this safe) and folds the
+//! remaining, genuinely independent clusters from both lanes into one
+//! `match_speakers` call, so a claim on a stored speaker can no longer be won
+//! twice by two clusters that are actually the same voice heard through two
+//! taps.
 
 use super::SpeakerCentroid;
 
@@ -37,6 +46,23 @@ pub const MATCH_MARGIN: f32 = 0.05;
 /// second of speech spawning a permanent identity that nothing will ever
 /// match against again.
 pub const MIN_ENROLL_SPEECH_S: f64 = 5.0;
+
+/// Cosine similarity above which a mic cluster is considered the same voice
+/// as a system cluster from the SAME session, i.e. the system audio leaking
+/// acoustically into the microphone, not two different people who happen to
+/// sound alike. Deliberately higher than `MATCH_THRESHOLD` (0.5):
+/// `MATCH_THRESHOLD` calibrates the same voice recorded on different
+/// days/mics/tones (0.48 to 0.66 in practice), a much noisier comparison
+/// than the same voice at the same instant of the same session, only
+/// degraded by one extra speaker-to-mic acoustic path.
+///
+/// The physical invariant that makes this safe: the system audio tap can
+/// never contain the local microphone's own voice (there is no return loop
+/// from mic input back into system output), so a mic cluster that closely
+/// matches a system cluster from the same session cannot be a coincidence of
+/// two different people sounding similar. It IS that system voice, heard
+/// twice.
+pub const CROSS_LANE_ECHO_THRESHOLD: f32 = 0.7;
 
 /// A stored, persistent speaker row as seen by the matcher: its recent
 /// embeddings (see `db::speakers::MAX_EMBEDDINGS_PER_SPEAKER`), decoded to
@@ -252,6 +278,129 @@ pub fn match_speakers(clusters: &[SpeakerCentroid], stored: &[StoredSpeaker]) ->
         });
     }
     decisions
+}
+
+/// What a mic cluster resolved to, once cross-lane echo has been factored
+/// in. See `resolve_session`.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MicResolution {
+    /// Not echo (or there was no system lane to compare against): resolved
+    /// on its own merits, exactly as `match_speakers` would in isolation.
+    Own(MatchDecision),
+    /// This mic cluster is the system audio leaking into the microphone,
+    /// heard a second time. `cluster` is its own (mic-lane) cluster id;
+    /// `system_cluster` is the system-lane cluster id (indexing into
+    /// `SessionResolution::system`, matched by `MatchDecision::cluster`) it
+    /// is an echo of. It is never matched, enrolled, or persisted on its
+    /// own: the caller must resolve it to whatever the system cluster
+    /// resolved to (including `Unlabeled`, if the system cluster itself
+    /// didn't resolve to a stored speaker) and must never write an embedding
+    /// for it, since it is a degraded copy of a voice already captured
+    /// cleanly by the system tap.
+    Echo { cluster: usize, system_cluster: usize },
+}
+
+/// One recording session's mic and system-audio clusters, resolved
+/// together. See `resolve_session`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SessionResolution {
+    /// One decision per system cluster, in no particular order. System
+    /// clusters are never echo: the system tap can never contain the local
+    /// mic's own voice, so nothing about a system cluster ever depends on
+    /// the mic lane.
+    pub system: Vec<MatchDecision>,
+    /// One resolution per mic cluster, index-aligned with the
+    /// `mic_clusters` slice passed to `resolve_session`.
+    pub mic: Vec<MicResolution>,
+}
+
+/// Resolve one session's system and mic clusters together against `stored`
+/// speakers, so a mic cluster that is just the system audio leaking into the
+/// microphone can never spawn a duplicate identity or steal a stored
+/// speaker's claim out from under the real system cluster.
+///
+/// Two steps:
+/// 1. Every mic cluster is compared against every system cluster of the same
+///    session (max cosine similarity, see `max_similarity`'s sibling logic
+///    here). A mic cluster whose best system match is at or above
+///    `CROSS_LANE_ECHO_THRESHOLD` is echo: it is excluded from matching and
+///    instead tagged with the system cluster it echoes.
+/// 2. Every system cluster, plus every non-echo mic cluster, is matched
+///    together in a single `match_speakers` call, so the greedy same-target
+///    conflict resolution there (see its doc comment) now also arbitrates
+///    between the two lanes, not just within one.
+///
+/// Mic and system clusters can carry numerically identical `.speaker` ids
+/// (each lane numbers its own clusters from its own `diarize()` run), so
+/// non-echo mic clusters are re-tagged with an id past every system id
+/// before the combined `match_speakers` call, and untagged again on the way
+/// out; `MicResolution`/`MatchDecision::cluster` always carries the real,
+/// original per-lane id.
+///
+/// A meeting with only one lane (mic-only or system-only) behaves exactly as
+/// `match_speakers` would on that lane alone: an empty other-lane slice
+/// finds no echo and contributes nothing to the combined match.
+pub fn resolve_session(
+    system_clusters: &[SpeakerCentroid],
+    mic_clusters: &[SpeakerCentroid],
+    stored: &[StoredSpeaker],
+) -> SessionResolution {
+    // For each mic cluster (keyed by its real cluster id), the system
+    // cluster id it is an echo of, if any.
+    let echo_of: std::collections::HashMap<usize, usize> = mic_clusters
+        .iter()
+        .filter_map(|mic| {
+            system_clusters
+                .iter()
+                .map(|sys| (sys.speaker, cosine_similarity(&mic.embedding, &sys.embedding)))
+                .filter(|&(_, sim)| sim >= CROSS_LANE_ECHO_THRESHOLD)
+                .max_by(|a, b| a.1.total_cmp(&b.1))
+                .map(|(sys_speaker, _)| (mic.speaker, sys_speaker))
+        })
+        .collect();
+
+    let tag_offset = system_clusters.iter().map(|c| c.speaker).max().map_or(0, |m| m + 1);
+    let mut combined: Vec<SpeakerCentroid> = system_clusters.to_vec();
+    // Maps a tagged (combined-list) id back to the real mic cluster id it
+    // stands in for, so the match result can be untagged on the way out.
+    let mut tag_to_mic_speaker: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
+    for mic in mic_clusters {
+        if echo_of.contains_key(&mic.speaker) {
+            continue;
+        }
+        let tag = tag_offset + mic.speaker;
+        tag_to_mic_speaker.insert(tag, mic.speaker);
+        combined.push(SpeakerCentroid {
+            speaker: tag,
+            embedding: mic.embedding.clone(),
+            speech_seconds: mic.speech_seconds,
+        });
+    }
+
+    let mut system: Vec<MatchDecision> = Vec::with_capacity(system_clusters.len());
+    let mut mic_own: std::collections::HashMap<usize, MatchDecision> = std::collections::HashMap::new();
+    for mut decision in match_speakers(&combined, stored) {
+        if let Some(&mic_speaker) = tag_to_mic_speaker.get(&decision.cluster) {
+            decision.cluster = mic_speaker;
+            mic_own.insert(mic_speaker, decision);
+        } else {
+            system.push(decision);
+        }
+    }
+
+    let mic = mic_clusters
+        .iter()
+        .map(|c| match echo_of.get(&c.speaker) {
+            Some(&system_cluster) => MicResolution::Echo { cluster: c.speaker, system_cluster },
+            None => MicResolution::Own(
+                mic_own
+                    .remove(&c.speaker)
+                    .expect("every non-echo mic cluster was included in the combined match_speakers call"),
+            ),
+        })
+        .collect();
+
+    SessionResolution { system, mic }
 }
 
 #[cfg(test)]
@@ -535,5 +684,165 @@ mod tests {
         let decisions = match_speakers(&clusters, &[]);
         assert_eq!(decisions[0].embedding, embedding);
         assert_eq!(decisions[0].speech_seconds, 7.5);
+    }
+
+    // resolve_session
+
+    #[test]
+    fn resolve_session_near_identical_mic_cluster_is_echo_of_system_cluster() {
+        let sys_emb = unit(4, 0);
+        let mic_emb = normalize(vec![1.0, 0.1, 0.0, 0.0]); // sim ~0.995, well above 0.7
+        let system_clusters = vec![centroid(0, sys_emb, LONG)];
+        let mic_clusters = vec![centroid(0, mic_emb, LONG)];
+        let resolution = resolve_session(&system_clusters, &mic_clusters, &[]);
+
+        assert_eq!(resolution.system.len(), 1);
+        assert_eq!(resolution.mic, vec![MicResolution::Echo { cluster: 0, system_cluster: 0 }]);
+    }
+
+    #[test]
+    fn resolve_session_echo_of_an_unlabeled_system_cluster_stays_tagged_echo() {
+        // Orthogonal to the only stored speaker and too little speech to
+        // enroll: the system cluster itself resolves to Unlabeled.
+        let stored_speakers = vec![stored(10, "Alice", vec![unit(4, 1)])];
+        let sys_emb = unit(4, 0); // sim to Alice = 0.0
+        let mic_emb = normalize(vec![1.0, 0.05, 0.0, 0.0]); // echo of the system cluster
+        let system_clusters = vec![centroid(0, sys_emb, SHORT)];
+        let mic_clusters = vec![centroid(0, mic_emb, LONG)];
+        let resolution = resolve_session(&system_clusters, &mic_clusters, &stored_speakers);
+
+        assert_eq!(resolution.system[0].outcome, MatchOutcome::Unlabeled);
+        assert_eq!(resolution.mic, vec![MicResolution::Echo { cluster: 0, system_cluster: 0 }]);
+    }
+
+    #[test]
+    fn resolve_session_echo_of_a_newly_enrolled_system_cluster_stays_tagged_echo() {
+        let sys_emb = unit(4, 0);
+        let mic_emb = normalize(vec![1.0, 0.05, 0.0, 0.0]); // echo of the system cluster
+        let system_clusters = vec![centroid(0, sys_emb, LONG)]; // no stored speakers: enrolls new
+        let mic_clusters = vec![centroid(0, mic_emb, LONG)];
+        let resolution = resolve_session(&system_clusters, &mic_clusters, &[]);
+
+        assert_eq!(
+            resolution.system[0].outcome,
+            MatchOutcome::NewSpeaker { name: "Speaker 1".to_string() }
+        );
+        assert_eq!(resolution.mic, vec![MicResolution::Echo { cluster: 0, system_cluster: 0 }]);
+    }
+
+    #[test]
+    fn resolve_session_mic_cluster_below_echo_threshold_matches_independently() {
+        // Orthogonal to the system cluster: not echo, resolved on its own.
+        let system_clusters = vec![centroid(0, unit(4, 0), LONG)];
+        let mic_clusters = vec![centroid(0, unit(4, 1), LONG)];
+        let resolution = resolve_session(&system_clusters, &mic_clusters, &[]);
+
+        assert_eq!(
+            resolution.system[0].outcome,
+            MatchOutcome::NewSpeaker { name: "Speaker 1".to_string() }
+        );
+        match &resolution.mic[..] {
+            [MicResolution::Own(decision)] => {
+                assert_eq!(decision.cluster, 0);
+                assert_eq!(decision.outcome, MatchOutcome::NewSpeaker { name: "Speaker 2".to_string() });
+            }
+            other => panic!("expected a single Own resolution, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_session_coordinates_claims_across_lanes() {
+        // Both clusters are well clear of the 0.7 echo threshold against each
+        // other, but each independently clears MATCH_THRESHOLD against the
+        // single stored speaker, with the system cluster the stronger match.
+        // Combined matching must let only one of them win the claim.
+        let alice = unit(5, 0);
+        let system_emb = normalize(vec![1.0, 0.5, 0.0, 0.0, 0.0]); // sim to alice ~0.894
+        let mic_emb = normalize(vec![1.0, -0.5, 0.9, 0.0, 0.0]); // sim to alice ~0.697
+        assert!(
+            cosine_similarity(&system_emb, &mic_emb) < CROSS_LANE_ECHO_THRESHOLD,
+            "test fixture must not be flagged as echo"
+        );
+        let stored_speakers = vec![stored(10, "Alice", vec![alice])];
+        let system_clusters = vec![centroid(0, system_emb, LONG)];
+        let mic_clusters = vec![centroid(0, mic_emb, LONG)];
+        let resolution = resolve_session(&system_clusters, &mic_clusters, &stored_speakers);
+
+        assert_eq!(resolution.system[0].outcome, MatchOutcome::Matched { speaker_id: 10 });
+        match &resolution.mic[..] {
+            [MicResolution::Own(decision)] => {
+                assert_eq!(
+                    decision.outcome,
+                    MatchOutcome::Unlabeled,
+                    "the weaker cross-lane claim on the same stored speaker must lose, not double-map"
+                );
+            }
+            other => panic!("expected a single Own resolution, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_session_identical_cluster_ids_across_lanes_do_not_collide() {
+        // Both lanes number their first cluster "0"; they must not be
+        // conflated by the internal retagging used to combine them.
+        let system_clusters = vec![centroid(0, unit(4, 0), LONG)];
+        let mic_clusters = vec![centroid(0, unit(4, 1), LONG)]; // orthogonal: not echo
+        let resolution = resolve_session(&system_clusters, &mic_clusters, &[]);
+
+        assert_eq!(resolution.system.len(), 1);
+        assert_eq!(resolution.system[0].cluster, 0);
+        match &resolution.mic[..] {
+            [MicResolution::Own(decision)] => assert_eq!(decision.cluster, 0),
+            other => panic!("expected a single Own resolution, got {other:?}"),
+        }
+        // Distinct clusters, so distinct enrolled names, not a single shared one.
+        let names: Vec<String> = std::iter::once(&resolution.system[0])
+            .chain(resolution.mic.iter().map(|m| match m {
+                MicResolution::Own(d) => d,
+                MicResolution::Echo { .. } => panic!("unexpected echo"),
+            }))
+            .map(|d| match &d.outcome {
+                MatchOutcome::NewSpeaker { name } => name.clone(),
+                other => panic!("expected NewSpeaker, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(names, vec!["Speaker 1".to_string(), "Speaker 2".to_string()]);
+    }
+
+    #[test]
+    fn resolve_session_mic_only_matches_exactly_like_match_speakers_alone() {
+        let stored_speakers = vec![stored(10, "Alice", vec![unit(4, 0)])];
+        let mic_clusters = vec![centroid(0, unit(4, 0), LONG), centroid(1, unit(4, 1), LONG)];
+        let resolution = resolve_session(&[], &mic_clusters, &stored_speakers);
+
+        assert!(resolution.system.is_empty());
+        let direct = match_speakers(&mic_clusters, &stored_speakers);
+        let via_resolve: Vec<MatchDecision> = resolution
+            .mic
+            .into_iter()
+            .map(|m| match m {
+                MicResolution::Own(d) => d,
+                MicResolution::Echo { .. } => panic!("empty system lane can never produce echo"),
+            })
+            .collect();
+        assert_eq!(via_resolve, direct);
+    }
+
+    #[test]
+    fn resolve_session_system_only_matches_exactly_like_match_speakers_alone() {
+        let stored_speakers = vec![stored(10, "Alice", vec![unit(4, 0)])];
+        let system_clusters = vec![centroid(0, unit(4, 0), LONG), centroid(1, unit(4, 1), LONG)];
+        let resolution = resolve_session(&system_clusters, &[], &stored_speakers);
+
+        assert!(resolution.mic.is_empty());
+        assert_eq!(resolution.system, match_speakers(&system_clusters, &stored_speakers));
+    }
+
+    #[test]
+    fn resolve_session_both_lanes_empty_returns_empty_resolution() {
+        let stored_speakers = vec![stored(10, "Alice", vec![unit(4, 0)])];
+        let resolution = resolve_session(&[], &[], &stored_speakers);
+        assert!(resolution.system.is_empty());
+        assert!(resolution.mic.is_empty());
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -114,6 +114,8 @@ fn specta_builder() -> Builder<tauri::Wry> {
             commands::list_speakers,
             commands::list_speaker_profiles,
             commands::delete_speaker,
+            commands::merge_speakers,
+            commands::set_speaker_is_me,
             commands::retag_meeting_speaker,
             commands::check_summary_providers,
             commands::summarize_meeting,

--- a/src-tauri/src/pipeline/diarize_task.rs
+++ b/src-tauri/src/pipeline/diarize_task.rs
@@ -26,8 +26,8 @@ use crate::app_events::{DiarizationProgress, MeetingDiarized};
 use crate::audio::diarize_tap;
 use crate::db::Database;
 use crate::diarize::assign::{SegmentSpan, assign_by_overlap};
-use crate::diarize::persist::{StoredSpeaker, decode_centroid, encode_centroid, match_speakers};
-use crate::diarize::{DiarizeConfig, models};
+use crate::diarize::persist::{MatchOutcome, StoredSpeaker, decode_embedding, encode_embedding, match_speakers};
+use crate::diarize::{DiarizeConfig, SpeakerCentroid, models};
 use crate::engine::Speaker;
 use crate::state::AppState;
 
@@ -278,8 +278,8 @@ fn diarize_meeting(
 
 /// Diarize one recording session's WAV and return the (sort_order, speaker)
 /// assignments for that session's slice of the meeting's segments. Persists
-/// speaker rows and centroid updates as a side effect, so a later session in
-/// the same meeting (and any later meeting) matches against fresh centroids.
+/// speaker rows and embeddings as a side effect, so a later session in the
+/// same meeting (and any later meeting) matches against fresh data.
 fn diarize_session(
     db: &Database,
     meeting: &crate::transcript::MeetingTranscript,
@@ -313,7 +313,7 @@ fn diarize_session(
     // the tapped WAV, so session-local segment spans line up with diarized
     // ranges directly. Mapped before any speaker-row write: a pass whose
     // ranges match no segment at all must not create orphan "Speaker N"
-    // rows or fold their centroids.
+    // rows or spend embedding slots on them.
     let spans: Vec<SegmentSpan> = meeting.segments[start..end]
         .iter()
         .map(|seg| SegmentSpan {
@@ -323,41 +323,46 @@ fn diarize_session(
         })
         .collect();
     let cluster_per_span = assign_by_overlap(&result.segments, &spans);
-    if cluster_per_span.iter().all(Option::is_none) {
+    let assigned_clusters: std::collections::HashSet<usize> =
+        cluster_per_span.iter().flatten().copied().collect();
+    if assigned_clusters.is_empty() {
         return Ok(Vec::new());
     }
 
-    // Resolve each detected cluster to a persistent speaker id, creating
-    // rows / folding centroids as decided by the pure matcher.
-    let stored: Vec<StoredSpeaker> = db
-        .list_speakers()?
+    // Only clusters that actually labeled at least one span are worth
+    // matching: an unassigned cluster (e.g. a stray VAD trigger nothing
+    // overlaps) must never create a stored speaker row or spend one of a
+    // speaker's limited embedding slots.
+    let clusters_to_match: Vec<SpeakerCentroid> = result
+        .speakers
         .into_iter()
-        .map(|record| StoredSpeaker {
-            id: record.id,
-            name: record.name,
-            centroid: record.centroid.as_deref().and_then(decode_centroid),
-            embedding_count: record.embedding_count,
+        .filter(|c| assigned_clusters.contains(&c.speaker))
+        .collect();
+
+    let stored: Vec<StoredSpeaker> = db
+        .list_speakers_with_embeddings()?
+        .into_iter()
+        .map(|s| StoredSpeaker {
+            id: s.speaker.id,
+            name: s.speaker.name,
+            embeddings: s.embeddings.iter().filter_map(|e| decode_embedding(e)).collect(),
         })
         .collect();
-    let decisions = match_speakers(&result.speakers, &stored);
+    let decisions = match_speakers(&clusters_to_match, &stored);
 
     let now = chrono::Utc::now();
     let mut cluster_to_speaker: std::collections::HashMap<usize, i64> = std::collections::HashMap::new();
     for decision in &decisions {
-        let speaker_id = match decision.matched_speaker_id {
-            Some(id) => id,
-            None => {
-                let name = decision
-                    .new_name
-                    .as_deref()
-                    .ok_or("Match decision with neither id nor name")?;
-                db.create_speaker(name)?
-            }
+        let speaker_id = match &decision.outcome {
+            MatchOutcome::Matched { speaker_id } => *speaker_id,
+            MatchOutcome::NewSpeaker { name } => db.create_speaker(name)?,
+            MatchOutcome::Unlabeled => continue,
         };
-        db.update_speaker_centroid(
+        db.append_speaker_embedding(
             speaker_id,
-            &encode_centroid(&decision.updated_centroid),
-            decision.updated_embedding_count,
+            Some(meeting.id.as_str()),
+            &encode_embedding(&decision.embedding),
+            decision.speech_seconds,
             now,
         )?;
         cluster_to_speaker.insert(decision.cluster, speaker_id);
@@ -460,14 +465,14 @@ mod tests {
         meeting.recording_sessions[0].end_segment_index = meeting.segments.len() as u64;
         db.save_meeting(&meeting).unwrap();
 
-        // Seed a fake stored speaker with an orthogonal-ish centroid that
+        // Seed a fake stored speaker with an orthogonal-ish embedding that
         // should NOT match any real voice cluster (unit vector on dim 0 of a
         // 256-dim space is essentially uncorrelated with real embeddings),
         // proving new-speaker creation coexists with the stored row.
         let fake_id = db.create_speaker("Preexisting").unwrap();
-        let mut fake_centroid = vec![0.0f32; 256];
-        fake_centroid[0] = 1.0;
-        db.update_speaker_centroid(fake_id, &encode_centroid(&fake_centroid), 1, chrono::Utc::now())
+        let mut fake_embedding = vec![0.0f32; 256];
+        fake_embedding[0] = 1.0;
+        db.append_speaker_embedding(fake_id, None, &encode_embedding(&fake_embedding), 10.0, chrono::Utc::now())
             .unwrap();
 
         let cfg = DiarizeConfig::new(models::segmentation_model_path(), models::embedding_model_path());

--- a/src-tauri/src/pipeline/diarize_task.rs
+++ b/src-tauri/src/pipeline/diarize_task.rs
@@ -7,10 +7,16 @@
 //! map the diarized time ranges onto that session's transcript segments
 //! (`diarize::assign`), and write the labels back in one transaction.
 //!
-//! Mic and system-audio passes are independent: the mic WAV rewrites Me-lane
-//! segments (Them and persistent labels stay locked); the system WAV rewrites
-//! Them-lane segments (Me and persistent labels stay locked). Live Me/Them
-//! lanes during recording are unchanged.
+//! Mic and system-audio passes are independent for which transcript lane
+//! they may rewrite: the mic WAV rewrites Me-lane segments (Them and
+//! persistent labels stay locked); the system WAV rewrites Them-lane
+//! segments (Me and persistent labels stay locked). Live Me/Them lanes
+//! during recording are unchanged. They are NOT independent for persistent
+//! speaker matching: within one session, both lanes' inference runs first,
+//! then `diarize::persist::resolve_session` matches their clusters together
+//! (see its doc comment), so a mic cluster that is just the system audio
+//! leaking into the microphone can never spawn a duplicate persistent
+//! speaker or steal a stored speaker's claim from the real system cluster.
 //!
 //! Everything here is best-effort: any failure just leaves the meeting
 //! unlabeled (logged, surfaced via `DiarizationProgress.error`), and the
@@ -28,7 +34,9 @@ use crate::app_events::{DiarizationProgress, MeetingDiarized};
 use crate::audio::diarize_tap;
 use crate::db::Database;
 use crate::diarize::assign::{SegmentSpan, assign_by_overlap};
-use crate::diarize::persist::{MatchOutcome, StoredSpeaker, decode_embedding, encode_embedding, match_speakers};
+use crate::diarize::persist::{
+    MatchDecision, MatchOutcome, MicResolution, StoredSpeaker, decode_embedding, encode_embedding, resolve_session,
+};
 use crate::diarize::{DiarizeConfig, SpeakerCentroid, models};
 use crate::engine::Speaker;
 use crate::state::AppState;
@@ -215,8 +223,11 @@ fn parse_diarize_wav_stem(stem: &str) -> Option<(usize, DiarizationPass)> {
 /// Diarize every tapped session of one meeting and write the resulting
 /// speaker labels back. Each session may run a mic pass, a system pass, or
 /// both; a failed pass is logged and skipped (its segments stay unlabeled),
-/// it does not abort the rest. Segment updates land at the end, one
-/// transaction per lane: the mic pass may replace live `me` labels, the
+/// it does not abort the rest. Within a session, both passes' inference runs
+/// first and only then are their clusters resolved together
+/// (`resolve_session`), so persistent speaker matching sees the whole
+/// session at once, not one lane at a time. Segment updates land at the end,
+/// one transaction per lane: the mic pass may replace live `me` labels, the
 /// system pass may replace live `them` labels, and either may fill NULL
 /// speakers (mic-only meetings). Returns how many segments were relabeled.
 fn diarize_meeting(
@@ -231,49 +242,56 @@ fn diarize_meeting(
     let mut cfg = DiarizeConfig::new(models::segmentation_model_path(), models::embedding_model_path());
     cfg.max_speakers = settings.diarize_max_speakers.map(|n| n as usize);
 
-    let mut mic_assignments: Vec<(u64, Speaker)> = Vec::new();
-    let mut system_assignments: Vec<(u64, Speaker)> = Vec::new();
+    let mut mic_assignments: SegmentAssignments = Vec::new();
+    let mut system_assignments: SegmentAssignments = Vec::new();
     let mut done_passes = 0u32;
     for session in session_files {
-        if let Some(wav_path) = &session.mic_wav {
-            match diarize_session(
-                db,
-                &meeting,
-                session.session_index,
-                wav_path,
-                &cfg,
-                DiarizationPass::Mic,
-            ) {
-                Ok(mut session_assignments) => mic_assignments.append(&mut session_assignments),
-                Err(e) => warn!(
-                    meeting_id = %meeting_id,
-                    session = session.session_index,
-                    pass = "mic",
-                    "Diarization failed for one session (its segments stay unlabeled): {e}"
-                ),
-            }
+        let mic_pass = if let Some(wav_path) = &session.mic_wav {
+            let pass = run_diarize_pass(&meeting, session.session_index, wav_path, &cfg, DiarizationPass::Mic)
+                .unwrap_or_else(|e| {
+                    warn!(
+                        meeting_id = %meeting_id,
+                        session = session.session_index,
+                        pass = "mic",
+                        "Diarization failed for one session (its segments stay unlabeled): {e}"
+                    );
+                    PassResult::empty()
+                });
             done_passes += 1;
             on_pass_done(done_passes);
-        }
-        if let Some(wav_path) = &session.system_wav {
-            match diarize_session(
-                db,
-                &meeting,
-                session.session_index,
-                wav_path,
-                &cfg,
-                DiarizationPass::System,
-            ) {
-                Ok(mut session_assignments) => system_assignments.append(&mut session_assignments),
-                Err(e) => warn!(
-                    meeting_id = %meeting_id,
-                    session = session.session_index,
-                    pass = "system",
-                    "Diarization failed for one session (its segments stay unlabeled): {e}"
-                ),
-            }
+            pass
+        } else {
+            PassResult::empty()
+        };
+
+        let system_pass = if let Some(wav_path) = &session.system_wav {
+            let pass = run_diarize_pass(&meeting, session.session_index, wav_path, &cfg, DiarizationPass::System)
+                .unwrap_or_else(|e| {
+                    warn!(
+                        meeting_id = %meeting_id,
+                        session = session.session_index,
+                        pass = "system",
+                        "Diarization failed for one session (its segments stay unlabeled): {e}"
+                    );
+                    PassResult::empty()
+                });
             done_passes += 1;
             on_pass_done(done_passes);
+            pass
+        } else {
+            PassResult::empty()
+        };
+
+        match resolve_and_persist_session(db, meeting_id, &system_pass, &mic_pass) {
+            Ok((mut session_mic, mut session_system)) => {
+                mic_assignments.append(&mut session_mic);
+                system_assignments.append(&mut session_system);
+            }
+            Err(e) => warn!(
+                meeting_id = %meeting_id,
+                session = session.session_index,
+                "Speaker matching failed for one session (its segments stay unlabeled): {e}"
+            ),
         }
     }
 
@@ -293,44 +311,70 @@ fn diarize_meeting(
     Ok(mic_changed + system_changed)
 }
 
-/// Diarize one recording session's WAV and return the (sort_order, speaker)
-/// assignments for that session's slice of the meeting's segments. Persists
-/// speaker rows and embeddings as a side effect, so a later session in the
-/// same meeting (and any later meeting) matches against fresh data.
-fn diarize_session(
-    db: &Database,
+/// (sort_order, speaker) pairs ready for `Database::set_segment_speakers`.
+type SegmentAssignments = Vec<(u64, Speaker)>;
+
+/// One pass's (mic or system) local cluster assignment, ready to be resolved
+/// against the other lane and persistent speakers. Carries no database
+/// state: `run_diarize_pass` is pure inference plus overlap assignment.
+struct PassResult {
+    /// Where this session's segments start in the meeting's segment list;
+    /// `cluster_per_span[i]` is segment `start + i`.
+    start: usize,
+    cluster_per_span: Vec<Option<usize>>,
+    /// Only clusters that labeled at least one span: an unassigned cluster
+    /// (e.g. a stray VAD trigger nothing overlaps) must never create a
+    /// stored speaker row or spend one of a speaker's limited embedding
+    /// slots.
+    clusters_to_match: Vec<SpeakerCentroid>,
+}
+
+impl PassResult {
+    /// A pass that ran but found nothing to label: absent WAV, failed
+    /// inference, an out-of-range session, or no overlapping clusters. Safe
+    /// to feed into `resolve_and_persist_session` unconditionally, since an
+    /// empty `cluster_per_span` never reads `start`.
+    fn empty() -> Self {
+        PassResult { start: 0, cluster_per_span: Vec::new(), clusters_to_match: Vec::new() }
+    }
+}
+
+/// Run inference for one recording session's WAV and map the resulting
+/// clusters onto that session's slice of the meeting's segments by overlap.
+/// No database access: matching against persistent speakers happens
+/// afterwards, once both lanes of the session are available (see
+/// `resolve_and_persist_session`).
+fn run_diarize_pass(
     meeting: &crate::transcript::MeetingTranscript,
     session_index: usize,
     wav_path: &std::path::Path,
     cfg: &DiarizeConfig,
     pass: DiarizationPass,
-) -> Result<Vec<(u64, Speaker)>, String> {
+) -> Result<PassResult, String> {
     let session = meeting
         .recording_sessions
         .get(session_index)
         .ok_or_else(|| format!("No recording session at index {session_index}"))?;
 
     // The session's slice of the meeting's segments, checked before any
-    // inference or speaker-row writes: a session with nothing to label must
-    // not create orphan "Speaker N" rows.
+    // inference: a session with nothing to label must not spend the cost of
+    // running the models at all.
     let start = session.start_segment_index as usize;
     let end = (session.end_segment_index as usize).min(meeting.segments.len());
     if start >= end {
-        return Ok(Vec::new());
+        return Ok(PassResult::empty());
     }
 
     let samples = diarize_tap::read_diarize_wav(wav_path)?;
     let result = crate::diarize::diarize(&samples, crate::diarize::segmentation::SAMPLE_RATE, cfg)
         .map_err(|e| format!("Diarize inference: {e}"))?;
     if result.segments.is_empty() || result.speakers.is_empty() {
-        return Ok(Vec::new());
+        return Ok(PassResult::empty());
     }
 
     // Segment times restart at zero for each recording session, and so does
     // the tapped WAV, so session-local segment spans line up with diarized
-    // ranges directly. Mapped before any speaker-row write: a pass whose
-    // ranges match no segment at all must not create orphan "Speaker N"
-    // rows or spend embedding slots on them.
+    // ranges directly.
     let spans: Vec<SegmentSpan> = meeting.segments[start..end]
         .iter()
         .map(|seg| SegmentSpan {
@@ -343,19 +387,31 @@ fn diarize_session(
     let assigned_clusters: std::collections::HashSet<usize> =
         cluster_per_span.iter().flatten().copied().collect();
     if assigned_clusters.is_empty() {
-        return Ok(Vec::new());
+        return Ok(PassResult { start, cluster_per_span, clusters_to_match: Vec::new() });
     }
 
-    // Only clusters that actually labeled at least one span are worth
-    // matching: an unassigned cluster (e.g. a stray VAD trigger nothing
-    // overlaps) must never create a stored speaker row or spend one of a
-    // speaker's limited embedding slots.
     let clusters_to_match: Vec<SpeakerCentroid> = result
         .speakers
         .into_iter()
         .filter(|c| assigned_clusters.contains(&c.speaker))
         .collect();
 
+    Ok(PassResult { start, cluster_per_span, clusters_to_match })
+}
+
+/// Resolve one session's system and mic passes together
+/// (`diarize::persist::resolve_session`) and turn the result into
+/// `(mic_assignments, system_assignments)`, each a list of (sort_order,
+/// speaker) pairs. Persists speaker rows and embeddings as a side effect for
+/// every non-echo decision, so a later session (in this meeting or any
+/// later one) matches against fresh data; a mic cluster resolved as echo is
+/// never persisted on its own (see `MicResolution::Echo`'s doc comment).
+fn resolve_and_persist_session(
+    db: &Database,
+    meeting_id: &str,
+    system_pass: &PassResult,
+    mic_pass: &PassResult,
+) -> Result<(SegmentAssignments, SegmentAssignments), String> {
     let stored: Vec<StoredSpeaker> = db
         .list_speakers_with_embeddings()?
         .into_iter()
@@ -365,34 +421,82 @@ fn diarize_session(
             embeddings: s.embeddings.iter().filter_map(|e| decode_embedding(e)).collect(),
         })
         .collect();
-    let decisions = match_speakers(&clusters_to_match, &stored);
 
+    let resolution = resolve_session(&system_pass.clusters_to_match, &mic_pass.clusters_to_match, &stored);
     let now = chrono::Utc::now();
-    let mut cluster_to_speaker: std::collections::HashMap<usize, i64> = std::collections::HashMap::new();
-    for decision in &decisions {
-        let speaker_id = match &decision.outcome {
-            MatchOutcome::Matched { speaker_id } => *speaker_id,
-            MatchOutcome::NewSpeaker { name } => db.create_speaker(name)?,
-            MatchOutcome::Unlabeled => continue,
-        };
-        db.append_speaker_embedding(
-            speaker_id,
-            Some(meeting.id.as_str()),
-            &encode_embedding(&decision.embedding),
-            decision.speech_seconds,
-            now,
-        )?;
-        cluster_to_speaker.insert(decision.cluster, speaker_id);
+
+    let mut system_cluster_to_speaker: std::collections::HashMap<usize, i64> = std::collections::HashMap::new();
+    for decision in &resolution.system {
+        if let Some(speaker_id) = persist_match_decision(db, meeting_id, decision, now)? {
+            system_cluster_to_speaker.insert(decision.cluster, speaker_id);
+        }
     }
 
-    Ok(cluster_per_span
-        .into_iter()
+    let mut mic_cluster_to_speaker: std::collections::HashMap<usize, i64> = std::collections::HashMap::new();
+    for mic_resolution in &resolution.mic {
+        match mic_resolution {
+            MicResolution::Own(decision) => {
+                if let Some(speaker_id) = persist_match_decision(db, meeting_id, decision, now)? {
+                    mic_cluster_to_speaker.insert(decision.cluster, speaker_id);
+                }
+            }
+            MicResolution::Echo { cluster, system_cluster } => {
+                // A degraded copy of the system voice leaking into the mic:
+                // inherit whatever the system cluster resolved to (including
+                // nothing, if it stayed Unlabeled), never persist it on its
+                // own.
+                if let Some(&speaker_id) = system_cluster_to_speaker.get(system_cluster) {
+                    mic_cluster_to_speaker.insert(*cluster, speaker_id);
+                }
+            }
+        }
+    }
+
+    Ok((
+        build_assignments(mic_pass, &mic_cluster_to_speaker),
+        build_assignments(system_pass, &system_cluster_to_speaker),
+    ))
+}
+
+/// Create/append the speaker row for one `MatchDecision`, returning the
+/// resulting speaker id, or `None` for `Unlabeled` (nothing to persist).
+fn persist_match_decision(
+    db: &Database,
+    meeting_id: &str,
+    decision: &MatchDecision,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Option<i64>, String> {
+    let speaker_id = match &decision.outcome {
+        MatchOutcome::Matched { speaker_id } => *speaker_id,
+        MatchOutcome::NewSpeaker { name } => db.create_speaker(name)?,
+        MatchOutcome::Unlabeled => return Ok(None),
+    };
+    db.append_speaker_embedding(
+        speaker_id,
+        Some(meeting_id),
+        &encode_embedding(&decision.embedding),
+        decision.speech_seconds,
+        now,
+    )?;
+    Ok(Some(speaker_id))
+}
+
+/// Turn one pass's cluster-per-span assignment into (sort_order, speaker)
+/// pairs, using the final speaker id resolved for each cluster. A span whose
+/// cluster never resolved to a speaker (unlabeled, or echo of an unlabeled
+/// parent) is simply absent from the result, exactly as before.
+fn build_assignments(
+    pass: &PassResult,
+    cluster_to_speaker: &std::collections::HashMap<usize, i64>,
+) -> SegmentAssignments {
+    pass.cluster_per_span
+        .iter()
         .enumerate()
         .filter_map(|(offset, cluster)| {
-            let speaker_id = cluster_to_speaker.get(&cluster?)?;
-            Some(((start + offset) as u64, Speaker::Persistent(*speaker_id)))
+            let speaker_id = cluster_to_speaker.get(&(*cluster)?)?;
+            Some(((pass.start + offset) as u64, Speaker::Persistent(*speaker_id)))
         })
-        .collect())
+        .collect()
 }
 
 /// Mic pass locks Them and persistent speakers; system pass locks Me and
@@ -494,16 +598,19 @@ mod tests {
 
         let cfg = DiarizeConfig::new(models::segmentation_model_path(), models::embedding_model_path());
         let loaded = db.load_meeting("diarize-e2e").unwrap();
-        let assignments = diarize_session(
-            &db,
+        let mic_pass = run_diarize_pass(
             &loaded,
             0,
             std::path::Path::new("/tmp/diarize_test.wav"),
             &cfg,
             DiarizationPass::Mic,
         )
-        .expect("diarize session");
+        .expect("diarize pass");
+        let (assignments, system_assignments) =
+            resolve_and_persist_session(&db, "diarize-e2e", &PassResult::empty(), &mic_pass)
+                .expect("resolve and persist session");
         assert!(!assignments.is_empty(), "expected at least one labeled segment");
+        assert!(system_assignments.is_empty(), "no system WAV was tapped, nothing to assign there");
 
         let changed = db
             .set_segment_speakers("diarize-e2e", &assignments, Some(Speaker::Me))
@@ -528,15 +635,16 @@ mod tests {
         // rows (the whole point of persistent matching). Reset the labels
         // first so assignment isn't blocked by the has_speaker guard.
         let speakers_before = db.list_speakers().unwrap().len();
-        let assignments2 = diarize_session(
-            &db,
+        let mic_pass2 = run_diarize_pass(
             &loaded,
             0,
             std::path::Path::new("/tmp/diarize_test.wav"),
             &cfg,
             DiarizationPass::Mic,
         )
-        .expect("second diarize session");
+        .expect("second diarize pass");
+        let (assignments2, _) = resolve_and_persist_session(&db, "diarize-e2e", &PassResult::empty(), &mic_pass2)
+            .expect("second resolve and persist session");
         let speakers_after = db.list_speakers().unwrap().len();
         assert_eq!(
             speakers_before, speakers_after,

--- a/src-tauri/src/pipeline/diarize_task.rs
+++ b/src-tauri/src/pipeline/diarize_task.rs
@@ -18,6 +18,8 @@
 //! runs under `catch_unwind` so a bug in the ONNX stack can never take the
 //! app down from a background thread.
 
+use std::sync::Mutex;
+
 use tauri::Manager;
 use tauri_specta::Event;
 use tracing::{info, warn};
@@ -77,7 +79,22 @@ pub fn spawn_post_meeting_diarization(app: tauri::AppHandle, meeting_id: String)
     }
 }
 
+/// Serializes diarization runs across meetings. `diarize_session` reads
+/// `list_speakers_with_embeddings`, decides matches, then writes
+/// `create_speaker`/`append_speaker_embedding` with no transaction spanning
+/// that whole read-decide-write sequence, so two runs interleaving it can
+/// both decide "no match" for the same voice and each create their own
+/// "Speaker N" row. Held for the whole `run()` call, which also serializes
+/// the ONNX inference itself: a smaller cost than the duplicate rows.
+static DIARIZE_TASK_LOCK: Mutex<()> = Mutex::new(());
+
 fn run(app: &tauri::AppHandle, meeting_id: &str) {
+    // See DIARIZE_TASK_LOCK's doc comment. A panic from an earlier run under
+    // this lock (caught by catch_unwind in the caller) must not poison it
+    // forever, since diarization for later meetings would then silently stop
+    // being serialized.
+    let _diarize_task_guard = DIARIZE_TASK_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
     // Pending WAVs are the trigger: they only exist if this meeting was
     // recorded with speaker recognition enabled and models present.
     let session_files = pending_session_diarize_files(meeting_id);

--- a/src/lib/api/speakers.ts
+++ b/src/lib/api/speakers.ts
@@ -17,6 +17,14 @@ export async function deleteSpeaker(id: number): Promise<void> {
   await unwrap(commands.deleteSpeaker(id));
 }
 
+export async function mergeSpeakers(sourceId: number, targetId: number): Promise<void> {
+  await unwrap(commands.mergeSpeakers(sourceId, targetId));
+}
+
+export async function setSpeakerIsMe(id: number, isMe: boolean): Promise<void> {
+  await unwrap(commands.setSpeakerIsMe(id, isMe));
+}
+
 export async function retagMeetingSpeaker(
   request: RetagMeetingSpeakerRequest,
 ): Promise<MeetingTranscript> {

--- a/src/lib/features/meeting/components/MeetingTranscriptSection.svelte
+++ b/src/lib/features/meeting/components/MeetingTranscriptSection.svelte
@@ -66,6 +66,7 @@
       scope: "turn" | "meeting";
       toSpeakerId: number | null;
       newSpeakerName: string | null;
+      remember: boolean;
     }) => void | Promise<void>;
   } = $props();
 

--- a/src/lib/features/meeting/components/SpeakerManagePopover.svelte
+++ b/src/lib/features/meeting/components/SpeakerManagePopover.svelte
@@ -24,6 +24,7 @@
       scope: "turn" | "meeting";
       toSpeakerId: number | null;
       newSpeakerName: string | null;
+      remember: boolean;
     }) => void | Promise<void>;
   } = $props();
 
@@ -32,6 +33,7 @@
   let targetMode = $state<"existing" | "new">("existing");
   let targetSpeakerId = $state<number | null>(null);
   let newSpeakerName = $state("");
+  let remember = $state(true);
   let isSaving = $state(false);
 
   const panelStyle = $derived(
@@ -43,6 +45,7 @@
     retagScope = "turn";
     targetMode = "existing";
     newSpeakerName = "";
+    remember = true;
   });
 
   const pickerSpeakers = $derived.by(() => {
@@ -79,6 +82,11 @@
   }
 
   async function applyRetag() {
+    // Remembering only ever moves this meeting's voice embeddings once the
+    // source speaker has no turns left in it. A meeting-scoped retag always
+    // satisfies that; a turn-scoped one only sometimes does, so the choice
+    // is only offered (and only ever sent as true) for the meeting scope.
+    const effectiveRemember = retagScope === "meeting" && remember;
     isSaving = true;
     try {
       if (targetMode === "existing") {
@@ -87,6 +95,7 @@
           scope: retagScope,
           toSpeakerId: targetSpeakerId,
           newSpeakerName: null,
+          remember: effectiveRemember,
         });
       } else {
         const trimmed = newSpeakerName.trim();
@@ -95,6 +104,7 @@
           scope: retagScope,
           toSpeakerId: null,
           newSpeakerName: trimmed,
+          remember: effectiveRemember,
         });
       }
       onClose();
@@ -181,6 +191,16 @@
         />
       {/if}
     </div>
+
+    {#if retagScope === "meeting"}
+      <label class="mb-1 flex items-center gap-2 text-[12.5px] text-text-secondary">
+        <input type="checkbox" bind:checked={remember} />
+        {$t("speaker_manage.remember_label")}
+      </label>
+      <p class="m-0 mb-2 text-[11px] text-text-faint">
+        {remember ? $t("speaker_manage.remember_help_on") : $t("speaker_manage.remember_help_off")}
+      </p>
+    {/if}
 
     <button
       class="btn btn-primary w-full text-[12.5px]"

--- a/src/lib/features/meeting/components/SpeakerManagePopover.test.ts
+++ b/src/lib/features/meeting/components/SpeakerManagePopover.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/svelte";
+import SpeakerManagePopover from "./SpeakerManagePopover.svelte";
+import type { MeetingSpeaker } from "../../../types";
+import type { AnchorRect } from "../../../utils";
+
+const anchorRect: AnchorRect = { top: 10, left: 10, bottom: 20, right: 20, width: 10, height: 10 };
+const otherSpeaker: MeetingSpeaker = { id: 2, name: "Bob" };
+
+function renderPopover(onRetag: (options: {
+  scope: "turn" | "meeting";
+  toSpeakerId: number | null;
+  newSpeakerName: string | null;
+  remember: boolean;
+}) => void) {
+  return render(SpeakerManagePopover, {
+    props: {
+      speakerId: 1,
+      speakerName: "Alice",
+      meetingSpeakers: [otherSpeaker],
+      allSpeakers: [otherSpeaker],
+      anchorRect,
+      onClose: vi.fn(),
+      onRename: vi.fn(),
+      onRetag,
+    },
+  });
+}
+
+function selectMeetingScope() {
+  return fireEvent.click(screen.getByText("All turns in this meeting"));
+}
+
+describe("SpeakerManagePopover", () => {
+  it("has no remember checkbox for a turn-scoped retag and sends remember=false", async () => {
+    const onRetag = vi.fn();
+    renderPopover(onRetag);
+
+    // Default scope is "This turn only".
+    expect(screen.queryByRole("checkbox")).toBeNull();
+
+    await fireEvent.click(screen.getByText("Apply reassignment"));
+
+    expect(onRetag).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "turn", toSpeakerId: 2, remember: false }),
+    );
+  });
+
+  it("remembers the voice by default when retagging the whole meeting", async () => {
+    const onRetag = vi.fn();
+    renderPopover(onRetag);
+
+    await selectMeetingScope();
+
+    expect((screen.getByRole("checkbox") as HTMLInputElement).checked).toBe(true);
+    await fireEvent.click(screen.getByText("Apply reassignment"));
+
+    expect(onRetag).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "meeting", toSpeakerId: 2, remember: true }),
+    );
+  });
+
+  it("does not remember the voice when the checkbox is unchecked in meeting scope", async () => {
+    const onRetag = vi.fn();
+    renderPopover(onRetag);
+
+    await selectMeetingScope();
+    await fireEvent.click(screen.getByRole("checkbox"));
+    expect(screen.getByText("Only changes this meeting.")).toBeTruthy();
+
+    await fireEvent.click(screen.getByText("Apply reassignment"));
+
+    expect(onRetag).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "meeting", toSpeakerId: 2, remember: false }),
+    );
+  });
+
+  it("hides the checkbox again when switching back to turn scope", async () => {
+    renderPopover(vi.fn());
+
+    await selectMeetingScope();
+    expect(screen.getByRole("checkbox")).toBeTruthy();
+
+    await fireEvent.click(screen.getByText("This turn only"));
+
+    expect(screen.queryByRole("checkbox")).toBeNull();
+  });
+});

--- a/src/lib/features/meeting/controller.svelte.test.ts
+++ b/src/lib/features/meeting/controller.svelte.test.ts
@@ -45,6 +45,17 @@ const mockExportMeetingToFile = vi.fn<
   (id: string, format: import("../../types").ExportFormat, path: string) => Promise<void>
 >();
 const mockShowSaveDialog = vi.fn<(opts: unknown) => Promise<string | null>>();
+const mockListSpeakers = vi.fn<() => Promise<import("../../types").MeetingSpeaker[]>>();
+const mockRetagMeetingSpeaker = vi.fn<
+  (request: import("../../types").RetagMeetingSpeakerRequest) => Promise<MeetingTranscript>
+>();
+
+vi.mock("../../api/speakers", () => ({
+  listSpeakers: (...a: unknown[]) => mockListSpeakers(...(a as [])),
+  retagMeetingSpeaker: (...a: unknown[]) =>
+    mockRetagMeetingSpeaker(...(a as [import("../../types").RetagMeetingSpeakerRequest])),
+  renameSpeaker: vi.fn(),
+}));
 
 vi.mock("../../api/meetings", () => ({
   startMeetingRecording: (...a: unknown[]) =>
@@ -232,6 +243,7 @@ describe("MeetingController", () => {
     vi.clearAllMocks();
     resetMeetingControllerForTest();
     mockApp = createMockAppState();
+    mockListSpeakers.mockResolvedValue([]);
   });
 
   it("mount checks ollama and loads transcription catalog", async () => {
@@ -443,6 +455,53 @@ describe("MeetingController", () => {
     expect(mockDeleteMeeting).toHaveBeenCalledWith("meet-1");
     expect(ctrl.meeting).toBeNull();
     expect(mockApp.currentMeetingId).toBeNull();
+  });
+
+  it("retagSpeaker forwards the remember flag to the request", async () => {
+    mockGetSummaryProvidersStatus.mockResolvedValue(makeSummaryProvidersStatus());
+    mockGetTranscriptionCatalog.mockResolvedValue(makeCatalog());
+    mockGetMeeting.mockResolvedValue(makeMeeting());
+    mockRetagMeetingSpeaker.mockResolvedValue(makeMeeting());
+
+    const ctrl = createMeetingController();
+    await ctrl.mount();
+    await ctrl.onMeetingSelectionChange("meet-1");
+
+    await ctrl.retagSpeaker({
+      fromSpeakerId: 1,
+      segmentSortOrders: [3, 4],
+      scope: "turn",
+      toSpeakerId: 2,
+      newSpeakerName: null,
+      remember: true,
+    });
+
+    expect(mockRetagMeetingSpeaker).toHaveBeenCalledWith({
+      meeting_id: "meet-1",
+      from_speaker_id: 1,
+      sort_orders: [3, 4],
+      to_speaker_id: 2,
+      new_speaker_name: null,
+      remember: true,
+    });
+
+    await ctrl.retagSpeaker({
+      fromSpeakerId: 1,
+      segmentSortOrders: [3, 4],
+      scope: "meeting",
+      toSpeakerId: null,
+      newSpeakerName: "Carol",
+      remember: false,
+    });
+
+    expect(mockRetagMeetingSpeaker).toHaveBeenLastCalledWith({
+      meeting_id: "meet-1",
+      from_speaker_id: 1,
+      sort_orders: [],
+      to_speaker_id: null,
+      new_speaker_name: "Carol",
+      remember: false,
+    });
   });
 
   it("exportMeeting looks up the filename, opens the save dialog, and writes the file", async () => {

--- a/src/lib/features/meeting/controller.svelte.ts
+++ b/src/lib/features/meeting/controller.svelte.ts
@@ -665,6 +665,7 @@ function createMeetingControllerInstance() {
     scope: "turn" | "meeting";
     toSpeakerId: number | null;
     newSpeakerName: string | null;
+    remember: boolean;
   }) {
     if (!meeting?.id) return;
     try {
@@ -674,6 +675,7 @@ function createMeetingControllerInstance() {
         sort_orders: options.scope === "turn" ? options.segmentSortOrders : [],
         to_speaker_id: options.toSpeakerId,
         new_speaker_name: options.newSpeakerName,
+        remember: options.remember,
       });
       allSpeakers = await listSpeakers().catch(() => []);
     } catch (e) {

--- a/src/lib/features/settings/components/SpeakersListSettingsSection.svelte
+++ b/src/lib/features/settings/components/SpeakersListSettingsSection.svelte
@@ -23,8 +23,28 @@
     try {
       profiles = await listSpeakerProfiles();
       error = "";
+      reconcileMergePanel();
     } catch (e) {
       error = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  // Svelte 5 keeps a bound <select> value even when its backing option
+  // disappears, so a merge panel left open across a refresh (another row's
+  // merge/delete, a background retag) can point at a source or target that
+  // no longer exists. Close the panel if the source is gone; otherwise drop
+  // back to the first remaining candidate if the target is gone or now
+  // equals the source.
+  function reconcileMergePanel() {
+    if (mergingId === null) return;
+    if (!profiles.some((p) => p.id === mergingId)) {
+      cancelMerge();
+      return;
+    }
+    const targetStillValid =
+      mergeTargetId !== null && mergeTargetId !== mergingId && profiles.some((p) => p.id === mergeTargetId);
+    if (!targetStillValid) {
+      mergeTargetId = profiles.find((p) => p.id !== mergingId)?.id ?? null;
     }
   }
 
@@ -78,7 +98,10 @@
   }
 
   async function handleMerge(sourceId: number, targetId: number | null) {
-    if (targetId == null) return;
+    if (targetId == null || targetId === sourceId || !profiles.some((p) => p.id === targetId)) {
+      cancelMerge();
+      return;
+    }
     try {
       await mergeSpeakers(sourceId, targetId);
       cancelMerge();

--- a/src/lib/features/settings/components/SpeakersListSettingsSection.svelte
+++ b/src/lib/features/settings/components/SpeakersListSettingsSection.svelte
@@ -3,13 +3,21 @@
   import { Pencil } from "@lucide/svelte";
   import { t } from "svelte-i18n";
   import ConfirmAction from "../../../components/ui/ConfirmAction.svelte";
-  import { deleteSpeaker, listSpeakerProfiles, renameSpeaker } from "../../../api/speakers";
+  import {
+    deleteSpeaker,
+    listSpeakerProfiles,
+    mergeSpeakers,
+    renameSpeaker,
+    setSpeakerIsMe,
+  } from "../../../api/speakers";
   import type { SpeakerProfile } from "../../../types";
 
   let profiles = $state<SpeakerProfile[]>([]);
   let error = $state("");
   let editingId = $state<number | null>(null);
   let editName = $state("");
+  let mergingId = $state<number | null>(null);
+  let mergeTargetId = $state<number | null>(null);
 
   async function refresh() {
     try {
@@ -50,6 +58,36 @@
     }
   }
 
+  async function handleSetIsMe(id: number, isMe: boolean) {
+    try {
+      await setSpeakerIsMe(id, isMe);
+      await refresh();
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    }
+  }
+
+  function startMerge(profile: SpeakerProfile) {
+    mergingId = profile.id;
+    mergeTargetId = profiles.find((candidate) => candidate.id !== profile.id)?.id ?? null;
+  }
+
+  function cancelMerge() {
+    mergingId = null;
+    mergeTargetId = null;
+  }
+
+  async function handleMerge(sourceId: number, targetId: number | null) {
+    if (targetId == null) return;
+    try {
+      await mergeSpeakers(sourceId, targetId);
+      cancelMerge();
+      await refresh();
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    }
+  }
+
   function formatLastSeen(iso: string): string {
     const date = new Date(iso);
     return Number.isNaN(date.getTime()) ? "" : date.toLocaleDateString();
@@ -70,51 +108,108 @@
     {:else}
       <ul class="m-0 flex list-none flex-col gap-1 p-0">
         {#each profiles as profile (profile.id)}
-          <li class="flex items-center justify-between gap-3 py-1.5">
-            <div class="min-w-0 flex-1">
-              {#if editingId === profile.id}
-                <!-- svelte-ignore a11y_autofocus -->
-                <input
-                  type="text"
-                  class="field-input"
-                  bind:value={editName}
-                  autofocus
-                  onblur={() => void saveName(profile.id)}
-                  onkeydown={(event) => {
-                    if (event.key === "Enter") (event.currentTarget as HTMLInputElement).blur();
-                    if (event.key === "Escape") {
-                      editName = profile.name;
-                      (event.currentTarget as HTMLInputElement).blur();
-                    }
-                  }}
-                  aria-label={$t("settings_speakers.rename_aria", { values: { name: profile.name } })}
-                />
-              {:else}
+          <li class="flex flex-col gap-1.5 py-1.5">
+            <div class="flex items-center justify-between gap-3">
+              <div class="min-w-0 flex-1">
+                <div class="flex items-center gap-1.5">
+                  {#if editingId === profile.id}
+                    <!-- svelte-ignore a11y_autofocus -->
+                    <input
+                      type="text"
+                      class="field-input"
+                      bind:value={editName}
+                      autofocus
+                      onblur={() => void saveName(profile.id)}
+                      onkeydown={(event) => {
+                        if (event.key === "Enter") (event.currentTarget as HTMLInputElement).blur();
+                        if (event.key === "Escape") {
+                          editName = profile.name;
+                          (event.currentTarget as HTMLInputElement).blur();
+                        }
+                      }}
+                      aria-label={$t("settings_speakers.rename_aria", { values: { name: profile.name } })}
+                    />
+                  {:else}
+                    <button
+                      class="btn btn-ghost gap-[7px] px-1.5 py-1 text-[13px] font-medium"
+                      onclick={() => startEditing(profile)}
+                      title={$t("settings_speakers.rename_hint")}
+                    >
+                      <span class="truncate">{profile.name}</span>
+                      <Pencil size={13} aria-hidden="true" />
+                    </button>
+                  {/if}
+                  {#if profile.is_me}
+                    <span class="pill pill-accent">
+                      {$t("settings_speakers.me_badge")}
+                    </span>
+                  {/if}
+                </div>
+                <p class="setting-desc m-0 px-1.5">
+                  {$t("settings_speakers.list_meta", {
+                    values: {
+                      date: formatLastSeen(profile.last_seen_at),
+                      count: profile.meeting_count,
+                    },
+                  })}
+                </p>
+              </div>
+              <div class="flex shrink-0 items-center gap-1.5">
                 <button
-                  class="btn btn-ghost gap-[7px] px-1.5 py-1 text-[13px] font-medium"
-                  onclick={() => startEditing(profile)}
-                  title={$t("settings_speakers.rename_hint")}
+                  class="btn btn-ghost px-2.5 py-1.5 text-[12.5px]"
+                  onclick={() => void handleSetIsMe(profile.id, !profile.is_me)}
                 >
-                  <span class="truncate">{profile.name}</span>
-                  <Pencil size={13} aria-hidden="true" />
+                  {profile.is_me ? $t("settings_speakers.unmark_me") : $t("settings_speakers.mark_me")}
                 </button>
-              {/if}
-              <p class="setting-desc m-0 px-1.5">
-                {$t("settings_speakers.list_meta", {
-                  values: {
-                    date: formatLastSeen(profile.last_seen_at),
-                    count: profile.meeting_count,
-                  },
-                })}
-              </p>
+                {#if profiles.length > 1 && mergingId !== profile.id}
+                  <button
+                    class="btn btn-ghost px-2.5 py-1.5 text-[12.5px]"
+                    onclick={() => startMerge(profile)}
+                  >
+                    {$t("settings_speakers.merge")}
+                  </button>
+                {/if}
+                <ConfirmAction
+                  label={$t("settings_speakers.delete")}
+                  confirmLabel={$t("settings_speakers.delete_confirm")}
+                  confirmMessage={$t("settings_speakers.delete_msg")}
+                  variant="danger"
+                  onConfirm={() => void handleDelete(profile.id)}
+                />
+              </div>
             </div>
-            <ConfirmAction
-              label={$t("settings_speakers.delete")}
-              confirmLabel={$t("settings_speakers.delete_confirm")}
-              confirmMessage={$t("settings_speakers.delete_msg")}
-              variant="danger"
-              onConfirm={() => void handleDelete(profile.id)}
-            />
+
+            {#if mergingId === profile.id}
+              <div class="flex flex-wrap items-center gap-2 rounded-[9px] bg-surface-2 px-2.5 py-2">
+                <span class="text-[12.5px] text-text-secondary">
+                  {$t("settings_speakers.merge_into", { values: { name: profile.name } })}
+                </span>
+                <select
+                  bind:value={mergeTargetId}
+                  class="field-select max-w-[180px] text-[12.5px]"
+                  aria-label={$t("settings_speakers.merge_into", { values: { name: profile.name } })}
+                >
+                  {#each profiles.filter((candidate) => candidate.id !== profile.id) as candidate (candidate.id)}
+                    <option value={candidate.id}>{candidate.name}</option>
+                  {/each}
+                </select>
+                <ConfirmAction
+                  label={$t("settings_speakers.merge")}
+                  confirmLabel={$t("settings_speakers.merge_confirm")}
+                  confirmMessage={$t("settings_speakers.merge_msg", {
+                    values: {
+                      source: profile.name,
+                      target: profiles.find((candidate) => candidate.id === mergeTargetId)?.name ?? "",
+                    },
+                  })}
+                  variant="danger"
+                  onConfirm={() => void handleMerge(profile.id, mergeTargetId)}
+                />
+                <button class="btn btn-ghost px-2.5 py-1.5 text-[12.5px]" onclick={cancelMerge}>
+                  {$t("ui.cancel")}
+                </button>
+              </div>
+            {/if}
           </li>
         {/each}
       </ul>

--- a/src/lib/features/settings/components/SpeakersListSettingsSection.test.ts
+++ b/src/lib/features/settings/components/SpeakersListSettingsSection.test.ts
@@ -94,6 +94,60 @@ describe("SpeakersListSettingsSection", () => {
     });
   });
 
+  it("drops a stale merge target on refresh instead of merging into it", async () => {
+    const alice = makeProfile({ id: 1, name: "Alice" });
+    const bob = makeProfile({ id: 2, name: "Bob" });
+    const carol = makeProfile({ id: 3, name: "Carol" });
+    mockListSpeakerProfiles.mockResolvedValue([alice, bob]);
+
+    render(SpeakersListSettingsSection);
+    await screen.findByText("Alice");
+
+    const aliceItem = screen.getAllByRole("listitem")[0];
+    await fireEvent.click(within(aliceItem).getByText("Merge"));
+    // Defaults to the only other speaker, Bob, as the merge target.
+    await within(aliceItem).findByText("Merge Alice into:", { exact: false });
+
+    // Bob disappears from a refresh triggered while the panel is still
+    // open (e.g. another row's action); Carol is now the only candidate.
+    mockListSpeakerProfiles.mockResolvedValue([alice, carol]);
+    await fireEvent.click(within(aliceItem).getByText("Mark as me"));
+    await vi.waitFor(() => {
+      expect(mockListSpeakerProfiles).toHaveBeenCalledTimes(2);
+    });
+
+    const refreshedAliceItem = screen.getAllByRole("listitem")[0];
+    await within(refreshedAliceItem).findByText("Merge Alice into:", { exact: false });
+    await fireEvent.click(within(refreshedAliceItem).getByText("Merge"));
+    await fireEvent.click(within(refreshedAliceItem).getByText("Merge"));
+
+    expect(mockMergeSpeakers).toHaveBeenCalledWith(1, 3);
+    expect(mockMergeSpeakers).not.toHaveBeenCalledWith(1, 2);
+  });
+
+  it("closes the merge panel on refresh if its source speaker disappears", async () => {
+    const alice = makeProfile({ id: 1, name: "Alice" });
+    const bob = makeProfile({ id: 2, name: "Bob" });
+    mockListSpeakerProfiles.mockResolvedValue([alice, bob]);
+
+    render(SpeakersListSettingsSection);
+    await screen.findByText("Alice");
+
+    const aliceItem = screen.getAllByRole("listitem")[0];
+    await fireEvent.click(within(aliceItem).getByText("Merge"));
+    await within(aliceItem).findByText("Merge Alice into:", { exact: false });
+
+    // Alice (the merge source) is deleted from elsewhere; the next refresh
+    // must close the panel rather than leave it pointed at a dead source.
+    mockListSpeakerProfiles.mockResolvedValue([bob]);
+    await fireEvent.click(within(aliceItem).getByText("Mark as me"));
+
+    await vi.waitFor(() => {
+      expect(screen.queryByText("Merge Alice into:", { exact: false })).toBeNull();
+    });
+    expect(mockMergeSpeakers).not.toHaveBeenCalled();
+  });
+
   it("does not show a merge action when only one speaker is remembered", async () => {
     mockListSpeakerProfiles.mockResolvedValue([makeProfile({ id: 1, name: "Alice" })]);
 

--- a/src/lib/features/settings/components/SpeakersListSettingsSection.test.ts
+++ b/src/lib/features/settings/components/SpeakersListSettingsSection.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, within } from "@testing-library/svelte";
+import type { SpeakerProfile } from "../../../types";
+
+const mockListSpeakerProfiles = vi.fn<() => Promise<SpeakerProfile[]>>();
+const mockMergeSpeakers = vi.fn<(sourceId: number, targetId: number) => Promise<void>>();
+const mockSetSpeakerIsMe = vi.fn<(id: number, isMe: boolean) => Promise<void>>();
+const mockRenameSpeaker = vi.fn<(id: number, name: string) => Promise<void>>();
+const mockDeleteSpeaker = vi.fn<(id: number) => Promise<void>>();
+
+vi.mock("../../../api/speakers", () => ({
+  listSpeakerProfiles: (...a: unknown[]) => mockListSpeakerProfiles(...(a as [])),
+  mergeSpeakers: (...a: unknown[]) => mockMergeSpeakers(...(a as [number, number])),
+  setSpeakerIsMe: (...a: unknown[]) => mockSetSpeakerIsMe(...(a as [number, boolean])),
+  renameSpeaker: (...a: unknown[]) => mockRenameSpeaker(...(a as [number, string])),
+  deleteSpeaker: (...a: unknown[]) => mockDeleteSpeaker(...(a as [number])),
+}));
+
+import SpeakersListSettingsSection from "./SpeakersListSettingsSection.svelte";
+
+function makeProfile(overrides: Partial<SpeakerProfile> = {}): SpeakerProfile {
+  return {
+    id: 1,
+    name: "Alice",
+    last_seen_at: "2026-07-01T10:00:00Z",
+    meeting_count: 3,
+    segment_count: 42,
+    is_me: false,
+    ...overrides,
+  };
+}
+
+describe("SpeakersListSettingsSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRenameSpeaker.mockResolvedValue(undefined);
+    mockDeleteSpeaker.mockResolvedValue(undefined);
+    mockSetSpeakerIsMe.mockResolvedValue(undefined);
+    mockMergeSpeakers.mockResolvedValue(undefined);
+  });
+
+  it("marks a speaker as me and refreshes the list", async () => {
+    const alice = makeProfile({ id: 1, name: "Alice", is_me: false });
+    mockListSpeakerProfiles.mockResolvedValue([alice]);
+
+    render(SpeakersListSettingsSection);
+    await screen.findByText("Alice");
+
+    mockListSpeakerProfiles.mockResolvedValue([{ ...alice, is_me: true }]);
+    await fireEvent.click(screen.getByText("Mark as me"));
+
+    expect(mockSetSpeakerIsMe).toHaveBeenCalledWith(1, true);
+    await screen.findByText("Me");
+    expect(mockListSpeakerProfiles).toHaveBeenCalledTimes(2);
+  });
+
+  it("unmarks a speaker that is currently me", async () => {
+    const alice = makeProfile({ id: 1, name: "Alice", is_me: true });
+    mockListSpeakerProfiles.mockResolvedValue([alice]);
+
+    render(SpeakersListSettingsSection);
+    await screen.findByText("Alice");
+
+    mockListSpeakerProfiles.mockResolvedValue([{ ...alice, is_me: false }]);
+    await fireEvent.click(screen.getByText("Unmark as me"));
+
+    expect(mockSetSpeakerIsMe).toHaveBeenCalledWith(1, false);
+    await vi.waitFor(() => {
+      expect(screen.queryByText("Me")).toBeNull();
+    });
+  });
+
+  it("merges a speaker into the selected target and refreshes the list", async () => {
+    const alice = makeProfile({ id: 1, name: "Alice" });
+    const bob = makeProfile({ id: 2, name: "Bob" });
+    mockListSpeakerProfiles.mockResolvedValue([alice, bob]);
+
+    render(SpeakersListSettingsSection);
+    await screen.findByText("Alice");
+
+    const aliceItem = screen.getAllByRole("listitem")[0];
+    await fireEvent.click(within(aliceItem).getByText("Merge"));
+
+    // The panel defaults to the only other speaker (Bob) as target.
+    await within(aliceItem).findByText("Merge Alice into:", { exact: false });
+
+    mockListSpeakerProfiles.mockResolvedValue([bob]);
+    await fireEvent.click(within(aliceItem).getByText("Merge"));
+    await fireEvent.click(within(aliceItem).getByText("Merge"));
+
+    expect(mockMergeSpeakers).toHaveBeenCalledWith(1, 2);
+    await vi.waitFor(() => {
+      expect(mockListSpeakerProfiles).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("does not show a merge action when only one speaker is remembered", async () => {
+    mockListSpeakerProfiles.mockResolvedValue([makeProfile({ id: 1, name: "Alice" })]);
+
+    render(SpeakersListSettingsSection);
+    await screen.findByText("Alice");
+
+    expect(screen.queryByText("Merge")).toBeNull();
+  });
+
+  it("shows an error message when refresh fails", async () => {
+    mockListSpeakerProfiles.mockRejectedValue(new Error("db offline"));
+
+    render(SpeakersListSettingsSection);
+
+    await screen.findByText("db offline");
+  });
+});

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -31,7 +31,14 @@
     "rename_aria": "Rename speaker {name}",
     "delete": "Delete",
     "delete_confirm": "Delete",
-    "delete_msg": "Forget this voice and unlabel its lines?"
+    "delete_msg": "Forget this voice and unlabel its lines?",
+    "me_badge": "Me",
+    "mark_me": "Mark as me",
+    "unmark_me": "Unmark as me",
+    "merge": "Merge",
+    "merge_into": "Merge {name} into:",
+    "merge_confirm": "Merge",
+    "merge_msg": "Merge {source} into {target}? Their meetings and voice will be combined. This cannot be undone."
   },
   "settings_audio": {
     "title": "Audio",
@@ -311,6 +318,9 @@
     "no_other_speakers": "No other speakers yet",
     "new_speaker": "New speaker",
     "new_speaker_placeholder": "Enter a name",
+    "remember_label": "Remember for future meetings",
+    "remember_help_on": "Souffle will recognize this voice better next time.",
+    "remember_help_off": "Only changes this meeting.",
     "apply_retag": "Apply reassignment"
   },
   "meeting_audio": {

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -31,7 +31,14 @@
     "rename_aria": "Renommer l'interlocuteur {name}",
     "delete": "Supprimer",
     "delete_confirm": "Supprimer",
-    "delete_msg": "Oublier cette voix et retirer ses annotations ?"
+    "delete_msg": "Oublier cette voix et retirer ses annotations ?",
+    "me_badge": "Moi",
+    "mark_me": "Marquer comme moi",
+    "unmark_me": "Ne plus marquer comme moi",
+    "merge": "Fusionner",
+    "merge_into": "Fusionner {name} dans :",
+    "merge_confirm": "Fusionner",
+    "merge_msg": "Fusionner {source} dans {target} ? Leurs réunions et leur voix seront regroupées. Action irréversible."
   },
   "settings_audio": {
     "title": "Audio",
@@ -311,6 +318,9 @@
     "no_other_speakers": "Aucun autre intervenant",
     "new_speaker": "Nouvel intervenant",
     "new_speaker_placeholder": "Saisir un nom",
+    "remember_label": "Mémoriser pour les prochaines réunions",
+    "remember_help_on": "Souffle reconnaîtra mieux cette voix la prochaine fois.",
+    "remember_help_off": "Ne change que cette réunion.",
     "apply_retag": "Appliquer la reattribution"
   },
   "meeting_audio": {

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -406,6 +406,29 @@ async deleteSpeaker(id: number) : Promise<Result<null, string>> {
 }
 },
 /**
+ * Merge one persistent speaker into another: segments and voice embeddings
+ * move to the target, and the source is deleted.
+ */
+async mergeSpeakers(sourceId: number, targetId: number) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("merge_speakers", { sourceId, targetId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Flag (or unflag) a persistent speaker as the app's user.
+ */
+async setSpeakerIsMe(id: number, isMe: boolean) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("set_speaker_is_me", { id, isMe }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Reassign persistent-speaker labels within one meeting. Me/Them segments
  * are never touched. Returns the reloaded meeting so the UI can refresh.
  */
@@ -1442,7 +1465,13 @@ to_speaker_id: number | null;
 /**
  * Create a new persistent speaker with this name and assign to it.
  */
-new_speaker_name: string | null }
+new_speaker_name: string | null; 
+/**
+ * When true, also move this meeting's voice embeddings for the source
+ * speaker to the target, so future matching benefits from the
+ * correction. When false, the retag only relabels this meeting.
+ */
+remember?: boolean }
 /**
  * Search result from FTS5 full-text search
  */
@@ -1458,7 +1487,7 @@ export type SpeakerProfile = { id: number; name: string;
 /**
  * RFC3339 timestamp of the last meeting this voice was recognized in.
  */
-last_seen_at: string; meeting_count: number; segment_count: number }
+last_seen_at: string; meeting_count: number; segment_count: number; is_me: boolean }
 export type StateChanged = AppStateMachine
 /**
  * A single action item extracted from a meeting summary pass.


### PR DESCRIPTION
## Why

An audit of the shipped diarization (PRs #64, #68-73) against production data showed cross-meeting speaker recognition never worked: zero segments ever received a persistent label, and the speakers table accumulated only orphaned duplicate rows. Measured same-voice inter-session cosine similarity (0.48-0.66) sat below the 0.65 match threshold, the 0.03 margin turned existing duplicates into a self-reinforcing spiral, and the in-meeting clustering threshold (0.7 similarity) over-split voices versus the sherpa-onnx reference (0.5).

## What changed

**Matching v2 (schema v13)**
- Speakers never referenced by any segment are purged on migration.
- New `speaker_embeddings` table: up to 20 recent embeddings per speaker, matched by max cosine similarity instead of a single running-mean centroid.
- Match threshold recalibrated to 0.5; the ambiguity margin (0.05) now applies against the raw second-best, and an ambiguous cluster stays unlabeled instead of spawning a duplicate speaker.
- A new voice only enrolls with at least 5 seconds of speech and at least one labeled segment; unassigned clusters no longer touch the database.
- In-meeting clustering aligned with the reference (0.5), long segments chunked to 10 s before embedding, and clustering now caches its similarity matrix (the chunking-induced cubic recompute is gone).
- Diarization runs are serialized process-wide so back-to-back meetings cannot enroll duplicate rows from stale snapshots.

**Management**
- Merge two speakers (segments, embeddings, is-me flag, one transaction) from the Speakers settings tab, with confirmation and stale-target revalidation.
- Retag gains a remember option: a meeting-wide correction moves that meeting's embeddings to the corrected speaker so matching learns; embeddings only move when the source speaker is fully displaced from the meeting, so a partial fix can never corrupt a profile.
- Mark a speaker as Me (single row, enforced by a partial unique index; the index exposed and fixed a transient statement-order violation in merge).
- `--diarize-file` now reports per-cluster speech duration and similarity against stored speakers for threshold calibration, reading the database read-only without migrations.

## Verification

- 727 Rust tests, 278 frontend tests, clippy -D warnings, svelte-check, build: all green.
- Final multi-angle review (8 finder angles, 5 verified findings) applied in the last commit.
- QA suggestion before release: record two short meetings with the same voices and confirm the second one reuses the same speaker rows (embedding_count style check via Settings > Speakers counters), then exercise merge and a remembered retag.

## Notes

- `speakers.centroid`/`embedding_count` columns remain in the schema (unused; dropping them needs a table rebuild, candidate for a later migration).
- Follow-ups deferred: explicit 30 s Me enrollment recording in Settings, per-segment embedding provenance for finer retag learning, duration-weighted cluster centroids.