### PR TITLE
Let the user pick the summary provider, and stop swapping it in silence

### DIFF
--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -307,14 +307,12 @@ impl AppSettings {
         {
             settings.ollama_url = ollama_url;
         }
-        if let Some(summary_provider) =
-            read_json_setting::<SummaryProviderChoice>(db, SUMMARY_PROVIDER_KEY)?
-        {
-            settings.summary_provider = summary_provider;
-        }
         if let Some(ollama_model) = read_json_setting::<String>(db, OLLAMA_MODEL_KEY)? {
             settings.ollama_model = ollama_model;
         }
+        let stored_provider = read_json_setting::<SummaryProviderChoice>(db, SUMMARY_PROVIDER_KEY)?;
+        settings.summary_provider =
+            SummaryProviderChoice::from_stored(stored_provider, &settings.ollama_model);
         if let Some(debug_transcription) = read_json_setting::<bool>(db, DEBUG_TRANSCRIPTION_KEY)? {
             settings.debug_transcription = debug_transcription;
         }
@@ -1463,6 +1461,39 @@ mod tests {
         assert_eq!(settings.ollama_url, OLLAMA_DEFAULT_URL);
         assert_eq!(shortcuts.toggle, "F6");
         assert_eq!(shortcuts.push_to_talk, "");
+    }
+
+    /// Pre-provider-setting installs stored the engine in `ollama_model`.
+    /// Loading that row with no `summary_provider` key must not default to
+    /// Auto, or those users would silently start hitting Apple Intelligence.
+    #[test]
+    fn missing_summary_provider_with_an_ollama_model_migrates_to_ollama() {
+        let (db, _dir) = test_db();
+        db.set_setting("ollama_model", "\"qwen2.5:7b\"")
+            .expect("save model");
+
+        let settings = AppSettings::load(&db).expect("load settings");
+        assert_eq!(settings.summary_provider, SummaryProviderChoice::Ollama);
+        assert_eq!(settings.ollama_model, "qwen2.5:7b");
+    }
+
+    #[test]
+    fn missing_summary_provider_without_a_model_stays_auto() {
+        let (db, _dir) = test_db();
+        let settings = AppSettings::load(&db).expect("load settings");
+        assert_eq!(settings.summary_provider, SummaryProviderChoice::Auto);
+    }
+
+    #[test]
+    fn explicit_auto_is_kept_even_with_a_stored_ollama_model() {
+        let (db, _dir) = test_db();
+        db.set_setting("summary_provider", "\"auto\"")
+            .expect("save provider");
+        db.set_setting("ollama_model", "\"qwen2.5:7b\"")
+            .expect("save model");
+
+        let settings = AppSettings::load(&db).expect("load settings");
+        assert_eq!(settings.summary_provider, SummaryProviderChoice::Auto);
     }
 
     /// `Keep7d`/`Keep30d` pin an explicit `#[serde(rename)]` because serde's

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -8,12 +8,14 @@ use crate::engine::{
     CANDLE_BACKEND_ID, KYUTAI_ENGINE_ID, KYUTAI_MODEL_ID, resolve_transcription_profile,
 };
 use crate::logging::LogLevel;
+use crate::summary::SummaryProviderChoice;
 
 const THEME_KEY: &str = "theme";
 const AUTO_PASTE_KEY: &str = "auto_paste";
 const PASTE_DELAY_MS_KEY: &str = "paste_delay_ms";
 const OLLAMA_URL_KEY: &str = "ollama_url";
 const OLLAMA_MODEL_KEY: &str = "ollama_model";
+const SUMMARY_PROVIDER_KEY: &str = "summary_provider";
 const DEBUG_TRANSCRIPTION_KEY: &str = "debug_transcription";
 const AUDIO_DEVICE_KEY: &str = "audio_device";
 const CLAMSHELL_AUDIO_DEVICE_KEY: &str = "clamshell_audio_device";
@@ -130,6 +132,9 @@ pub struct AppSettings {
     /// or the focused AX field.
     pub paste_method: PasteMethod,
     pub ollama_url: String,
+    /// Which provider runs summaries and dictation polish. `ollama_model` only
+    /// applies when this resolves to Ollama.
+    pub summary_provider: SummaryProviderChoice,
     pub ollama_model: String,
     pub debug_transcription: bool,
     /// Global tracing verbosity for the `souffle` crate.
@@ -223,6 +228,7 @@ impl Default for AppSettings {
             paste_delay_ms: 100,
             paste_method: PasteMethod::default(),
             ollama_url: OLLAMA_DEFAULT_URL.to_string(),
+            summary_provider: SummaryProviderChoice::default(),
             ollama_model: String::new(),
             debug_transcription: false,
             log_level: LogLevel::default(),
@@ -300,6 +306,11 @@ impl AppSettings {
             && !ollama_url.trim().is_empty()
         {
             settings.ollama_url = ollama_url;
+        }
+        if let Some(summary_provider) =
+            read_json_setting::<SummaryProviderChoice>(db, SUMMARY_PROVIDER_KEY)?
+        {
+            settings.summary_provider = summary_provider;
         }
         if let Some(ollama_model) = read_json_setting::<String>(db, OLLAMA_MODEL_KEY)? {
             settings.ollama_model = ollama_model;
@@ -725,6 +736,7 @@ impl AppSettings {
         write_json_setting(db, PASTE_DELAY_MS_KEY, &normalized.paste_delay_ms)?;
         write_json_setting(db, PASTE_METHOD_KEY, &normalized.paste_method)?;
         write_json_setting(db, OLLAMA_URL_KEY, &normalized.ollama_url)?;
+        write_json_setting(db, SUMMARY_PROVIDER_KEY, &normalized.summary_provider)?;
         write_json_setting(db, OLLAMA_MODEL_KEY, &normalized.ollama_model)?;
         write_json_setting(
             db,
@@ -985,7 +997,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{AppSettings, MeetingAudioRetention, PasteMethod, ShortcutSettings, Theme};
+    use super::{
+        AppSettings, MeetingAudioRetention, PasteMethod, ShortcutSettings, SummaryProviderChoice,
+        Theme,
+    };
     use crate::audio::InputPriority;
     use crate::constants::OLLAMA_DEFAULT_URL;
     use crate::logging::LogLevel;
@@ -1001,6 +1016,7 @@ mod tests {
             paste_delay_ms: 250,
             paste_method: PasteMethod::Type,
             ollama_url: "http://example.test:11434".into(),
+            summary_provider: SummaryProviderChoice::Ollama,
             ollama_model: "qwen2.5".into(),
             debug_transcription: true,
             log_level: LogLevel::Debug,

--- a/src-tauri/src/summary/mod.rs
+++ b/src-tauri/src/summary/mod.rs
@@ -109,6 +109,26 @@ pub enum SummaryProviderChoice {
     Ollama,
 }
 
+impl SummaryProviderChoice {
+    /// Before this setting existed, a non-empty `ollama_model` *was* the
+    /// provider choice. Infer Ollama so an upgrade does not silently switch
+    /// those users onto Apple Intelligence under the new Auto default.
+    ///
+    /// A stored `"auto"` is left alone: the user (or a later save) picked it
+    /// on purpose. Only a missing key is inferred.
+    pub fn from_stored(stored: Option<Self>, ollama_model: &str) -> Self {
+        if let Some(choice) = stored {
+            return choice;
+        }
+        let model = ollama_model.trim();
+        if !model.is_empty() && model != APPLE_INTELLIGENCE_MODEL_ID {
+            Self::Ollama
+        } else {
+            Self::Auto
+        }
+    }
+}
+
 /// Why no model could be selected, so the caller can say so instead of
 /// quietly doing nothing.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -802,6 +822,43 @@ mod tests {
         assert_eq!(
             choose_summary_model(&settings, &available).unwrap(),
             "qwen2.5:7b"
+        );
+    }
+
+    /// Explicit Auto is Apple first even when a stored Ollama model is
+    /// installed. Existing users who had picked that model are migrated to
+    /// the Ollama provider by `from_stored`; they never land in this branch.
+    #[test]
+    fn auto_with_a_stored_ollama_model_still_prefers_apple() {
+        let both = [
+            model("apple-intelligence", SummaryProviderKind::AppleIntelligence),
+            model("qwen2.5:7b", SummaryProviderKind::Ollama),
+        ];
+        let settings = settings_with(SummaryProviderChoice::Auto, "qwen2.5:7b");
+        assert_eq!(
+            choose_summary_model(&settings, &both).unwrap(),
+            "apple-intelligence"
+        );
+    }
+
+    #[test]
+    fn a_missing_provider_setting_with_an_ollama_model_is_ollama() {
+        assert_eq!(
+            SummaryProviderChoice::from_stored(None, "qwen2.5:7b"),
+            SummaryProviderChoice::Ollama
+        );
+        assert_eq!(
+            SummaryProviderChoice::from_stored(None, "  "),
+            SummaryProviderChoice::Auto
+        );
+        assert_eq!(
+            SummaryProviderChoice::from_stored(None, APPLE_INTELLIGENCE_MODEL_ID),
+            SummaryProviderChoice::Auto
+        );
+        assert_eq!(
+            SummaryProviderChoice::from_stored(Some(SummaryProviderChoice::Auto), "qwen2.5:7b"),
+            SummaryProviderChoice::Auto,
+            "an explicit Auto must not be rewritten because an Ollama model is stored"
         );
     }
 

--- a/src-tauri/src/summary/mod.rs
+++ b/src-tauri/src/summary/mod.rs
@@ -94,6 +94,48 @@ pub enum SummaryProviderKind {
     AppleIntelligence,
 }
 
+/// Which provider the user wants summaries and dictation polish to use.
+///
+/// Before this existed the provider was inferred from the selected model id,
+/// so a stale Ollama model name silently decided the provider, and an
+/// unavailable one silently handed the work to whatever else was around.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, specta::Type, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum SummaryProviderChoice {
+    /// Apple Intelligence when this Mac offers it, Ollama otherwise.
+    #[default]
+    Auto,
+    AppleIntelligence,
+    Ollama,
+}
+
+/// Why no model could be selected, so the caller can say so instead of
+/// quietly doing nothing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ModelChoiceError {
+    /// The user asked for Apple Intelligence and this Mac cannot provide it.
+    AppleIntelligenceUnavailable,
+    /// The user asked for Ollama and it has no model this app can use.
+    NoOllamaModel,
+    /// Nothing at all is available, under `Auto`.
+    NoProvider,
+}
+
+impl ModelChoiceError {
+    pub fn message(&self) -> &'static str {
+        match self {
+            Self::AppleIntelligenceUnavailable => {
+                "Apple Intelligence is selected but is not available on this Mac"
+            }
+            Self::NoOllamaModel => "Ollama is selected but has no usable model installed",
+            Self::NoProvider => {
+                "No summary provider is available: Apple Intelligence is unavailable \
+                 and Ollama has no usable model"
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 pub struct SummaryModelDescriptor {
     pub id: String,
@@ -224,18 +266,45 @@ fn chunk_config(provider: SummaryProviderKind) -> ChunkConfig {
     }
 }
 
+/// The model to run, honouring the user's provider choice.
+///
+/// An explicit choice is never silently traded for the other provider: asking
+/// for Apple Intelligence and being served an Ollama model, or the reverse, is
+/// how a stale setting turned into "the feature does nothing and says nothing".
+pub fn choose_summary_model(
+    settings: &crate::settings::AppSettings,
+    models: &[SummaryModelDescriptor],
+) -> Result<String, ModelChoiceError> {
+    let apple = models
+        .iter()
+        .find(|model| model.provider == SummaryProviderKind::AppleIntelligence)
+        .map(|model| model.id.clone());
+
+    let preferred = settings.ollama_model.trim();
+    let ollama = models
+        .iter()
+        .filter(|model| model.provider == SummaryProviderKind::Ollama);
+    let ollama: Vec<&SummaryModelDescriptor> = ollama.collect();
+    let ollama_choice = ollama
+        .iter()
+        .find(|model| model.id == preferred)
+        .or_else(|| ollama.first())
+        .map(|model| model.id.clone());
+
+    match settings.summary_provider {
+        SummaryProviderChoice::AppleIntelligence => {
+            apple.ok_or(ModelChoiceError::AppleIntelligenceUnavailable)
+        }
+        SummaryProviderChoice::Ollama => ollama_choice.ok_or(ModelChoiceError::NoOllamaModel),
+        SummaryProviderChoice::Auto => apple.or(ollama_choice).ok_or(ModelChoiceError::NoProvider),
+    }
+}
+
 pub fn pick_summary_model(
     settings: &crate::settings::AppSettings,
     models: &[SummaryModelDescriptor],
 ) -> Option<String> {
-    if models.is_empty() {
-        return None;
-    }
-    let preferred = settings.ollama_model.trim();
-    if !preferred.is_empty() && models.iter().any(|model| model.id == preferred) {
-        return Some(preferred.to_string());
-    }
-    models.first().map(|model| model.id.clone())
+    choose_summary_model(settings, models).ok()
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -596,7 +665,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        APPLE_INTELLIGENCE_MODEL_ID, ChunkConfig, SummaryProviderKind, apple, check_providers,
+        APPLE_INTELLIGENCE_MODEL_ID, ChunkConfig, ModelChoiceError, SummaryModelDescriptor,
+        SummaryProviderChoice, SummaryProviderKind, apple, check_providers, choose_summary_model,
         ollama, reduce_call_system_prompt, resolve_provider, run_reduce_tree, sanitize_summary,
         structured_extract_for_persist,
     };
@@ -649,6 +719,102 @@ mod tests {
         let input = "Here is a summary of the meeting.\n## Summary\nKey points are listed below.";
         let result = sanitize_summary(input);
         assert_eq!(result, "## Summary\nKey points are listed below.");
+    }
+
+    fn model(id: &str, provider: SummaryProviderKind) -> SummaryModelDescriptor {
+        SummaryModelDescriptor {
+            id: id.to_string(),
+            label: id.to_string(),
+            provider,
+            can_summarize: true,
+        }
+    }
+
+    fn settings_with(
+        provider: SummaryProviderChoice,
+        ollama_model: &str,
+    ) -> crate::settings::AppSettings {
+        crate::settings::AppSettings {
+            summary_provider: provider,
+            ollama_model: ollama_model.to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// The bug this replaced: a stored Ollama model that is not installed used
+    /// to fall through to whatever was first in the list, so the app quietly
+    /// ran a provider the user had not chosen, or nothing at all.
+    #[test]
+    fn an_unavailable_stored_model_does_not_change_provider() {
+        let available = [model(
+            "apple-intelligence",
+            SummaryProviderKind::AppleIntelligence,
+        )];
+        let settings = settings_with(SummaryProviderChoice::Ollama, "codellama:latest");
+        assert_eq!(
+            choose_summary_model(&settings, &available),
+            Err(ModelChoiceError::NoOllamaModel),
+            "asking for Ollama must not be served Apple Intelligence"
+        );
+    }
+
+    #[test]
+    fn apple_intelligence_is_refused_rather_than_swapped_for_ollama() {
+        let available = [model("qwen2.5:7b", SummaryProviderKind::Ollama)];
+        let settings = settings_with(SummaryProviderChoice::AppleIntelligence, "");
+        assert_eq!(
+            choose_summary_model(&settings, &available),
+            Err(ModelChoiceError::AppleIntelligenceUnavailable)
+        );
+    }
+
+    #[test]
+    fn auto_prefers_apple_intelligence_then_falls_back_to_ollama() {
+        let both = [
+            model("apple-intelligence", SummaryProviderKind::AppleIntelligence),
+            model("qwen2.5:7b", SummaryProviderKind::Ollama),
+        ];
+        let settings = settings_with(SummaryProviderChoice::Auto, "");
+        assert_eq!(
+            choose_summary_model(&settings, &both).unwrap(),
+            "apple-intelligence"
+        );
+
+        let ollama_only = [model("qwen2.5:7b", SummaryProviderKind::Ollama)];
+        assert_eq!(
+            choose_summary_model(&settings, &ollama_only).unwrap(),
+            "qwen2.5:7b"
+        );
+
+        assert_eq!(
+            choose_summary_model(&settings, &[]),
+            Err(ModelChoiceError::NoProvider)
+        );
+    }
+
+    #[test]
+    fn the_stored_ollama_model_wins_when_it_is_installed() {
+        let available = [
+            model("llama3.1:8b", SummaryProviderKind::Ollama),
+            model("qwen2.5:7b", SummaryProviderKind::Ollama),
+        ];
+        let settings = settings_with(SummaryProviderChoice::Ollama, "qwen2.5:7b");
+        assert_eq!(
+            choose_summary_model(&settings, &available).unwrap(),
+            "qwen2.5:7b"
+        );
+    }
+
+    /// Choosing Ollama without naming a model is not an error while one is
+    /// installed: the first available stands in.
+    #[test]
+    fn ollama_without_a_stored_model_uses_the_first_available() {
+        let available = [model("llama3.1:8b", SummaryProviderKind::Ollama)];
+        let settings = settings_with(SummaryProviderChoice::Ollama, "");
+        assert_eq!(
+            choose_summary_model(&settings, &available).unwrap(),
+            "llama3.1:8b"
+        );
     }
 
     #[test]

--- a/src-tauri/src/summary/ollama.rs
+++ b/src-tauri/src/summary/ollama.rs
@@ -69,15 +69,23 @@ pub fn is_summary_capable_model(model: &str) -> bool {
 
     let lower = model.to_ascii_lowercase();
 
-    let blocked_substrings = ["whisper", "speech", "wav2vec", "embed", "minilm"];
-    if blocked_substrings
+    // Speech and embedding models cannot follow a prose instruction at all.
+    // Code models can, badly: they are tuned for completion, and asked to clean
+    // a dictation they tend to echo it back or comment on it. Offering one is
+    // worse than offering nothing, because the feature then looks broken
+    // instead of unconfigured.
+    let speech_or_embedding = ["whisper", "speech", "wav2vec", "embed", "minilm"];
+    // "coder" alone covers starcoder, sqlcoder, deepseek-coder and qwen-coder.
+    let code_models = ["coder", "codellama", "codegemma", "codestral", "code-"];
+    if speech_or_embedding
         .iter()
+        .chain(code_models.iter())
         .any(|keyword| lower.contains(keyword))
     {
         return false;
     }
 
-    let blocked_tokens = ["stt", "asr", "e5", "bge", "gte"];
+    let blocked_tokens = ["stt", "asr", "e5", "bge", "gte", "code"];
     let tokens = lower.split(|c: char| !c.is_alphanumeric());
     !tokens
         .into_iter()
@@ -439,6 +447,19 @@ mod tests {
     fn accepts_models_where_short_keyword_is_only_a_substring() {
         assert!(is_summary_capable_model("faste5ish:latest"));
         assert!(is_summary_capable_model("vgte-model:latest"));
+    }
+
+    /// A code model can follow the polish prompt just enough to look like it
+    /// is working, and then echoes the dictation back unchanged. Offering one
+    /// makes the feature look broken rather than unconfigured.
+    #[test]
+    fn rejects_code_models_for_summary() {
+        assert!(!is_summary_capable_model("codellama:latest"));
+        assert!(!is_summary_capable_model("qwen2.5-coder:7b"));
+        assert!(!is_summary_capable_model("deepseek-coder-v2:16b"));
+        assert!(!is_summary_capable_model("starcoder2:3b"));
+        assert!(!is_summary_capable_model("codegemma:7b"));
+        assert!(!is_summary_capable_model("codestral:22b"));
     }
 
     #[test]

--- a/src-tauri/src/summary/polish.rs
+++ b/src-tauri/src/summary/polish.rs
@@ -4,8 +4,8 @@ use crate::filter::{DictionaryEntry, pronunciation_aliases};
 use crate::settings::{AppSettings, DictationPolishTemplate};
 
 use super::{
-    SummarizeProgress, SummaryProviderKind, extract::extract_json_payload, generate_with_provider,
-    pick_summary_model, resolve_provider,
+    SummarizeProgress, SummaryProviderKind, choose_summary_model, extract::extract_json_payload,
+    generate_with_provider, resolve_provider,
 };
 
 pub const TEMPLATE_CLEAN: &str = "clean";
@@ -411,20 +411,24 @@ pub async fn polish_dictation_text(
         };
     };
 
-    let Some(model) = pick_summary_model(settings, available_models) else {
-        return DictationPolishResult {
-            text: stripped.trim().to_string(),
-            skipped: true,
-            warning: Some(
-                "No summarization provider available — install Ollama or enable Apple Intelligence"
-                    .into(),
-            ),
-        };
+    let model = match choose_summary_model(settings, available_models) {
+        Ok(model) => model,
+        Err(err) => {
+            // Silence here is what made this look like a broken feature: polish
+            // was on, nothing happened, and nothing was written down.
+            tracing::warn!(reason = err.message(), "Dictation polish skipped");
+            return DictationPolishResult {
+                text: stripped.trim().to_string(),
+                skipped: true,
+                warning: Some(err.message().to_string()),
+            };
+        }
     };
 
     let provider = match resolve_provider(&model) {
         Ok(provider) => provider,
         Err(err) => {
+            tracing::warn!(model = %model, error = %err, "Dictation polish provider unusable");
             return DictationPolishResult {
                 text: stripped.trim().to_string(),
                 skipped: true,
@@ -467,6 +471,7 @@ pub async fn polish_dictation_text(
     {
         Ok(raw) => raw,
         Err(err) => {
+            tracing::warn!(model = %model, error = %err, "Dictation polish request failed");
             return DictationPolishResult {
                 text: stripped.trim().to_string(),
                 skipped: false,

--- a/src/lib/components/SettingsView.svelte
+++ b/src/lib/components/SettingsView.svelte
@@ -248,6 +248,7 @@
         appleIntelligenceUnavailableReason={controller.appleIntelligenceUnavailableReason}
         ollamaModels={controller.ollamaModels}
         summaryModels={controller.summaryModels}
+        summaryProvider={controller.app.settings.summary_provider}
         selectedOllamaModel={controller.app.settings.ollama_model}
         recommendedOllamaModel={controller.recommendedOllamaModel}
         ollamaPulling={controller.ollamaPulling}
@@ -257,6 +258,7 @@
         ollamaPullError={controller.ollamaPullError}
         onOllamaUrlChange={controller.onOllamaUrlChange}
         onOllamaModelChange={controller.onOllamaModelChange}
+        onSummaryProviderChange={controller.onSummaryProviderChange}
         onRetrySummaryProviders={controller.refreshSummaryProviders}
         onDownloadRecommendedOllamaModel={controller.downloadRecommendedOllamaModel}
       />

--- a/src/lib/features/meeting/controller.svelte.test.ts
+++ b/src/lib/features/meeting/controller.svelte.test.ts
@@ -248,6 +248,93 @@ describe("MeetingController", () => {
     expect(ctrl.summaryModels[0].id).toBe("llama3");
   });
 
+  function makeBothProvidersStatus(): SummaryProvidersStatus {
+    return makeSummaryProvidersStatus({
+      apple_intelligence_available: true,
+      apple_intelligence_is_stub: false,
+      apple_intelligence_unavailable_reason: null,
+      models: [
+        {
+          id: "apple-intelligence",
+          label: "Apple Intelligence",
+          provider: "apple_intelligence",
+          can_summarize: true,
+        },
+        { id: "qwen2.5:7b", label: "qwen2.5:7b", provider: "ollama", can_summarize: true },
+        { id: "codellama", label: "Code Llama", provider: "ollama", can_summarize: false },
+      ],
+    });
+  }
+
+  it("auto keeps both providers and defaults to Apple Intelligence", async () => {
+    mockGetSummaryProvidersStatus.mockResolvedValue(makeBothProvidersStatus());
+    mockGetTranscriptionCatalog.mockResolvedValue(makeCatalog());
+    mockApp.settings.summary_provider = "auto";
+    mockApp.settings.ollama_model = "qwen2.5:7b";
+
+    const ctrl = createMeetingController();
+    await ctrl.mount();
+
+    expect(ctrl.summaryModels.map((model) => model.id)).toEqual([
+      "apple-intelligence",
+      "qwen2.5:7b",
+    ]);
+    expect(ctrl.selectedModel).toBe("apple-intelligence");
+  });
+
+  it("an explicit Ollama choice hides Apple Intelligence from the picker", async () => {
+    mockGetSummaryProvidersStatus.mockResolvedValue(makeBothProvidersStatus());
+    mockGetTranscriptionCatalog.mockResolvedValue(makeCatalog());
+    mockApp.settings.summary_provider = "ollama";
+    mockApp.settings.ollama_model = "qwen2.5:7b";
+
+    const ctrl = createMeetingController();
+    await ctrl.mount();
+
+    expect(ctrl.summaryModels.map((model) => model.id)).toEqual(["qwen2.5:7b"]);
+    expect(ctrl.selectedModel).toBe("qwen2.5:7b");
+  });
+
+  it("an explicit Apple Intelligence choice hides Ollama from the picker", async () => {
+    mockGetSummaryProvidersStatus.mockResolvedValue(makeBothProvidersStatus());
+    mockGetTranscriptionCatalog.mockResolvedValue(makeCatalog());
+    mockApp.settings.summary_provider = "apple_intelligence";
+
+    const ctrl = createMeetingController();
+    await ctrl.mount();
+
+    expect(ctrl.summaryModels.map((model) => model.id)).toEqual(["apple-intelligence"]);
+    expect(ctrl.selectedModel).toBe("apple-intelligence");
+  });
+
+  it("explicit Ollama with only Apple available offers no model", async () => {
+    mockGetSummaryProvidersStatus.mockResolvedValue(
+      makeSummaryProvidersStatus({
+        apple_intelligence_available: true,
+        apple_intelligence_is_stub: false,
+        apple_intelligence_unavailable_reason: null,
+        ollama_available: false,
+        models: [
+          {
+            id: "apple-intelligence",
+            label: "Apple Intelligence",
+            provider: "apple_intelligence",
+            can_summarize: true,
+          },
+        ],
+      }),
+    );
+    mockGetTranscriptionCatalog.mockResolvedValue(makeCatalog());
+    mockApp.settings.summary_provider = "ollama";
+
+    const ctrl = createMeetingController();
+    await ctrl.mount();
+
+    expect(ctrl.summaryModels).toEqual([]);
+    expect(ctrl.selectedModel).toBe("");
+    expect(ctrl.summaryAvailable).toBe(false);
+  });
+
   it("startRecording starts with a dated default title", async () => {
     mockGetSummaryProvidersStatus.mockResolvedValue(makeSummaryProvidersStatus());
     mockGetTranscriptionCatalog.mockResolvedValue(makeCatalog());
@@ -606,7 +693,7 @@ describe("MeetingController", () => {
     expect(ctrl.selectedModel).toBe("llama3");
   });
 
-  it("syncSelectedModel prefers saved ollama_model over apple when both available", async () => {
+  it("under Auto, Apple Intelligence wins over a stored Ollama model", async () => {
     mockGetSummaryProvidersStatus.mockResolvedValue(
       makeSummaryProvidersStatus({
         apple_intelligence_available: true,
@@ -622,12 +709,13 @@ describe("MeetingController", () => {
       }),
     );
     mockGetTranscriptionCatalog.mockResolvedValue(makeCatalog());
+    mockApp.settings.summary_provider = "auto";
     mockApp.settings.ollama_model = "llama3";
 
     const ctrl = createMeetingController();
     await ctrl.mount();
 
-    expect(ctrl.selectedModel).toBe("llama3");
+    expect(ctrl.selectedModel).toBe("apple-intelligence");
   });
 
   describe("notifyMeetingIdle", () => {

--- a/src/lib/features/meeting/controller.svelte.ts
+++ b/src/lib/features/meeting/controller.svelte.ts
@@ -19,7 +19,7 @@ import {
 import { getSummaryProvidersStatus } from "../../api/summary";
 import { getTranscriptionCatalog } from "../../api/transcription";
 import { getAppState } from "../../stores/app.svelte";
-import type { ExportFormat, MeetingAudioSession, MeetingCalendarContext, MeetingIdle, MeetingTranscript, SummaryModelDescriptor, SummarizeProgress, TranscriptionCatalog, TranscriptionSegment } from "../../types";
+import type { ExportFormat, MeetingAudioSession, MeetingCalendarContext, MeetingIdle, MeetingTranscript, SummaryModelDescriptor, SummaryProviderChoice, SummarizeProgress, TranscriptionCatalog, TranscriptionSegment } from "../../types";
 import { errorMessage } from "../../utils";
 import { toSelectedTranscriptionProfile } from "../transcription/catalog";
 import { ensureModelLoaded } from "../transcription/runtime";
@@ -33,6 +33,24 @@ function defaultMeetingTitle(): string {
 /** Extra silence tolerated after the banner first appears before auto-stop
  * kicks in, on top of the configured silence threshold. */
 const SILENCE_AUTOSTOP_GRACE_SECONDS = 120;
+
+/** Honour the Settings provider so the meeting picker cannot run Apple
+ * Intelligence when the user locked Ollama, or the reverse. Auto keeps
+ * both; the default selection still prefers Apple, matching
+ * `choose_summary_model`. */
+function modelsForSummaryProvider(
+  models: SummaryModelDescriptor[],
+  provider: SummaryProviderChoice,
+): SummaryModelDescriptor[] {
+  const capable = models.filter((model) => model.can_summarize);
+  if (provider === "apple_intelligence") {
+    return capable.filter((model) => model.provider === "apple_intelligence");
+  }
+  if (provider === "ollama") {
+    return capable.filter((model) => model.provider === "ollama");
+  }
+  return capable;
+}
 
 function createMeetingControllerInstance() {
   const app = getAppState();
@@ -143,11 +161,17 @@ function createMeetingControllerInstance() {
       selectedModel = preferredModel;
       return;
     }
+    if (selectedModel && summaryModels.some((model) => model.id === selectedModel)) return;
+
+    const apple = summaryModels.find((model) => model.provider === "apple_intelligence");
+    if (app.settings.summary_provider !== "ollama" && apple) {
+      selectedModel = apple.id;
+      return;
+    }
     if (app.settings.ollama_model && summaryModels.some((model) => model.id === app.settings.ollama_model)) {
       selectedModel = app.settings.ollama_model;
       return;
     }
-    if (selectedModel && summaryModels.some((model) => model.id === selectedModel)) return;
     selectedModel = summaryModels[0].id;
   }
 
@@ -222,7 +246,7 @@ function createMeetingControllerInstance() {
       const status = await getSummaryProvidersStatus();
       ollamaAvailable = status.ollama_available;
       appleIntelligenceAvailable = status.apple_intelligence_available;
-      summaryModels = status.models.filter((model) => model.can_summarize);
+      summaryModels = modelsForSummaryProvider(status.models, app.settings.summary_provider);
       syncSelectedModel(meeting?.summary_model);
     } catch {
       ollamaAvailable = false;
@@ -536,6 +560,7 @@ function createMeetingControllerInstance() {
   }
 
   async function summarizeMeeting() {
+    syncSelectedModel(meeting?.summary_model);
     if (!selectedModel || !meeting || !meeting.id) return;
     const meetingId = meeting.id;
     isSummarizing = true;

--- a/src/lib/features/settings/components/IntelligenceSettingsSection.svelte
+++ b/src/lib/features/settings/components/IntelligenceSettingsSection.svelte
@@ -3,7 +3,7 @@
   import ProgressBar from "../../../components/ui/ProgressBar.svelte";
   import SettingsField from "../../../components/ui/SettingsField.svelte";
   import StatusBanner from "../../../components/ui/StatusBanner.svelte";
-  import type { SummaryModelDescriptor } from "../../../types";
+  import type { SummaryModelDescriptor, SummaryProviderChoice } from "../../../types";
 
   let {
     ollamaUrl,
@@ -12,6 +12,8 @@
     appleIntelligenceUnavailableReason = null,
     ollamaModels,
     summaryModels,
+    summaryProvider,
+    onSummaryProviderChange,
     selectedOllamaModel,
     recommendedOllamaModel,
     ollamaPulling,
@@ -30,6 +32,8 @@
     appleIntelligenceUnavailableReason?: string | null;
     ollamaModels: SummaryModelDescriptor[];
     summaryModels: SummaryModelDescriptor[];
+    summaryProvider: SummaryProviderChoice;
+    onSummaryProviderChange: (event: Event) => void;
     selectedOllamaModel: string;
     recommendedOllamaModel: string;
     ollamaPulling: boolean;
@@ -57,11 +61,61 @@
       ? (KNOWN_REASON_KEYS[appleIntelligenceUnavailableReason] ?? "settings_intelligence.ai_reason_unknown")
       : null,
   );
+
+  // Which provider would actually run, mirroring choose_summary_model in Rust.
+  let effectiveProvider = $derived(
+    summaryProvider === "auto"
+      ? appleIntelligenceAvailable
+        ? "apple_intelligence"
+        : summaryModels.length > 0
+          ? "ollama"
+          : "none"
+      : summaryProvider,
+  );
+
+  // The chosen provider cannot run. Saying so here is the whole point: the old
+  // behaviour was to fall back in silence, so summaries and dictation polish
+  // just did nothing.
+  let unusableKey = $derived(
+    (summaryProvider === "apple_intelligence" || effectiveProvider === "apple_intelligence")
+    && !appleIntelligenceAvailable
+      ? "settings_intelligence.provider_apple_unusable"
+      : (summaryProvider === "ollama" || effectiveProvider === "ollama") && summaryModels.length === 0
+        ? "settings_intelligence.provider_ollama_unusable"
+        : effectiveProvider === "none"
+          ? "settings_intelligence.provider_none_usable"
+          : null,
+  );
+
+  let showModelPicker = $derived(summaryProvider !== "apple_intelligence" && summaryModels.length > 0);
 </script>
 
 <section class="settings-group">
   <h3>{$t("settings_intelligence.title")}</h3>
   <div class="settings-rows">
+  <SettingsField
+    label={$t("settings_intelligence.provider")}
+    description={$t("settings_intelligence.provider_desc")}
+    htmlFor="summary-provider"
+  >
+    {#snippet control()}
+      <select
+        id="summary-provider"
+        value={summaryProvider}
+        onchange={onSummaryProviderChange}
+        class="field-select max-w-64"
+      >
+        <option value="auto">{$t("settings_intelligence.provider_auto")}</option>
+        <option value="apple_intelligence">{$t("settings_intelligence.apple_intelligence")}</option>
+        <option value="ollama">{$t("settings_intelligence.provider_ollama")}</option>
+      </select>
+    {/snippet}
+  </SettingsField>
+
+  {#if unusableKey}
+    <StatusBanner variant="danger" message={$t(unusableKey)} />
+  {/if}
+
   <SettingsField
     label={$t("settings_intelligence.apple_intelligence")}
     description={$t("settings_intelligence.apple_intelligence_desc")}
@@ -109,7 +163,7 @@
     {/snippet}
   </SettingsField>
 
-  {#if ollamaAvailable && summaryModels.length > 0}
+  {#if showModelPicker}
     <div class="flex items-center justify-between gap-4">
       <label for="summary-model" class="setting-label shrink-0">{$t("settings_intelligence.summary_model")}</label>
       <select

--- a/src/lib/features/settings/components/IntelligenceSettingsSection.svelte
+++ b/src/lib/features/settings/components/IntelligenceSettingsSection.svelte
@@ -87,9 +87,14 @@
           : null,
   );
 
-  // Ollama only matters when it could actually be used. Picking Apple
-  // Intelligence must not leave the Ollama setup prompts on screen.
-  let ollamaRelevant = $derived(summaryProvider !== "apple_intelligence");
+  // Ollama's model picker and setup prompts only belong on screen when
+  // Ollama would actually run. Auto + Apple Intelligence available used to
+  // leave the dropdown up, so changing the model looked like it did something
+  // while polish kept using Apple. Explicit Ollama still shows both, even
+  // when Apple is around — that choice is a lock, not a fallback.
+  let ollamaRelevant = $derived(
+    summaryProvider === "ollama" || (summaryProvider === "auto" && !appleIntelligenceAvailable),
+  );
   let showModelPicker = $derived(ollamaRelevant && summaryModels.length > 0);
   // Online but with nothing usable: offer the way out rather than a dead end.
   let showOllamaSetup = $derived(ollamaRelevant && ollamaAvailable && summaryModels.length === 0);

--- a/src/lib/features/settings/components/IntelligenceSettingsSection.svelte
+++ b/src/lib/features/settings/components/IntelligenceSettingsSection.svelte
@@ -87,7 +87,12 @@
           : null,
   );
 
-  let showModelPicker = $derived(summaryProvider !== "apple_intelligence" && summaryModels.length > 0);
+  // Ollama only matters when it could actually be used. Picking Apple
+  // Intelligence must not leave the Ollama setup prompts on screen.
+  let ollamaRelevant = $derived(summaryProvider !== "apple_intelligence");
+  let showModelPicker = $derived(ollamaRelevant && summaryModels.length > 0);
+  // Online but with nothing usable: offer the way out rather than a dead end.
+  let showOllamaSetup = $derived(ollamaRelevant && ollamaAvailable && summaryModels.length === 0);
 </script>
 
 <section class="settings-group">
@@ -177,9 +182,13 @@
         {/each}
       </select>
     </div>
-  {:else if ollamaAvailable}
+  {/if}
+
+  {#if showOllamaSetup}
     {#if ollamaModels.length > 0}
       <StatusBanner message={$t("settings_intelligence.no_compatible_model")} />
+    {:else}
+      <StatusBanner message={$t("settings_intelligence.no_model_installed")} />
     {/if}
     {#if ollamaPullError}
       <StatusBanner variant="danger" message={$t("settings_intelligence.pull_failed", { values: { error: ollamaPullError } })} />

--- a/src/lib/features/settings/controller.svelte.test.ts
+++ b/src/lib/features/settings/controller.svelte.test.ts
@@ -52,6 +52,7 @@ const defaultSettings: AppSettings = {
   paste_delay_ms: 100,
   paste_method: "clipboard",
   ollama_url: "http://localhost:11434",
+  summary_provider: "auto",
   ollama_model: "",
   debug_transcription: false,
   log_level: "info",

--- a/src/lib/features/settings/controller.svelte.ts
+++ b/src/lib/features/settings/controller.svelte.ts
@@ -29,6 +29,7 @@ import type {
   DictionaryEntry,
   PermState,
   SummaryModelDescriptor,
+  SummaryProviderChoice,
   ShortcutSettings,
   Theme,
   TranscriptionCatalog,
@@ -537,6 +538,13 @@ export function createSettingsController() {
     });
   }
 
+  function onSummaryProviderChange(event: Event) {
+    const value = (event.target as HTMLSelectElement).value as SummaryProviderChoice;
+    void persistSettings((settings) => {
+      settings.summary_provider = value;
+    });
+  }
+
   function onVadEnabledChange(event: Event) {
     const checked = (event.target as HTMLInputElement).checked;
     void persistSettings((settings) => {
@@ -884,6 +892,7 @@ export function createSettingsController() {
     onLogLevelChange,
     onOllamaUrlChange,
     onOllamaModelChange,
+    onSummaryProviderChange,
     get systemAudioSupported() { return systemAudioSupported; },
     get isLaptop() { return isLaptop; },
     onCaptureSystemAudioChange,

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -144,6 +144,13 @@
   "settings_intelligence": {
     "title": "Summarization",
     "description": "Summaries use Apple Intelligence on supported Macs, or a local Ollama server.",
+    "provider": "Provider",
+    "provider_desc": "Which engine writes summaries and cleans up dictation.",
+    "provider_auto": "Automatic",
+    "provider_ollama": "Ollama",
+    "provider_apple_unusable": "Apple Intelligence is selected but not available on this Mac, so summaries and dictation polish will not run.",
+    "provider_ollama_unusable": "Ollama is selected but has no usable model installed, so summaries and dictation polish will not run. Install a chat model such as qwen2.5:7b-instruct.",
+    "provider_none_usable": "No provider is available: Apple Intelligence is unavailable and Ollama has no usable model. Summaries and dictation polish will not run.",
     "apple_intelligence": "Apple Intelligence",
     "apple_intelligence_desc": "On-device summaries on Apple Silicon with macOS 26+ and Apple Intelligence enabled.",
     "apple_available": "Available",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -170,6 +170,7 @@
     "not_available": "Not available",
     "retry": "Retry",
     "summary_model": "Summarization model",
+    "no_model_installed": "Ollama is running but has no model installed. Download the recommended one below, or install your own with ollama pull.",
     "no_compatible_model": "No compatible model found. Install a model like Llama or Mistral to enable summaries.",
     "download_recommended": "Download {model}",
     "download_recommended_desc": "Recommended for summaries and dictation polish (~4.7 GB).",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -170,6 +170,7 @@
     "not_available": "Non disponible",
     "retry": "Réessayer",
     "summary_model": "Modèle de résumé",
+    "no_model_installed": "Ollama tourne mais aucun modèle n'est installé. Téléchargez le modèle recommandé ci-dessous, ou installez le vôtre avec ollama pull.",
     "no_compatible_model": "Aucun modèle compatible trouvé. Installez un modèle comme Llama ou Mistral pour activer les résumés.",
     "download_recommended": "Télécharger {model}",
     "download_recommended_desc": "Recommandé pour les résumés et le polish de dictée (~4,7 Go).",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -144,6 +144,13 @@
   "settings_intelligence": {
     "title": "Résumés",
     "description": "Les résumés utilisent Apple Intelligence sur les Mac compatibles, ou un serveur Ollama local.",
+    "provider": "Moteur",
+    "provider_desc": "Le moteur qui rédige les résumés et nettoie la dictée.",
+    "provider_auto": "Automatique",
+    "provider_ollama": "Ollama",
+    "provider_apple_unusable": "Apple Intelligence est sélectionné mais indisponible sur ce Mac : les résumés et le nettoyage de la dictée ne s'exécuteront pas.",
+    "provider_ollama_unusable": "Ollama est sélectionné mais aucun modèle utilisable n'est installé : les résumés et le nettoyage de la dictée ne s'exécuteront pas. Installez un modèle de conversation, par exemple qwen2.5:7b-instruct.",
+    "provider_none_usable": "Aucun moteur disponible : Apple Intelligence est indisponible et Ollama n'a aucun modèle utilisable. Les résumés et le nettoyage de la dictée ne s'exécuteront pas.",
     "apple_intelligence": "Apple Intelligence",
     "apple_intelligence_desc": "Résumés on-device sur Apple Silicon avec macOS 26+ et Apple Intelligence activé.",
     "apple_available": "Disponible",

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -57,6 +57,7 @@ let settings = $state<AppSettings>({
   paste_delay_ms: 100,
   paste_method: "clipboard",
   ollama_url: "http://localhost:11434",
+  summary_provider: "auto",
   ollama_model: "",
   debug_transcription: false,
   log_level: "info",

--- a/src/lib/test-helpers/fixtures.ts
+++ b/src/lib/test-helpers/fixtures.ts
@@ -184,6 +184,7 @@ export const mockSettings: AppSettings = {
   paste_delay_ms: 100,
   paste_method: "clipboard",
   ollama_url: "http://localhost:11434",
+  summary_provider: "auto",
   ollama_model: "",
   debug_transcription: false,
   log_level: "info",

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -934,7 +934,12 @@ export type AppSettings = { theme: Theme; locale: string; auto_paste: boolean; p
  * How dictation text is inserted: clipboard Cmd+V, simulated keystrokes,
  * or the focused AX field.
  */
-paste_method: PasteMethod; ollama_url: string; ollama_model: string; debug_transcription: boolean; 
+paste_method: PasteMethod; ollama_url: string; 
+/**
+ * Which provider runs summaries and dictation polish. `ollama_model` only
+ * applies when this resolves to Ollama.
+ */
+summary_provider: SummaryProviderChoice; ollama_model: string; debug_transcription: boolean; 
 /**
  * Global tracing verbosity for the `souffle` crate.
  */
@@ -1436,6 +1441,18 @@ export type SummarizeStage =
  */
 "extract"
 export type SummaryModelDescriptor = { id: string; label: string; provider: SummaryProviderKind; can_summarize: boolean }
+/**
+ * Which provider the user wants summaries and dictation polish to use.
+ * 
+ * Before this existed the provider was inferred from the selected model id,
+ * so a stale Ollama model name silently decided the provider, and an
+ * unavailable one silently handed the work to whatever else was around.
+ */
+export type SummaryProviderChoice = 
+/**
+ * Apple Intelligence when this Mac offers it, Ollama otherwise.
+ */
+"auto" | "apple_intelligence" | "ollama"
 export type SummaryProviderKind = "ollama" | "apple_intelligence"
 export type SummaryProvidersStatus = { ollama_url: string; ollama_available: boolean; apple_intelligence_available: boolean; 
 /**

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -33,6 +33,7 @@ export type {
   ModelArtifactDescriptor,
   OllamaPullProgress,
   SummaryModelDescriptor,
+  SummaryProviderChoice,
   SummaryProvidersStatus,
   SummaryTemplate,
   PermState,


### PR DESCRIPTION
Found while investigating three dictations that came back untouched with polish enabled: the self-correction was not applied, `call` misheard as `curl` was not repaired, and nothing anywhere said why.

## What was wrong

**There was no provider setting.** The provider was inferred from the selected model id: `resolve_provider` checked whether the string equalled the Apple Intelligence id and otherwise assumed Ollama. So `ollama_model` doubled as the provider switch, and a value left over from months ago decided which engine ran.

**An unavailable model silently became a different provider.** `pick_summary_model` returned the stored preference only if it appeared in the available list, and otherwise fell through to `models.first()`. A stored Ollama model that is no longer installed therefore selected Apple Intelligence, or, with nothing available, returned `None` and the feature did nothing. No message, no log line.

**Apple Intelligence could not be selected while Ollama was down.** The model dropdown was rendered under `{#if ollamaAvailable && summaryModels.length > 0}`, even though Apple Intelligence needs no server and was already in that list.

**Code models were offered, and ranked highly.** `is_summary_capable_model` blocked speech and embedding models but let `codellama` through, and `summary_model_priority` then ranked it just under qwen because the name contains "llama". A code model follows the polish prompt just enough to look like it is working and hands the dictation back unchanged.

**Polish logged nothing.** Not a single `warn!` in `polish.rs`, which is why the log file covering the failing dictations contained only startup lines.

## What this changes

- New `summary_provider` setting: `auto` (default, Apple Intelligence first, as today), `apple_intelligence`, or `ollama`. Stored separately from the model; `ollama_model` now only applies when the provider resolves to Ollama.
- `choose_summary_model` replaces the silent fallback and returns a typed reason when nothing can run. An explicit choice is never traded for the other provider in either direction.
- The provider selector and the model picker no longer depend on Ollama being reachable, and Settings states plainly when the chosen provider cannot run.
- `coder`, `codellama`, `codegemma`, `codestral` and a `code-` prefix are filtered out alongside the speech and embedding models.
- Polish now warns with a reason on skip and on failure.

## Verification

620 Rust tests, 271 frontend, clippy clean, build, `npm run check` back to its 6 pre-existing errors with none added, generated types regenerated. Five new tests pin the resolution rules, including the exact reported case: provider Ollama, stored `codellama:latest`, only Apple Intelligence available, must be an error rather than a silent switch.

`cargo fmt` is not run in this repo (it rewrites well over a hundred places on pristine master); touched files were verified individually with `rustfmt --check`.

Not verified here: whether polish now produces the expected result end to end. That needs a machine with a usable provider, and on the reporting machine Ollama currently has zero models installed, which is what made the failure visible in the first place.
