### PR TITLE
Check once a day whether a newer release exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Settings > Permissions shows the current state of each and links straight to the
 The privacy claim above is worth checking rather than believing, so here is every outbound connection the app makes:
 
 - **huggingface.co**, to download a speech model the first time you select it. Nothing is sent, and once the model is on disk transcription works offline forever.
-- **api.github.com**, only when you press *Check for updates* in Settings > About. There is no timer and no automatic check.
+- **api.github.com**, once a day to ask whether a newer release exists, and whenever you press *Check for updates* in Settings > About. The daily check sends nothing but the request itself: no identifier, no account, no usage data. It shows a dialog when there is an update and never downloads or installs anything. Turn it off in Settings > About.
 - **Your Ollama instance**, `http://localhost:11434` by default, if you enable summaries with Ollama. It is your machine unless you point it elsewhere.
 
 Your audio, transcripts, notes and summaries are never sent anywhere. They live in a local SQLite database, and Settings > Data exports or deletes the lot.

--- a/src-tauri/src/app_events.rs
+++ b/src-tauri/src/app_events.rs
@@ -247,3 +247,12 @@ pub struct InputRouteNotice {
     pub to_uid: Option<String>,
     pub transport: Option<crate::audio::TransportType>,
 }
+
+/// A newer GitHub release exists. Emitted by the daily check, never more than
+/// once per launch for the same version.
+#[derive(Debug, Clone, Serialize, Deserialize, Type, Event)]
+pub struct UpdateAvailable {
+    pub latest_version: String,
+    pub release_notes: Option<String>,
+    pub release_url: Option<String>,
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -179,6 +179,7 @@ fn specta_builder() -> Builder<tauri::Wry> {
             app_events::InputPinAvailable,
             app_events::InputPinUnavailable,
             app_events::InputRouteNotice,
+            app_events::UpdateAvailable,
         ])
 }
 
@@ -413,6 +414,7 @@ pub fn run() {
 
             tray::setup_tray(app.handle())?;
             calendar::scheduler::spawn(app.handle().clone());
+            update_check::scheduler::spawn(app.handle().clone());
             info!("Souffle started");
             Ok(())
         })

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -34,6 +34,10 @@ const CALENDAR_AUTOSTART_ENABLED_KEY: &str = "calendar_autostart_enabled";
 const FEEDBACK_SOUNDS_ENABLED_KEY: &str = "feedback_sounds_enabled";
 const FEEDBACK_SOUNDS_VOLUME_KEY: &str = "feedback_sounds_volume";
 const MODEL_UNLOAD_TIMEOUT_MINUTES_KEY: &str = "model_unload_timeout_minutes";
+const AUTO_UPDATE_CHECK_ENABLED_KEY: &str = "auto_update_check_enabled";
+/// Unix seconds of the last completed check. Not part of `AppSettings`: it is
+/// bookkeeping, not a preference, and nothing in the UI shows it.
+pub const LAST_UPDATE_CHECK_AT_KEY: &str = "last_update_check_at";
 const MEETING_AUTOSTOP_ENABLED_KEY: &str = "meeting_autostop_enabled";
 const MEETING_AUTOSTOP_MINUTES_KEY: &str = "meeting_autostop_minutes";
 const MEETING_MAX_DURATION_MINUTES_KEY: &str = "meeting_max_duration_minutes";
