### PR TITLE
Show the meeting export save panel from Rust so WKWebView cannot swallow it

### DIFF
--- a/src-tauri/src/commands/meetings.rs
+++ b/src-tauri/src/commands/meetings.rs
@@ -1,11 +1,64 @@
-use tauri::State;
+use std::path::PathBuf;
+
 use tauri::ipc::Channel;
+use tauri::{AppHandle, Manager, State};
+use tauri_plugin_dialog::DialogExt;
 
 use crate::db::search::SearchResult;
 use crate::engine::TranscriptionSegment;
 use crate::export::{self, ExportFormat};
 use crate::settings::AppSettings;
 use crate::state::AppState;
+
+/// Native save panel, parented to `main` after bringing the app forward.
+///
+/// The JS dialog plugin parents to whichever webview invoked it. The pill
+/// overlay is a non-activating `NSPanel`, and WKWebView swallows OS surfaces
+/// the same way it swallows `target="_blank"` (see `open_release_page`):
+/// click, nothing opens. Talk to AppKit from this side of the webview.
+pub(crate) fn pick_save_path(
+    app: &AppHandle,
+    file_name: &str,
+    extension: &str,
+) -> Result<Option<PathBuf>, String> {
+    bring_app_forward(app);
+
+    let Some(main) = app.get_webview_window("main") else {
+        return Err("Main window is gone; cannot show the save dialog".into());
+    };
+
+    let picked = app
+        .dialog()
+        .file()
+        .set_file_name(file_name)
+        .add_filter(extension.to_uppercase(), &[extension])
+        .set_parent(&main)
+        .blocking_save_file();
+
+    match picked {
+        Some(path) => path
+            .into_path()
+            .map(Some)
+            .map_err(|e| format!("Save path: {e}")),
+        None => Ok(None),
+    }
+}
+
+fn bring_app_forward(app: &AppHandle) {
+    let (tx, rx) = std::sync::mpsc::sync_channel(0);
+    let app = app.clone();
+    let _ = app.clone().run_on_main_thread(move || {
+        #[cfg(target_os = "macos")]
+        crate::tray::activate_app();
+        if let Some(main) = app.get_webview_window("main") {
+            let _ = main.unminimize();
+            let _ = main.show();
+            let _ = main.set_focus();
+        }
+        let _ = tx.send(());
+    });
+    let _ = rx.recv();
+}
 
 /// List all saved meetings
 #[tauri::command]
@@ -305,8 +358,7 @@ pub fn export_meeting_filename(
     Ok(export::export_default_filename(&meeting, format))
 }
 
