### PR TITLE
Say what Soufflé needs, what it asks for, and what it connects to

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: Something does not work as described
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Most bugs so far have come from audio hardware the app had never met:
+        a dock, a Bluetooth headset, an unusual default input. The fields below
+        are the ones that make those reproducible.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you did, what you expected, and what you got instead.
+    validations:
+      required: true
+  - type: input
+    id: macos
+    attributes:
+      label: macOS version
+      description: Apple menu > About This Mac. Meetings capture other participants only on 14.4 and newer.
+      placeholder: "15.3"
+    validations:
+      required: true
+  - type: input
+    id: mac-model
+    attributes:
+      label: Mac model
+      placeholder: "MacBook Pro M4, 16 GB"
+    validations:
+      required: true
+  - type: input
+    id: audio
+    attributes:
+      label: Microphone and output in use
+      description: Including anything between the Mac and them, such as a dock or a Bluetooth headset.
+      placeholder: "Bose 700 over Bluetooth, external display via CalDigit dock"
+    validations:
+      required: false
+  - type: dropdown
+    id: feature
+    attributes:
+      label: Where
+      options:
+        - Dictation
+        - Meeting recording
+        - Summaries
+        - Speech models or downloads
+        - Settings, permissions or onboarding
+        - Export, search or MCP
+        - Something else
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics
+      description: |
+        Settings > Diagnostics, copy the bundle and the log tail. No transcript
+        text is included; the paths do contain your user name, so redact them if
+        you would rather not share it.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Suggest something Soufflé should do
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do
+      description: The situation you are in, rather than the solution you have in mind. It usually leads somewhere better.
+    validations:
+      required: true
+  - type: textarea
+    id: idea
+    attributes:
+      label: What you had in mind
+    validations:
+      required: false
+  - type: checkboxes
+    id: local
+    attributes:
+      label: Constraint
+      options:
+        - label: I understand Soufflé runs entirely on-device, and this suggestion does not require a cloud service.
+          required: false

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 <p><strong>Private speech-to-text for macOS that never leaves your Mac.</strong></p>
 
 <p>
-  Dictate into any app, transcribe meetings with speaker separation, and get on-device summaries<br>
-  with decisions and action items. No cloud, no accounts, no API keys.
+  Dictate into any app, transcribe meetings that tell your voice from everyone else's, and get<br>
+  on-device summaries with decisions and action items. No cloud, no accounts, no API keys.
 </p>
 
 <p>
@@ -20,6 +20,8 @@
 
 <p>
   <a href="#download"><strong>Download</strong></a> ·
+  <a href="#requirements">Requirements</a> ·
+  <a href="#permissions">Permissions</a> ·
   <a href="#speech-models">Speech models</a> ·
   <a href="#build-from-source">Build from source</a>
 </p>
