### PR TITLE
Fix crash when starting transcription (cpal 0.17)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -80,9 +80,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alsa"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
 dependencies = [
  "alsa-sys",
  "bitflags 2.11.0",
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "alsa-sys"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
 dependencies = [
  "libc",
  "pkg-config",
@@ -1093,11 +1093,11 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.13.0"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aae284fbaf7d27aa0e292f7677dfbe26503b0d555026f702940805a630eac17"
+checksum = "7d5d7dca3ebcf65a035582c9ad4385371a9d9ee6537474d2a278f4e1e475bb58"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "libc",
  "objc2-audio-toolbox",
  "objc2-core-audio",
@@ -1107,9 +1107,9 @@ dependencies = [
 
 [[package]]
 name = "cpal"
-version = "0.16.0"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd307f43cc2a697e2d1f8bc7a1d824b5269e052209e28883e5bc04d095aaa3f"
+checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
 dependencies = [
  "alsa",
  "coreaudio-rs",
@@ -1122,13 +1122,17 @@ dependencies = [
  "ndk-context",
  "num-derive",
  "num-traits",
+ "objc2 0.6.4",
  "objc2-audio-toolbox",
+ "objc2-avf-audio",
  "objc2-core-audio",
  "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows 0.54.0",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -3531,9 +3535,9 @@ dependencies = [
 
 [[package]]
 name = "mach2"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
 ]
@@ -4094,6 +4098,16 @@ dependencies = [
  "objc2-core-audio",
  "objc2-core-audio-types",
  "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]
 
@@ -8393,16 +8407,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
-dependencies = [
- "windows-core 0.54.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -8431,16 +8435,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.54.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
-dependencies = [
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -8555,15 +8549,6 @@ dependencies = [
  "windows-link 0.2.1",
  "windows-result 0.4.1",
  "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,10 +42,12 @@ tracing-subscriber = { version = "0.3", default-features = false, features = ["e
 tracing-appender = "0.2"
 log = "0.4"
 crossbeam-channel = "0.5"
-# 0.16 actually disposes the CoreAudio AudioUnit when a Stream drops. 0.15
-# leaked StreamInner via a disconnect-listener cycle (RustAudio/cpal#771),
-# which left Bluetooth headsets stuck in HFP/mono until process exit.
-cpal = "0.16"
+# 0.16 disposes the CoreAudio AudioUnit on Stream drop (0.15 leaked it and
+# left Bluetooth headsets in HFP/mono). 0.16 also had a release-mode UB in
+# device enumeration (`let data_size = 0` then read it back) that SIGSEGV'd
+# at 0x4 on session start; 0.17 fixed that ("segfaults when enumerating
+# devices").
+cpal = "0.17"
 rubato = "0.16"
 hound = "3.5"
 uuid = { version = "1", features = ["v4"] }

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -12,7 +12,7 @@ use tracing::{debug, error, info, warn};
 use super::mixer::MeetingMixer;
 use super::recorder::MeetingRecorder;
 use super::resampler::Resampler;
-use crate::audio::device::{AudioInputDevice, resolve_device_name, uid_for_device_name};
+use crate::audio::device::AudioInputDevice;
 use crate::audio::priority::{InputPriority, ResolveInputParams, resolve_input};
 use crate::state::AudioCommand;
 
@@ -345,10 +345,26 @@ fn list_input_devices_impl() -> Vec<AudioInputDevice> {
         .collect()
 }
 
+/// CoreAudio UID of a cpal device (`kAudioDevicePropertyDeviceUID`). Cheap
+/// property read — unlike `name()` / `description()`, this does not open
+/// an AudioUnit.
+fn cpal_device_uid(device: &Device) -> Option<String> {
+    device.id().ok().map(|id| id.1)
+}
+
+/// Locate a cpal device by UID without probing supported configs.
+fn find_cpal_device_by_uid(host: &cpal::Host, uid: &str) -> Option<Device> {
+    host.devices()
+        .ok()?
+        .find(|device| cpal_device_uid(device).as_deref() == Some(uid))
+}
+
 /// Manages audio capture from a selected input device.
 /// Sends resampled 24kHz mono f32 chunks over a crossbeam channel.
 ///
-/// This struct lives on a dedicated thread because cpal's Stream is !Send on macOS.
+/// Lives on a dedicated thread so CoreAudio IO and Stream lifecycle stay
+/// off the UI / async runtime. (cpal 0.17's macOS Stream is Send; isolation
+/// is still the right ownership model.)
 pub struct AudioCapture {
     stream: Option<Stream>,
     audio_sender: Sender<AudioMessage>,
@@ -602,34 +618,26 @@ impl AudioCapture {
         let host = cpal::default_host();
 
         if let Some(uid) = self.resolved_input_uid(known_devices) {
-            let target_name = resolve_device_name(known_devices, &uid).or({
-                // Disconnected UID or legacy name not in the current snapshot:
-                // try the stored value as a cpal device name directly.
-                Some(uid.as_str())
-            });
-
-            if let Some(name) = target_name {
-                // Unfiltered `devices()`, not `input_devices()`: the latter's
-                // default filter probes every device's supported input configs
-                // (opens an AudioUnit per device on coreaudio) just to enumerate
-                // them, which can flip a Bluetooth headset into HFP mono. This
-                // runs on every session start and every mic health check
-                // (MIC_CHECK_INTERVAL), so the unfiltered form matters even when
-                // no device is pinned below the fallback. `Device::name`
-                // itself is a cheap property read, safe to call on every device.
-                let devices = host
-                    .devices()
-                    .map_err(|e| format!("Failed to list devices: {e}"))?;
-
-                for device in devices {
-                    if let Ok(n) = device.name()
-                        && n == name
-                    {
-                        return Ok(device);
-                    }
-                }
-                warn!("Input device '{name}' not found, falling back to default");
+            // Unfiltered `devices()` + `Device::id()` (`kAudioDevicePropertyDeviceUID`).
+            // Do not use `input_devices()`, `name()`, or `description()`: in
+            // cpal 0.17 those open an AudioUnit per device (input *and*
+            // output for `description`) just to inspect it, which can flip a
+            // Bluetooth headset into HFP mono. This runs on every session
+            // start and every mic rebuild.
+            if let Some(device) = find_cpal_device_by_uid(&host, &uid) {
+                return Ok(device);
             }
+
+            // Legacy pin stored as a display name: map through our snapshot
+            // (cheap CoreAudio list) then look up by UID. Never cpal name().
+            if let Some(mapped) = known_devices.iter().find(|d| d.name == uid)
+                && mapped.uid != uid
+                && let Some(device) = find_cpal_device_by_uid(&host, &mapped.uid)
+            {
+                return Ok(device);
+            }
+
+            warn!("Input device '{uid}' not found, falling back to default");
         }
 
         // Also reached when `resolve_input` found no auto-eligible device
@@ -678,16 +686,26 @@ impl AudioCapture {
         let known_devices = list_input_devices_impl();
         let device = self.find_device(&known_devices)?;
 
-        let device_name = device.name().unwrap_or_else(|_| "Unknown".into());
-        // Track the UID of the device cpal actually opened, not just what
-        // resolve_input picked: find_device may fall back to the OS default
-        // when the resolved name is missing from the cpal device list.
-        self.mic_device_uid = uid_for_device_name(&known_devices, &device_name);
+        // Track the UID cpal actually opened, not just what resolve_input
+        // picked: find_device may fall back to the OS default. `id()` is a
+        // UID property read; `name()`/`description()` would open AudioUnits.
+        let opened_uid = cpal_device_uid(&device);
+        let device_name = opened_uid
+            .as_deref()
+            .and_then(|uid| {
+                known_devices
+                    .iter()
+                    .find(|d| d.uid == uid)
+                    .map(|d| d.name.clone())
+            })
+            .or_else(|| opened_uid.clone())
+            .unwrap_or_else(|| "Unknown".into());
+        self.mic_device_uid = opened_uid;
         info!("Using input device: {device_name}");
         self.mic_device_name = Some(device_name.clone());
 
         let config = Self::preferred_config(&device)?;
-        let sample_rate = config.sample_rate.0;
+        let sample_rate = config.sample_rate;
         let channels = config.channels;
 
         info!("Audio config: {sample_rate}Hz, {channels}ch");
@@ -875,7 +893,7 @@ impl AudioCapture {
         mic_gain: f32,
         diarize: bool,
     ) -> Result<(), String> {
-        let sample_rate = config.sample_rate.0;
+        let sample_rate = config.sample_rate;
         let channels = config.channels;
 
         // ~2s of headroom per ring; the 5ms tick drains far faster.
@@ -1220,11 +1238,7 @@ impl AudioCapture {
         self.mic_device_name = None;
         self.mic_device_uid = None;
         self.route_attempt_uid = None;
-        let released = self.release_capture_stream();
-        #[cfg(target_os = "macos")]
-        if released {
-            super::output_route::restore_bluetooth_a2dp();
-        }
+        self.release_capture_stream();
         self.resampler.take();
         #[cfg(target_os = "macos")]
         if let Some(mut meeting) = self.meeting.take() {
@@ -1303,10 +1317,6 @@ impl AudioCapture {
         // Stop IO and dispose the AudioUnit — after this, no callback runs
         // and a Bluetooth headset can leave HFP/mono for A2DP stereo.
         let had_stream = self.release_capture_stream();
-        #[cfg(target_os = "macos")]
-        if had_stream {
-            super::output_route::restore_bluetooth_a2dp();
-        }
 
         if let Some(mut meeting) = self.meeting.take() {
             // Tear down the tap first so its ring stops filling; then one

--- a/src-tauri/src/audio/feedback.rs
+++ b/src-tauri/src/audio/feedback.rs
@@ -76,7 +76,7 @@ fn play_wav_blocking(path: &Path, volume: f32) -> Result<(), String> {
     let supported = device
         .default_output_config()
         .map_err(|e| format!("Output config: {e}"))?;
-    let sample_rate = supported.sample_rate().0;
+    let sample_rate = supported.sample_rate();
     let channels = supported.channels() as usize;
 
     let scaled: Vec<f32> = samples

--- a/src-tauri/src/audio/output_route.rs
+++ b/src-tauri/src/audio/output_route.rs
@@ -14,11 +14,9 @@ use std::ffi::c_void;
 use std::ptr::NonNull;
 
 use objc2_core_audio::{
-    AudioObjectGetPropertyData, AudioObjectGetPropertyDataSize, AudioObjectID,
-    AudioObjectPropertyAddress, AudioObjectSetPropertyData, kAudioDevicePropertyDataSource,
-    kAudioDevicePropertyDataSources, kAudioDevicePropertyDeviceUID, kAudioDevicePropertyMute,
+    AudioObjectGetPropertyData, AudioObjectID, AudioObjectPropertyAddress,
+    kAudioDevicePropertyDataSource, kAudioDevicePropertyDeviceUID, kAudioDevicePropertyMute,
     kAudioDevicePropertyTransportType, kAudioDevicePropertyVolumeScalar,
-    kAudioDeviceTransportTypeBluetooth, kAudioDeviceTransportTypeBluetoothLE,
     kAudioDeviceTransportTypeBuiltIn, kAudioHardwarePropertyDefaultOutputDevice,
     kAudioObjectPropertyElementMain, kAudioObjectPropertyScopeGlobal,
     kAudioObjectPropertyScopeOutput, kAudioObjectSystemObject,
@@ -27,9 +25,6 @@ use objc2_core_foundation::{CFRetained, CFString};
 
 /// Built-in output data source: internal speaker ('ispk').
 const DATA_SOURCE_INTERNAL_SPEAKER: u32 = u32::from_be_bytes(*b"ispk");
-/// Bluetooth stereo output ('a2dp') versus hands-free SCO ('hfp ').
-const DATA_SOURCE_A2DP: u32 = u32::from_be_bytes(*b"a2dp");
-const DATA_SOURCE_HFP: u32 = u32::from_be_bytes(*b"hfp ");
 
 fn global_address(selector: u32) -> AudioObjectPropertyAddress {
     AudioObjectPropertyAddress {
@@ -173,117 +168,6 @@ const AUDIBLE_VOLUME_THRESHOLD: f32 = 0.01;
 /// external devices can't leak regardless of volume or mute state.
 fn can_leak(is_speakers: bool, muted: bool, volume: f32) -> bool {
     is_speakers && !muted && volume > AUDIBLE_VOLUME_THRESHOLD
-}
-
-/// After releasing a Bluetooth microphone, ask Core Audio to put the
-/// headset back on A2DP stereo if it is still advertising HFP.
-///
-/// Disposing the input AudioUnit is what actually frees the SCO link; this
-/// is a nudge for headsets (Bose in particular) that otherwise stay in HFP
-/// until something else retoggles the output profile. No-op when the
-/// default output is not Bluetooth, is already A2DP, or does not list
-/// `a2dp` as a data source.
-pub fn restore_bluetooth_a2dp() {
-    let Ok(device) = default_output_device() else {
-        return;
-    };
-    let mut transport: u32 = 0;
-    if get_property(
-        device,
-        global_address(kAudioDevicePropertyTransportType),
-        &mut transport,
-    )
-    .is_err()
-        || (transport != kAudioDeviceTransportTypeBluetooth
-            && transport != kAudioDeviceTransportTypeBluetoothLE)
-    {
-        return;
-    }
-
-    let mut source: u32 = 0;
-    if get_property(
-        device,
-        output_address(kAudioDevicePropertyDataSource),
-        &mut source,
-    )
-    .is_err()
-        || source != DATA_SOURCE_HFP
-    {
-        return;
-    }
-
-    let sources = u32_property_list(device, output_address(kAudioDevicePropertyDataSources));
-    if !sources.contains(&DATA_SOURCE_A2DP) {
-        return;
-    }
-
-    if set_property(
-        device,
-        output_address(kAudioDevicePropertyDataSource),
-        &DATA_SOURCE_A2DP,
-    )
-    .is_ok()
-    {
-        tracing::info!("Restored Bluetooth output from HFP to A2DP");
-    }
-}
-
-fn set_property<T>(
-    object: AudioObjectID,
-    mut address: AudioObjectPropertyAddress,
-    value: &T,
-) -> Result<(), String> {
-    let status = unsafe {
-        AudioObjectSetPropertyData(
-            object,
-            NonNull::from(&mut address),
-            0,
-            std::ptr::null(),
-            size_of::<T>() as u32,
-            NonNull::new(value as *const T as *mut c_void).expect("non-null in pointer"),
-        )
-    };
-    if status != 0 {
-        return Err(format!(
-            "AudioObjectSetPropertyData({:#x}) failed: {status}",
-            address.mSelector
-        ));
-    }
-    Ok(())
-}
-
-fn u32_property_list(object: AudioObjectID, mut address: AudioObjectPropertyAddress) -> Vec<u32> {
-    let mut size: u32 = 0;
-    let size_status = unsafe {
-        AudioObjectGetPropertyDataSize(
-            object,
-            NonNull::from(&mut address),
-            0,
-            std::ptr::null(),
-            NonNull::from(&mut size),
-        )
-    };
-    if size_status != 0 || size == 0 {
-        return Vec::new();
-    }
-    let count = size as usize / size_of::<u32>();
-    let mut values = vec![0u32; count];
-    let mut out_size = size;
-    let status = unsafe {
-        AudioObjectGetPropertyData(
-            object,
-            NonNull::from(&mut address),
-            0,
-            std::ptr::null(),
-            NonNull::from(&mut out_size),
-            NonNull::new(values.as_mut_ptr() as *mut c_void).expect("non-null out pointer"),
-        )
-    };
-    if status != 0 {
-        return Vec::new();
-    }
-    values.truncate(out_size as usize / size_of::<u32>());
-    values
 }
 
 /// Whether the default output can acoustically leak into the microphone

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -198,7 +198,8 @@ pub fn run() {
     // the actor's AudioGone handler.
     let audio_gone_reason = Arc::new(std::sync::Mutex::new(None));
 
-    // Spawn the audio thread before Tauri starts (cpal Stream is !Send on macOS)
+    // Spawn the audio thread before Tauri starts so CoreAudio IO stays off
+    // the UI / async runtime.
     let (cmd_tx, audio_rx) = match AudioCapture::spawn(
         Arc::clone(&audio_rms),
         Arc::clone(&dropped_counter),

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -139,9 +139,9 @@ impl MeetingAccumulator {
 }
 
 /// Shared application state, managed by Tauri.
-/// AudioCapture lives on its own thread (cpal Stream is !Send on macOS),
-/// and the transcription engine lives on the engine actor thread —
-/// both are driven via command channels.
+/// AudioCapture lives on its own thread so CoreAudio IO stays off the UI /
+/// async runtime, and the transcription engine lives on the engine actor
+/// thread — both are driven via command channels.
 pub struct AppState {
     pub audio_cmd_sender: Sender<AudioCommand>,
     /// Wrapped in Arc so async commands can clone a handle into a blocking


### PR DESCRIPTION
## Summary
- Release builds could SIGSEGV at `0x4` the moment a dictation or meeting started (cpal 0.16 CoreAudio device-list UB, folded by LTO). Bump to 0.17.3.
- Match the capture device by UID instead of `name()`: in 0.17 that path opens AudioUnits on every device and can flip a Bluetooth headset into HFP.
- Drop the speculative A2DP `SetPropertyData` nudge from 0.8.1. Disposing the AudioUnit (`pause` then `drop`) is what actually releases SCO.

## Test plan
- [ ] Release build: start a dictation — app must not crash (the M4 / v0.8.1 case).
- [ ] Bluetooth headset as mic: stereo → mono while recording → stereo again after stop, without quitting.
- [ ] Built-in mic with a Bluetooth headset as output only: starting dictation must not wake HFP on the headset.
- [ ] Meeting + system audio still starts (tap + mic coexist).


Made with [Cursor](https://cursor.com)