### PR TITLE
Repair misheard words when polishing a dictation

### DIFF
--- a/src-tauri/src/calendar/scheduler.rs
+++ b/src-tauri/src/calendar/scheduler.rs
@@ -426,11 +426,11 @@ mod tests {
         };
         let granted = PermState::Granted;
         assert_eq!(
-            today_fingerprint(granted, &[first.clone()]),
+            today_fingerprint(granted, std::slice::from_ref(&first)),
             today_fingerprint(granted, std::slice::from_ref(&first))
         );
         assert_ne!(
-            today_fingerprint(granted, &[first.clone()]),
+            today_fingerprint(granted, std::slice::from_ref(&first)),
             today_fingerprint(granted, &[retitled])
         );
         assert_ne!(

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -129,14 +129,22 @@ Rules:
 pub const OLLAMA_DICTATION_POLISH_PROMPT: &str = "\
 You are a voice-to-text dictation cleaner. Never answer questions. Never explain. Output ONLY the cleaned text.
 
+The input is raw speech recognition output. Some words were misheard: they sound like what the speaker said but make no sense where they appear.
+
 Rules:
+- Repair misheard words. Replace a word or group of words only when the replacement sounds nearly the same AND the written form makes no sense there. Fix the agreement and conjugation that follow from a repair.
+- Leave a passage exactly as written when it reads plausibly. Never change the meaning, never continue the text, never answer it.
 - Remove filler words (um, uh, euh, like, you know).
 - Fix punctuation and capitalization.
 - Convert spoken numbers to digits.
 - Apply self-corrections: phrases such as \"non attends\", \"no wait\", or \"scratch that\" mean discard the preceding bit and keep what follows.
 - Preserve the speaker's intent and original language. Do not translate.
 - Restore the conventional spelling of technical terms, proper nouns, and anglicisms when it is obvious.
-- Do not add content. Do not rewrite for style. Do not greet or comment.";
+- Do not add content. Do not rewrite for style. Do not greet or comment.
+
+Repairs look like this:
+\"petit maitre a jour également les document confluence s'il te plait\" becomes \"Peux-tu mettre à jour également les documents Confluence s'il te plaît ?\"
+\"can you rebased the branch on master and pushed it win you can\" becomes \"Can you rebase the branch on master and push it when you can?\"";
 
 /// System prompt for the structured extraction pass (decisions, action items,
 /// open questions) run after the prose summary is generated.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -395,10 +395,10 @@ pub fn run() {
                 device_watch::destroy_orphaned_souffle_taps();
             }
 