-/// Render a meeting export and write it to `path`. The save dialog itself
-/// (picking `path`) runs frontend-side via the dialog plugin.
+/// Render a meeting export and write it to `path`.
 #[tauri::command]
 #[specta::specta]
 pub fn export_meeting_to_file(
@@ -317,6 +369,32 @@ pub fn export_meeting_to_file(
 ) -> Result<(), String> {
     let meeting = state.db.load_meeting(&id)?;
     let rendered = export::render_meeting(&meeting, format)?;
+    std::fs::write(&path, rendered).map_err(|e| format!("Write export file: {e}"))
+}
+
+/// Show a native save dialog and write the meeting export. Runs off the
+/// webview (see [`pick_save_path`]); cancel is a no-op, not an error.
+#[tauri::command]
+#[specta::specta]
+pub async fn save_meeting_export(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    id: String,
+    format: ExportFormat,
+) -> Result<(), String> {
+    let meeting = state.db.load_meeting(&id)?;
+    let filename = export::export_default_filename(&meeting, format);
+    let extension = export::export_extension(format).to_string();
+    let rendered = export::render_meeting(&meeting, format)?;
+
+    let picked =
+        tauri::async_runtime::spawn_blocking(move || pick_save_path(&app, &filename, &extension))
+            .await
+            .map_err(|e| format!("Save dialog task failed: {e}"))??;
+
+    let Some(path) = picked else {
+        return Ok(());
+    };
     std::fs::write(&path, rendered).map_err(|e| format!("Write export file: {e}"))
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -111,6 +111,7 @@ fn specta_builder() -> Builder<tauri::Wry> {
             commands::export_meeting_preview,
             commands::export_meeting_filename,
             commands::export_meeting_to_file,
+            commands::save_meeting_export,
             commands::check_summary_providers,
             commands::pull_recommended_ollama_model,
             commands::summarize_meeting,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -86,7 +86,7 @@ pub fn should_restore_main_on_reopen(_has_visible_windows: bool) -> bool {
 }
 
 #[cfg(target_os = "macos")]
-fn activate_app() {
+pub(crate) fn activate_app() {
     use objc2::MainThreadMarker;
     use objc2_app_kit::NSApplication;
 

--- a/src/lib/api/meetings.test.ts
+++ b/src/lib/api/meetings.test.ts
@@ -25,6 +25,7 @@ import {
   exportMeetingFilename,
   exportMeetingPreview,
   exportMeetingToFile,
+  saveMeetingExport,
 } from './meetings';
 
 describe('meetings API', () => {
@@ -163,5 +164,13 @@ describe('meetings API', () => {
     await exportMeetingToFile('meeting-1', 'vtt', '/tmp/export.vtt');
 
     expect(mockInvoke).toHaveBeenCalledWith('export_meeting_to_file', expect.objectContaining({ id: 'meeting-1', format: 'vtt', path: '/tmp/export.vtt' }), undefined);
+  });
+
+  it('saveMeetingExport passes id and format', async () => {
+    mockInvoke.mockResolvedValue(null);
+
+    await saveMeetingExport('meeting-1', 'markdown');
+
+    expect(mockInvoke).toHaveBeenCalledWith('save_meeting_export', expect.objectContaining({ id: 'meeting-1', format: 'markdown' }), undefined);
   });
 });

--- a/src/lib/api/meetings.ts
+++ b/src/lib/api/meetings.ts
@@ -110,3 +110,8 @@ export async function exportMeetingPreview(id: string, format: ExportFormat): Pr
 export async function exportMeetingToFile(id: string, format: ExportFormat, path: string): Promise<void> {
   await unwrap(commands.exportMeetingToFile(id, format, path));
 }
+
+/** Native save dialog + write. Cancel is a no-op. */
+export async function saveMeetingExport(id: string, format: ExportFormat): Promise<void> {
+  await unwrap(commands.saveMeetingExport(id, format));
+}

--- a/src/lib/features/meeting/controller.svelte.test.ts
+++ b/src/lib/features/meeting/controller.svelte.test.ts
@@ -38,13 +38,9 @@ const mockSummarizeMeeting = vi.fn<
     onProgress: (p: SummarizeProgress) => void,
   ) => Promise<void>
 >();
-const mockExportMeetingFilename = vi.fn<
-  (id: string, format: import("../../types").ExportFormat) => Promise<string>
+const mockSaveMeetingExport = vi.fn<
+  (id: string, format: import("../../types").ExportFormat) => Promise<void>
 >();
-const mockExportMeetingToFile = vi.fn<
-  (id: string, format: import("../../types").ExportFormat, path: string) => Promise<void>
->();
-const mockShowSaveDialog = vi.fn<(opts: unknown) => Promise<string | null>>();
 
 vi.mock("../../api/meetings", () => ({
   startMeetingRecording: (...a: unknown[]) =>
@@ -65,14 +61,8 @@ vi.mock("../../api/meetings", () => ({
     mockSummarizeMeeting(
       ...(a as [string, string, string | null, (p: SummarizeProgress) => void]),
     ),
-  exportMeetingFilename: (...a: unknown[]) =>
-    mockExportMeetingFilename(...(a as [string, import("../../types").ExportFormat])),
-  exportMeetingToFile: (...a: unknown[]) =>
-    mockExportMeetingToFile(...(a as [string, import("../../types").ExportFormat, string])),
-}));
-
-vi.mock("@tauri-apps/plugin-dialog", () => ({
-  save: (...a: unknown[]) => mockShowSaveDialog(...(a as [unknown])),
+  saveMeetingExport: (...a: unknown[]) =>
+    mockSaveMeetingExport(...(a as [string, import("../../types").ExportFormat])),
 }));
 
 vi.mock("../../api/summary", () => ({
@@ -531,13 +521,11 @@ describe("MeetingController", () => {
     expect(mockApp.currentMeetingId).toBeNull();
   });
 
-  it("exportMeeting looks up the filename, opens the save dialog, and writes the file", async () => {
+  it("exportMeeting asks the backend to show the save dialog and write the file", async () => {
     mockGetSummaryProvidersStatus.mockResolvedValue(makeSummaryProvidersStatus());
     mockGetTranscriptionCatalog.mockResolvedValue(makeCatalog());
     mockGetMeeting.mockResolvedValue(makeMeeting());
-    mockExportMeetingFilename.mockResolvedValue("2026-07-09-standup.md");
-    mockShowSaveDialog.mockResolvedValue("/Users/damien/Downloads/2026-07-09-standup.md");
-    mockExportMeetingToFile.mockResolvedValue(undefined);
+    mockSaveMeetingExport.mockResolvedValue(undefined);
 
     const ctrl = createMeetingController();
     await ctrl.mount();
@@ -545,43 +533,15 @@ describe("MeetingController", () => {
 
     await ctrl.exportMeeting("markdown");
 
-    expect(mockExportMeetingFilename).toHaveBeenCalledWith("meet-1", "markdown");
-    expect(mockShowSaveDialog).toHaveBeenCalledWith(
-      expect.objectContaining({
-        defaultPath: "2026-07-09-standup.md",
-        filters: [{ name: "MD", extensions: ["md"] }],
-      }),
-    );
-    expect(mockExportMeetingToFile).toHaveBeenCalledWith(
-      "meet-1",
-      "markdown",
-      "/Users/damien/Downloads/2026-07-09-standup.md",
-    );
+    expect(mockSaveMeetingExport).toHaveBeenCalledWith("meet-1", "markdown");
     expect(ctrl.isExporting).toBe(false);
-  });
-
-  it("exportMeeting does not write a file when the save dialog is cancelled", async () => {
-    mockGetSummaryProvidersStatus.mockResolvedValue(makeSummaryProvidersStatus());
-    mockGetTranscriptionCatalog.mockResolvedValue(makeCatalog());
-    mockGetMeeting.mockResolvedValue(makeMeeting());
-    mockExportMeetingFilename.mockResolvedValue("2026-07-09-standup.srt");
-    mockShowSaveDialog.mockResolvedValue(null);
-
-    const ctrl = createMeetingController();
-    await ctrl.mount();
-    await ctrl.onMeetingSelectionChange("meet-1");
-
-    await ctrl.exportMeeting("srt");
-
-    expect(mockShowSaveDialog).toHaveBeenCalledOnce();
-    expect(mockExportMeetingToFile).not.toHaveBeenCalled();
   });
 
   it("exportMeeting surfaces backend errors via statusMessage", async () => {
     mockGetSummaryProvidersStatus.mockResolvedValue(makeSummaryProvidersStatus());
     mockGetTranscriptionCatalog.mockResolvedValue(makeCatalog());
     mockGetMeeting.mockResolvedValue(makeMeeting());
-    mockExportMeetingFilename.mockRejectedValue(new Error("meeting not found"));
+    mockSaveMeetingExport.mockRejectedValue(new Error("meeting not found"));
 
     const ctrl = createMeetingController();
     await ctrl.mount();
@@ -590,7 +550,6 @@ describe("MeetingController", () => {
     await ctrl.exportMeeting("json");
 
     expect(ctrl.statusMessage).toContain("meeting not found");
-    expect(mockShowSaveDialog).not.toHaveBeenCalled();
     expect(ctrl.isExporting).toBe(false);
   });
 
@@ -613,8 +572,7 @@ describe("MeetingController", () => {
 
     await ctrl.exportMeeting("vtt");
 
-    expect(mockExportMeetingFilename).not.toHaveBeenCalled();
-    expect(mockShowSaveDialog).not.toHaveBeenCalled();
+    expect(mockSaveMeetingExport).not.toHaveBeenCalled();
   });
 
   it("notes autosave debounces and targets the live accumulator id", async () => {

--- a/src/lib/features/meeting/controller.svelte.ts
+++ b/src/lib/features/meeting/controller.svelte.ts
@@ -1,9 +1,7 @@
-import { save as showSaveDialog } from "@tauri-apps/plugin-dialog";
 import { addDictionaryEntry, addSessionCorrection } from "../../api/dictionary";
 import {
   deleteMeeting as removeMeeting,
-  exportMeetingFilename,
-  exportMeetingToFile,
+  saveMeetingExport,
   getMeeting,
   getMeetingAudio,
   renameMeeting as applyMeetingRename,
@@ -650,25 +648,16 @@ function createMeetingControllerInstance() {
   }
 
   /**
-   * Export the current meeting to a file the user picks via the native save
-   * dialog. The suggested filename (and its extension) come from the
-   * backend (`export_meeting_filename`) so the slugify/date-formatting rules
-   * live in exactly one place; the dialog plugin only needs the extension
-   * for its filter, which we read back off that filename.
+   * Export the current meeting via a native save dialog. The dialog is
+   * shown by the backend (not the webview) so WKWebView / the overlay
+   * panel cannot swallow it.
    */
   async function exportMeeting(format: ExportFormat) {
     if (!meeting || !meeting.id || isRecordingMeeting) return;
     isExporting = true;
     statusMessage = "";
     try {
-      const filename = await exportMeetingFilename(meeting.id, format);
-      const extension = filename.split(".").pop() ?? format;
-      const path = await showSaveDialog({
-        defaultPath: filename,
-        filters: [{ name: extension.toUpperCase(), extensions: [extension] }],
-      });
-      if (!path) return; // user cancelled the dialog
-      await exportMeetingToFile(meeting.id, format, path);
+      await saveMeetingExport(meeting.id, format);
     } catch (e) {
       statusMessage = errorMessage(e);
     } finally {

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -358,12 +358,23 @@ async exportMeetingFilename(id: string, format: ExportFormat) : Promise<Result<s
 }
 },
 /**
- * Render a meeting export and write it to `path`. The save dialog itself
- * (picking `path`) runs frontend-side via the dialog plugin.
+ * Render a meeting export and write it to `path`.
  */
 async exportMeetingToFile(id: string, format: ExportFormat, path: string) : Promise<Result<null, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("export_meeting_to_file", { id, format, path }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Show a native save dialog and write the meeting export. Runs off the
+ * webview (see [`pick_save_path`]); cancel is a no-op, not an error.
+ */
+async saveMeetingExport(id: string, format: ExportFormat) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("save_meeting_export", { id, format }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };


### PR DESCRIPTION
Clicking Export (markdown / srt / vtt / json) did nothing. Same class of bug as `open_release_page`: `@tauri-apps/plugin-dialog` `save()` parents to the invoking webview, the overlay is a non-activating `NSPanel`, and WKWebView swallows the native save panel.

## What this changes

`save_meeting_export` runs the save panel on the Rust side, parented to `main`, after bringing the app forward (`activateIgnoringOtherApps`). Cancel is a no-op. The JS `save()` path is gone from the meeting controller.

## Test plan

- [ ] Export markdown / srt / vtt / json from a saved meeting: native save panel opens
- [ ] Cancel: no file, no error toast
- [ ] Confirm: file written at the chosen path
- [ ] Export still a no-op while a meeting is recording