@@ -82,6 +84,43 @@ All models run locally and are downloaded on first use from HuggingFace:
 - [Whisper Large V3 Turbo](https://huggingface.co/ggerganov/whisper.cpp): multilingual, ~1.6 GB, Metal via whisper.cpp
 - [Parakeet TDT 0.6B v3](https://huggingface.co/istupakov/parakeet-tdt-0.6b-v3-onnx): 25 languages with punctuation and capitalization, ~670 MB int8, fast CPU inference via ONNX Runtime
 
+## Requirements
+
+- **Apple Silicon Mac.** There is no Intel build.
+- **macOS 13 or newer** for dictation.
+- **macOS 14.4 or newer** for meetings that capture the other participants. System-audio capture uses the Core Audio process tap, which does not exist before 14.4; on macOS 13 a meeting still records, but only your microphone, and the app shows *Mic only*.
+- **Disk space for the speech model**, downloaded on first use: ~670 MB for the smallest, ~2.4 GB for the default. See [Speech models](#speech-models).
+- **Summaries** need either Apple Intelligence, when your Mac offers it, or a local [Ollama](https://ollama.com/). Transcription itself needs neither.
+
+## Permissions
+
+Soufflé asks for these as you use the features that need them, never up front:
+
+| Permission | Why | Needed for |
+| --- | --- | --- |
+| Microphone | Records your voice to transcribe it | Everything |
+| System Audio Recording | Captures what the other participants say, without a virtual audio device | Meetings (macOS 14.4+) |
+| Accessibility | Pastes into the app you were using, and reads back your corrections when "learn from edits" is on | Auto-paste, dictation polish |
+| Calendar | Reads today's events to list them and offer to start recording | Calendar integration (optional) |
+
+Settings > Permissions shows the current state of each and links straight to the matching System Settings pane.
+
+## What touches the network
+
+The privacy claim above is worth checking rather than believing, so here is every outbound connection the app makes:
+
+- **huggingface.co**, to download a speech model the first time you select it. Nothing is sent, and once the model is on disk transcription works offline forever.
+- **api.github.com**, only when you press *Check for updates* in Settings > About. There is no timer and no automatic check.
+- **Your Ollama instance**, `http://localhost:11434` by default, if you enable summaries with Ollama. It is your machine unless you point it elsewhere.
+
+Your audio, transcripts, notes and summaries are never sent anywhere. They live in a local SQLite database, and Settings > Data exports or deletes the lot.
+
+## Status
+
+Early and actively developed. The engineering is covered by a large test suite and every release is signed and notarized, but the app has been run on very few machines, and the fragile parts are the ones that vary most from one Mac to another: audio routing, Bluetooth headsets, docks, and permission prompts. Expect rough edges there, and please report them.
+
+The fastest useful bug report is Settings > Diagnostics, which copies the app version, the current pipeline state and the log settings and paths, plus a live tail of the log. Paste that into a [new issue](https://github.com/damione1/souffle/issues/new/choose) with your macOS version, your Mac model and what you were doing. None of it contains transcript text, though the paths do include your user name.
+
 ## Download
 
 Install with [Homebrew](https://brew.sh/):
@@ -90,7 +129,7 @@ Install with [Homebrew](https://brew.sh/):
 brew install --cask damione1/tap/souffle
 ```
 
-Or grab a prebuilt installer from the [**Releases**](https://github.com/damione1/souffle/releases/latest) page: a `.dmg` for Apple Silicon Macs, requiring macOS 13 or newer.
+Or grab a prebuilt installer from the [**Releases**](https://github.com/damione1/souffle/releases/latest) page: a `.dmg` for Apple Silicon Macs. See [Requirements](#requirements) for the macOS versions.
 
 ## Build from source
 


### PR DESCRIPTION
Presentation only, no code. Every claim added here was checked against the source rather than written from memory, and one of them was wrong on the first pass (see below).

## What changed

**Requirements.** The README said macOS 13 while leading with system-audio capture, which needs the Core Audio process tap and therefore 14.4. The two floors are now separate, with what a meeting actually degrades to on 13: it records, but only your microphone, and the app shows *Mic only*. Model download size moved up here too, since ~2.4 GB for the default is something you want to know before installing.

**Permissions.** There was no mention of any. For an app whose pitch is privacy, that is the first thing the audience looks for, and the list is short and defensible: Microphone, System Audio Recording, Accessibility, Calendar, each with the feature it unlocks.

**What touches the network.** "Nothing is uploaded" was an assertion. It is now the enumerated list, verified by grepping every outbound URL in the Rust source: `huggingface.co` for model downloads, `api.github.com` only on the Check for updates button (no timer, confirmed: the only caller is a click handler in About), and your own Ollama on localhost if you enable summaries.

**Hero wording.** "transcribe meetings with speaker separation" reads as per-speaker diarization. The `diarize/` module is gone from master and `Speaker` is `Me | Them`, so it now says the meeting tells your voice from everyone else's.

**Status section and issue templates.** The app has ~4 installs per release, and every hardware bug fixed recently came from one machine hitting something: a dock reboot, a Bluetooth headset stuck in HFP, a fullscreen Space. The section says so, and points at Settings > Diagnostics, which no user would guess exists. The bug template asks for macOS version, Mac model and the audio path, which are the three facts those bugs turned on.

## One correction worth flagging

The first draft claimed the diagnostics bundle carries "your macOS version, Mac model, selected audio devices and recent logs". It does not: `DiagnosticsBundle` is app version, data/log/db/models paths, machine state and log settings. The text now describes what it really contains, notes that the paths include the user name, and asks for the macOS version and Mac model separately, which is why the issue template collects them.

## Not included

The demo GIF. Static screenshots undersell a dictation app, where the point is text appearing as you speak, but that needs a screen recording.