### PR TITLE
Fix Bluetooth headsets stuck in HFP/mono after capture

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -814,8 +814,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -1095,41 +1093,38 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.11.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+checksum = "1aae284fbaf7d27aa0e292f7677dfbe26503b0d555026f702940805a630eac17"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation-sys",
- "coreaudio-sys",
-]
-
-[[package]]
-name = "coreaudio-sys"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
-dependencies = [
- "bindgen",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
 ]
 
 [[package]]
 name = "cpal"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+checksum = "cbd307f43cc2a697e2d1f8bc7a1d824b5269e052209e28883e5bc04d095aaa3f"
 dependencies = [
  "alsa",
- "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
  "jni",
  "js-sys",
  "libc",
  "mach2",
- "ndk 0.8.0",
+ "ndk",
  "ndk-context",
- "oboe",
+ "num-derive",
+ "num-traits",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3319,16 +3314,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3813,20 +3798,6 @@ dependencies = [
 
 [[package]]
 name = "ndk"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
-dependencies = [
- "bitflags 2.11.0",
- "jni-sys",
- "log",
- "ndk-sys 0.5.0+25.2.9519653",
- "num_enum",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
@@ -3834,7 +3805,7 @@ dependencies = [
  "bitflags 2.11.0",
  "jni-sys",
  "log",
- "ndk-sys 0.6.0+11769913",
+ "ndk-sys",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -3845,15 +3816,6 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
-name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
-dependencies = [
- "jni-sys",
-]
 
 [[package]]
 name = "ndk-sys"
@@ -4118,6 +4080,21 @@ dependencies = [
  "objc2-core-video",
  "objc2-foundation 0.3.2",
  "objc2-quartz-core 0.3.2",
+]
+
+[[package]]
+name = "objc2-audio-toolbox"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "objc2 0.6.4",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -4433,29 +4410,6 @@ dependencies = [
  "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
-]
-
-[[package]]
-name = "oboe"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
-dependencies = [
- "jni",
- "ndk 0.8.0",
- "ndk-context",
- "num-derive",
- "num-traits",
- "oboe-sys",
-]
-
-[[package]]
-name = "oboe-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -6334,7 +6288,7 @@ checksum = "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3"
 dependencies = [
  "bytemuck",
  "js-sys",
- "ndk 0.9.0",
+ "ndk",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -6791,8 +6745,8 @@ dependencies = [
  "jni",
  "libc",
  "log",
- "ndk 0.9.0",
- "ndk-sys 0.6.0+11769913",
+ "ndk",
+ "ndk-sys",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
@@ -9067,7 +9021,7 @@ dependencies = [
  "javascriptcore-rs",
  "jni",
  "libc",
- "ndk 0.9.0",
+ "ndk",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-core-foundation",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,7 +42,10 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["e
 tracing-appender = "0.2"
 log = "0.4"
 crossbeam-channel = "0.5"
-cpal = "0.15"
+# 0.16 actually disposes the CoreAudio AudioUnit when a Stream drops. 0.15
+# leaked StreamInner via a disconnect-listener cycle (RustAudio/cpal#771),
+# which left Bluetooth headsets stuck in HFP/mono until process exit.
+cpal = "0.16"
 rubato = "0.16"
 hound = "3.5"
 uuid = { version = "1", features = ["v4"] }

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -656,7 +656,7 @@ impl AudioCapture {
         // NOT torn down here; see `sync_recorder`, so a mid-session mic
         // rebuild (same session_id) keeps recording to the same file.
         self.active_session_id.store(0, Ordering::Release);
-        self.stream.take();
+        self.release_capture_stream();
         self.meeting.take();
         self.sync_recorder(session_id, record_path.as_deref(), target_sample_rate);
 
@@ -1220,7 +1220,11 @@ impl AudioCapture {
         self.mic_device_name = None;
         self.mic_device_uid = None;
         self.route_attempt_uid = None;
-        self.stream.take();
+        let released = self.release_capture_stream();
+        #[cfg(target_os = "macos")]
+        if released {
+            super::output_route::restore_bluetooth_a2dp();
+        }
         self.resampler.take();
         #[cfg(target_os = "macos")]
         if let Some(mut meeting) = self.meeting.take() {
@@ -1259,6 +1263,26 @@ impl AudioCapture {
         self.teardown_session_state();
     }
 
+    /// Stop IO and dispose the capture AudioUnit.
+    ///
+    /// On macOS, a Bluetooth headset cannot run A2DP stereo output and HFP
+    /// input at once: opening the mic forces HFP/SCO (mono). Stopping the
+    /// unit (`pause`) is not enough — Core Audio keeps the input route until
+    /// `AudioUnitUninitialize` + `AudioComponentInstanceDispose`, which run
+    /// when cpal's `StreamInner` drops. cpal 0.15 leaked that inner via a
+    /// disconnect-listener `Arc` cycle (RustAudio/cpal#771), so the headset
+    /// stayed in HFP until process exit. Pause then drop so both happen here.
+    fn release_capture_stream(&mut self) -> bool {
+        let Some(stream) = self.stream.take() else {
+            return false;
+        };
+        if let Err(e) = stream.pause() {
+            debug!("Audio stream pause on release: {e}");
+        }
+        drop(stream);
+        true
+    }
+
     fn stop(&mut self) {
         let mut session_id = self.active_session_id.swap(0, Ordering::AcqRel);
         // A session whose stream died mid-rebuild has id 0 in the atomic but
@@ -1276,8 +1300,13 @@ impl AudioCapture {
         self.emit_audio_level(0.0);
         self.level_throttle.reset();
 
-        // Dropping the stream is synchronous — after this, no callback runs.
-        let had_stream = self.stream.take().is_some();
+        // Stop IO and dispose the AudioUnit — after this, no callback runs
+        // and a Bluetooth headset can leave HFP/mono for A2DP stereo.
+        let had_stream = self.release_capture_stream();
+        #[cfg(target_os = "macos")]
+        if had_stream {
+            super::output_route::restore_bluetooth_a2dp();
+        }
 
         if let Some(mut meeting) = self.meeting.take() {
             // Tear down the tap first so its ring stops filling; then one

--- a/src-tauri/src/audio/feedback.rs
+++ b/src-tauri/src/audio/feedback.rs
@@ -127,6 +127,8 @@ fn play_wav_blocking(path: &Path, volume: f32) -> Result<(), String> {
     stream.play().map_err(|e| format!("Play stream: {e}"))?;
     let duration = duration_from_samples(sample_count, channels, sample_rate);
     thread::sleep(duration + std::time::Duration::from_millis(30));
+    let _ = stream.pause();
+    drop(stream);
     Ok(())
 }
 

--- a/src-tauri/src/audio/output_route.rs
+++ b/src-tauri/src/audio/output_route.rs
@@ -14,9 +14,11 @@ use std::ffi::c_void;
 use std::ptr::NonNull;
 
 use objc2_core_audio::{
-    AudioObjectGetPropertyData, AudioObjectID, AudioObjectPropertyAddress,
-    kAudioDevicePropertyDataSource, kAudioDevicePropertyDeviceUID, kAudioDevicePropertyMute,
+    AudioObjectGetPropertyData, AudioObjectGetPropertyDataSize, AudioObjectID,
+    AudioObjectPropertyAddress, AudioObjectSetPropertyData, kAudioDevicePropertyDataSource,
+    kAudioDevicePropertyDataSources, kAudioDevicePropertyDeviceUID, kAudioDevicePropertyMute,
     kAudioDevicePropertyTransportType, kAudioDevicePropertyVolumeScalar,
+    kAudioDeviceTransportTypeBluetooth, kAudioDeviceTransportTypeBluetoothLE,
     kAudioDeviceTransportTypeBuiltIn, kAudioHardwarePropertyDefaultOutputDevice,
     kAudioObjectPropertyElementMain, kAudioObjectPropertyScopeGlobal,
     kAudioObjectPropertyScopeOutput, kAudioObjectSystemObject,
@@ -24,7 +26,10 @@ use objc2_core_audio::{
 use objc2_core_foundation::{CFRetained, CFString};
 
 /// Built-in output data source: internal speaker ('ispk').
-const DATA_SOURCE_INTERNAL_SPEAKER: u32 = 0x6973_706b;
+const DATA_SOURCE_INTERNAL_SPEAKER: u32 = u32::from_be_bytes(*b"ispk");
+/// Bluetooth stereo output ('a2dp') versus hands-free SCO ('hfp ').
+const DATA_SOURCE_A2DP: u32 = u32::from_be_bytes(*b"a2dp");
+const DATA_SOURCE_HFP: u32 = u32::from_be_bytes(*b"hfp ");
 
 fn global_address(selector: u32) -> AudioObjectPropertyAddress {
     AudioObjectPropertyAddress {
@@ -168,6 +173,117 @@ const AUDIBLE_VOLUME_THRESHOLD: f32 = 0.01;
 /// external devices can't leak regardless of volume or mute state.
 fn can_leak(is_speakers: bool, muted: bool, volume: f32) -> bool {
     is_speakers && !muted && volume > AUDIBLE_VOLUME_THRESHOLD
+}
+
+/// After releasing a Bluetooth microphone, ask Core Audio to put the
+/// headset back on A2DP stereo if it is still advertising HFP.
+///
+/// Disposing the input AudioUnit is what actually frees the SCO link; this
+/// is a nudge for headsets (Bose in particular) that otherwise stay in HFP
+/// until something else retoggles the output profile. No-op when the
+/// default output is not Bluetooth, is already A2DP, or does not list
+/// `a2dp` as a data source.
+pub fn restore_bluetooth_a2dp() {
+    let Ok(device) = default_output_device() else {
+        return;
+    };
+    let mut transport: u32 = 0;
+    if get_property(
+        device,
+        global_address(kAudioDevicePropertyTransportType),
+        &mut transport,
+    )
+    .is_err()
+        || (transport != kAudioDeviceTransportTypeBluetooth
+            && transport != kAudioDeviceTransportTypeBluetoothLE)
+    {
+        return;
+    }
+
+    let mut source: u32 = 0;
+    if get_property(
+        device,
+        output_address(kAudioDevicePropertyDataSource),
+        &mut source,
+    )
+    .is_err()
+        || source != DATA_SOURCE_HFP
+    {
+        return;
+    }
+
+    let sources = u32_property_list(device, output_address(kAudioDevicePropertyDataSources));
+    if !sources.contains(&DATA_SOURCE_A2DP) {
+        return;
+    }
+
+    if set_property(
+        device,
+        output_address(kAudioDevicePropertyDataSource),
+        &DATA_SOURCE_A2DP,
+    )
+    .is_ok()
+    {
+        tracing::info!("Restored Bluetooth output from HFP to A2DP");
+    }
+}
+
+fn set_property<T>(
+    object: AudioObjectID,
+    mut address: AudioObjectPropertyAddress,
+    value: &T,
+) -> Result<(), String> {
+    let status = unsafe {
+        AudioObjectSetPropertyData(
+            object,
+            NonNull::from(&mut address),
+            0,
+            std::ptr::null(),
+            size_of::<T>() as u32,
+            NonNull::new(value as *const T as *mut c_void).expect("non-null in pointer"),
+        )
+    };
+    if status != 0 {
+        return Err(format!(
+            "AudioObjectSetPropertyData({:#x}) failed: {status}",
+            address.mSelector
+        ));
+    }
+    Ok(())
+}
+
+fn u32_property_list(object: AudioObjectID, mut address: AudioObjectPropertyAddress) -> Vec<u32> {
+    let mut size: u32 = 0;
+    let size_status = unsafe {
+        AudioObjectGetPropertyDataSize(
+            object,
+            NonNull::from(&mut address),
+            0,
+            std::ptr::null(),
+            NonNull::from(&mut size),
+        )
+    };
+    if size_status != 0 || size == 0 {
+        return Vec::new();
+    }
+    let count = size as usize / size_of::<u32>();
+    let mut values = vec![0u32; count];
+    let mut out_size = size;
+    let status = unsafe {
+        AudioObjectGetPropertyData(
+            object,
+            NonNull::from(&mut address),
+            0,
+            std::ptr::null(),
+            NonNull::from(&mut out_size),
+            NonNull::new(values.as_mut_ptr() as *mut c_void).expect("non-null out pointer"),
+        )
+    };
+    if status != 0 {
+        return Vec::new();
+    }
+    values.truncate(out_size as usize / size_of::<u32>());
+    values
 }
 
 /// Whether the default output can acoustically leak into the microphone

--- a/src-tauri/src/permissions.rs
+++ b/src-tauri/src/permissions.rs
@@ -211,6 +211,10 @@ pub fn probe_microphone() -> PermState {
         }
         std::thread::sleep(Duration::from_millis(100));
     }
+    // Pause then drop so the probe's AudioUnit is actually disposed. cpal
+    // 0.15 leaked StreamInner on macOS, which would leave a Bluetooth
+    // headset in HFP/mono after the onboarding mic check.
+    let _ = stream.pause();
     drop(stream);
 
     if got.load(Ordering::Relaxed) {


### PR DESCRIPTION
## Summary
- Opening a Bluetooth headset mic (Bose, etc.) correctly switches the device from A2DP stereo to HFP/SCO mono. After dictation or a meeting stopped, Soufflé never released the CoreAudio input AudioUnit, so the headset stayed in mono until the app quit.
- Root cause: cpal 0.15 leaks `StreamInner` on macOS via a disconnect-listener `Arc` cycle (RustAudio/cpal#771). `drop(stream)` was a no-op; `AudioUnitUninitialize` / `AudioComponentInstanceDispose` only ran at process exit.
- Bump to cpal 0.16 so Stream drop actually disposes the unit, pause-then-drop on every capture teardown (including the TCC mic probe and feedback output), and nudge the output data source back to A2DP when Core Audio still advertises HFP.

## Test plan
- [x] Bose as selected/default mic: start dictation → headset goes mono (expected) → stop → stereo returns without quitting the app (validated)
- [x] Same with a meeting session
- [x] Built-in / USB mic still records and stops cleanly
- [x] Settings device list still does not flip a connected BT headset into HFP just by opening Settings
