### PR TITLE
Fix ghost taps, stale calendar, fullscreen pill, and dead mic after a dock reboot

### DIFF
--- a/src-tauri/src/app_events.rs
+++ b/src-tauri/src/app_events.rs
@@ -125,6 +125,15 @@ pub struct UpcomingMeeting {
     pub kind: CalendarMeetingNudgeKind,
 }
 
+/// Pushed by the calendar scheduler whenever today's event list changes
+/// (new invite, reschedule, midnight rollover). The home view listens so it
+/// does not depend on a webview timer surviving overnight.
+#[derive(Debug, Clone, Serialize, Deserialize, Type, Event)]
+pub struct TodayCalendarUpdated {
+    pub permission: crate::permissions::PermState,
+    pub events: Vec<crate::calendar::CalendarEvent>,
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Type)]
 #[serde(rename_all = "snake_case")]
 pub enum MeetingIdleReason {

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -6,7 +6,7 @@ use ringbuf::traits::{Producer, Split};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tracing::{debug, error, info, warn};
 
 use super::mixer::MeetingMixer;
@@ -43,6 +43,11 @@ const DICTATION_TICK: Duration = LEVEL_EMIT_INTERVAL;
 /// still the system default (closing the laptop lid switches the default
 /// input to a headset or webcam mic — the stream must follow it).
 const MIC_CHECK_INTERVAL: Duration = Duration::from_secs(2);
+
+/// A live input stream delivers callbacks many times a second. If none
+/// arrive for this long the AudioUnit is a zombie (USB dock reboot that
+/// never fires cpal's error callback) and the mic leg must be rebuilt.
+const MIC_STALE_AFTER: Duration = Duration::from_secs(2);
 
 /// Ceiling on how often AudioLevel is pushed to the frontend. Meeting mode's
 /// 5ms tick would otherwise emit at ~200Hz; the dictation tick matches this
@@ -90,6 +95,41 @@ fn decide_mic_loss(
     } else {
         MicLossAction::KeepRetrying
     }
+}
+
+fn unix_now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// True when the cpal input callback has been silent longer than `threshold`.
+fn mic_callbacks_stale(last_callback_ms: u64, now_ms: u64, threshold: Duration) -> bool {
+    last_callback_ms > 0 && now_ms.saturating_sub(last_callback_ms) >= threshold.as_millis() as u64
+}
+
+/// USB unplug/replug keeps the device UID and allocates a new CoreAudio
+/// object. `None` current means the UID disappeared from the HAL list.
+fn opened_device_replaced(opened_id: Option<u32>, current_id: Option<u32>) -> bool {
+    match (opened_id, current_id) {
+        (Some(opened), Some(current)) => opened != current,
+        (Some(_), None) => true,
+        _ => false,
+    }
+}
+
+/// Whether the capture leg should be torn down and reopened. UID-only
+/// comparison misses dock reboots: the pin still resolves, the stream is
+/// just bound to a dead HAL object.
+fn should_rebuild_mic(
+    stream_failed: bool,
+    callbacks_stale: bool,
+    device_replaced: bool,
+    device_not_alive: bool,
+    resolved_changed: bool,
+) -> bool {
+    stream_failed || callbacks_stale || device_replaced || device_not_alive || resolved_changed
 }
 
 #[cfg(test)]
@@ -148,6 +188,48 @@ mod mic_loss_tests {
         // A caller resets `already_warned_this_episode` to false once a
         // rebuild succeeds; the next loss episode should warn again.
         assert_eq!(decide_mic_loss(1, true, false), MicLossAction::WarnOnce);
+    }
+
+    #[test]
+    fn callbacks_stale_after_threshold_not_before() {
+        let t0 = 1_000;
+        assert!(!mic_callbacks_stale(t0, t0 + 1_999, MIC_STALE_AFTER));
+        assert!(mic_callbacks_stale(t0, t0 + 2_000, MIC_STALE_AFTER));
+        assert!(
+            !mic_callbacks_stale(0, t0 + 10_000, MIC_STALE_AFTER),
+            "unset timestamp must not look stale (pre-start)"
+        );
+    }
+
+    #[test]
+    fn replaced_when_object_id_changes_or_uid_vanishes() {
+        assert!(!opened_device_replaced(Some(42), Some(42)));
+        assert!(opened_device_replaced(Some(42), Some(99)));
+        assert!(opened_device_replaced(Some(42), None));
+        assert!(!opened_device_replaced(None, Some(99)));
+        assert!(!opened_device_replaced(None, None));
+    }
+
+    #[test]
+    fn rebuilds_on_dock_reboot_signals_not_just_uid_change() {
+        assert!(
+            !should_rebuild_mic(false, false, false, false, false),
+            "healthy stream must not rebuild"
+        );
+        assert!(
+            should_rebuild_mic(false, false, true, false, false),
+            "same UID, new HAL object (USB replug)"
+        );
+        assert!(
+            should_rebuild_mic(false, true, false, false, false),
+            "callbacks stopped"
+        );
+        assert!(
+            should_rebuild_mic(false, false, false, true, false),
+            "DeviceIsAlive flipped off"
+        );
+        assert!(should_rebuild_mic(true, false, false, false, false));
+        assert!(should_rebuild_mic(false, false, false, false, true));
     }
 }
 
