### PR TITLE
Keep the recording HUD off screen shares, and smaller during meetings

### DIFF
--- a/src-tauri/src/pill.rs
+++ b/src-tauri/src/pill.rs
@@ -157,10 +157,11 @@ pub(crate) fn position_top_center(pill: &tauri::WebviewWindow) -> tauri::Result<
 
 /// Lower/upper bounds on the pill's size, defensively clamped in
 /// `set_frame_top_center` against whatever the frontend's live-text
-/// measurement comes up with.
-const MIN_WIDTH: f64 = 280.0;
+/// measurement comes up with. The floor is the compact *meeting* HUD
+/// (dot + stop); dictation compact is larger and is requested explicitly.
+const MIN_WIDTH: f64 = 88.0;
 const MAX_WIDTH: f64 = 600.0;
-const MIN_HEIGHT: f64 = 64.0;
+const MIN_HEIGHT: f64 = 40.0;
 const MAX_HEIGHT: f64 = 260.0;
 
 /// AppKit frame origin (bottom-left corner, global screen coordinates) that
@@ -272,6 +273,13 @@ fn overlay_style_mask(
     current | objc2_app_kit::NSWindowStyleMask::NonactivatingPanel
 }
 
+/// Exclude the HUD from screenshots and screen sharing. The user still sees
+/// it on their display; Zoom / Meet / ScreenCaptureKit do not. `None` is
+/// the documented AppKit opt-out (`NSWindowSharingNone`).
+fn overlay_sharing_type() -> objc2_app_kit::NSWindowSharingType {
+    objc2_app_kit::NSWindowSharingType::None
+}
+
 /// Promote the Tauri webview's `NSWindow` to a non-activating `NSPanel`.
 /// `FullScreenAuxiliary` is documented as an auxiliary-panel behavior —
 /// setting it on a regular `NSWindow` (what we did previously) is ignored
@@ -306,6 +314,7 @@ fn configure_overlay_window(ns_window: &objc2_app_kit::NSWindow) -> &objc2_app_k
 
     ns_window.setStyleMask(overlay_style_mask(ns_window.styleMask()));
     ns_window.setCollectionBehavior(overlay_collection_behavior());
+    ns_window.setSharingType(overlay_sharing_type());
     ns_window.setLevel(NSStatusWindowLevel);
     ns_window.setHidesOnDeactivate(false);
     ns_window.setAnimationBehavior(NSWindowAnimationBehavior::None);
@@ -378,6 +387,12 @@ mod tests {
         use objc2_app_kit::NSWindowStyleMask;
         let mask = overlay_style_mask(NSWindowStyleMask::Borderless);
         assert!(mask.contains(NSWindowStyleMask::NonactivatingPanel));
+    }
+
+    #[test]
+    fn overlay_is_excluded_from_screen_capture() {
+        use objc2_app_kit::NSWindowSharingType;
+        assert_eq!(overlay_sharing_type(), NSWindowSharingType::None);
     }
 
     #[test]

--- a/src/lib/pill/PillApp.svelte
+++ b/src/lib/pill/PillApp.svelte
@@ -9,10 +9,15 @@
   import { micToast, micToastCopy } from "../features/audio/mic-toast.svelte";
   import type { AppStateMachine, PillHoldKind } from "../types";
 
-  // Compact state (idle row only): must match the "pill" window's initial
-  // size in tauri.conf.json.
+  // Compact dictation (idle row only): must match the "pill" window's
+  // initial size in tauri.conf.json.
   const PILL_WIDTH = 280;
   const BASE_HEIGHT = 64;
+  // Compact meeting: just the recording dot + stop. Screen capture already
+  // skips this window (`NSWindowSharingNone`); shrinking it also keeps it
+  // out of the way on the user's own display during a call.
+  const MEETING_WIDTH = 96;
+  const MEETING_HEIGHT = 44;
   // Expanded state (live-text preview showing): wide immediately; height is
   // measured from the rounded container's natural content instead, so it
   // grows line by line as the live-text tail fills in.
@@ -56,6 +61,7 @@
   const showLiveText = $derived(displayMode === "dictation" && liveText.trim().length > 0);
   const routeToast = $derived(micToast.current);
   const routeToastCopy = $derived(routeToast ? micToastCopy(routeToast, $t) : null);