@@ -165,6 +169,9 @@ pub struct AppSettings {
     /// When a calendar event starts and system audio is active, suggest
     /// starting a meeting transcription (nudge only, never auto-records).
     pub calendar_autostart_enabled: bool,
+    /// Ask GitHub once a day whether a newer release exists, and show a
+    /// dialog when there is one. Never downloads or installs anything.
+    pub auto_update_check_enabled: bool,
     /// Audible start/stop cues for dictation sessions.
     pub feedback_sounds_enabled: bool,
     /// Feedback sound volume (0-100).
@@ -242,6 +249,7 @@ impl Default for AppSettings {
             calendar_selected_ids: Vec::new(),
             calendar_reminder_minutes: 2,
             calendar_autostart_enabled: true,
+            auto_update_check_enabled: true,
             feedback_sounds_enabled: true,
             feedback_sounds_volume: 70,
             model_unload_timeout_minutes: 60,
@@ -386,6 +394,11 @@ impl AppSettings {
             read_json_setting::<u32>(db, FEEDBACK_SOUNDS_VOLUME_KEY)?
         {
             settings.feedback_sounds_volume = feedback_sounds_volume;
+        }
+        if let Some(auto_update_check_enabled) =
+            read_json_setting::<bool>(db, AUTO_UPDATE_CHECK_ENABLED_KEY)?
+        {
+            settings.auto_update_check_enabled = auto_update_check_enabled;
         }
         if let Some(model_unload_timeout_minutes) =
             read_json_setting::<u32>(db, MODEL_UNLOAD_TIMEOUT_MINUTES_KEY)?
@@ -788,6 +801,11 @@ impl AppSettings {
         )?;
         write_json_setting(
             db,
+            AUTO_UPDATE_CHECK_ENABLED_KEY,
+            &normalized.auto_update_check_enabled,
+        )?;
+        write_json_setting(
+            db,
             MODEL_UNLOAD_TIMEOUT_MINUTES_KEY,
             &normalized.model_unload_timeout_minutes,
         )?;
@@ -995,6 +1013,7 @@ mod tests {
     fn app_settings_round_trip() {
         let (db, _dir) = test_db();
         let settings = AppSettings {
+            auto_update_check_enabled: false,
             theme: Theme::Light,
             locale: "fr".into(),
             auto_paste: true,

--- a/src-tauri/src/update_check.rs
+++ b/src-tauri/src/update_check.rs
@@ -135,3 +135,141 @@ mod tests {
         assert_eq!(version_tag_for_api("v0.1.1"), "v0.1.1");
     }
 }
+
+/// Background daily check.
+///
+/// Deliberately the same request the About button makes: ask GitHub for the
+/// latest release, compare versions, show a dialog when ours is older. It
+/// never downloads or installs anything.
+pub mod scheduler {
+    use std::time::Duration;
+
+    use tauri::Manager;
+    use tauri_specta::Event;
+    use tracing::{info, warn};
+
+    use crate::app_events::UpdateAvailable;
+    use crate::settings::{AppSettings, LAST_UPDATE_CHECK_AT_KEY};
+    use crate::state::AppState;
+
+    /// How often the task wakes to decide whether a check is due.
+    const TICK: Duration = Duration::from_secs(60 * 60);
+
+    /// Minimum gap between two checks. Under a day on purpose: at exactly 24h
+    /// a machine woken at a slightly earlier hour each day would skip a day.
+    const MIN_GAP_SECONDS: i64 = 20 * 60 * 60;
+
+    /// Grace period after launch, so the check never competes with startup.
+    const STARTUP_DELAY: Duration = Duration::from_secs(90);
+
+    pub fn spawn(app: tauri::AppHandle) {
+        tauri::async_runtime::spawn(run(app));
+    }
+
+    /// Whether a check is due, given the last recorded time. `None` means
+    /// never checked, which is due.
+    fn check_is_due(now: i64, last: Option<i64>) -> bool {
+        match last {
+            // A clock moved backwards leaves a future timestamp; check anyway
+            // rather than going quiet until it catches up.
+            Some(last) => now - last >= MIN_GAP_SECONDS || last > now,
+            None => true,
+        }
+    }
+
+    async fn run(app: tauri::AppHandle) {
+        tokio::time::sleep(STARTUP_DELAY).await;
+        let mut interval = tokio::time::interval(TICK);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // One dialog per launch per version: a user who dismissed it should not
+        // meet it again an hour later.
+        let mut announced: Option<String> = None;
+
+        loop {
+            interval.tick().await;
+
+            let db = app.state::<AppState>().db.clone();
+            let settings = match AppSettings::load(&db) {
+                Ok(settings) => settings,
+                Err(e) => {
+                    warn!("Update check: settings load failed: {e}");
+                    continue;
+                }
+            };
+            if !settings.auto_update_check_enabled {
+                continue;
+            }
+
+            let now = chrono::Utc::now().timestamp();
+            let last = db
+                .get_setting(LAST_UPDATE_CHECK_AT_KEY)
+                .ok()
+                .flatten()
+                .and_then(|raw| raw.trim().parse::<i64>().ok());
+            if !check_is_due(now, last) {
+                continue;
+            }
+
+            let result = match tauri::async_runtime::spawn_blocking(super::check_for_updates).await
+            {
+                Ok(result) => result,
+                Err(e) => {
+                    warn!("Update check: task failed: {e}");
+                    continue;
+                }
+            };
+            // Recorded even when the request failed, so a machine offline for a
+            // week does not retry every hour.
+            if let Err(e) = db.set_setting(LAST_UPDATE_CHECK_AT_KEY, &now.to_string()) {
+                warn!("Update check: could not record the check time: {e}");
+            }
+            if let Some(error) = &result.check_error {
+                info!("Update check: {error}");
+                continue;
+            }
+            let Some(latest) = result.latest_version.clone() else {
+                continue;
+            };
+            if !result.update_available || announced.as_deref() == Some(latest.as_str()) {
+                continue;
+            }
+
+            info!(latest = %latest, "Update check: newer release available");
+            announced = Some(latest.clone());
+            if let Err(e) = (UpdateAvailable {
+                latest_version: latest,
+                release_notes: result.release_notes,
+                release_url: result.release_url,
+            })
+            .emit(&app)
+            {
+                warn!("Update check: emit failed: {e}");
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::{MIN_GAP_SECONDS, check_is_due};
+
+        #[test]
+        fn a_first_run_is_due() {
+            assert!(check_is_due(1_000_000, None));
+        }
+
+        #[test]
+        fn a_recent_check_is_not_due() {
+            let now = 1_000_000;
+            assert!(!check_is_due(now, Some(now - MIN_GAP_SECONDS + 1)));
+            assert!(check_is_due(now, Some(now - MIN_GAP_SECONDS)));
+        }
+
+        /// A timestamp in the future means the clock moved, not that we checked
+        /// tomorrow. Going quiet until it catches up would be worse.
+        #[test]
+        fn a_future_timestamp_still_checks() {
+            let now = 1_000_000;
+            assert!(check_is_due(now, Some(now + 86_400)));
+        }
+    }
+}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -15,6 +15,7 @@
   import OnboardingView from "./lib/features/onboarding/OnboardingView.svelte";
   import PermissionsOnboarding from "./lib/features/onboarding/PermissionsOnboarding.svelte";
   import WhatsNewDialog from "./lib/features/onboarding/WhatsNewDialog.svelte";
+  import UpdateAvailableDialog from "./lib/features/onboarding/UpdateAvailableDialog.svelte";
   import {
     notifyMeetingAborted,
     notifyMeetingFinalized,
@@ -36,6 +37,7 @@
   const transcription = createTranscriptionController();
 
   let unlistenNav: (() => void) | null = null;
+  let unlistenUpdate: (() => void) | null = null;
   let unlistenState: (() => void) | null = null;
   let unlistenHealth: (() => void) | null = null;
   let unlistenPipelineError: (() => void) | null = null;
@@ -60,6 +62,11 @@
   let isRecovering = $state(false);
   let showPermissions = $state(false);
   let whatsNew = $state<{ version: string; releaseNotes: string } | null>(null);
+  let updateAvailable = $state<{
+    version: string;
+    releaseNotes: string | null;
+    releaseUrl: string | null;
+  } | null>(null);
   let modelLabel = $state("");
 
   const isLightTheme = $derived(
@@ -138,6 +145,18 @@
     } catch {
       showPermissions = false;
     }
+
+    events.updateAvailable.listen((event) => {
+      // The backend emits at most once per launch per version, so this never
+      // reopens a dialog the user has dismissed.
+      updateAvailable = {
+        version: event.payload.latest_version,
+        releaseNotes: event.payload.release_notes,
+        releaseUrl: event.payload.release_url,
+      };
+    }).then((fn) => {
+      unlistenUpdate = fn;
+    });
 
     events.navigate.listen((event) => {
       if (event.payload === "settings") {
@@ -228,6 +247,7 @@
     return () => {
       cleanupTranscription();
       unlistenNav?.();
+      unlistenUpdate?.();
       unlistenState?.();
       unlistenHealth?.();
       unlistenPipelineError?.();
@@ -391,6 +411,15 @@
     version={whatsNew.version}
     releaseNotes={whatsNew.releaseNotes}
     onDismiss={dismissWhatsNew}
+  />
+{/if}
+
+{#if updateAvailable}
+  <UpdateAvailableDialog
+    version={updateAvailable.version}
+    releaseNotes={updateAvailable.releaseNotes}
+    releaseUrl={updateAvailable.releaseUrl}
+    onDismiss={() => (updateAvailable = null)}
   />
 {/if}
 

--- a/src/lib/components/SettingsView.svelte
+++ b/src/lib/components/SettingsView.svelte
@@ -304,6 +304,8 @@
       <AboutSettingsSection
         selectedTranscriptionLabel={selectedTranscriptionLabel}
         selectedOllamaModelLabel={selectedOllamaModelLabel}
+        autoUpdateCheck={controller.app.settings.auto_update_check_enabled}
+        onAutoUpdateCheckChange={controller.onAutoUpdateCheckChange}
       />
     {/if}
   </div>

--- a/src/lib/features/onboarding/UpdateAvailableDialog.svelte
+++ b/src/lib/features/onboarding/UpdateAvailableDialog.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+  import { t } from "svelte-i18n";
+  import { openReleasePage } from "../../api/diagnostics";
+  import { renderReleaseNotesMarkdown } from "../../utils";
+
+  let {
+    version,
+    releaseNotes,
+    releaseUrl,
+    onDismiss,
+  }: {
+    version: string;
+    releaseNotes: string | null;
+    releaseUrl: string | null;
+    onDismiss: () => void;
+  } = $props();
+
+  // renderReleaseNotesMarkdown escapes all input text and emits only a fixed
+  // set of tags, so this HTML is safe to inject (see its module docs).
+  let notesHtml = $derived(releaseNotes ? renderReleaseNotesMarkdown(releaseNotes) : "");
+
+  // Same reason as WhatsNewDialog: WKWebView suppresses new-window navigation
+  // and the dialog must not navigate in place, so links go to the system
+  // browser through the backend command.
+  function handleNotesClick(event: MouseEvent) {
+    const anchor = (event.target as HTMLElement).closest("a");
+    if (!anchor) return;
+    event.preventDefault();
+    void openReleasePage(anchor.href);
+  }
+
+  function download() {
+    if (releaseUrl) void openReleasePage(releaseUrl);
+    onDismiss();
+  }
+</script>
+
+<div
+  class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-6 backdrop-blur-sm"
+  role="dialog"
+  aria-modal="true"
+  aria-label={$t("update_available.title")}
+>
+  <div class="surface-card flex w-full max-w-lg max-h-[80vh] flex-col gap-4">
+    <div class="flex flex-col gap-1">
+      <h2 class="font-heading text-lg font-bold">{$t("update_available.title")}</h2>
+      <p class="text-sm text-text-muted">
+        {$t("update_available.subtitle", { values: { version } })}
+      </p>
+    </div>
+
+    {#if notesHtml}
+      <!-- svelte-ignore a11y_no_static_element_interactions, a11y_click_events_have_key_events -->
+      <div
+        class="release-notes min-h-0 flex-1 overflow-y-auto rounded-lg bg-surface-1/70 p-4 text-sm leading-relaxed text-text-secondary"
+        onclick={handleNotesClick}
+      >
+        {@html notesHtml}
+      </div>
+    {/if}
+
+    <div class="flex justify-end gap-2">
+      <button onclick={onDismiss} class="btn">
+        {$t("update_available.later")}
+      </button>
+      {#if releaseUrl}
+        <button onclick={download} class="btn btn-active">
+          {$t("update_available.download")}
+        </button>
+      {/if}
+    </div>
+  </div>
+</div>

--- a/src/lib/features/settings/components/AboutSettingsSection.svelte
+++ b/src/lib/features/settings/components/AboutSettingsSection.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { t } from "svelte-i18n";
+  import SettingsField from "../../../components/ui/SettingsField.svelte";
   import { checkForUpdates, getAppVersion, openReleasePage } from "../../../api/diagnostics";
   import type { UpdateCheckResult } from "../../../types";
   import { errorMessage } from "../../../utils";
@@ -8,9 +9,13 @@
   let {
     selectedTranscriptionLabel,
     selectedOllamaModelLabel,
+    autoUpdateCheck,
+    onAutoUpdateCheckChange,
   }: {
     selectedTranscriptionLabel: string;
     selectedOllamaModelLabel: string;
+    autoUpdateCheck: boolean;
+    onAutoUpdateCheckChange: (event: Event) => void;
   } = $props();
 
   let appVersion = $state("");
@@ -89,6 +94,20 @@
         {/if}
       </div>
     </div>
+    <SettingsField
+      label={$t("settings_about.auto_check")}
+      description={$t("settings_about.auto_check_desc")}
+    >
+      {#snippet control()}
+        <input
+          type="checkbox"
+          checked={autoUpdateCheck}
+          onchange={onAutoUpdateCheckChange}
+          class="switch"
+          aria-label={$t("settings_about.auto_check")}
+        />
+      {/snippet}
+    </SettingsField>
     {#if statusMessage}
       <p class={`text-xs ${statusIsError ? "text-danger-soft" : "text-text-muted"}`}>
         {statusMessage}

--- a/src/lib/features/settings/controller.svelte.test.ts
+++ b/src/lib/features/settings/controller.svelte.test.ts
@@ -46,6 +46,7 @@ import type {
 // --- Test fixtures ---
 
 const defaultSettings: AppSettings = {
+  auto_update_check_enabled: true,
   theme: "dark",
   locale: "",
   auto_paste: false,
@@ -288,6 +289,21 @@ describe("settings controller", () => {
     await vi.waitFor(() => {
       expect(mockInvoke).toHaveBeenCalledWith("save_settings", expect.objectContaining({
         settings: expect.objectContaining({ theme: "light" }),
+      }));
+    });
+  });
+
+  it("onAutoUpdateCheckChange persists the daily check toggle", async () => {
+    const ctrl = createSettingsController();
+    await ctrl.mount();
+
+    ctrl.onAutoUpdateCheckChange({
+      target: { checked: false },
+    } as unknown as Event);
+
+    await vi.waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("save_settings", expect.objectContaining({
+        settings: expect.objectContaining({ auto_update_check_enabled: false }),
       }));
     });
   });

--- a/src/lib/features/settings/controller.svelte.ts
+++ b/src/lib/features/settings/controller.svelte.ts
@@ -419,6 +419,13 @@ export function createSettingsController() {
     });
   }
 
+  function onAutoUpdateCheckChange(event: Event) {
+    const checked = (event.target as HTMLInputElement).checked;
+    void persistSettings((settings) => {
+      settings.auto_update_check_enabled = checked;
+    });
+  }
+
   function onDictationPolishEnabledChange(event: Event) {
     const checked = (event.target as HTMLInputElement).checked;
     void persistSettings((settings) => {
@@ -870,6 +877,7 @@ export function createSettingsController() {
     onLocaleChange,
     onAutoPasteChange,
     onLearnFromEditChange,
+    onAutoUpdateCheckChange,
     onDictationPolishEnabledChange,
     onDictationPolishTemplateChange,
     onDictationPolishPromptChange,

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -232,7 +232,9 @@
     "checking": "Checking…",
     "up_to_date": "You're on the latest release.",
     "update_available": "Version {version} is available.",
-    "download_update": "Download on GitHub"
+    "download_update": "Download on GitHub",
+    "auto_check": "Check daily for updates",
+    "auto_check_desc": "Ask GitHub once a day whether a newer version exists, and show a dialog when there is one. Nothing is downloaded or installed."
   },
   "whats_new": {
     "title": "What's New",
@@ -488,5 +490,11 @@
     "starts_in_minutes": "Starts in {minutes} min",
     "started_system_audio": "Meeting started — system audio active",
     "dismiss": "Dismiss"
+  },
+  "update_available": {
+    "title": "Update available",
+    "subtitle": "Soufflé v{version} is out.",
+    "later": "Later",
+    "download": "Download"
   }
 }

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -232,7 +232,9 @@
     "checking": "Vérification…",
     "up_to_date": "Vous utilisez la dernière version.",
     "update_available": "La version {version} est disponible.",
-    "download_update": "Télécharger sur GitHub"
+    "download_update": "Télécharger sur GitHub",
+    "auto_check": "Vérifier les mises à jour chaque jour",
+    "auto_check_desc": "Demande à GitHub une fois par jour si une version plus récente existe, et affiche une fenêtre le cas échéant. Rien n'est téléchargé ni installé."
   },
   "whats_new": {
     "title": "Nouveautés",
@@ -488,5 +490,11 @@
     "starts_in_minutes": "Commence dans {minutes} min",
     "started_system_audio": "Réunion commencée — audio système actif",
     "dismiss": "Ignorer"
+  },
+  "update_available": {
+    "title": "Mise à jour disponible",
+    "subtitle": "Soufflé v{version} est disponible.",
+    "later": "Plus tard",
+    "download": "Télécharger"
   }
 }

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -92,6 +92,7 @@ let settings = $state<AppSettings>({
     { id: "bullets", label: "Bullet points", prompt: "Use bullets." },
     { id: "no_fillers", label: "Remove fillers", prompt: "Remove fillers." },
   ],
+  auto_update_check_enabled: true,
   dictation_learn_from_edit: true,
   default_summary_template_id: "default",
   summary_templates: [

--- a/src/lib/test-helpers/fixtures.ts
+++ b/src/lib/test-helpers/fixtures.ts
@@ -219,6 +219,7 @@ export const mockSettings: AppSettings = {
     { id: "bullets", label: "Bullet points", prompt: "Use bullets." },
     { id: "no_fillers", label: "Remove fillers", prompt: "Remove fillers." },
   ],
+  auto_update_check_enabled: true,
   dictation_learn_from_edit: true,
   default_summary_template_id: "default",
   summary_templates: [

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -896,7 +896,8 @@ systemAudioStatus: SystemAudioStatus,
 systemWokeUp: SystemWokeUp,
 todayCalendarUpdated: TodayCalendarUpdated,
 transcriptionHealth: TranscriptionHealth,
-upcomingMeeting: UpcomingMeeting
+upcomingMeeting: UpcomingMeeting,
+updateAvailable: UpdateAvailable
 }>({
 archiveExportProgress: "archive-export-progress",
 audioLevel: "audio-level",
@@ -920,7 +921,8 @@ systemAudioStatus: "system-audio-status",
 systemWokeUp: "system-woke-up",
 todayCalendarUpdated: "today-calendar-updated",
 transcriptionHealth: "transcription-health",
-upcomingMeeting: "upcoming-meeting"
+upcomingMeeting: "upcoming-meeting",
+updateAvailable: "update-available"
 })
 
 /** user-defined constants **/
@@ -981,6 +983,11 @@ calendar_reminder_minutes: number;
  * starting a meeting transcription (nudge only, never auto-records).
  */
 calendar_autostart_enabled: boolean; 
+/**
+ * Ask GitHub once a day whether a newer release exists, and show a
+ * dialog when there is one. Never downloads or installs anything.
+ */
+auto_update_check_enabled: boolean; 
 /**
  * Audible start/stop cues for dictation sessions.
  */
@@ -1526,6 +1533,11 @@ export type TransportType = "built_in" | "usb" | "bluetooth" | "bluetooth_le" | 
  * banner (notification clicks are not reliably delivered on macOS).
  */
 export type UpcomingMeeting = { event: CalendarEvent; starts_in_seconds: number; kind?: CalendarMeetingNudgeKind }
+/**
+ * A newer GitHub release exists. Emitted by the daily check, never more than
+ * once per launch for the same version.
+ */
+export type UpdateAvailable = { latest_version: string; release_notes: string | null; release_url: string | null }
 export type UpdateCheckResult = { current_version: string; latest_version: string | null; update_available: boolean; release_notes: string | null; release_url: string | null; check_error: string | null }
 
 /** tauri-specta globals **/


### PR DESCRIPTION
Notification only. No minisign key, no updater plugin, no download, no install: exactly the request the About button already makes, on a timer, with a dialog.

## Behaviour

An hourly task asks whether twenty hours have passed since the last completed check.

- **Twenty rather than twenty-four**, so a machine woken slightly earlier each day does not silently skip one.
- **The time is recorded even when the request fails**, so a laptop offline for a week does not retry every hour.
- **A timestamp in the future** means the clock moved, not that we checked tomorrow, so it checks rather than going quiet until the clock catches up.
- **Ninety seconds of grace after launch**, to stay out of startup's way.
- **At most one dialog per launch per version**, so dismissing it means dismissing it.

The three decision rules are a pure function with tests; the rest is plumbing.

## The dialog

A sibling of `WhatsNewDialog`, not a reuse. Both render release notes through the same escaping helper and route link clicks to the system browser through the same backend command, but one tells you what you just installed and the other offers something you have not, and collapsing them would have muddled the copy for both. Download opens the release page, which is the existing `open_release_page`, still restricted to `https://github.com/` URLs.

## The setting

`auto_update_check_enabled`, on by default, in Settings > About next to the manual button.

On by default is the call I made: an update notification nobody opted into is the point of the feature, the request carries no identifier and no usage data, the README names it, and the switch is one click away in the place people already look for updates.

## Verified

617 Rust tests including the three scheduling rules, 272 frontend including the toggle persisting, clippy clean, build, `npm run check` back to its pre-existing 6 errors in files this does not touch, generated types regenerated.

Not exercised here: the dialog only appears when GitHub reports a newer version than the running build, so seeing it end to end means either waiting for the next release or temporarily lowering the local version.