@@ -256,7 +338,8 @@ impl MeetingState {
         if can_leak != self.aec_active {
             if can_leak {
                 info!("Speakers audible, echo cancellation engaged");
-                self.mixer.set_aec(Some(aec::Aec::new_with_default_delay_hint(mixer::MIX_RATE)));
+                self.mixer
+                    .set_aec(Some(aec::Aec::new_with_default_delay_hint(mixer::MIX_RATE)));
             } else {
                 info!("Output muted or off speakers, echo cancellation disengaged");
                 self.mixer.set_aec(None);
@@ -359,6 +442,30 @@ fn find_cpal_device_by_uid(host: &cpal::Host, uid: &str) -> Option<Device> {
         .find(|device| cpal_device_uid(device).as_deref() == Some(uid))
 }
 
+fn current_mic_object_id(uid: &str) -> Option<u32> {
+    #[cfg(target_os = "macos")]
+    {
+        super::device_watch::object_id_for_uid(uid)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = uid;
+        None
+    }
+}
+
+fn mic_device_is_alive(id: u32) -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        super::device_watch::device_is_alive(id)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = id;
+        true
+    }
+}
+
 /// Manages audio capture from a selected input device.
 /// Sends resampled 24kHz mono f32 chunks over a crossbeam channel.
 ///
@@ -401,6 +508,11 @@ pub struct AudioCapture {
     mic_device_name: Option<String>,
     /// UID resolved when the current stream was built (for route hot-swap).
     mic_device_uid: Option<String>,
+    /// CoreAudio object ID of that UID at open. USB replug keeps the UID
+    /// and issues a new ID; comparing them is how we detect a dock reboot.
+    mic_device_object_id: Option<u32>,
+    /// Last cpal input-callback time (unix ms). 0 = never.
+    last_mic_callback_ms: Arc<AtomicU64>,
     /// Resolved target UID of the last route-change rebuild. When the opened
     /// device cannot converge on that target (duplicate device names, or a
     /// resolved device cpal cannot open), this stops the periodic health
@@ -466,6 +578,8 @@ impl AudioCapture {
                     active_params: None,
                     mic_device_name: None,
                     mic_device_uid: None,
+                    mic_device_object_id: None,
+                    last_mic_callback_ms: Arc::new(AtomicU64::new(0)),
                     route_attempt_uid: None,
                     stream_failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
                     last_mic_check: Instant::now(),
@@ -682,6 +796,9 @@ impl AudioCapture {
             .store(false, std::sync::atomic::Ordering::Relaxed);
         self.mic_device_name = None;
         self.mic_device_uid = None;
+        self.mic_device_object_id = None;
+        self.last_mic_callback_ms
+            .store(unix_now_ms(), Ordering::Relaxed);
 
         let known_devices = list_input_devices_impl();
         let device = self.find_device(&known_devices)?;
@@ -700,7 +817,8 @@ impl AudioCapture {
             })
             .or_else(|| opened_uid.clone())
             .unwrap_or_else(|| "Unknown".into());
-        self.mic_device_uid = opened_uid;
+        self.mic_device_uid = opened_uid.clone();
+        self.mic_device_object_id = opened_uid.as_deref().and_then(current_mic_object_id);
         info!("Using input device: {device_name}");
         self.mic_device_name = Some(device_name.clone());
 
@@ -734,6 +852,7 @@ impl AudioCapture {
         let dropped_counter = Arc::clone(&self.dropped_counter);
 
         let stream_failed = Arc::clone(&self.stream_failed);
+        let last_mic_callback_ms = Arc::clone(&self.last_mic_callback_ms);
         let err_fn = move |err: cpal::StreamError| {
             error!("Audio stream error: {err}");
             stream_failed.store(true, std::sync::atomic::Ordering::Relaxed);
@@ -754,6 +873,7 @@ impl AudioCapture {
                     if active_session_id.load(Ordering::Acquire) != session_id {
                         return;
                     }
+                    last_mic_callback_ms.store(unix_now_ms(), Ordering::Relaxed);
 
                     let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     let resampled = match resampler.lock() {
@@ -823,8 +943,16 @@ impl AudioCapture {
     /// A failure to start the recorder is logged and otherwise ignored —
     /// recording is a best-effort opt-in feature, never a reason to fail the
     /// audio session itself.
-    fn sync_recorder(&mut self, session_id: u64, record_path: Option<&std::path::Path>, sample_rate: u32) {
-        let same_session = self.recorder.as_ref().is_some_and(|r| r.session_id() == session_id);
+    fn sync_recorder(
+        &mut self,
+        session_id: u64,
+        record_path: Option<&std::path::Path>,
+        sample_rate: u32,
+    ) {
+        let same_session = self
+            .recorder
+            .as_ref()
+            .is_some_and(|r| r.session_id() == session_id);
         match record_path {
             Some(_) if same_session => {}
             Some(path) => {
@@ -905,6 +1033,7 @@ impl AudioCapture {
         // be held hostage by tap startup (see system_tap.rs module docs).
         let active_session_id = Arc::clone(&self.active_session_id);
         let stream_failed = Arc::clone(&self.stream_failed);
+        let last_mic_callback_ms = Arc::clone(&self.last_mic_callback_ms);
         let err_fn = move |err: cpal::StreamError| {
             error!("Audio stream error: {err}");
             stream_failed.store(true, std::sync::atomic::Ordering::Relaxed);
@@ -916,6 +1045,7 @@ impl AudioCapture {
                     if active_session_id.load(Ordering::Acquire) != session_id {
                         return;
                     }
+                    last_mic_callback_ms.store(unix_now_ms(), Ordering::Relaxed);
                     // Ring full means the mixer is wedged; losing mic samples
                     // here is the only safe option in a realtime callback.
                     let _ = mic_prod.push_slice(data);
@@ -976,7 +1106,9 @@ impl AudioCapture {
             let can_leak = tap.is_some() && super::output_route::output_can_leak_into_mic();
             if can_leak {
                 info!("Speakers audible, echo cancellation engaged");
-                mixer.set_aec(Some(super::aec::Aec::new_with_default_delay_hint(super::mixer::MIX_RATE)));
+                mixer.set_aec(Some(super::aec::Aec::new_with_default_delay_hint(
+                    super::mixer::MIX_RATE,
+                )));
             }
             can_leak
         };
@@ -998,10 +1130,11 @@ impl AudioCapture {
         Ok(())
     }
 
-    /// Rebuild the capture leg when the stream died or the default input
-    /// device changed (lid closed, headset plugged in…). The session keeps
-    /// its id, so the engine actor sees one continuous stream; at most a
-    /// couple of seconds of audio are lost.
+    /// Rebuild the capture leg when the stream died, the HAL object behind
+    /// the same UID was replaced (USB dock reboot), callbacks stopped, or
+    /// the resolved input UID changed (lid closed, headset plugged in).
+    /// The session keeps its id, so the engine actor sees one continuous
+    /// stream; at most a couple of seconds of audio are lost.
     ///
     /// Returns `true` if the microphone is unrecoverable and has no other
     /// audio source to fall back on (dictation): the session has already
@@ -1017,21 +1150,31 @@ impl AudioCapture {
         let failed = self
             .stream_failed
             .swap(false, std::sync::atomic::Ordering::Relaxed);
+        let stale = mic_callbacks_stale(
+            self.last_mic_callback_ms.load(Ordering::Relaxed),
+            unix_now_ms(),
+            MIC_STALE_AFTER,
+        );
+        let current_id = self
+            .mic_device_uid
+            .as_deref()
+            .and_then(current_mic_object_id);
+        let replaced = opened_device_replaced(self.mic_device_object_id, current_id);
+        let not_alive = self
+            .mic_device_object_id
+            .is_some_and(|id| !mic_device_is_alive(id));
 
-        // Rebuild when the resolved input UID changes (lid closed, headset
-        // plugged in, priority policy update) or the stream died. Two guards
-        // keep this from looping every MIC_CHECK_INTERVAL:
+        // Two guards keep UID-change rebuilds from looping every interval:
         // - `None` (no auto-eligible device under the current policy) never
-        //   tears down a healthy stream; a dead one is caught by `failed`.
-        // - A target already attempted without converging (duplicate device
-        //   names, resolved device cpal cannot open) is parked in
+        //   tears down a healthy stream; a dead one is caught above.
+        // - A target already attempted without converging is parked in
         //   `route_attempt_uid` until an explicit route event retries it.
         let resolved = self.resolved_input_uid(&list_input_devices_impl());
         let resolved_changed = resolved.is_some()
             && resolved != self.mic_device_uid
             && resolved != self.route_attempt_uid;
 
-        if !failed && !resolved_changed {
+        if !should_rebuild_mic(failed, stale, replaced, not_alive, resolved_changed) {
             return false;
         }
 
@@ -1039,10 +1182,18 @@ impl AudioCapture {
             self.route_attempt_uid = resolved.clone();
         }
 
-        info!(
-            "Input device {}, rebuilding audio capture",
-            if failed { "failed" } else { "changed" }
-        );
+        let reason = if failed {
+            "failed"
+        } else if stale {
+            "callbacks stalled"
+        } else if replaced {
+            "HAL object replaced (same UID)"
+        } else if not_alive {
+            "device not alive"
+        } else {
+            "changed"
+        };
+        info!("Input device {reason}, rebuilding audio capture");
         match self.start(
             params.session_id,
             params.target_sample_rate,
@@ -1237,7 +1388,9 @@ impl AudioCapture {
         self.active_params = None;
         self.mic_device_name = None;
         self.mic_device_uid = None;
+        self.mic_device_object_id = None;
         self.route_attempt_uid = None;
+        self.last_mic_callback_ms.store(0, Ordering::Relaxed);
         self.release_capture_stream();
         self.resampler.take();
         #[cfg(target_os = "macos")]
@@ -1310,7 +1463,9 @@ impl AudioCapture {
         self.active_params = None;
         self.mic_device_name = None;
         self.mic_device_uid = None;
+        self.mic_device_object_id = None;
         self.route_attempt_uid = None;
+        self.last_mic_callback_ms.store(0, Ordering::Relaxed);
         self.emit_audio_level(0.0);
         self.level_throttle.reset();
 

--- a/src-tauri/src/audio/device.rs
+++ b/src-tauri/src/audio/device.rs
@@ -23,12 +23,30 @@ pub struct AudioInputDevice {
     pub is_default: bool,
 }
 
-/// Name of the private aggregate device created for system-audio capture.
-pub const SOUFFLE_TAP_DEVICE_NAME: &str = "Souffle system audio tap";
+/// Visible name of the private aggregate wrapping the process tap. This is
+/// what CoreAudio (and the Settings device list) report — not the
+/// `CATapDescription` name below. Copies leftover from a crash or a wedged
+/// tap may appear as `"Souffle Tap 2"`, etc.
+pub const SOUFFLE_TAP_AGGREGATE_NAME: &str = "Souffle Tap";
 
-/// Whether `name` refers to Souffle's own system-audio tap aggregate device.
+/// Name set on the `CATapDescription`. Kept for matching in case CoreAudio
+/// ever surfaces the tap object itself rather than the aggregate.
+pub const SOUFFLE_TAP_DESCRIPTION_NAME: &str = "Souffle system audio tap";
+
+/// UID prefix for every aggregate we create, so orphans are identifiable
+/// even if CoreAudio rewrites the display name.
+pub const SOUFFLE_TAP_UID_PREFIX: &str = "com.souffle.tap.";
+
+/// Whether `name` refers to Souffle's own system-audio tap aggregate (or a
+/// numbered leftover like `"Souffle Tap 2"`).
 pub fn is_souffle_tap_device(name: &str) -> bool {
-    name.contains(SOUFFLE_TAP_DEVICE_NAME)
+    let lower = name.to_ascii_lowercase();
+    lower.contains("souffle") && lower.contains("tap")
+}
+
+/// Whether `uid` was issued by Souffle for a process-tap aggregate.
+pub fn is_souffle_tap_uid(uid: &str) -> bool {
+    uid.starts_with(SOUFFLE_TAP_UID_PREFIX)
 }
 
 /// Convert a stored preference (`uid` or legacy `name`) to the device name cpal
@@ -155,7 +173,18 @@ mod tests {
 
     #[test]
     fn souffle_tap_name_is_detected() {
+        assert!(is_souffle_tap_device("Souffle Tap"));
+        assert!(is_souffle_tap_device("Souffle Tap 2"));
         assert!(is_souffle_tap_device("Souffle system audio tap"));
         assert!(!is_souffle_tap_device("MacBook Pro Microphone"));
+        assert!(!is_souffle_tap_device("Souffle Mix"));
+    }
+
+    #[test]
+    fn souffle_tap_uid_matches_prefix() {
+        assert!(is_souffle_tap_uid(
+            "com.souffle.tap.aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        ));
+        assert!(!is_souffle_tap_uid("BuiltInMicUID"));
     }
 }

--- a/src-tauri/src/audio/device_watch.rs
+++ b/src-tauri/src/audio/device_watch.rs
@@ -25,7 +25,7 @@ use dispatch2::{DispatchQueue, DispatchRetained};
 use objc2_core_audio::{
     AudioObjectAddPropertyListenerBlock, AudioObjectGetPropertyData,
     AudioObjectGetPropertyDataSize, AudioObjectID, AudioObjectPropertyAddress,
-    kAudioDevicePropertyDeviceUID, kAudioDevicePropertyStreams,
+    kAudioDevicePropertyDeviceIsAlive, kAudioDevicePropertyDeviceUID, kAudioDevicePropertyStreams,
     kAudioDevicePropertyTransportType, kAudioDeviceTransportTypeAggregate,
     kAudioDeviceTransportTypeBluetooth, kAudioDeviceTransportTypeBluetoothLE,
     kAudioDeviceTransportTypeBuiltIn, kAudioDeviceTransportTypeUSB,
@@ -37,7 +37,9 @@ use objc2_core_audio::{
 use objc2_core_foundation::{CFRetained, CFString};
 use tracing::{info, warn};
 
-use crate::audio::device::{AudioInputDevice, TransportType, is_souffle_tap_device};
+use crate::audio::device::{
+    AudioInputDevice, TransportType, is_souffle_tap_device, is_souffle_tap_uid,
+};
 use crate::power::is_clamshell;
 
 type ListenerBlock = RcBlock<dyn Fn(u32, NonNull<AudioObjectPropertyAddress>)>;
@@ -133,7 +135,10 @@ fn add_listener(
         )
     };
     if status != 0 {
-        warn!(selector = format!("{selector:#x}"), status, "Failed to register CoreAudio device listener");
+        warn!(
+            selector = format!("{selector:#x}"),
+            status, "Failed to register CoreAudio device listener"
+        );
     }
     block
 }
@@ -186,13 +191,25 @@ fn log_initial_snapshot(
         info!(device = %info.name, transport = %info.transport, "Audio input device present at startup");
     }
     let (input_device, input_transport) = describe(default_input);
-    info!(device = input_device, transport = input_transport, lid_closed, "Default input device at startup");
+    info!(
+        device = input_device,
+        transport = input_transport,
+        lid_closed,
+        "Default input device at startup"
+    );
     let (output_device, output_transport) = describe(default_output);
-    info!(device = output_device, transport = output_transport, "Default output device at startup");
+    info!(
+        device = output_device,
+        transport = output_transport,
+        "Default output device at startup"
+    );
     info!(lid_closed, "Lid state at startup");
 }
 
-fn log_device_diff(old: &HashMap<AudioObjectID, DeviceInfo>, new: &HashMap<AudioObjectID, DeviceInfo>) {
+fn log_device_diff(
+    old: &HashMap<AudioObjectID, DeviceInfo>,
+    new: &HashMap<AudioObjectID, DeviceInfo>,
+) {
     let diff = diff_devices(old, new);
     if diff.arrived.is_empty() && diff.removed.is_empty() {
         return;
@@ -215,11 +232,7 @@ fn log_default_input_change(old: &Option<DeviceInfo>, new: &Option<DeviceInfo>) 
     let lid_closed = is_clamshell();
     info!(
         old_device,
-        old_transport,
-        new_device,
-        new_transport,
-        lid_closed,
-        "Default input device changed"
+        old_transport, new_device, new_transport, lid_closed, "Default input device changed"
     );
 }
 
@@ -231,10 +244,7 @@ fn log_default_output_change(old: &Option<DeviceInfo>, new: &Option<DeviceInfo>)
     let (new_device, new_transport) = describe(new);
     info!(
         old_device,
-        old_transport,
-        new_device,
-        new_transport,
-        "Default output device changed"
+        old_transport, new_device, new_transport, "Default output device changed"
     );
 }
 
@@ -314,7 +324,11 @@ fn input_scope_address(selector: u32) -> AudioObjectPropertyAddress {
     }
 }
 
-fn get_property<T>(object: AudioObjectID, mut address: AudioObjectPropertyAddress, out: &mut T) -> bool {
+fn get_property<T>(
+    object: AudioObjectID,
+    mut address: AudioObjectPropertyAddress,
+    out: &mut T,
+) -> bool {
     let mut size = size_of::<T>() as u32;
     let status = unsafe {
         AudioObjectGetPropertyData(
@@ -376,7 +390,11 @@ fn device_ids(object: AudioObjectID, address: AudioObjectPropertyAddress) -> Vec
 
 fn device_name(device: AudioObjectID) -> String {
     let mut name_ptr: *const CFString = std::ptr::null();
-    if !get_property(device, global_address(kAudioObjectPropertyName), &mut name_ptr) {
+    if !get_property(
+        device,
+        global_address(kAudioObjectPropertyName),
+        &mut name_ptr,
+    ) {
         return format!("device#{device}");
     }
     match NonNull::new(name_ptr.cast_mut()) {
@@ -388,7 +406,11 @@ fn device_name(device: AudioObjectID) -> String {
 
 fn device_uid(device: AudioObjectID) -> String {
     let mut uid_ptr: *const CFString = std::ptr::null();
-    if !get_property(device, global_address(kAudioDevicePropertyDeviceUID), &mut uid_ptr) {
+    if !get_property(
+        device,
+        global_address(kAudioDevicePropertyDeviceUID),
+        &mut uid_ptr,
+    ) {
         return format!("device#{device}");
     }
     match NonNull::new(uid_ptr.cast_mut()) {
@@ -441,7 +463,11 @@ fn enumerate_input_devices() -> HashMap<AudioObjectID, DeviceInfo> {
 
 fn default_device_id(selector: u32) -> Option<AudioObjectID> {
     let mut device: AudioObjectID = 0;
-    if !get_property(kAudioObjectSystemObject as AudioObjectID, global_address(selector), &mut device) {
+    if !get_property(
+        kAudioObjectSystemObject as AudioObjectID,
+        global_address(selector),
+        &mut device,
+    ) {
         return None;
     }
     (device != 0).then_some(device)
@@ -470,8 +496,69 @@ pub(crate) fn list_devices() -> Vec<AudioInputDevice> {
     .into_iter()
     .filter(|&id| is_input_capable(id))
     .map(|id| input_device(id, Some(id) == default))
-    .filter(|device| !is_souffle_tap_device(&device.name))
+    .filter(|device| !is_souffle_tap_device(&device.name) && !is_souffle_tap_uid(&device.uid))
     .collect()
+}
+
+/// CoreAudio object ID currently bound to `uid`, if that device is still in
+/// the HAL list. A USB dock unplug/replug keeps the UID and allocates a new
+/// ID — callers compare against the ID they opened to know the stream is stale.
+pub(crate) fn object_id_for_uid(uid: &str) -> Option<AudioObjectID> {
+    device_ids(
+        kAudioObjectSystemObject as AudioObjectID,
+        global_address(kAudioHardwarePropertyDevices),
+    )
+    .into_iter()
+    .find(|&id| device_uid(id) == uid)
+}
+
+/// `kAudioDevicePropertyDeviceIsAlive`. A dock reboot often leaves the UID
+/// in the list while this flips to 0; treat a failed read as dead.
+pub(crate) fn device_is_alive(id: AudioObjectID) -> bool {
+    let mut alive: u32 = 0;
+    if !get_property(
+        id,
+        global_address(kAudioDevicePropertyDeviceIsAlive),
+        &mut alive,
+    ) {
+        return false;
+    }
+    alive != 0
+}
+
+/// Destroy leftover "Souffle Tap" aggregates from a previous crash, a
+/// timed-out `spawn_tap`, or an older build that created them as public
+/// devices. Safe at startup, before any session has created a tap.
+pub(crate) fn destroy_orphaned_souffle_taps() {
+    use objc2_core_audio::AudioHardwareDestroyAggregateDevice;
+
+    let orphans: Vec<(AudioObjectID, String)> = device_ids(
+        kAudioObjectSystemObject as AudioObjectID,
+        global_address(kAudioHardwarePropertyDevices),
+    )
+    .into_iter()
+    .filter_map(|id| {
+        if device_transport(id) != TransportType::Aggregate {
+            return None;
+        }
+        let name = device_name(id);
+        let uid = device_uid(id);
+        if is_souffle_tap_device(&name) || is_souffle_tap_uid(&uid) {
+            Some((id, name))
+        } else {
+            None
+        }
+    })
+    .collect();
+
+    for (id, name) in orphans {
+        let status = unsafe { AudioHardwareDestroyAggregateDevice(id) };
+        if status == 0 {
+            info!(device = %name, id, "Destroyed orphaned Souffle tap aggregate");
+        } else {
+            warn!(device = %name, id, status, "Failed to destroy orphaned Souffle tap aggregate");
+        }
+    }
 }
 
 #[cfg(test)]
@@ -549,7 +636,10 @@ mod tests {
 
     #[test]
     fn map_transport_covers_coreaudio_codes() {
-        assert_eq!(map_transport(kAudioDeviceTransportTypeBuiltIn), TransportType::BuiltIn);
+        assert_eq!(
+            map_transport(kAudioDeviceTransportTypeBuiltIn),
+            TransportType::BuiltIn
+        );
         assert_eq!(
             map_transport(kAudioDeviceTransportTypeBluetooth),
             TransportType::Bluetooth

--- a/src-tauri/src/audio/route_notice.rs
+++ b/src-tauri/src/audio/route_notice.rs
@@ -253,7 +253,15 @@ mod tests {
 
     #[test]
     fn skip_souffle_tap_aggregates() {
-        let tap = device("tap", "Souffle system audio tap", TransportType::Aggregate);
+        let tap = device("tap", "Souffle Tap", TransportType::Aggregate);
+        let previous = snap(&[builtin()], Some("builtin"));
+        let next = snap(&[builtin(), tap], Some("builtin"));
+        assert!(notices_for_change(Some(&previous), &next).is_empty());
+    }
+
+    #[test]
+    fn skip_numbered_souffle_tap_leftovers() {
+        let tap = device("tap-2", "Souffle Tap 2", TransportType::Aggregate);
         let previous = snap(&[builtin()], Some("builtin"));
         let next = snap(&[builtin(), tap], Some("builtin"));
         assert!(notices_for_change(Some(&previous), &next).is_empty());

--- a/src-tauri/src/audio/system_tap.rs
+++ b/src-tauri/src/audio/system_tap.rs
@@ -159,7 +159,9 @@ impl SystemTap {
             )
         };
         unsafe {
-            description.setName(&NSString::from_str("Souffle system audio tap"));
+            description.setName(&NSString::from_str(
+                crate::audio::device::SOUFFLE_TAP_DESCRIPTION_NAME,
+            ));
             description.setPrivate(true);
         }
 
@@ -366,7 +368,16 @@ fn aggregate_description(
     description: &CATapDescription,
 ) -> Retained<NSDictionary<NSString, AnyObject>> {
     let key = |k: &CStr| NSString::from_str(k.to_str().expect("ASCII key"));
-    let aggregate_uid = NSString::from_str(&uuid::Uuid::new_v4().to_string());
+    // CoreAudio wants CFNumber (int), not CFBoolean, for the private /
+    // autostart flags. `NSNumber::new_bool(true)` is the latter and is
+    // ignored, which is how leftover aggregates leaked into the system
+    // input list as public "Souffle Tap" devices.
+    let one = NSNumber::new_i32(1);
+    let aggregate_uid = NSString::from_str(&format!(
+        "{}{}",
+        crate::audio::device::SOUFFLE_TAP_UID_PREFIX,
+        uuid::Uuid::new_v4()
+    ));
     let tap_uid = unsafe { description.UUID().UUIDString() };
 
     let sub_tap: Retained<NSDictionary<NSString, AnyObject>> = NSDictionary::from_slices(
@@ -374,10 +385,7 @@ fn aggregate_description(
             &*key(kAudioSubTapUIDKey),
             &*key(kAudioSubTapDriftCompensationKey),
         ],
-        &[
-            &*tap_uid as &AnyObject,
-            &*NSNumber::new_bool(true) as &AnyObject,
-        ],
+        &[&*tap_uid as &AnyObject, &*one as &AnyObject],
     );
 
     NSDictionary::from_slices(
@@ -389,10 +397,10 @@ fn aggregate_description(
             &*key(kAudioAggregateDeviceTapListKey),
         ],
         &[
-            &*NSString::from_str("Souffle Tap") as &AnyObject,
+            &*NSString::from_str(crate::audio::device::SOUFFLE_TAP_AGGREGATE_NAME) as &AnyObject,
             &*aggregate_uid as &AnyObject,
-            &*NSNumber::new_bool(true) as &AnyObject,
-            &*NSNumber::new_bool(true) as &AnyObject,
+            &*one as &AnyObject,
+            &*one as &AnyObject,
             &*NSArray::from_slice(&[&*sub_tap]) as &AnyObject,
         ],
     )

--- a/src-tauri/src/calendar/scheduler.rs
+++ b/src-tauri/src/calendar/scheduler.rs
@@ -9,6 +9,9 @@
 //! The fired-reminder set lives in memory only; restarting the app inside
 //! the reminder window can re-fire one reminder for the same occurrence.
 //! That rare duplicate is accepted over persisting scheduler state.
+//!
+//! Each tick also diffs today's events and emits [`crate::app_events::TodayCalendarUpdated`]
+//! so the home list stays current without depending on a webview timer.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -21,7 +24,7 @@ use tauri_specta::Event;
 use tokio::time::MissedTickBehavior;
 use tracing::warn;
 
-use crate::app_events::{CalendarMeetingNudgeKind, UpcomingMeeting};
+use crate::app_events::{CalendarMeetingNudgeKind, TodayCalendarUpdated, UpcomingMeeting};
 use crate::audio::system_activity::{self, SystemAudioProbe};
 use crate::calendar::{self, CalendarEvent};
 use crate::permissions::PermState;
@@ -35,6 +38,12 @@ type OccurrenceKey = (String, i64);
 /// How long after an event starts the auto-start nudge remains eligible.
 const AUTOSTART_WINDOW_MINUTES: u32 = 10;
 
+/// Backoff after a failed system-audio probe start, so a wedged CoreAudio
+/// tap does not spawn a new "Souffle Tap" aggregate every minute.
+const PROBE_RETRY_BACKOFF: Duration = Duration::from_secs(300);
+
+type TodayFingerprint = (PermState, Vec<(String, i64, i64, String)>);
+
 pub fn spawn(app: tauri::AppHandle) {
     tauri::async_runtime::spawn(run(app));
 }
@@ -45,6 +54,8 @@ async fn run(app: tauri::AppHandle) {
     let mut fired_reminders: HashSet<OccurrenceKey> = HashSet::new();
     let mut fired_autostart: HashSet<OccurrenceKey> = HashSet::new();
     let mut probe: Option<SystemAudioProbe> = None;
+    let mut probe_retry_at = std::time::Instant::now();
+    let mut last_today: Option<TodayFingerprint> = None;
 
     loop {
         interval.tick().await;
@@ -63,11 +74,14 @@ async fn run(app: tauri::AppHandle) {
         };
         if !settings.calendar_integration_enabled {
             probe = None;
+            emit_today_if_changed(&app, &mut last_today, PermState::Unknown, &[]);
             continue;
         }
         // Revoked mid-session: go quiet instead of erroring every minute.
-        if calendar::authorization_state() != PermState::Granted {
+        let permission = calendar::authorization_state();
+        if permission != PermState::Granted {
             probe = None;
+            emit_today_if_changed(&app, &mut last_today, permission, &[]);
             continue;
         }
 
@@ -94,6 +108,8 @@ async fn run(app: tauri::AppHandle) {
             }
         };
 
+        emit_today_if_changed(&app, &mut last_today, PermState::Granted, &events);
+
         let now = Utc::now();
         prune_fired(&mut fired_reminders, now);
         prune_fired(&mut fired_autostart, now);
@@ -103,8 +119,11 @@ async fn run(app: tauri::AppHandle) {
             && settings.calendar_autostart_enabled
             && has_in_progress_events(now, &events);
         if should_probe {
-            if probe.is_none() {
+            if probe.is_none() && std::time::Instant::now() >= probe_retry_at {
                 probe = SystemAudioProbe::start(Arc::clone(&activity));
+                if probe.is_none() {
+                    probe_retry_at = std::time::Instant::now() + PROBE_RETRY_BACKOFF;
+                }
             }
         } else {
             probe = None;
@@ -164,7 +183,9 @@ async fn run(app: tauri::AppHandle) {
 }
 
 fn has_in_progress_events(now: DateTime<Utc>, events: &[CalendarEvent]) -> bool {
-    events.iter().any(|event| event.start <= now && now < event.end)
+    events
+        .iter()
+        .any(|event| event.start <= now && now < event.end)
 }
 
 /// Events whose start lies within the reminder window and that have not
@@ -214,6 +235,47 @@ fn prune_fired(fired: &mut HashSet<OccurrenceKey>, now: DateTime<Utc>) {
     fired.retain(|(_, start)| *start >= cutoff);
 }
 
+fn today_fingerprint(permission: PermState, events: &[CalendarEvent]) -> TodayFingerprint {
+    (
+        permission,
+        events
+            .iter()
+            .map(|event| {
+                (
+                    event.id.clone(),
+                    event.start.timestamp(),
+                    event.end.timestamp(),
+                    event.title.clone(),
+                )
+            })
+            .collect(),
+    )
+}
+
+/// Push today's events to the frontend when the snapshot actually changed
+/// (new invite, reschedule, midnight rollover). The home view cannot rely
+/// on a webview timer surviving overnight in the background.
+fn emit_today_if_changed(
+    app: &tauri::AppHandle,
+    last: &mut Option<TodayFingerprint>,
+    permission: PermState,
+    events: &[CalendarEvent],
+) {
+    let fingerprint = today_fingerprint(permission, events);
+    if last.as_ref() == Some(&fingerprint) {
+        return;
+    }
+    *last = Some(fingerprint);
+    if let Err(e) = (TodayCalendarUpdated {
+        permission,
+        events: events.to_vec(),
+    })
+    .emit(app)
+    {
+        warn!("Calendar scheduler: today emit failed: {e}");
+    }
+}
+
 /// System notification: informational only. Action buttons and click
 /// callbacks are unreliable on macOS with the notification plugin, so the
 /// actionable path is the in-app banner driven by [`UpcomingMeeting`].
@@ -228,9 +290,7 @@ fn notify(
         CalendarMeetingNudgeKind::Reminder => {
             let minutes = starts_in_seconds.div_ceil(60).max(1);
             if locale.starts_with("fr") {
-                format!(
-                    "Commence dans {minutes} min. Ouvrez Soufflé pour transcrire la réunion."
-                )
+                format!("Commence dans {minutes} min. Ouvrez Soufflé pour transcrire la réunion.")
             } else {
                 format!("Starts in {minutes} min. Open Soufflé to transcribe the meeting.")
             }
@@ -354,5 +414,28 @@ mod tests {
         prune_fired(&mut fired, now);
         assert_eq!(fired.len(), 1);
         assert!(fired.iter().any(|(id, _)| id == "recent"));
+    }
+
+    #[test]
+    fn today_fingerprint_changes_on_new_or_retitled_event() {
+        let now = Utc::now();
+        let first = event("a", now);
+        let retitled = CalendarEvent {
+            title: "Renamed".to_string(),
+            ..first.clone()
+        };
+        let granted = PermState::Granted;
+        assert_eq!(
+            today_fingerprint(granted, &[first.clone()]),
+            today_fingerprint(granted, std::slice::from_ref(&first))
+        );
+        assert_ne!(
+            today_fingerprint(granted, &[first.clone()]),
+            today_fingerprint(granted, &[retitled])
+        );
+        assert_ne!(
+            today_fingerprint(granted, &[first]),
+            today_fingerprint(granted, &[])
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -170,6 +170,7 @@ fn specta_builder() -> Builder<tauri::Wry> {
             app_events::MeetingStopRequested,
             app_events::MeetingFinalized,
             app_events::UpcomingMeeting,
+            app_events::TodayCalendarUpdated,
             app_events::MeetingIdle,
             app_events::SystemWokeUp,
             app_events::ArchiveExportProgress,
@@ -393,6 +394,14 @@ pub fn run() {
                         }
                     })
                     .expect("failed to spawn input-route thread");
+
+                device_watch::destroy_orphaned_souffle_taps();
+            }
+
+            if let Some(pill) = app.get_webview_window("pill") {
+                if let Err(e) = crate::pill::position_top_center(&pill) {
+                    tracing::warn!("Pill overlay configure failed: {e}");
+                }
             }
 
             tray::setup_tray(app.handle())?;

--- a/src-tauri/src/pill.rs
+++ b/src-tauri/src/pill.rs
@@ -7,7 +7,7 @@
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
-use tauri::{AppHandle, LogicalPosition, Manager};
+use tauri::{AppHandle, Manager};
 use tauri_specta::Event;
 use tracing::warn;
 
@@ -42,7 +42,9 @@ fn set_hold_state(kind: PillHoldKind) {
 /// Clears the hold, returning whether one was actually active (so callers
 /// only emit a change event when something changed).
 fn clear_hold_state() -> bool {
-    HOLD.lock().map(|mut guard| guard.take().is_some()).unwrap_or(false)
+    HOLD.lock()
+        .map(|mut guard| guard.take().is_some())
+        .unwrap_or(false)
 }
 
 fn is_held() -> bool {
@@ -103,7 +105,11 @@ pub fn sync(app: &AppHandle, machine: &AppStateMachine) {
 /// Whether enough time has passed since the last live-text emission to send
 /// another one. Pure decision — the `Instant::now()` call lives at the call
 /// site so this is testable with fixed timestamps.
-pub fn should_emit_live_text(last_emit: Option<Instant>, now: Instant, min_interval: Duration) -> bool {
+pub fn should_emit_live_text(
+    last_emit: Option<Instant>,
+    now: Instant,
+    min_interval: Duration,
+) -> bool {
     match last_emit {
         None => true,
         Some(last) => now.duration_since(last) >= min_interval,
@@ -121,19 +127,15 @@ pub fn live_text_tail(text: &str, max_chars: usize) -> String {
     text.chars().skip(total - max_chars).collect()
 }
 
-/// Recenters the pill horizontally below the menu bar. `pub(crate)` so
-/// `sync` can call it when showing the pill in its compact state.
+/// Recenters the pill horizontally below the menu bar on the active screen.
+/// `pub(crate)` so `sync` can call it when showing the pill in its compact state.
 pub(crate) fn position_top_center(pill: &tauri::WebviewWindow) -> tauri::Result<()> {
-    let Some(monitor) = pill.primary_monitor()? else {
-        return Ok(());
-    };
-    let scale = monitor.scale_factor();
-    let monitor_width = monitor.size().to_logical::<f64>(scale).width;
-    let pill_width = pill.outer_size()?.to_logical::<f64>(scale).width;
-    pill.set_position(LogicalPosition::new(
-        (monitor_width - pill_width) / 2.0,
-        TOP_MARGIN,
-    ))
+    let scale = pill
+        .primary_monitor()?
+        .map(|m| m.scale_factor())
+        .unwrap_or(1.0);
+    let size = pill.outer_size()?.to_logical::<f64>(scale);
+    set_frame_top_center(pill, size.width, size.height)
 }
 
 /// Lower/upper bounds on the pill's size, defensively clamped in
@@ -144,13 +146,21 @@ const MAX_WIDTH: f64 = 600.0;
 const MIN_HEIGHT: f64 = 64.0;
 const MAX_HEIGHT: f64 = 260.0;
 
-/// AppKit frame origin (bottom-left corner, in the primary screen's
-/// coordinate space) that keeps the pill's TOP edge pinned at `top_margin`
-/// below the menu bar and horizontally centered. Pure so the anchoring math
-/// is unit-testable without a live window.
-fn frame_origin(monitor_width: f64, monitor_height: f64, width: f64, height: f64, top_margin: f64) -> (f64, f64) {
-    let x = (monitor_width - width) / 2.0;
-    let y = monitor_height - top_margin - height;
+/// AppKit frame origin (bottom-left corner, global screen coordinates) that
+/// keeps the pill's TOP edge pinned at `top_margin` below the top of
+/// `screen` and horizontally centered on that screen. Pure so the anchoring
+/// math is unit-testable without a live window.
+fn frame_origin(
+    screen_x: f64,
+    screen_y: f64,
+    screen_width: f64,
+    screen_height: f64,
+    width: f64,
+    height: f64,
+    top_margin: f64,
+) -> (f64, f64) {
+    let x = screen_x + (screen_width - width) / 2.0;
+    let y = screen_y + screen_height - top_margin - height;
     (x, y)
 }
 
@@ -171,16 +181,13 @@ fn frame_origin(monitor_width: f64, monitor_height: f64, width: f64, height: f64
 /// mid-animation. At end-of-dictation the pill resizes back to compact at
 /// the same moment the backend hides the window, so an animated call here
 /// can spin forever and deadlock the main thread.
-pub(crate) fn set_frame_top_center(pill: &tauri::WebviewWindow, width: f64, height: f64) -> tauri::Result<()> {
+pub(crate) fn set_frame_top_center(
+    pill: &tauri::WebviewWindow,
+    width: f64,
+    height: f64,
+) -> tauri::Result<()> {
     let width = width.clamp(MIN_WIDTH, MAX_WIDTH);
     let height = height.clamp(MIN_HEIGHT, MAX_HEIGHT);
-
-    let Some(monitor) = pill.primary_monitor()? else {
-        return Ok(());
-    };
-    let scale = monitor.scale_factor();
-    let monitor_size = monitor.size().to_logical::<f64>(scale);
-    let (x, y) = frame_origin(monitor_size.width, monitor_size.height, width, height, TOP_MARGIN);
 
     let window = pill.clone();
     pill.run_on_main_thread(move || {
@@ -193,12 +200,65 @@ pub(crate) fn set_frame_top_center(pill: &tauri::WebviewWindow, width: f64, heig
         // alive; we're on the main thread (required for AppKit calls) inside
         // this `run_on_main_thread` closure.
         let ns_window: &objc2_app_kit::NSWindow = unsafe { &*ns_window_ptr.cast() };
+        configure_overlay_window(ns_window);
+        let (screen_x, screen_y, screen_width, screen_height) = active_screen_frame();
+        let (x, y) = frame_origin(
+            screen_x,
+            screen_y,
+            screen_width,
+            screen_height,
+            width,
+            height,
+            TOP_MARGIN,
+        );
         let frame = objc2_foundation::NSRect {
             origin: objc2_foundation::NSPoint { x, y },
             size: objc2_foundation::NSSize { width, height },
         };
         ns_window.setFrame_display(frame, true);
     })
+}
+
+/// Make the pill a HUD that follows the user onto any Space — including a
+/// Space created by putting an app fullscreen. Tauri's
+/// `visibleOnAllWorkspaces` only sets `CanJoinAllSpaces`, which does not
+/// cover fullscreen application Spaces; those need `FullScreenAuxiliary`.
+fn configure_overlay_window(ns_window: &objc2_app_kit::NSWindow) {
+    use objc2_app_kit::{NSStatusWindowLevel, NSWindowCollectionBehavior};
+
+    ns_window.setCollectionBehavior(
+        NSWindowCollectionBehavior::CanJoinAllSpaces
+            | NSWindowCollectionBehavior::FullScreenAuxiliary
+            | NSWindowCollectionBehavior::IgnoresCycle,
+    );
+    ns_window.setLevel(NSStatusWindowLevel);
+    ns_window.setHidesOnDeactivate(false);
+}
+
+/// Screen that currently has keyboard focus (`NSScreen.main`), falling back
+/// to the first screen. Fullscreen apps put the key window on that Space's
+/// display, so this is where the HUD belongs — not always the primary
+/// monitor.
+fn active_screen_frame() -> (f64, f64, f64, f64) {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::NSScreen;
+
+    let Some(mtm) = MainThreadMarker::new() else {
+        return (0.0, 0.0, 0.0, 0.0);
+    };
+    let screen = NSScreen::mainScreen(mtm).or_else(|| NSScreen::screens(mtm).firstObject());
+    match screen {
+        Some(screen) => {
+            let frame = screen.frame();
+            (
+                frame.origin.x,
+                frame.origin.y,
+                frame.size.width,
+                frame.size.height,
+            )
+        }
+        None => (0.0, 0.0, 0.0, 0.0),
+    }
 }
 
 #[cfg(test)]
@@ -218,7 +278,10 @@ mod tests {
         let interval = Duration::from_millis(100);
         let t0 = Instant::now();
 
-        assert!(should_emit_live_text(None, t0, interval), "first sample always emits");
+        assert!(
+            should_emit_live_text(None, t0, interval),
+            "first sample always emits"
+        );
         assert!(
             !should_emit_live_text(Some(t0), t0 + Duration::from_millis(50), interval),
             "under the interval must be throttled"
@@ -258,7 +321,7 @@ mod tests {
 
     #[test]
     fn frame_origin_centers_horizontally() {
-        let (x, _y) = frame_origin(1920.0, 1080.0, 400.0, 100.0, 40.0);
+        let (x, _y) = frame_origin(0.0, 0.0, 1920.0, 1080.0, 400.0, 100.0, 40.0);
         assert_eq!(x, (1920.0 - 400.0) / 2.0);
     }
 
@@ -266,7 +329,7 @@ mod tests {
     fn frame_origin_pins_the_top_edge_at_top_margin() {
         let monitor_height = 1080.0;
         let top_margin = 40.0;
-        let (_x, y) = frame_origin(1920.0, monitor_height, 400.0, 100.0, top_margin);
+        let (_x, y) = frame_origin(0.0, 0.0, 1920.0, monitor_height, 400.0, 100.0, top_margin);
         // AppKit's y is measured from the bottom, so the top edge sits at
         // `y + height`; that must land exactly `top_margin` below the
         // monitor's top (i.e. `monitor_height - top_margin`).
@@ -277,11 +340,19 @@ mod tests {
     fn frame_origin_keeps_top_edge_fixed_as_height_grows() {
         let monitor_height = 1080.0;
         let top_margin = 40.0;
-        let (_x, y_short) = frame_origin(1920.0, monitor_height, 400.0, 100.0, top_margin);
-        let (_x, y_tall) = frame_origin(1920.0, monitor_height, 400.0, 180.0, top_margin);
+        let (_x, y_short) =
+            frame_origin(0.0, 0.0, 1920.0, monitor_height, 400.0, 100.0, top_margin);
+        let (_x, y_tall) = frame_origin(0.0, 0.0, 1920.0, monitor_height, 400.0, 180.0, top_margin);
         // Growing height by 80 must shift y down by exactly 80 to keep the
         // top edge (y + height) fixed.
         assert_eq!(y_short - y_tall, 80.0);
+    }
+
+    #[test]
+    fn frame_origin_offsets_onto_a_secondary_screen() {
+        let (x, y) = frame_origin(1920.0, 0.0, 1512.0, 982.0, 400.0, 100.0, 40.0);
+        assert_eq!(x, 1920.0 + (1512.0 - 400.0) / 2.0);
+        assert_eq!(y + 100.0 + 40.0, 982.0);
     }
 
     /// Exercises the full hold lifecycle against the shared module-level
@@ -293,7 +364,10 @@ mod tests {
         set_hold_state(PillHoldKind::Polishing);
         assert!(is_held());
 
-        assert!(clear_hold_state(), "release reports it actually released something");
+        assert!(
+            clear_hold_state(),
+            "release reports it actually released something"
+        );
         assert!(!is_held());
 
         assert!(

--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -2,6 +2,7 @@
   import { Search, Settings } from "@lucide/svelte";
   import { onMount } from "svelte";
   import { t } from "svelte-i18n";
+  import { events } from "../api/generated";
   import { getShortcuts } from "../api/settings";
   import { formatShortcutLabel } from "../utils";
   import ActionHero from "../features/home/ActionHero.svelte";
@@ -45,6 +46,31 @@
         dictationShortcut = formatShortcutLabel(shortcuts.toggle);
       })
       .catch(() => {});
+
+    let unlistenToday: (() => void) | null = null;
+    void events.todayCalendarUpdated.listen((event) => {
+      calendar.applyToday(event.payload);
+    }).then((fn) => {
+      unlistenToday = fn;
+    });
+
+    // Backend pushes on change every minute; this covers a missed event
+    // (webview throttled overnight) and mid-day invites that EventKit
+    // only surfaces on the next poll.
+    const interval = setInterval(() => {
+      void calendar.refresh();
+    }, 2 * 60 * 1000);
+
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") void calendar.refresh();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      unlistenToday?.();
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
   });
 
   $effect(() => {

--- a/src/lib/features/calendar/controller.svelte.test.ts
+++ b/src/lib/features/calendar/controller.svelte.test.ts
@@ -110,4 +110,13 @@ describe("calendar controller", () => {
 
     expect(ctrl.statusMessage).not.toBe("");
   });
+
+  it("applyToday replaces events without hitting the backend", () => {
+    const ctrl = createCalendarController();
+    const event = makeEvent({ id: "evt-2", title: "New invite" });
+    ctrl.applyToday({ permission: "granted", events: [event] });
+    expect(ctrl.events).toEqual([event]);
+    expect(ctrl.permission).toBe("granted");
+    expect(mockListTodaysCalendarEvents).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/features/calendar/controller.svelte.ts
+++ b/src/lib/features/calendar/controller.svelte.ts
@@ -1,6 +1,6 @@
 import { listTodaysCalendarEvents } from "../../api/calendar";
 import { getAppState } from "../../stores/app.svelte";
-import type { CalendarEvent, PermState } from "../../types";
+import type { CalendarEvent, PermState, TodayCalendar } from "../../types";
 import { errorMessage } from "../../utils";
 import { createMeetingController } from "../meeting/controller.svelte";
 
@@ -11,6 +11,12 @@ function createCalendarControllerInstance() {
   let permission = $state<PermState>("unknown");
   let statusMessage = $state("");
 
+  function applyToday(today: TodayCalendar) {
+    permission = today.permission;
+    events = today.events;
+    statusMessage = "";
+  }
+
   /** Refresh today's events. A no-op while the integration is disabled so
    * callers can invoke it unconditionally. */
   async function refresh() {
@@ -19,10 +25,7 @@ function createCalendarControllerInstance() {
       return;
     }
     try {
-      const today = await listTodaysCalendarEvents();
-      permission = today.permission;
-      events = today.events;
-      statusMessage = "";
+      applyToday(await listTodaysCalendarEvents());
     } catch (e) {
       statusMessage = errorMessage(e);
     }
@@ -47,6 +50,7 @@ function createCalendarControllerInstance() {
     get permission() { return permission; },
     get statusMessage() { return statusMessage; },
     get enabled() { return app.settings.calendar_integration_enabled; },
+    applyToday,
     refresh,
     startFromEvent,
   };

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -893,6 +893,7 @@ shortcutToggle: ShortcutToggle,
 stateChanged: StateChanged,
 systemAudioStatus: SystemAudioStatus,
 systemWokeUp: SystemWokeUp,
+todayCalendarUpdated: TodayCalendarUpdated,
 transcriptionHealth: TranscriptionHealth,
 upcomingMeeting: UpcomingMeeting
 }>({
@@ -916,6 +917,7 @@ shortcutToggle: "shortcut-toggle",
 stateChanged: "state-changed",
 systemAudioStatus: "system-audio-status",
 systemWokeUp: "system-woke-up",
+todayCalendarUpdated: "today-calendar-updated",
 transcriptionHealth: "transcription-health",
 upcomingMeeting: "upcoming-meeting"
 })
@@ -1473,6 +1475,12 @@ export type Theme = "dark" | "light" | "system"
  * no-permission case without string-matching errors.
  */
 export type TodayCalendar = { permission: PermState; events: CalendarEvent[] }
+/**
+ * Pushed by the calendar scheduler whenever today's event list changes
+ * (new invite, reschedule, midnight rollover). The home view listens so it
+ * does not depend on a webview timer surviving overnight.
+ */
+export type TodayCalendarUpdated = { permission: PermState; events: CalendarEvent[] }
 export type TranscriptionCapabilities = { supports_streaming: boolean; supports_batch_transcription: boolean; supports_language_auto_detect: boolean; supports_word_timestamps: boolean; supports_partial_results: boolean }
 export type TranscriptionCatalog = { engines: TranscriptionEngineDescriptor[]; selected_engine_id: string; selected_model_id: string; selected_backend_id: string }
 export type TranscriptionEngineDescriptor = { id: string; label: string; description: string; models: TranscriptionModelDescriptor[] }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -45,6 +45,7 @@ export type {
   SummarizeProgress,
   Theme,
   TodayCalendar,
+  TodayCalendarUpdated,
   UpcomingMeeting,
   CalendarMeetingNudgeKind,
   HealthStatus,


### PR DESCRIPTION
## Summary
- Hide and destroy leaked **Souffle Tap** CoreAudio aggregates (wrong name filter + non-private `IsPrivate` flag), and stop the calendar probe from spawning a new one every minute when tap startup wedges.
- Push today's calendar events when the snapshot changes (and poll/visibility-refresh the home list) so new invites and midnight rollover show up without restarting the app.
- Show the dictation HUD on fullscreen app Spaces (`FullScreenAuxiliary`) and pin it to the focused screen.
- Rebuild the mic mid-meeting when a USB dock reboot keeps the same UID but replaces the HAL object, stops callbacks, or flips `DeviceIsAlive` — so Teams audio is not the only thing transcribed.

## Test plan
- [ ] Start a meeting (or leave calendar autostart on during a call block): Settings mic list has no `Souffle Tap` / `Souffle Tap 2`. Restart the app: leftovers are swept.
- [ ] With calendar integration on, add or move an event for today; it appears on home without restart. Leave the app running past midnight: the list rolls to the new day.
- [ ] Fullscreen another app (creates a Space), start dictation: the pill is visible on that Space with live text, not only on the desktop Space.
- [ ] Start a meeting, restart the docking station (or unplug/replug the dock mic): your voice comes back without quitting Soufflé. If the mic cannot reopen, the "Microphone lost; still recording system audio" warning shows.


Made with [Cursor](https://cursor.com)