### PR TITLE
Keep speech and meeting titles out of the log file

### DIFF
--- a/src-tauri/src/commands/diagnostics.rs
+++ b/src-tauri/src/commands/diagnostics.rs
@@ -10,7 +10,11 @@ use crate::update_check::UpdateCheckResult;
 #[specta::specta]
 pub fn get_log_tail(max_lines: u32) -> Result<String, String> {
     let lines = max_lines.clamp(1, 500) as usize;
-    tail_log_file(lines)
+    // Transcript lines are stripped and paths redacted here rather than in the
+    // panel: this is the text the README tells people to paste into an issue.
+    let tail = tail_log_file(lines)?;
+    let (tail, _dropped) = crate::diagnostics::strip_transcript_lines(&tail);
+    Ok(crate::diagnostics::redact_home(&tail))
 }
 
 /// Paths and runtime snapshot for the copy-diagnostics action.

--- a/src-tauri/src/commands/model.rs
+++ b/src-tauri/src/commands/model.rs
@@ -305,7 +305,14 @@ pub fn test_transcribe_wav(state: State<'_, AppState>) -> Result<String, String>
         .map(|s| s.text.as_str())
         .collect::<Vec<_>>()
         .join(" ");
-    info!(segments = result.len(), text = %text, "Test transcription result");
+    info!(
+        segments = result.len(),
+        chars = text.len(),
+        "Test transcription result"
+    );
+    if crate::debug::transcription_debug_enabled() {
+        info!(target: crate::logging::TRANSCRIPT_TARGET, text = %text, "Test transcription result");
+    }
 
     if text.is_empty() {
         Ok("No words detected (model produced 0 segments)".into())

--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -526,7 +526,9 @@ pub async fn start_meeting_recording(
     calendar: Option<MeetingCalendarContext>,
     channel: Channel<crate::engine::TranscriptionSegment>,
 ) -> Result<(), String> {
-    info!(title = %title, "Starting meeting recording");
+    // The title is not logged: started from a calendar event it is the event
+    // title, which routinely carries a client or a colleague's name.
+    info!("Starting meeting recording");
 
     let machine = state.current_machine_state()?;
     if !machine.is_model_ready() {

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -101,6 +101,42 @@ pub fn collect_bundle(state: &AppState, settings: &crate::settings::AppSettings)
     }
 }
 
+/// Replace the user's home directory with `~` so a pasted diagnostic does not
+/// carry their account name. Every path in the bundle sits under it.
+pub fn redact_home(text: &str) -> String {
+    match std::env::var("HOME") {
+        Ok(home) if !home.is_empty() && home != "/" => {
+            text.replace(home.trim_end_matches('/'), "~")
+        }
+        _ => text.to_string(),
+    }
+}
+
+/// Drop every log line emitted on the transcript target.
+///
+/// The tail is what the README asks people to paste into a public issue, and
+/// with "Detailed transcription logs" on those lines hold what the user said.
+/// Returns the surviving text and how many lines were removed, so the caller
+/// can say so rather than silently shortening the log. The user's own file on
+/// disk is untouched.
+pub fn strip_transcript_lines(tail: &str) -> (String, usize) {
+    let marker = format!(" {}", crate::logging::TRANSCRIPT_TARGET);
+    let mut kept = Vec::new();
+    let mut dropped = 0usize;
+    for line in tail.lines() {
+        if line.contains(&marker) {
+            dropped += 1;
+        } else {
+            kept.push(line);
+        }
+    }
+    let mut out = kept.join("\n");
+    if tail.ends_with('\n') && !out.is_empty() {
+        out.push('\n');
+    }
+    (out, dropped)
+}
+
 pub fn format_bundle_text(bundle: &DiagnosticsBundle, log_tail: &str) -> String {
     let mut out = String::new();
     out.push_str("Soufflé diagnostics\n");
@@ -119,14 +155,20 @@ pub fn format_bundle_text(bundle: &DiagnosticsBundle, log_tail: &str) -> String 
     if let Some(log_file) = &bundle.log_file {
         out.push_str(&format!("Log file: {log_file}\n"));
     }
-    if !log_tail.is_empty() {
+    let (tail, dropped) = strip_transcript_lines(log_tail);
+    if dropped > 0 {
+        out.push_str(&format!(
+            "Transcript lines removed from the tail below: {dropped}\n"
+        ));
+    }
+    if !tail.is_empty() {
         out.push_str("\n--- Recent log tail ---\n");
-        out.push_str(log_tail);
-        if !log_tail.ends_with('\n') {
+        out.push_str(&tail);
+        if !tail.ends_with('\n') {
             out.push('\n');
         }
     }
-    out
+    redact_home(&out)
 }
 
 #[cfg(test)]
@@ -155,5 +197,72 @@ mod tests {
         let path = dir.path().join("souffle.log");
         fs::File::create(&path).expect("create");
         assert_eq!(tail_file(&path, 5).expect("tail"), "");
+    }
+
+    /// The stripper keys on the target as the `fmt` layer prints it, so this
+    /// emits a real event through a real layer rather than trusting a
+    /// hand-written fixture to match the format.
+    #[test]
+    fn strip_removes_a_genuinely_emitted_transcript_line() {
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::layer::SubscriberExt;
+
+        #[derive(Clone)]
+        struct Buffer(Arc<Mutex<Vec<u8>>>);
+        impl std::io::Write for Buffer {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.0.lock().expect("buffer lock").extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let sink = Arc::new(Mutex::new(Vec::new()));
+        let buffer = Buffer(Arc::clone(&sink));
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_writer(move || buffer.clone()),
+        );
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::info!(target: crate::logging::TRANSCRIPT_TARGET, text = "my private sentence", "WORD emitted");
+            tracing::info!("Database opened");
+        });
+
+        let captured = String::from_utf8(sink.lock().expect("sink lock").clone()).expect("utf8");
+        assert!(
+            captured.contains("my private sentence"),
+            "the event must reach the writer for this test to mean anything"
+        );
+
+        let (cleaned, dropped) = strip_transcript_lines(&captured);
+        assert_eq!(dropped, 1);
+        assert!(
+            !cleaned.contains("my private sentence"),
+            "speech survived the strip: {cleaned}"
+        );
+        assert!(
+            cleaned.contains("Database opened"),
+            "ordinary lines must stay"
+        );
+    }
+
+    #[test]
+    fn strip_keeps_everything_when_no_transcript_lines() {
+        let tail = "line one\nline two\n";
+        let (cleaned, dropped) = strip_transcript_lines(tail);
+        assert_eq!(dropped, 0);
+        assert_eq!(cleaned, tail);
+    }
+
+    #[test]
+    fn redact_home_replaces_the_account_path() {
+        let home = std::env::var("HOME").expect("HOME set in tests");
+        let text = format!("Log dir: {home}/Library/Logs/souffle");
+        let redacted = redact_home(&text);
+        assert_eq!(redacted, "Log dir: ~/Library/Logs/souffle");
+        assert!(!redacted.contains(&home));
     }
 }

--- a/src-tauri/src/engine/kyutai.rs
+++ b/src-tauri/src/engine/kyutai.rs
@@ -591,7 +591,7 @@ impl KyutaiEngine {
                         .decode_piece_ids(tokens)
                         .unwrap_or_default();
                     if debug_enabled {
-                        debug!(tokens = ?tokens, text = ?text, t = format!("{start_time:.2}"), "WORD emitted");
+                        debug!(target: crate::logging::TRANSCRIPT_TARGET, tokens = ?tokens, text = ?text, t = format!("{start_time:.2}"), "WORD emitted");
                     }
                     if text.is_empty() {
                         continue;

--- a/src-tauri/src/engine/parakeet.rs
+++ b/src-tauri/src/engine/parakeet.rs
@@ -75,6 +75,7 @@ impl ParakeetEngine {
 
         if crate::debug::transcription_debug_enabled() {
             debug!(
+                target: crate::logging::TRANSCRIPT_TARGET,
                 sentences = result.tokens.len(),
                 text = %result.text,
                 "Parakeet inference complete"

--- a/src-tauri/src/logging.rs
+++ b/src-tauri/src/logging.rs
@@ -48,6 +48,17 @@ impl LogLevel {
     }
 }
 
+/// Tracing target for events that carry transcribed speech. It is a child of
+/// `souffle`, so the level filter reaches it, and naming it apart lets the
+/// diagnostics tail drop those lines before anyone pastes them into an issue.
+/// Emitters must still check [`crate::debug::transcription_debug_enabled`]:
+/// this target marks the lines, it does not gate them.
+pub const TRANSCRIPT_TARGET: &str = "souffle::transcript";
+
+/// Daily log files kept on disk. Rotation had no cap, so files accumulated for
+/// the life of the install.
+const MAX_LOG_FILES: usize = 14;
+
 pub fn log_dir() -> std::path::PathBuf {
     crate::constants::app_data_dir().join("logs")
 }
@@ -62,16 +73,21 @@ pub fn init(default_level: LogLevel) {
     let _ = FILTER_HANDLE.set(handle);
 
     let log_dir = log_dir();
-    let file_layer = if std::fs::create_dir_all(&log_dir).is_ok() {
-        let (writer, guard) = tracing_appender::non_blocking(tracing_appender::rolling::daily(
-            &log_dir,
-            "souffle.log",
-        ));
-        let _ = LOG_GUARD.set(guard);
-        Some(fmt::layer().with_ansi(false).with_writer(writer))
+    let appender = if std::fs::create_dir_all(&log_dir).is_ok() {
+        tracing_appender::rolling::Builder::new()
+            .rotation(tracing_appender::rolling::Rotation::DAILY)
+            .filename_prefix("souffle.log")
+            .max_log_files(MAX_LOG_FILES)
+            .build(&log_dir)
+            .ok()
     } else {
         None
     };
+    let file_layer = appender.map(|appender| {
+        let (writer, guard) = tracing_appender::non_blocking(appender);
+        let _ = LOG_GUARD.set(guard);
+        fmt::layer().with_ansi(false).with_writer(writer)
+    });
 
     let _ = tracing_subscriber::registry()
         .with(filter_layer)

--- a/src-tauri/src/pipeline/actor.rs
+++ b/src-tauri/src/pipeline/actor.rs
@@ -1289,7 +1289,7 @@ fn run_session_loop(
                             consecutive_errors = 0;
                             for seg in segments {
                                 if crate::debug::transcription_debug_enabled() {
-                                    debug!("Segment: {:?} final={}", seg.text, seg.is_final);
+                                    debug!(target: crate::logging::TRANSCRIPT_TARGET, "Segment: {:?} final={}", seg.text, seg.is_final);
                                 }
                                 segments_emitted += 1;
                                 if emit_filtered(engine, text_filters, seg, on_segment)
@@ -1384,7 +1384,7 @@ fn finish_session(
             Ok(segments) => {
                 for seg in segments {
                     if crate::debug::transcription_debug_enabled() {
-                        debug!("Drain segment: {:?} final={}", seg.text, seg.is_final);
+                        debug!(target: crate::logging::TRANSCRIPT_TARGET, "Drain segment: {:?} final={}", seg.text, seg.is_final);
                     }
                     emit_filtered(engine, text_filters, seg, on_segment);
                 }


### PR DESCRIPTION
Two real privacy bugs, found while specifying the bug-reporting feature. Both verified in the source before writing a line of this.

## The bugs

| Site | What it wrote | Gate |
| --- | --- | --- |
| `commands/model.rs:308` | The full text of the Settings test transcription, at INFO | none |
| `commands/transcription.rs:529` | The meeting title, which is the calendar event title when started from one | none |

The first means whatever you said while checking your microphone sat in a plain text file. The second means `1:1 with <name>` and client names did too.

This became urgent with #86, which now tells people to paste their diagnostics and log tail into a **public** issue. That instruction is right, there is no telemetry and it is the only way a report carries anything, but the log was not fit for it.

## The fix, in three layers

**At the source.** The test transcription logs a segment count and a character count; the text moves behind the existing `transcription_debug_enabled` toggle. The meeting title is not logged at all.

**A marked target.** Every event carrying speech, the two above plus the four already behind the debug toggle in `kyutai.rs`, `parakeet.rs` and `actor.rs`, now emits on `souffle::transcript`. It is a child of `souffle` so the level filter still reaches it, and naming it apart makes those lines identifiable by target instead of by guessing at their message text. The target marks lines, it does not gate them; the runtime toggle still does that.

**At the exit.** `get_log_tail` and the diagnostics text drop every `souffle::transcript` line and report how many were dropped, rather than quietly shortening the log. The file on disk keeps them: it is the user's machine and their own toggle. Paths are redacted to `~`, since all of them carried the account name.

## Also

`rolling::daily` had no `max_log_files`, so daily files accumulated for the life of the install. Capped at 14.

## On the test

`strip_removes_a_genuinely_emitted_transcript_line` builds a real `fmt` layer over a capturing writer, emits a real event on the transcript target, asserts the speech reached the buffer (otherwise the test proves nothing), then asserts it does not survive stripping. A fixture written by hand would pass while the real line format drifted.

## Verified clean

Grepped every remaining `info!/debug!/warn!/error!/trace!` that formats transcript text: none left unmarked. Window titles, focused app bundle ids, pasted text and clipboard contents have no log statements anywhere, so they never reached a log to begin with. Audio device names still do, deliberately: they are the diagnostic, and they are visible to the user in the panel before they copy anything.

617 Rust tests, 271 frontend, clippy clean. Touched files formatted individually and verified with `rustfmt --check`; `cargo fmt` is not run in this repo, it rewrites 131 places on pristine master.