### PR TITLE
Recover echo cancellation after a panic and fix the upstream filter bug

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6342,8 +6342,7 @@ dependencies = [
 [[package]]
 name = "sonora"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559f6011d42721f7b4599ef4cf3224ac07539ee5bc25967169701c7aeb6c6bb1"
+source = "git+https://github.com/dignifiedquire/sonora?rev=70c673606e1db8442a8ba20659b2bc7355555274#70c673606e1db8442a8ba20659b2bc7355555274"
 dependencies = [
  "sonora-aec3",
  "sonora-agc2",
@@ -6356,8 +6355,7 @@ dependencies = [
 [[package]]
 name = "sonora-aec3"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65d8b7e53b058aa4631cf2a8f483bd7a0dec093aa413d21b44b86d5704deedeb"
+source = "git+https://github.com/dignifiedquire/sonora?rev=70c673606e1db8442a8ba20659b2bc7355555274#70c673606e1db8442a8ba20659b2bc7355555274"
 dependencies = [
  "sonora-common-audio",
  "sonora-fft",
@@ -6367,8 +6365,7 @@ dependencies = [
 [[package]]
 name = "sonora-agc2"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132876fc38c4e191dee939a38243df5eb5830cd29f1d1ac9a67377389d74a10e"
+source = "git+https://github.com/dignifiedquire/sonora?rev=70c673606e1db8442a8ba20659b2bc7355555274#70c673606e1db8442a8ba20659b2bc7355555274"
 dependencies = [
  "bytemuck",
  "derive_more 2.1.1",
@@ -6381,8 +6378,7 @@ dependencies = [
 [[package]]
 name = "sonora-common-audio"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a16fa975fe4aa12e4d980d5453452bd3e6df2b33abfb89840e1757ebd212e6"
+source = "git+https://github.com/dignifiedquire/sonora?rev=70c673606e1db8442a8ba20659b2bc7355555274#70c673606e1db8442a8ba20659b2bc7355555274"
 dependencies = [
  "derive_more 2.1.1",
  "sonora-simd",
@@ -6391,14 +6387,12 @@ dependencies = [
 [[package]]
 name = "sonora-fft"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca158c4b6ace2cb3f4fa8084842da2b4ffcc25cf8ac4366675aea541aabc6af"
+source = "git+https://github.com/dignifiedquire/sonora?rev=70c673606e1db8442a8ba20659b2bc7355555274#70c673606e1db8442a8ba20659b2bc7355555274"
 
 [[package]]
 name = "sonora-ns"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc549f9bca1d60e7a2483e4949e9649467c5cca371a4341e44aaf24dae338fd4"
+source = "git+https://github.com/dignifiedquire/sonora?rev=70c673606e1db8442a8ba20659b2bc7355555274#70c673606e1db8442a8ba20659b2bc7355555274"
 dependencies = [
  "sonora-fft",
 ]
@@ -6406,8 +6400,7 @@ dependencies = [
 [[package]]
 name = "sonora-simd"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a053f93cc01f4e1cc51c61844a196b6d1da7e054cdd406d2cd27677ba4d898e0"
+source = "git+https://github.com/dignifiedquire/sonora?rev=70c673606e1db8442a8ba20659b2bc7355555274#70c673606e1db8442a8ba20659b2bc7355555274"
 dependencies = [
  "cpufeatures 0.3.0",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -130,6 +130,27 @@ souffle = { path = ".", features = ["test-support"] }
 # without a real webview.
 tauri = { version = "2", features = ["test"] }
 
+# sonora-aec3 0.1.0 (the only version published to crates.io) panics in
+# `AdaptiveFirFilter::set_size_partitions` when the filter shrinks immediately
+# (e.g. on an echo-path-change event after the filter grew past its initial
+# size): `zero_filter(old_size, new_size, ..)` slices `old_size..new_size`,
+# which is an invalid range once old_size > new_size. Fixed upstream in
+# dec6a074 ("prevent panic when shrinking adaptive FIR filter", #15) but not
+# yet released as a new crates.io version. Pinned to a specific commit
+# (rather than a branch) so the fix is reproducible via Cargo.lock; bump this
+# rev, or drop the patch entirely, once 0.1.1+ ships. Every sonora-* crate is
+# patched to the same rev (not just sonora-aec3) so the whole dependency
+# graph resolves to one source instead of building duplicate copies of the
+# shared DSP crates (sonora-common-audio, sonora-fft, sonora-simd).
+[patch.crates-io]
+sonora = { git = "https://github.com/dignifiedquire/sonora", rev = "70c673606e1db8442a8ba20659b2bc7355555274" }
+sonora-aec3 = { git = "https://github.com/dignifiedquire/sonora", rev = "70c673606e1db8442a8ba20659b2bc7355555274" }
+sonora-agc2 = { git = "https://github.com/dignifiedquire/sonora", rev = "70c673606e1db8442a8ba20659b2bc7355555274" }
+sonora-common-audio = { git = "https://github.com/dignifiedquire/sonora", rev = "70c673606e1db8442a8ba20659b2bc7355555274" }
+sonora-fft = { git = "https://github.com/dignifiedquire/sonora", rev = "70c673606e1db8442a8ba20659b2bc7355555274" }
+sonora-ns = { git = "https://github.com/dignifiedquire/sonora", rev = "70c673606e1db8442a8ba20659b2bc7355555274" }
+sonora-simd = { git = "https://github.com/dignifiedquire/sonora", rev = "70c673606e1db8442a8ba20659b2bc7355555274" }
+
 [profile.release]
 strip = true
 lto = true

--- a/src-tauri/src/audio/aec.rs
+++ b/src-tauri/src/audio/aec.rs
@@ -12,34 +12,116 @@
 use sonora::config::EchoCanceller;
 use sonora::{AudioProcessing, Config, StreamConfig};
 
+/// Coarse estimate of the delay between a render frame reaching sonora and
+/// the corresponding echo showing up in a capture frame, passed to
+/// `Aec::set_expected_delay_ms` by every real caller. This is not a measured
+/// value (macOS doesn't expose one cheaply from the mixer's position, and the
+/// combined output+input CoreAudio buffering plus acoustic propagation for
+/// built-in speakers/mic commonly falls in the tens of ms), just a mid-range
+/// heuristic for AEC3's own delay estimator to start searching from; see
+/// `set_expected_delay_ms`'s docs for why an approximate hint still helps.
+pub const EXPECTED_ACOUSTIC_DELAY_MS: i32 = 50;
+
+/// How many times a panicking sonora call may recreate a fresh instance
+/// before echo cancellation gives up for the rest of the session. Each
+/// rearm loses whatever echo-path convergence sonora had built up, so this
+/// trades a few seconds of reduced cancellation while it reconverges for
+/// not falling back to raw mic for the rest of a (possibly hour-long)
+/// meeting. Three gives real transient bugs (the kind seen in production:
+/// one panic on an unusual signal transition) room to recover without
+/// letting a pathological, repeatedly-panicking input spin forever.
+const MAX_REARM_ATTEMPTS: u32 = 3;
+
+/// What a panic during a sonora call should do next, given how many times
+/// this session has already rearmed. Pure decision function, kept free of
+/// `Aec`'s state so it can be unit-tested directly (mirrors `decide_mic_loss`
+/// in `capture.rs`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RearmDecision {
+    /// Recreate the sonora instance from scratch and keep going.
+    Rearm,
+    /// Give up for the rest of the session.
+    GiveUp,
+}
+
+fn decide_rearm(attempts_so_far: u32) -> RearmDecision {
+    if attempts_so_far < MAX_REARM_ATTEMPTS {
+        RearmDecision::Rearm
+    } else {
+        RearmDecision::GiveUp
+    }
+}
+
+fn build_apm(sample_rate: u32) -> AudioProcessing {
+    let stream = StreamConfig::new(sample_rate, 1);
+    AudioProcessing::builder()
+        .config(Config {
+            echo_canceller: Some(EchoCanceller::default()),
+            ..Config::default()
+        })
+        .capture_config(stream)
+        .render_config(stream)
+        .build()
+}
+
 pub struct Aec {
     apm: AudioProcessing,
+    sample_rate: u32,
     /// 10ms at the configured sample rate.
     frame_len: usize,
     render_out: Vec<f32>,
-    /// Set if a sonora call ever panicked. Echo cancellation is a non-essential
-    /// enhancement, so once it misbehaves we stop calling it and let the mic
-    /// pass through uncancelled rather than risk taking down the session.
-    poisoned: bool,
+    /// Hint passed to sonora's `set_stream_delay_ms` (the expected delay
+    /// between a render frame being handed to sonora and the corresponding
+    /// echo showing up in a capture frame). Reapplied on every rearm since a
+    /// fresh sonora instance starts with no delay set. `None` until
+    /// `set_expected_delay_ms` is called, matching sonora's own default.
+    expected_delay_ms: Option<i32>,
+    /// Panics recovered so far this session by recreating sonora fresh (see
+    /// `MAX_REARM_ATTEMPTS`).
+    rearm_count: u32,
+    /// Set once rearming is exhausted. Echo cancellation is a non-essential
+    /// enhancement, so once it can't recover we stop calling it and let the
+    /// mic pass through uncancelled rather than risk taking down the session.
+    disabled: bool,
 }
 
 impl Aec {
     pub fn new(sample_rate: u32) -> Self {
-        let stream = StreamConfig::new(sample_rate, 1);
-        let apm = AudioProcessing::builder()
-            .config(Config {
-                echo_canceller: Some(EchoCanceller::default()),
-                ..Config::default()
-            })
-            .capture_config(stream)
-            .render_config(stream)
-            .build();
         let frame_len = sample_rate as usize / 100;
         Self {
-            apm,
+            apm: build_apm(sample_rate),
+            sample_rate,
             frame_len,
             render_out: vec![0.0; frame_len],
-            poisoned: false,
+            expected_delay_ms: None,
+            rearm_count: 0,
+            disabled: false,
+        }
+    }
+
+    /// Builds an `Aec` with `EXPECTED_ACOUSTIC_DELAY_MS` applied. What every
+    /// real caller wants; `new` stays hint-free so tests (and the mixer
+    /// bench) can compare with and without it.
+    pub fn new_with_default_delay_hint(sample_rate: u32) -> Self {
+        let mut aec = Self::new(sample_rate);
+        aec.set_expected_delay_ms(EXPECTED_ACOUSTIC_DELAY_MS);
+        aec
+    }
+
+    /// Hints the expected delay between render and capture (see sonora's
+    /// `set_stream_delay_ms` docs). AEC3's own delay estimator does not
+    /// strictly require this (unlike the legacy AEC2 the doc comment is
+    /// inherited from), but an external estimate narrows its search and
+    /// speeds up convergence. Applied immediately and reapplied on every
+    /// rearm, since a freshly built sonora instance starts with no hint.
+    pub fn set_expected_delay_ms(&mut self, delay_ms: i32) {
+        self.expected_delay_ms = Some(delay_ms);
+        self.apply_delay_hint();
+    }
+
+    fn apply_delay_hint(&mut self) {
+        if let Some(delay_ms) = self.expected_delay_ms {
+            let _ = self.apm.set_stream_delay_ms(delay_ms);
         }
     }
 
@@ -47,7 +129,7 @@ impl Aec {
     /// speakers). Must be called before the capture frame of the same tick.
     pub fn process_render(&mut self, frame: &[f32]) {
         debug_assert_eq!(frame.len(), self.frame_len);
-        if self.poisoned {
+        if self.disabled {
             return;
         }
         let apm = &mut self.apm;
@@ -56,7 +138,7 @@ impl Aec {
             let _ = apm.process_render_f32(&[frame], &mut [&mut render_out[..]]);
         }));
         if result.is_err() {
-            self.poison();
+            self.handle_panic();
         }
     }
 
@@ -64,7 +146,7 @@ impl Aec {
     /// in place.
     pub fn process_capture(&mut self, frame: &mut [f32]) {
         debug_assert_eq!(frame.len(), self.frame_len);
-        if self.poisoned {
+        if self.disabled {
             return;
         }
         let mut out = vec![0.0; self.frame_len];
@@ -76,16 +158,33 @@ impl Aec {
         match result {
             Ok(true) => frame.copy_from_slice(&out),
             Ok(false) => {}
-            Err(_) => self.poison(),
+            Err(_) => self.handle_panic(),
         }
     }
 
-    fn poison(&mut self) {
-        if !self.poisoned {
-            self.poisoned = true;
-            tracing::error!(
-                "Echo cancellation panicked; disabling it for this session (mic passes through uncancelled)"
-            );
+    /// Recreate sonora from scratch (losing convergence state, which is
+    /// inherent and acceptable) up to `MAX_REARM_ATTEMPTS` times, then fall
+    /// back to disabled for the rest of the session.
+    fn handle_panic(&mut self) {
+        match decide_rearm(self.rearm_count) {
+            RearmDecision::Rearm => {
+                self.rearm_count += 1;
+                tracing::warn!(
+                    "Echo cancellation panicked; recreating it fresh (attempt {}/{MAX_REARM_ATTEMPTS}). \
+                     Convergence is lost and will take a few seconds to rebuild.",
+                    self.rearm_count
+                );
+                self.apm = build_apm(self.sample_rate);
+                self.apply_delay_hint();
+            }
+            RearmDecision::GiveUp => {
+                self.disabled = true;
+                tracing::error!(
+                    "Echo cancellation panicked again after {MAX_REARM_ATTEMPTS} rearms this \
+                     session; disabling it for the rest of the session (mic passes through \
+                     uncancelled)"
+                );
+            }
         }
     }
 }
@@ -138,6 +237,64 @@ mod tests {
         assert!(
             leaked_energy_late < leaked_energy_early * 0.2,
             "echo should converge: early={leaked_energy_early}, late={leaked_energy_late}"
+        );
+    }
+
+    #[test]
+    fn decide_rearm_allows_up_to_the_cap_then_gives_up() {
+        for n in 0..MAX_REARM_ATTEMPTS {
+            assert_eq!(decide_rearm(n), RearmDecision::Rearm, "attempt {n} should rearm");
+        }
+        assert_eq!(decide_rearm(MAX_REARM_ATTEMPTS), RearmDecision::GiveUp);
+        assert_eq!(decide_rearm(MAX_REARM_ATTEMPTS + 5), RearmDecision::GiveUp);
+    }
+
+    /// Repeated panics recreate sonora up to the cap, then disable it. This
+    /// drives the same `handle_panic` path a real sonora panic would, without
+    /// needing to reproduce the underlying crate bug.
+    #[test]
+    fn rearms_up_to_the_cap_then_disables() {
+        let mut aec = Aec::new(48_000);
+
+        for expected_attempt in 1..=MAX_REARM_ATTEMPTS {
+            aec.handle_panic();
+            assert_eq!(aec.rearm_count, expected_attempt);
+            assert!(!aec.disabled, "should still be rearming at attempt {expected_attempt}");
+        }
+
+        // One panic more than the cap allows: gives up for the session.
+        aec.handle_panic();
+        assert!(aec.disabled);
+    }
+
+    #[test]
+    fn process_calls_are_no_ops_once_disabled() {
+        let mut aec = Aec::new(48_000);
+        aec.disabled = true;
+
+        let frame = vec![0.5; aec.frame_len];
+        let mut mic = frame.clone();
+        aec.process_render(&frame);
+        aec.process_capture(&mut mic);
+
+        assert_eq!(mic, frame, "a disabled Aec must leave the mic frame untouched");
+    }
+
+    /// A fresh sonora instance starts with no delay hint, so a rearm must
+    /// reapply it or convergence speed regresses back to baseline on every
+    /// recovered panic.
+    #[test]
+    fn delay_hint_survives_a_rearm() {
+        let mut aec = Aec::new(48_000);
+        aec.set_expected_delay_ms(42);
+        assert_eq!(aec.apm.stream_delay_ms(), 42);
+
+        aec.handle_panic();
+
+        assert_eq!(
+            aec.apm.stream_delay_ms(),
+            42,
+            "the delay hint must be reapplied to the rearmed instance"
         );
     }
 }

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -264,7 +264,7 @@ impl MeetingState {
         if can_leak != self.aec_active {
             if can_leak {
                 info!("Speakers audible, echo cancellation engaged");
-                self.mixer.set_aec(Some(aec::Aec::new(mixer::MIX_RATE)));
+                self.mixer.set_aec(Some(aec::Aec::new_with_default_delay_hint(mixer::MIX_RATE)));
             } else {
                 info!("Output muted or off speakers, echo cancellation disengaged");
                 self.mixer.set_aec(None);
@@ -1084,7 +1084,7 @@ impl AudioCapture {
             let can_leak = tap.is_some() && super::output_route::output_can_leak_into_mic();
             if can_leak {
                 info!("Speakers audible, echo cancellation engaged");
-                mixer.set_aec(Some(super::aec::Aec::new(super::mixer::MIX_RATE)));
+                mixer.set_aec(Some(super::aec::Aec::new_with_default_delay_hint(super::mixer::MIX_RATE)));
             }
             can_leak
         };

--- a/src-tauri/src/audio/mixer.rs
+++ b/src-tauri/src/audio/mixer.rs
@@ -350,3 +350,245 @@ mod tests {
         );
     }
 }
+
+/// Echo-cancellation efficiency bench, run through the exact mixer
+/// integration (10ms frames at `MIX_RATE`, `split_frame`'s render-then-capture
+/// ordering) rather than the `Aec` wrapper in isolation. Ignored by default:
+/// several seconds of synthetic audio at 48kHz is too slow for the normal
+/// test loop. Run explicitly with:
+///   cargo test --release --manifest-path src-tauri/Cargo.toml audio::mixer::aec_bench -- --ignored --nocapture
+#[cfg(test)]
+mod aec_bench {
+    use ringbuf::HeapRb;
+    use ringbuf::traits::{Producer, Split};
+
+    use super::*;
+    use crate::audio::aec::Aec;
+
+    /// Deterministic xorshift64 PRNG so the bench is reproducible without an
+    /// external `rand` dependency.
+    struct Xorshift(u64);
+
+    impl Xorshift {
+        fn next_unit(&mut self) -> f32 {
+            let mut x = self.0;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            self.0 = x;
+            // Top 24 bits as a value in roughly [-1, 1).
+            ((x >> 40) as f32 / (1u64 << 24) as f32) * 2.0 - 1.0
+        }
+    }
+
+    /// Musical-ish frequencies with decreasing amplitude, meant to stand in
+    /// for video/music playback content (broadband, not a pure tone).
+    const VIDEO_FREQS: &[(f32, f32)] = &[
+        (220.0, 0.22),
+        (523.0, 0.18),
+        (1046.0, 0.14),
+        (1760.0, 0.10),
+        (2637.0, 0.07),
+    ];
+
+    /// A voice fundamental plus harmonics, distinct from `VIDEO_FREQS`, to
+    /// stand in for the user's own speech (near-end, double-talk). Kept well
+    /// under full scale together with the echo so `capture`'s clamp to
+    /// [-1, 1] is a safety net, not a routine clipper: real gain-staged mic
+    /// input doesn't clip, and clipping would distort capture in a way no
+    /// linear AEC can undo, swamping the echo-cancellation measurement with
+    /// an unrelated clipping artifact.
+    const VOICE_FREQS: &[(f32, f32)] = &[
+        (120.0, 0.15),
+        (240.0, 0.10),
+        (360.0, 0.06),
+        (480.0, 0.04),
+        (720.0, 0.025),
+    ];
+
+    /// Sum of sinusoids at `freqs` plus a touch of low-pass-filtered noise,
+    /// so the signal has broadband content like real speech/video audio
+    /// rather than a single tone.
+    fn synth_wideband(len: usize, sample_rate: u32, freqs: &[(f32, f32)], noise_amp: f32, seed: u64) -> Vec<f32> {
+        let mut rng = Xorshift(seed);
+        let mut noise_state = 0.0f32;
+        (0..len)
+            .map(|i| {
+                let t = i as f32 / sample_rate as f32;
+                let tonal: f32 = freqs
+                    .iter()
+                    .map(|(freq, amp)| amp * (t * freq * std::f32::consts::TAU).sin())
+                    .sum();
+                // One-pole low-pass on white noise: broadens the spectrum
+                // without the harshness of raw white noise.
+                noise_state = 0.9 * noise_state + 0.1 * rng.next_unit();
+                (tonal + noise_amp * noise_state).clamp(-1.0, 1.0)
+            })
+            .collect()
+    }
+
+    /// Feeds a synthetic "video playing on the speakers while the user
+    /// talks" scenario through `MeetingMixer` and reports (does not just
+    /// assert) how effectively the AEC integration attenuates the echo:
+    /// approximate ERLE post-convergence and roughly when convergence
+    /// happens. `expected_delay_hint_ms` mirrors what `Aec` would pass to
+    /// `set_stream_delay_ms` when that hint is wired up; pass `None` to
+    /// measure the current (no hint) baseline.
+    fn run_echo_bench(
+        expected_delay_hint_ms: Option<i32>,
+        voice_scale: f32,
+        delay_ms: u32,
+    ) -> (f32, Option<usize>) {
+        let sample_rate = MIX_RATE;
+        let delay_samples = (sample_rate as usize * delay_ms as usize) / 1000;
+        let attenuation = 0.3f32;
+        let duration_s = 8.0f32;
+        let total_samples = (sample_rate as f32 * duration_s) as usize;
+
+        let render = synth_wideband(total_samples, sample_rate, VIDEO_FREQS, 0.05, 0xC0FFEE);
+        let voice: Vec<f32> = synth_wideband(total_samples, sample_rate, VOICE_FREQS, 0.02, 0xBEEF)
+            .into_iter()
+            .map(|s| s * voice_scale)
+            .collect();
+
+        // Ground truth: exactly what the acoustic path adds to the mic and
+        // exactly what the user said, so residual echo can be estimated
+        // after the fact as `output - voice` (see comment below).
+        let echo: Vec<f32> = (0..total_samples)
+            .map(|n| {
+                if n >= delay_samples {
+                    render[n - delay_samples] * attenuation
+                } else {
+                    0.0
+                }
+            })
+            .collect();
+        let capture: Vec<f32> = (0..total_samples)
+            .map(|n| (voice[n] + echo[n]).clamp(-1.0, 1.0))
+            .collect();
+
+        let (mut mic_prod, mic_cons) = HeapRb::<f32>::new(sample_rate as usize).split();
+        let (mut tap_prod, tap_cons) = HeapRb::<f32>::new(sample_rate as usize).split();
+        // engine_rate == MIX_RATE: no cross-resampling, so the bench measures
+        // the AEC's contribution in isolation from resampler artifacts.
+        let mut mixer = MeetingMixer::new(mic_cons, sample_rate, 1, 1.0, tap_cons, sample_rate, sample_rate);
+        let mut aec = Aec::new(sample_rate);
+        if let Some(hint) = expected_delay_hint_ms {
+            aec.set_expected_delay_ms(hint);
+        }
+        mixer.set_aec(Some(aec));
+
+        let n_frames = total_samples / FRAME_SAMPLES;
+        let mut echo_energy_per_frame = Vec::with_capacity(n_frames);
+        let mut residual_energy_per_frame = Vec::with_capacity(n_frames);
+
+        for f in 0..n_frames {
+            let start = f * FRAME_SAMPLES;
+            let end = start + FRAME_SAMPLES;
+            mic_prod.push_slice(&capture[start..end]);
+            tap_prod.push_slice(&render[start..end]);
+
+            let (me, _them) = mixer.tick_split();
+            assert_eq!(
+                me.len(),
+                FRAME_SAMPLES,
+                "matching rates should pass one 10ms frame through per tick"
+            );
+
+            let echo_energy: f32 = echo[start..end].iter().map(|s| s * s).sum();
+            // Residual echo estimate: the AEC doesn't know `voice` separately,
+            // but we generated it, so subtracting it from the output isolates
+            // what the AEC left behind (residual echo plus any voice
+            // distortion the AEC itself introduced).
+            let residual_energy: f32 = me
+                .iter()
+                .zip(&voice[start..end])
+                .map(|(o, v)| (o - v).powi(2))
+                .sum();
+
+            echo_energy_per_frame.push(echo_energy);
+            residual_energy_per_frame.push(residual_energy);
+        }
+
+        // Post-convergence window: last quarter of the run.
+        let tail = n_frames / 4;
+        let pre: f32 = echo_energy_per_frame[n_frames - tail..].iter().sum();
+        let post: f32 = residual_energy_per_frame[n_frames - tail..].iter().sum();
+        let erle_db = 10.0 * (pre / post.max(1e-9)).log10();
+
+        // Convergence point: first frame after which a 500ms sliding window
+        // of residual energy stays below 10% (-10dB) of the echo energy in
+        // that same window.
+        let sustain_frames = 50;
+        let mut converge_frame = None;
+        for i in 0..n_frames.saturating_sub(sustain_frames) {
+            let window_pre: f32 = echo_energy_per_frame[i..i + sustain_frames].iter().sum();
+            let window_post: f32 = residual_energy_per_frame[i..i + sustain_frames].iter().sum();
+            if window_post < window_pre * 0.1 {
+                converge_frame = Some(i);
+                break;
+            }
+        }
+
+        (erle_db, converge_frame)
+    }
+
+    // Measured baselines (release build, this bench, 2026-07-18): double-talk
+    // (voice + echo together) comes out around -10dB, i.e. sonora's NLP stage
+    // leaves the output *further* from clean voice than the raw uncancelled
+    // echo would have been, both with and without the `stream_delay_ms` hint.
+    // Echo-only (no voice, see the diagnostic below) attenuates by a modest
+    // +3.6dB. That's weak for AEC3 and corroborates the production incident's
+    // report of echo passing through even before the crate panicked; it is
+    // not something this fix attempts to solve (see the investigation
+    // writeup). These asserts are regression floors against the measured
+    // baseline, not aspirational targets — tighten them if cancellation
+    // quality is improved later.
+    const DOUBLE_TALK_ERLE_FLOOR_DB: f32 = -14.0;
+
+    #[test]
+    #[ignore = "multi-second synthetic bench, run explicitly with -- --ignored --nocapture"]
+    fn wideband_echo_attenuation_baseline() {
+        let (erle_db, converge_frame) = run_echo_bench(None, 1.0, 50);
+        println!(
+            "AEC bench (no stream_delay_ms hint, 50ms acoustic delay): ERLE post-convergence = \
+             {erle_db:.1} dB, convergence at ~{}ms",
+            converge_frame.map(|f| f * 10).map_or("never".to_string(), |ms| ms.to_string())
+        );
+        assert!(
+            erle_db > DOUBLE_TALK_ERLE_FLOOR_DB,
+            "double-talk ERLE regressed below the measured baseline: got {erle_db:.1} dB"
+        );
+    }
+
+    #[test]
+    #[ignore = "multi-second synthetic bench, run explicitly with -- --ignored --nocapture"]
+    fn wideband_echo_attenuation_with_delay_hint() {
+        let (erle_db, converge_frame) = run_echo_bench(Some(50), 1.0, 50);
+        println!(
+            "AEC bench (50ms stream_delay_ms hint, 50ms acoustic delay): ERLE post-convergence = \
+             {erle_db:.1} dB, convergence at ~{}ms",
+            converge_frame.map(|f| f * 10).map_or("never".to_string(), |ms| ms.to_string())
+        );
+        assert!(
+            erle_db > DOUBLE_TALK_ERLE_FLOOR_DB,
+            "double-talk ERLE regressed below the measured baseline: got {erle_db:.1} dB"
+        );
+    }
+
+    /// Diagnostic (not a hard requirement): isolates echo-only cancellation
+    /// (no near-end voice) through the exact same mixer integration, to tell
+    /// whether a poor double-talk result comes from echo cancellation itself
+    /// or from the double-talk/voice interaction. Measured baseline: +3.6dB.
+    #[test]
+    #[ignore = "multi-second synthetic bench, run explicitly with -- --ignored --nocapture"]
+    fn wideband_echo_attenuation_no_voice_diagnostic() {
+        let (erle_db, converge_frame) = run_echo_bench(Some(50), 0.0, 50);
+        println!(
+            "AEC bench (echo only, no voice, 50ms hint, 50ms acoustic delay): ERLE \
+             post-convergence = {erle_db:.1} dB, convergence at ~{}ms",
+            converge_frame.map(|f| f * 10).map_or("never".to_string(), |ms| ms.to_string())
+        );
+    }
+
+}


### PR DESCRIPTION
## Why

During a real meeting on 2026-07-18, the echo canceller panicked 26 seconds in (`slice index starts at 13 but ends at 12`, sonora-aec3 `adaptive_fir_filter.rs:136`) and the existing guard disabled it for the rest of the session. The mic then re-captured everything the speakers played, polluting the Me lane with duplicated system audio and feeding junk into speaker diarization.

## What changed

- **Bounded rearm**: a sonora panic now rebuilds a fresh instance in place (up to 3 times per session, each logged) instead of disabling echo cancellation until the meeting ends. A few seconds of reconvergence beats an hour of raw mic.
- **Root cause fixed**: the panic is an upstream bug, triggered when an echo-path change shrinks the adaptive FIR filter below its grown size (13 -> 12 partitions, matching the incident log exactly). Fixed upstream in dignifiedquire/sonora@dec6a074 but never released to crates.io, so all sonora crates are pinned to the fixed commit via `[patch.crates-io]`. Drop the patch when 0.1.1 ships.
- **Delay hint**: sonora's docs require `set_stream_delay_ms` when echo cancellation is enabled; the wrapper never called it. A 50 ms heuristic hint is now applied at construction and reapplied on every rearm.
- **ERLE bench**: a new ignored test drives the real `MeetingMixer` split path with synthetic render/echo/voice signals and documents the measured baseline: +3.6 dB echo-only, about -10 dB under double talk (kept as a regression floor).

## Known limitation

The bench shows cancellation is weak even when healthy, which matches the incident (echo was audible in the transcript before the panic). Whether the double-talk degradation is a sonora AEC3 weakness or a synthetic-signal artifact needs a dedicated investigation with real recorded signals; tracked as a follow-up, not patched speculatively here.

## Verification

- 702 Rust tests green, clippy -D warnings clean.
- CI note: the `[patch.crates-io]` git pin means builds fetch from GitHub; the rev is locked in Cargo.lock.