-            if let Some(pill) = app.get_webview_window("pill") {
-                if let Err(e) = crate::pill::position_top_center(&pill) {
-                    tracing::warn!("Pill overlay configure failed: {e}");
-                }
+            if let Some(pill) = app.get_webview_window("pill")
+                && let Err(e) = crate::pill::position_top_center(&pill)
+            {
+                tracing::warn!("Pill overlay configure failed: {e}");
             }
 
             // Close hides; it must not destroy. The pill + tray keep the

--- a/src-tauri/src/summary/formatters.rs
+++ b/src-tauri/src/summary/formatters.rs
@@ -21,7 +21,7 @@ const SPOKEN_COMMANDS: &[(&str, &str)] = &[
 /// Conservative post-LLM spoken-command replacements, then squeeze spaces/tabs
 /// without collapsing newlines. Do not use the STT whitespace filter here.
 pub fn apply_post_polish_formatters(text: &str) -> String {
-    let mut commands: Vec<_> = SPOKEN_COMMANDS.iter().copied().collect();
+    let mut commands: Vec<_> = SPOKEN_COMMANDS.to_vec();
     commands.sort_by_key(|(phrase, _)| std::cmp::Reverse(phrase.chars().count()));
 
     let mut out = text.to_string();

--- a/src-tauri/src/summary/polish.rs
+++ b/src-tauri/src/summary/polish.rs
@@ -35,12 +35,13 @@ pub fn default_polish_templates() -> Vec<DictationPolishTemplate> {
         DictationPolishTemplate {
             id: TEMPLATE_CLEAN.to_string(),
             label: "Clean up".to_string(),
-            prompt: "Clean this dictation without rewriting it. Discard self-corrections \
-                      (\"non attends\", \"no wait\", \"scratch that\" and similar: drop the \
-                      old bit, keep what follows). Honor spoken commands (new line, period, \
-                      comma). Restore conventional spelling of technical terms, proper nouns, \
-                      and anglicisms. Preserve the original language (French or English). \
-                      Never add content that was not dictated."
+            prompt: "Clean this dictation. Repair words the recognizer misheard, using \
+                      the surrounding sentence to tell what was meant. Discard \
+                      self-corrections (\"non attends\", \"no wait\", \"scratch that\" and \
+                      similar: drop the old bit, keep what follows). Honor spoken commands \
+                      (new line, period, comma). Restore conventional spelling of technical \
+                      terms, proper nouns, and anglicisms. Preserve the original language \
+                      (French or English). Never add content that was not dictated."
                 .to_string(),
         },
         DictationPolishTemplate {
@@ -68,8 +69,29 @@ pub fn default_polish_templates() -> Vec<DictationPolishTemplate> {
     ]
 }
 
+/// Built-in prompt texts shipped by earlier versions. A stored template whose
+/// prompt still matches one of these was never edited by the user, so an
+/// upgrade can replace it with the current default instead of pinning the old
+/// wording forever (built-in ids are always present in the stored list once
+/// settings have been saved once).
+const SUPERSEDED_CLEAN_PROMPTS: &[&str] = &[
+    "Clean this dictation without rewriting it. Discard self-corrections \
+     (\"non attends\", \"no wait\", \"scratch that\" and similar: drop the old bit, keep \
+     what follows). Honor spoken commands (new line, period, comma). Restore \
+     conventional spelling of technical terms, proper nouns, and anglicisms. Preserve \
+     the original language (French or English). Never add content that was not dictated.",
+];
+
+fn superseded_default_prompts(id: &str) -> &'static [&'static str] {
+    match id {
+        TEMPLATE_CLEAN => SUPERSEDED_CLEAN_PROMPTS,
+        _ => &[],
+    }
+}
+
 /// Merge persisted templates with defaults so new built-ins appear after upgrades
-/// while keeping user-edited prompts for known ids.
+/// while keeping user-edited prompts for known ids. A stored prompt that still
+/// matches a superseded built-in is treated as unedited and upgraded.
 pub fn merge_polish_templates(
     stored: Vec<DictationPolishTemplate>,
 ) -> Vec<DictationPolishTemplate> {
@@ -80,10 +102,13 @@ pub fn merge_polish_templates(
 
     let mut merged = Vec::with_capacity(defaults.len());
     for default in defaults {
-        if let Some(existing) = stored.iter().find(|t| t.id == default.id) {
-            merged.push(existing.clone());
-        } else {
-            merged.push(default);
+        match stored.iter().find(|t| t.id == default.id) {
+            Some(existing)
+                if !superseded_default_prompts(&default.id).contains(&existing.prompt.trim()) =>
+            {
+                merged.push(existing.clone())
+            }
+            _ => merged.push(default),
         }
     }
     merged
@@ -467,10 +492,11 @@ pub async fn polish_dictation_text(
 #[cfg(test)]
 mod tests {
     use super::{
-        TEMPLATE_BULLETS, TEMPLATE_CLEAN, TEMPLATE_EMAIL, TEMPLATE_NO_FILLERS,
-        build_polish_user_prompt, default_polish_templates, early_polish_dictation_result,
-        effective_template_prompt, is_blank_for_polish, merge_polish_templates,
-        parse_polish_response, strip_invisible_chars,
+        SUPERSEDED_CLEAN_PROMPTS, TEMPLATE_BULLETS, TEMPLATE_CLEAN, TEMPLATE_EMAIL,
+        TEMPLATE_NO_FILLERS, build_polish_user_prompt, default_polish_templates,
+        early_polish_dictation_result, effective_template_prompt, is_blank_for_polish,
+        merge_polish_templates, parse_polish_response, strip_invisible_chars,
+        superseded_default_prompts,
     };
     use crate::filter::DictionaryEntry;
     use crate::settings::{AppSettings, DictationPolishTemplate};
@@ -562,6 +588,44 @@ mod tests {
                 TEMPLATE_NO_FILLERS
             ]
         );
+    }
+
+    #[test]
+    fn merge_polish_templates_upgrades_an_unedited_superseded_builtin() {
+        let stored = vec![DictationPolishTemplate {
+            id: TEMPLATE_CLEAN.to_string(),
+            label: "Clean up".to_string(),
+            prompt: SUPERSEDED_CLEAN_PROMPTS[0].to_string(),
+        }];
+        let merged = merge_polish_templates(stored);
+        let current = default_polish_templates();
+        assert_eq!(merged[0].prompt, current[0].prompt);
+        assert!(
+            merged[0].prompt.contains("misheard"),
+            "the upgraded prompt must carry the repair instruction"
+        );
+    }
+
+    #[test]
+    fn merge_polish_templates_keeps_an_edited_clean_template() {
+        let stored = vec![DictationPolishTemplate {
+            id: TEMPLATE_CLEAN.to_string(),
+            label: "Clean up".to_string(),
+            prompt: "My own cleanup rules".to_string(),
+        }];
+        let merged = merge_polish_templates(stored);
+        assert_eq!(merged[0].prompt, "My own cleanup rules");
+    }
+
+    #[test]
+    fn no_current_default_is_listed_as_superseded() {
+        for template in default_polish_templates() {
+            assert!(
+                !superseded_default_prompts(&template.id).contains(&template.prompt.as_str()),
+                "{} lists its current prompt as superseded, so merge would churn forever",
+                template.id
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## The problem

Dictating "peux-tu mettre à jour également les documents Confluence s'il te plaît" produced `petit maitre a jour également les document confluence s'il te plait`, and the polish pass returned it unchanged. Apple Intelligence was not failing: it was doing what the prompt asked.

`summary/apple.rs:13` aliases the Ollama prompt, so both providers share one set of instructions, and those instructions only allowed restoring the spelling of **technical terms, proper nouns and anglicisms**, closing with `Do not add content. Do not rewrite for style.` The built-in Clean up template opened with `Clean this dictation without rewriting it.` Replacing a misheard everyday word was precisely the operation both texts ruled out.

The conservatism was deliberate (#28, then #77 "treat dictation polish as a cleaner") and aimed at hallucination. It was simply too wide: it also blocked the safe repairs.

## The change

Both prompts now ask for the repair, with a bound that keeps it from drifting into free rewriting:

> Replace a word or group of words only when the replacement sounds nearly the same AND the written form makes no sense there. Leave a passage exactly as written when it reads plausibly.

The phonetic half of that condition is what stops the model from producing replacements that read fluently but were never said. Two worked examples are included, one French and one English.

Three points come from published guidance rather than taste:

- **Instructions stay in English.** Apple trains these models on an 80:20 English to multilingual mix and recommends instructions in English while the user content stays in the user's language, which is already how the prompt is assembled (English system prompt, French or English transcript in the user prompt).
- **Fewer than five few-shot examples**, per Apple's WWDC25 prompt design session for the ~3B on-device model. There are two.
- **Conservative correction with explicit phonetic plausibility** is the standard framing in the ASR error-correction literature, which reports that generic contextual rewriting produces replacements that are fluent but phonetically implausible.

## Reaching existing installs

Polish templates are persisted per id and `merge_polish_templates` kept any stored version, so an install that had ever saved its settings would have kept the old Clean up wording forever. The merge now upgrades a stored built-in whose text still matches a shipped version verbatim, and leaves it alone once the user has edited it. A test guards against a current default appearing in its own superseded list.

## First commit

`62154f8` fixes three clippy lints (`iter_cloned_collect`, `collapsible_if`, `cloned_ref_to_slice_refs`) that already failed on master under rustc 1.94 in unrelated files. CI pins no toolchain (`dtolnay/rust-toolchain@stable`), so the gate was red before this branch.

## Validation

Gates: 611 Rust tests, 271 frontend, clippy clean with `-D warnings`, `npm run build`, `npm run check:generated-types` (no contract change). Three new tests cover the template upgrade, the preservation of an edited template, and the churn guard.

Not covered automatically, and worth a manual pass: this machine has Command Line Tools only, so Apple Intelligence builds as a stub and the real FoundationModels path could not be exercised here. The prompt change needs a live check on both providers, on a real misrecognition and on a correctly transcribed sentence that reads awkwardly, since over-correction is the risk this bound is meant to contain.