+  const compactMeeting = $derived(displayMode === "meeting" && !routeToast);
 
   function stop() {
     if (recordingMode === "meeting") {
@@ -71,8 +77,8 @@
   let appliedHeight = 0;
 
   $effect(() => {
-    const targetWidth = showLiveText ? EXPANDED_WIDTH : PILL_WIDTH;
-    let targetHeight = BASE_HEIGHT;
+    let targetWidth = showLiveText ? EXPANDED_WIDTH : compactMeeting ? MEETING_WIDTH : PILL_WIDTH;
+    let targetHeight = compactMeeting ? MEETING_HEIGHT : BASE_HEIGHT;
     if (showLiveText) {
       // measuredHeight tracks the auto-height container, so it only moves
       // when the wrapped line count changes. Monotonic within a session: a
@@ -83,6 +89,8 @@
     } else if (routeToast) {
       sessionMaxHeight = BASE_HEIGHT;
       targetHeight = Math.min(Math.max(measuredHeight, BASE_HEIGHT), BASE_HEIGHT + 36);
+    } else if (compactMeeting) {
+      sessionMaxHeight = MEETING_HEIGHT;
     } else {
       sessionMaxHeight = BASE_HEIGHT;
     }
@@ -154,37 +162,43 @@
 <div
   data-tauri-drag-region
   bind:offsetHeight={measuredHeight}
-  class="flex w-full flex-col gap-1 rounded-[28px] border border-white/10 bg-black/75 px-4 py-2.5 shadow-lg backdrop-blur-md"
+  class="flex w-full flex-col gap-1 border border-white/10 bg-black/75 shadow-lg backdrop-blur-md {compactMeeting
+    ? 'rounded-[22px] px-2.5 py-1.5'
+    : 'rounded-[28px] px-4 py-2.5'}"
 >
-  <!-- h-[42px] keeps the compact pill's natural height at exactly
-       BASE_HEIGHT (42 + 2x10 padding + 2x1 border = 64). -->
-  <div class="flex h-[42px] shrink-0 items-center gap-3">
+  <!-- Compact dictation: h-[42px] + 2x10 padding + 2x1 border = BASE_HEIGHT.
+       Compact meeting: h-[30px] + 2x6 padding + 2x1 border = MEETING_HEIGHT. -->
+  <div class="flex shrink-0 items-center {compactMeeting ? 'h-[30px] justify-between gap-2' : 'h-[42px] gap-3'}">
     {#if displayMode !== "polishing"}
       <span class="recording-dot shrink-0" aria-hidden="true"></span>
     {/if}
-    <span class="shrink-0 text-xs font-medium text-white/90" data-tauri-drag-region>
-      {#if displayMode === "polishing"}
-        {$t("pill.polishing")}
-      {:else}
-        {displayMode === "meeting" ? $t("pill.meeting") : $t("pill.dictation")}
-      {/if}
-    </span>
-    <div class="min-w-0 flex-1">
-      {#if displayMode === "polishing"}
-        <div class="flex items-center justify-center text-accent">
-          <Spinner />
-        </div>
-      {:else}
-        <Waveform active variant="pill" />
-      {/if}
-    </div>
+    {#if !compactMeeting}
+      <span class="shrink-0 text-xs font-medium text-white/90" data-tauri-drag-region>
+        {#if displayMode === "polishing"}
+          {$t("pill.polishing")}
+        {:else}
+          {$t("pill.dictation")}
+        {/if}
+      </span>
+      <div class="min-w-0 flex-1">
+        {#if displayMode === "polishing"}
+          <div class="flex items-center justify-center text-accent">
+            <Spinner />
+          </div>
+        {:else}
+          <Waveform active variant="pill" />
+        {/if}
+      </div>
+    {/if}
     {#if displayMode !== "polishing"}
       <button
         onclick={stop}
-        class="flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded-full bg-red-500/90 text-white transition-colors hover:bg-red-500"
+        class="flex shrink-0 cursor-pointer items-center justify-center rounded-full bg-red-500/90 text-white transition-colors hover:bg-red-500 {compactMeeting
+          ? 'h-6 w-6'
+          : 'h-7 w-7'}"
         aria-label={$t("pill.stop")}
       >
-        <Square size={12} fill="currentColor" aria-hidden="true" />
+        <Square size={compactMeeting ? 10 : 12} fill="currentColor" aria-hidden="true" />
       </button>
     {/if}
   </div>


### PR DESCRIPTION
Fixes #90.

The overlay sits at the top of the display and does not move. Screen sharing (Zoom, Meet, ScreenCaptureKit) was picking it up because the window used the default sharing type.

## What this changes

- `NSWindowSharingNone` on the overlay panel. The user still sees it; capture does not.
- Compact meeting HUD is 96×44: recording dot + stop, no label, no waveform. Dictation is unchanged. A mic-route toast still expands it.

## Test plan

- [ ] Start a meeting, share the screen in Zoom/Meet, confirm the HUD is absent from the share
- [ ] Confirm the HUD is still visible on the local display
- [ ] Dictation pill size and live-text expansion unchanged
- [ ] Mic-route toast still expands the meeting HUD
- [ ] Stop still works on the compact meeting pill