### PR TITLE
Fix Soufflé getting stuck in the background with no way to bring it back

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -267,10 +267,7 @@ pub fn run() {
                 .build(),
         )
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.show();
-                let _ = window.set_focus();
-            }
+            tray::show_main_window(app);
         }))
         .manage(AppState::new(
             cmd_tx,
@@ -404,6 +401,19 @@ pub fn run() {
                 }
             }
 
+            // Close hides; it must not destroy. The pill + tray keep the
+            // process alive, so a destroyed `main` leaves Soufflé in the
+            // Dock and menu bar with no window to bring back.
+            if let Some(main) = app.get_webview_window("main") {
+                let window = main.clone();
+                main.on_window_event(move |event| {
+                    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                        api.prevent_close();
+                        let _ = window.hide();
+                    }
+                });
+            }
+
             tray::setup_tray(app.handle())?;
             calendar::scheduler::spawn(app.handle().clone());
             info!("Souffle started");
@@ -415,16 +425,31 @@ pub fn run() {
             std::process::exit(1);
         })
         .run(|app, event| {
-            if let tauri::RunEvent::ExitRequested { .. } = event {
-                // Shut down the engine actor before process exit. It unloads
-                // and drops the engine on its own thread — whisper.cpp's Metal
-                // residency sets and Candle's Metal objects must be freed
-                // before the Metal device is destroyed, otherwise C++ static
-                // destructor order causes a ggml_metal_rsets_free SIGABRT.
-                let state = app.state::<AppState>();
-                if let Err(e) = state.engine_actor.shutdown() {
-                    tracing::warn!("Engine actor shutdown failed: {e}");
+            match event {
+                tauri::RunEvent::ExitRequested { .. } => {
+                    // Shut down the engine actor before process exit. It unloads
+                    // and drops the engine on its own thread — whisper.cpp's Metal
+                    // residency sets and Candle's Metal objects must be freed
+                    // before the Metal device is destroyed, otherwise C++ static
+                    // destructor order causes a ggml_metal_rsets_free SIGABRT.
+                    let state = app.state::<AppState>();
+                    if let Err(e) = state.engine_actor.shutdown() {
+                        tracing::warn!("Engine actor shutdown failed: {e}");
+                    }
                 }
+                // Dock click / Cmd-click in the app switcher. The pill overlay
+                // is a visible NSPanel, so `has_visible_windows` is often true
+                // even when `main` is hidden — restore regardless.
+                #[cfg(target_os = "macos")]
+                tauri::RunEvent::Reopen {
+                    has_visible_windows,
+                    ..
+                } => {
+                    if tray::should_restore_main_on_reopen(has_visible_windows) {
+                        tray::show_main_window(app);
+                    }
+                }
+                _ => {}
             }
         });
 }

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -56,6 +56,52 @@ fn label(key: &str, fr: bool) -> &'static str {
     }
 }
 
+/// Bring the main window to the front. The recording pill is a visible
+/// NSPanel on every Space while dictating (and AppKit can keep counting it
+/// after `orderOut`), so a dock click's `has_visible_windows` is not a
+/// reliable stand-in for "the user can see Soufflé". Always restore `main`.
+pub fn show_main_window(app: &AppHandle) {
+    let Some(window) = app.get_webview_window("main") else {
+        warn!("Main window is gone; cannot bring Soufflé to the front");
+        return;
+    };
+    // Unhide the app first (⌘H / close-to-hide), then the window. `set_focus`
+    // alone will not switch Spaces onto a hidden/miniaturized window, and
+    // it will not win against a non-activating overlay panel.
+    #[cfg(target_os = "macos")]
+    {
+        let _ = app.show();
+        activate_app();
+    }
+    let _ = window.unminimize();
+    let _ = window.show();
+    let _ = window.set_focus();
+}
+
+/// Dock reopen must restore `main` even when AppKit reports other visible
+/// windows — the pill overlay is one. Pure so a regression that gates on
+/// `has_visible_windows` fails a unit test instead of a dock click.
+pub fn should_restore_main_on_reopen(_has_visible_windows: bool) -> bool {
+    true
+}
+
+#[cfg(target_os = "macos")]
+fn activate_app() {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::NSApplication;
+
+    let Some(mtm) = MainThreadMarker::new() else {
+        return;
+    };
+    let app = NSApplication::sharedApplication(mtm);
+    app.unhide(None);
+    // Cooperative `activate` is a no-op when another app is frontmost, which
+    // is exactly the "stuck in the background" case. The deprecated API is
+    // still the one that actually steals focus.
+    #[allow(deprecated)]
+    app.activateIgnoringOtherApps(true);
+}
+
 /// Set up the system tray with menu items
 pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
     let fr = is_french(app);
@@ -116,25 +162,18 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                 if recording_meeting {
                     let _ = MeetingStopRequested.emit(app);
                     info!("Meeting stop via tray");
-                } else if let Some(window) = app.get_webview_window("main") {
+                } else {
                     // Starting needs the main window; show the home screen.
-                    let _ = window.show();
-                    let _ = window.set_focus();
+                    show_main_window(app);
                     let _ = Navigate(AppView::Home).emit(app);
                 }
             }
             "settings" => {
-                if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.show();
-                    let _ = window.set_focus();
-                    let _ = Navigate(AppView::Settings).emit(app);
-                }
+                show_main_window(app);
+                let _ = Navigate(AppView::Settings).emit(app);
             }
             "show" => {
-                if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.show();
-                    let _ = window.set_focus();
-                }
+                show_main_window(app);
             }
             "quit" => {
                 info!("Quit requested from tray");
@@ -149,11 +188,7 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                 ..
             } = event
             {
-                let app = tray.app_handle();
-                if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.show();
-                    let _ = window.set_focus();
-                }
+                show_main_window(tray.app_handle());
             }
         })
         .build(app)?;
@@ -203,5 +238,19 @@ pub fn sync(app: &AppHandle, machine: &AppStateMachine) {
             },
             fr,
         ));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_restore_main_on_reopen;
+
+    #[test]
+    fn dock_reopen_restores_main_even_when_the_pill_counts_as_visible() {
+        assert!(
+            should_restore_main_on_reopen(true),
+            "the overlay panel is a visible NSWindow; gating on has_visible_windows leaves the main UI stuck behind"
+        );
+        assert!(should_restore_main_on_reopen(false));
     }
 }


### PR DESCRIPTION
## Summary
- Closing the main window no longer destroys it (hide instead). The tray + overlay were keeping the process alive with nothing to restore.
- Handle macOS dock reopen and always bring `main` forward — the recording pill is a visible NSPanel, so `has_visible_windows` is the wrong signal.

## Test plan
- [ ] Close Soufflé with the red button or ⌘W: Dock + menu bar stay. Click the Dock icon — the window comes back.
- [ ] ⌘H, then click the Dock icon — the window comes back.
- [ ] Minimize, then click the Dock icon — the window unminimizes.
- [ ] Start a dictation (pill visible), click the Dock icon — the main window comes to the front, not just the pill.
- [ ] Tray → Show Window / left-click the tray icon still restores the window.
- [ ] Tray → Quit still quits.


Made with [Cursor](https://cursor.com)