### PR TITLE
Keep interrupted speakers in the transcript in the order they spoke

### DIFF
--- a/src-tauri/src/engine/kyutai.rs
+++ b/src-tauri/src/engine/kyutai.rs
@@ -133,10 +133,7 @@ pub enum RefreshKind {
 enum RefreshDecision {
     None,
     Full(RefreshKind),
-    Lane {
-        batch_idx: usize,
-        kind: RefreshKind,
-    },
+    Lane { batch_idx: usize, kind: RefreshKind },
 }
 
 /// Decide proactive KV refresh before the next frame.
@@ -213,6 +210,19 @@ struct LoadedModel {
     vad_pause_streak: Vec<usize>,
     /// Per-lane LID and mismatch streak tracking.
     language_tracker: LanguageTracker,
+    /// Word waiting for its EndWord (or the next Word) before emit, per lane.
+    pending_words: Vec<Option<PendingWord>>,
+    /// Pending words closed by a KV refresh, emitted on the next consume.
+    orphaned_words: Vec<PendingWord>,
+}
+
+/// A decoded word held until moshi emits `EndWord` so `end_time` is real.
+#[derive(Clone)]
+struct PendingWord {
+    text: String,
+    start_time: f64,
+    language: Option<String>,
+    speaker: Option<Speaker>,
 }
 
 /// Kyutai STT engine implementation.
@@ -314,6 +324,8 @@ impl KyutaiEngine {
             refresh_count: 0,
             vad_pause_streak: vec![0; batch_size],
             language_tracker: LanguageTracker::new(batch_size, meeting_language_prior),
+            pending_words: vec![None; batch_size],
+            orphaned_words: Vec::new(),
         })
     }
 
@@ -357,13 +369,52 @@ impl KyutaiEngine {
         (moshi_start - time_offset_seconds + epoch_origin_seconds).max(0.0)
     }
 
+    fn pending_to_segment(pending: PendingWord, end_time: f64) -> TranscriptionSegment {
+        TranscriptionSegment {
+            text: pending.text,
+            start_time: pending.start_time,
+            end_time: end_time.max(pending.start_time),
+            is_final: true,
+            language: pending.language,
+            confidence: None,
+            speaker: pending.speaker,
+        }
+    }
+
+    fn emit_pending(
+        pending_words: &mut [Option<PendingWord>],
+        batch_idx: usize,
+        end_time: f64,
+        segments: &mut Vec<TranscriptionSegment>,
+    ) {
+        if let Some(pending) = pending_words.get_mut(batch_idx).and_then(Option::take) {
+            segments.push(Self::pending_to_segment(pending, end_time));
+        }
+    }
+
+    fn drain_orphans(model: &mut LoadedModel, segments: &mut Vec<TranscriptionSegment>) {
+        for pending in model.orphaned_words.drain(..) {
+            let end = pending.start_time;
+            segments.push(Self::pending_to_segment(pending, end));
+        }
+    }
+
+    fn drain_all_pending(model: &mut LoadedModel, segments: &mut Vec<TranscriptionSegment>) {
+        Self::drain_orphans(model, segments);
+        for batch_idx in 0..model.pending_words.len() {
+            if let Some(pending) = model.pending_words[batch_idx].take() {
+                let end = pending.start_time;
+                segments.push(Self::pending_to_segment(pending, end));
+            }
+        }
+    }
+
     /// Soft KV-cache clear: empties LM/Mimi/ItemState without rebuilding Metal
     /// devices or remapping weights. Preferred over full `reset_state` mid-session.
     fn refresh_loaded(model: &mut LoadedModel, kind: RefreshKind) -> Result<(), EngineError> {
         let frames = model.frames_since_refresh;
         let context = model.config.context;
-        let real_secs =
-            frames as f64 / MIMI_FRAMES_PER_SECOND - model.time_offset_seconds;
+        let real_secs = frames as f64 / MIMI_FRAMES_PER_SECOND - model.time_offset_seconds;
         model.epoch_origin_seconds += real_secs.max(0.0);
         model
             .state
@@ -374,6 +425,13 @@ impl KyutaiEngine {
         model.frames_since_refresh = 0;
         model.vad_pause_streak = vec![0; model.state.batch_size()];
         model.language_tracker.reset_all();
+        let mut orphaned: Vec<PendingWord> = Vec::new();
+        for pending in &mut model.pending_words {
+            if let Some(word) = pending.take() {
+                orphaned.push(word);
+            }
+        }
+        model.orphaned_words.append(&mut orphaned);
         model.refresh_count = model.refresh_count.saturating_add(1);
         info!(
             kind = ?kind,
@@ -388,7 +446,11 @@ impl KyutaiEngine {
 
     /// Per-lane KV clear via moshi `reset_batch_idx`. Does not rebuild Metal or
     /// re-feed the silence prefix; the other lane keeps decoding uninterrupted.
-    fn refresh_lane(model: &mut LoadedModel, batch_idx: usize, kind: RefreshKind) -> Result<(), EngineError> {
+    fn refresh_lane(
+        model: &mut LoadedModel,
+        batch_idx: usize,
+        kind: RefreshKind,
+    ) -> Result<(), EngineError> {
         model
             .state
             .reset_batch_idx(batch_idx)
@@ -397,6 +459,13 @@ impl KyutaiEngine {
             *streak = 0;
         }
         model.language_tracker.reset_lane(batch_idx);
+        let pending = model
+            .pending_words
+            .get_mut(batch_idx)
+            .and_then(Option::take);
+        if let Some(pending) = pending {
+            model.orphaned_words.push(pending);
+        }
         debug!(
             kind = ?kind,
             batch_idx,
@@ -415,7 +484,9 @@ impl KyutaiEngine {
         ) {
             RefreshDecision::None => {}
             RefreshDecision::Full(kind) => Self::refresh_loaded(model, kind)?,
-            RefreshDecision::Lane { batch_idx, kind } => Self::refresh_lane(model, batch_idx, kind)?,
+            RefreshDecision::Lane { batch_idx, kind } => {
+                Self::refresh_lane(model, batch_idx, kind)?
+            }
         }
         Ok(())
     }
@@ -548,6 +619,7 @@ impl KyutaiEngine {
         debug_enabled: bool,
         segments: &mut Vec<TranscriptionSegment>,
     ) {
+        Self::drain_orphans(model, segments);
         let frame_num = FRAME_COUNT.load(Ordering::Relaxed).saturating_sub(1);
         let diarized = model.state.batch_size() == 2;
 
@@ -614,22 +686,32 @@ impl KyutaiEngine {
                     } else {
                         None
                     };
-                    segments.push(TranscriptionSegment {
+                    // Previous word on this lane never got EndWord: close it
+                    // at this word's start so we don't drop it.
+                    Self::emit_pending(&mut model.pending_words, *batch_idx, start_time, segments);
+                    if *batch_idx >= model.pending_words.len() {
+                        model.pending_words.resize_with(*batch_idx + 1, || None);
+                    }
+                    model.pending_words[*batch_idx] = Some(PendingWord {
                         text,
                         start_time,
-                        end_time: start_time,
-                        is_final: true,
                         language,
-                        confidence: None,
                         speaker,
                     });
                 }
-                moshi::asr::AsrMsg::EndWord { .. } => {}
+                moshi::asr::AsrMsg::EndWord {
+                    stop_time,
+                    batch_idx,
+                } => {
+                    let end_time = Self::word_start_time(model, *stop_time);
+                    Self::emit_pending(&mut model.pending_words, *batch_idx, end_time, segments);
+                }
                 moshi::asr::AsrMsg::Step { prs, .. } => {
                     Self::note_vad_pause(model, prs);
                 }
             }
         }
+        Self::drain_orphans(model, segments);
     }
 
     fn context_window_stats(&self) -> Option<super::ContextWindowStats> {
@@ -847,8 +929,7 @@ impl TranscriptionEngine for KyutaiEngine {
                 chunk
             };
 
-            let asr_msgs =
-                Self::step_pcm_single(model, &device, chunk_data, debug_enabled)?;
+            let asr_msgs = Self::step_pcm_single(model, &device, chunk_data, debug_enabled)?;
             Self::consume_asr_msgs(model, &asr_msgs, debug_enabled, &mut segments);
         }
 
@@ -856,40 +937,46 @@ impl TranscriptionEngine for KyutaiEngine {
     }
 
     fn flush(&mut self) -> Result<Vec<TranscriptionSegment>, EngineError> {
-        let model = self.model.as_ref().ok_or(EngineError::NotInitialized)?;
-
-        // Words are emitted audio_delay after they are spoken. If the semantic
-        // VAD has reported a pause for longer than that delay (plus margin),
-        // every word has already cleared the pipeline and the silence suffix
-        // would only burn inference time at stop.
-        let delay_frames =
-            (model.config.stt_config.audio_delay_seconds * MIMI_FRAMES_PER_SECOND) as usize;
-        let suffix_seconds = model.config.stt_config.audio_delay_seconds + 1.0;
+        let (delay_frames, suffix_seconds, pause_streak) = {
+            let model = self.model.as_ref().ok_or(EngineError::NotInitialized)?;
+            // Words are emitted audio_delay after they are spoken. If the semantic
+            // VAD has reported a pause for longer than that delay (plus margin),
+            // every word has already cleared the pipeline and the silence suffix
+            // would only burn inference time at stop.
+            let delay_frames =
+                (model.config.stt_config.audio_delay_seconds * MIMI_FRAMES_PER_SECOND) as usize;
+            let suffix_seconds = model.config.stt_config.audio_delay_seconds + 1.0;
+            let pause_streak = model.vad_pause_streak.first().copied().unwrap_or(0);
+            (delay_frames, suffix_seconds, pause_streak)
+        };
         let silence_samples = (suffix_seconds * SAMPLE_RATE as f64) as usize;
         let diarize = self.diarize;
-        let pause_streak = model
-            .vad_pause_streak
-            .first()
-            .copied()
-            .unwrap_or(0);
 
         if !diarize && pause_streak >= delay_frames + VAD_FLUSH_MARGIN_FRAMES {
             info!(
                 streak = pause_streak,
                 delay_frames, "VAD pause covers ASR delay, skipping silence flush"
             );
-            return Ok(Vec::new());
+            let mut segments = Vec::new();
+            if let Some(model) = self.model.as_mut() {
+                Self::drain_all_pending(model, &mut segments);
+            }
+            return Ok(segments);
         }
 
         // Feed silence suffix to push any remaining words out of the model's
         // internal pipeline (audio_delay + 1 second of silence). Both lanes get
         // the same silence in diarized mode.
         let silence = vec![0.0f32; silence_samples];
-        if diarize {
-            self.transcribe_dual(&silence, &silence)
+        let mut segments = if diarize {
+            self.transcribe_dual(&silence, &silence)?
         } else {
-            self.transcribe(&silence, None)
+            self.transcribe(&silence, None)?
+        };
+        if let Some(model) = self.model.as_mut() {
+            Self::drain_all_pending(model, &mut segments);
         }
+        Ok(segments)
     }
 
     fn reset_state(&mut self) -> Result<(), EngineError> {
@@ -1052,5 +1139,33 @@ mod tests {
         assert_eq!(KyutaiEngine::word_start_time_raw(2.0, 1.0, 30.0), 31.0);
         // Prefix still draining: clamp at 0.
         assert_eq!(KyutaiEngine::word_start_time_raw(0.5, 1.0, 0.0), 0.0);
+    }
+
+    #[test]
+    fn pending_word_uses_endword_stop_time() {
+        let pending = PendingWord {
+            text: "hello".into(),
+            start_time: 1.2,
+            language: Some("en".into()),
+            speaker: Some(Speaker::Me),
+        };
+        let seg = KyutaiEngine::pending_to_segment(pending, 1.6);
+        assert_eq!(seg.text, "hello");
+        assert_eq!(seg.start_time, 1.2);
+        assert_eq!(seg.end_time, 1.6);
+        assert_eq!(seg.speaker, Some(Speaker::Me));
+        assert!(seg.is_final);
+    }
+
+    #[test]
+    fn pending_word_end_time_never_precedes_start() {
+        let pending = PendingWord {
+            text: "hi".into(),
+            start_time: 2.0,
+            language: None,
+            speaker: None,
+        };
+        let seg = KyutaiEngine::pending_to_segment(pending, 1.5);
+        assert_eq!(seg.end_time, 2.0);
     }
 }

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -449,6 +449,7 @@ mod paragraphs {
     #[derive(Debug, Clone, PartialEq)]
     pub struct Paragraph {
         pub timestamp: String,
+        pub start_time: f64,
         pub text: String,
         pub speaker: Option<Speaker>,
     }
@@ -505,147 +506,246 @@ mod paragraphs {
         count
     }
 
-    /// Cluster time-sorted diarized segments into per-speaker turns, then
-    /// emit them ordered by each turn's start time (turn segments stay
-    /// contiguous and chronological internally). A segment joins its
-    /// speaker's currently open turn if the gap since that turn's last
-    /// segment is under `pause_threshold`; otherwise that speaker's turn
-    /// closes and a new one opens. Port of `clusterIntoTurns` in
-    /// `src/lib/utils/paragraphs.ts`; a `HashMap<Speaker, usize>` of open
-    /// turn indices stands in for the TS `Map`, generalizing to any number of
-    /// speakers (not just Me/Them).
-    ///
-    /// Without a pause, a monologue would otherwise absorb everything
-    /// indefinitely. Opening a new turn for speaker B:
-    /// - If B starts clearly after A's last end (>= 350ms handoff), A's turn
-    ///   closes immediately so A's later speech opens a fresh line below.
-    /// - If B overlaps A or starts within 350ms (crosstalk / tight
-    ///   interjection), A is marked interrupted and keeps absorbing until a
-    ///   sentence end.
-    fn cluster_into_turns<'a>(
-        sorted: Vec<&'a TranscriptionSegment>,
-        pause_threshold: f64,
-    ) -> Vec<&'a TranscriptionSegment> {
-        const HANDOFF_GAP_S: f64 = 0.35;
-        struct Turn<'a> {
-            start: f64,
-            last_end: f64,
-            segments: Vec<&'a TranscriptionSegment>,
-            interrupted: bool,
+    fn seg_end(seg: &TranscriptionSegment) -> f64 {
+        if seg.end_time != 0.0 {
+            seg.end_time
+        } else {
+            seg.start_time
         }
+    }
 
-        let mut open_turns: std::collections::HashMap<Speaker, usize> =
+    struct Turn<'a> {
+        start: f64,
+        last_end: f64,
+        speaker: Option<Speaker>,
+        segments: Vec<&'a TranscriptionSegment>,
+    }
+
+    /// Cluster diarized segments into per-speaker turns. Port of
+    /// `clusterIntoTurns` in `src/lib/utils/paragraphs.ts`.
+    ///
+    /// Within a lane, emission order is kept (timestamps can jitter after a
+    /// KV refresh; time-sorting the same speaker zippers two hypotheses).
+    /// Overlapping turns from another speaker split the interrupted turn
+    /// so the interruption can sort between the two halves:
+    /// - Sequential handoff (>= 350ms after the other speaker's last end):
+    ///   close immediately.
+    /// - Overlap: close at the earlier of the next sentence end or 1s after
+    ///   the interrupter started, but only when the interrupted turn is long
+    ///   enough to be a monologue.
+    fn cluster_into_turns(
+        segments: &[TranscriptionSegment],
+        pause_threshold: f64,
+    ) -> Vec<Turn<'_>> {
+        const HANDOFF_GAP_S: f64 = 0.35;
+        const INTERRUPT_HOLD_S: f64 = 1.0;
+        const MONOLOGUE_MIN_S: f64 = 2.0;
+
+        let mut lane_order: Vec<Speaker> = Vec::new();
+        let mut lanes: std::collections::HashMap<Speaker, Vec<&TranscriptionSegment>> =
             std::collections::HashMap::new();
-        let mut turns: Vec<Turn<'a>> = Vec::new();
+        let mut untagged: Vec<&TranscriptionSegment> = Vec::new();
 
-        for seg in sorted {
-            let end = if seg.end_time != 0.0 {
-                seg.end_time
-            } else {
-                seg.start_time
-            };
-            let Some(speaker) = seg.speaker else {
-                turns.push(Turn {
-                    start: seg.start_time,
-                    last_end: end,
-                    segments: vec![seg],
-                    interrupted: false,
-                });
-                continue;
-            };
-
-            let open_idx = open_turns.get(&speaker).copied();
-            let joins = match open_idx {
-                Some(idx) => seg.start_time - turns[idx].last_end < pause_threshold,
-                None => false,
-            };
-            if let Some(idx) = open_idx.filter(|_| joins) {
-                turns[idx].segments.push(seg);
-                turns[idx].last_end = turns[idx].last_end.max(end);
-                if turns[idx].interrupted && ends_sentence(seg.text.trim()) {
-                    // First sentence end at or after the interruption: close
-                    // now so the speaker's next segment starts a fresh,
-                    // later-sorting turn.
-                    open_turns.remove(&speaker);
-                }
-            } else {
-                turns.push(Turn {
-                    start: seg.start_time,
-                    last_end: end,
-                    segments: vec![seg],
-                    interrupted: false,
-                });
-                let new_idx = turns.len() - 1;
-                open_turns.insert(speaker, new_idx);
-                let handoffs: Vec<(Speaker, usize)> = open_turns
-                    .iter()
-                    .filter(|(other, _)| **other != speaker)
-                    .map(|(&other, &idx)| (other, idx))
-                    .collect();
-                for (other_speaker, idx) in handoffs {
-                    if turns[new_idx].start >= turns[idx].last_end + HANDOFF_GAP_S {
-                        open_turns.remove(&other_speaker);
-                    } else {
-                        turns[idx].interrupted = true;
+        for seg in segments {
+            match seg.speaker {
+                Some(speaker) => {
+                    if !lanes.contains_key(&speaker) {
+                        lane_order.push(speaker);
+                        lanes.insert(speaker, Vec::new());
                     }
+                    lanes.get_mut(&speaker).unwrap().push(seg);
                 }
+                None => untagged.push(seg),
             }
         }
 
-        turns.sort_by(|a, b| {
-            a.start
-                .partial_cmp(&b.start)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        });
-        turns.into_iter().flat_map(|t| t.segments).collect()
+        let mut turns: Vec<Turn<'_>> = Vec::new();
+        for speaker in lane_order {
+            let segs = lanes.get(&speaker).map(Vec::as_slice).unwrap_or(&[]);
+            turns.extend(pause_split_lane(segs, speaker, pause_threshold));
+        }
+        for seg in untagged {
+            turns.push(Turn {
+                start: seg.start_time,
+                last_end: seg_end(seg),
+                speaker: None,
+                segments: vec![seg],
+            });
+        }
+
+        split_interrupted_turns(turns, HANDOFF_GAP_S, INTERRUPT_HOLD_S, MONOLOGUE_MIN_S)
+    }
+
+    fn pause_split_lane<'a>(
+        segs: &[&'a TranscriptionSegment],
+        speaker: Speaker,
+        pause_threshold: f64,
+    ) -> Vec<Turn<'a>> {
+        let mut turns: Vec<Turn<'a>> = Vec::new();
+        for &seg in segs {
+            let end = seg_end(seg);
+            if let Some(current) = turns.last_mut()
+                && seg.start_time - current.last_end < pause_threshold
+            {
+                current.segments.push(seg);
+                current.last_end = current.last_end.max(end);
+            } else {
+                turns.push(Turn {
+                    start: seg.start_time,
+                    last_end: end,
+                    speaker: Some(speaker),
+                    segments: vec![seg],
+                });
+            }
+        }
+        turns
+    }
+
+    fn interrupt_split_index(
+        turn: &Turn<'_>,
+        interrupter: &Turn<'_>,
+        handoff_gap_s: f64,
+        interrupt_hold_s: f64,
+        monologue_min_s: f64,
+    ) -> Option<usize> {
+        let spoken_before = turn
+            .segments
+            .iter()
+            .position(|s| s.start_time >= interrupter.start)
+            .unwrap_or(turn.segments.len());
+        let last_before_end = if spoken_before > 0 {
+            seg_end(turn.segments[spoken_before - 1])
+        } else {
+            turn.start
+        };
+
+        if interrupter.start >= last_before_end + handoff_gap_s {
+            return if spoken_before > 0 && spoken_before < turn.segments.len() {
+                Some(spoken_before)
+            } else {
+                None
+            };
+        }
+
+        let hold_at = interrupter.start + interrupt_hold_s;
+        let apply_hold = turn.last_end - turn.start >= monologue_min_s;
+        for i in spoken_before..turn.segments.len() {
+            let seg = turn.segments[i];
+            if ends_sentence(seg.text.trim()) {
+                return Some(i + 1);
+            }
+            if apply_hold && seg.start_time >= hold_at {
+                return Some(i);
+            }
+        }
+        None
+    }
+
+    fn split_interrupted_turns<'a>(
+        mut remaining: Vec<Turn<'a>>,
+        handoff_gap_s: f64,
+        interrupt_hold_s: f64,
+        monologue_min_s: f64,
+    ) -> Vec<Turn<'a>> {
+        let mut out: Vec<Turn<'a>> = Vec::new();
+        while !remaining.is_empty() {
+            remaining.sort_by(|a, b| {
+                a.start
+                    .partial_cmp(&b.start)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+            let turn = remaining.remove(0);
+            if turn.speaker.is_none() || turn.segments.is_empty() {
+                out.push(turn);
+                continue;
+            }
+
+            let interrupter_idx = remaining.iter().position(|other| {
+                other.speaker.is_some()
+                    && other.speaker != turn.speaker
+                    && other.start < turn.last_end
+                    && other.start >= turn.start
+            });
+
+            let Some(interrupter_idx) = interrupter_idx else {
+                out.push(turn);
+                continue;
+            };
+
+            let split_at = interrupt_split_index(
+                &turn,
+                &remaining[interrupter_idx],
+                handoff_gap_s,
+                interrupt_hold_s,
+                monologue_min_s,
+            );
+            let Some(split_at) = split_at else {
+                out.push(turn);
+                continue;
+            };
+            if split_at == 0 || split_at >= turn.segments.len() {
+                out.push(turn);
+                continue;
+            }
+
+            let tail_segs = turn.segments[split_at..].to_vec();
+            let head_segs = turn.segments[..split_at].to_vec();
+            let head_end = head_segs.iter().map(|s| seg_end(s)).fold(0.0, f64::max);
+            let tail_end = tail_segs.iter().map(|s| seg_end(s)).fold(0.0, f64::max);
+            let tail_start = tail_segs[0].start_time;
+            let speaker = turn.speaker;
+            out.push(Turn {
+                start: turn.start,
+                last_end: head_end,
+                speaker,
+                segments: head_segs,
+            });
+            remaining.push(Turn {
+                start: tail_start,
+                last_end: tail_end,
+                speaker,
+                segments: tail_segs,
+            });
+        }
+        out
     }
 
     fn flush_paragraph(
         paragraphs: &mut Vec<Paragraph>,
         timestamp: &str,
+        start_time: f64,
         speaker: Option<Speaker>,
         words: &mut Vec<String>,
     ) {
         paragraphs.push(Paragraph {
             timestamp: timestamp.to_string(),
+            start_time,
             text: words.join(" "),
             speaker,
         });
         words.clear();
     }
 
-    /// Group segments into flowing paragraphs with a leading timestamp. See
-    /// `groupIntoParagraphs` in `src/lib/utils/paragraphs.ts` for the
-    /// authoritative rule set (pause threshold, sentence/char caps, diarized
-    /// sort-then-cluster-into-turns): this is a line-for-line port,
-    /// including its quirk of seeding the first paragraph's timestamp from
-    /// `ordered[0]` even if that segment's text turns out to be empty.
-    pub fn group_into_paragraphs(
-        segments: &[TranscriptionSegment],
+    fn paragraphs_from_refs(
+        segments: &[&TranscriptionSegment],
         pause_threshold: f64,
+        break_on_speaker_change: bool,
     ) -> Vec<Paragraph> {
         if segments.is_empty() {
             return Vec::new();
         }
 
-        let diarized = segments.iter().any(|s| s.speaker.is_some());
-        let time_ordered = super::time_ordered_segments(segments);
-        let ordered = if diarized {
-            cluster_into_turns(time_ordered, pause_threshold)
-        } else {
-            time_ordered
-        };
-
         let mut paragraphs: Vec<Paragraph> = Vec::new();
-        let mut current_timestamp = format_timestamp(ordered[0].start_time);
-        let mut current_speaker: Option<Speaker> = ordered[0].speaker;
+        let mut current_timestamp = format_timestamp(segments[0].start_time);
+        let mut current_start = segments[0].start_time;
+        let mut current_speaker: Option<Speaker> = segments[0].speaker;
         let mut current_words: Vec<String> = Vec::new();
         let mut current_chars: usize = 0;
         let mut sentence_count: usize = 0;
         let mut ends_sentence_flag = false;
-        let mut last_end = ordered[0].start_time;
+        let mut last_end = segments[0].start_time;
 
-        for seg in &ordered {
+        for seg in segments {
             let text = seg.text.trim();
             if text.is_empty() {
                 continue;
@@ -654,10 +754,11 @@ mod paragraphs {
 
             if !current_words.is_empty() {
                 let mut broke = false;
-                if diarized && speaker != current_speaker {
+                if break_on_speaker_change && speaker != current_speaker {
                     flush_paragraph(
                         &mut paragraphs,
                         &current_timestamp,
+                        current_start,
                         current_speaker,
                         &mut current_words,
                     );
@@ -674,6 +775,7 @@ mod paragraphs {
                         flush_paragraph(
                             &mut paragraphs,
                             &current_timestamp,
+                            current_start,
                             current_speaker,
                             &mut current_words,
                         );
@@ -683,11 +785,10 @@ mod paragraphs {
 
                 if broke {
                     current_timestamp = format_timestamp(seg.start_time);
+                    current_start = seg.start_time;
                     current_speaker = speaker;
                     current_chars = 0;
                     sentence_count = 0;
-                    // ends_sentence_flag is unconditionally recomputed below
-                    // from this segment's text, so no reset needed here.
                 }
             } else {
                 current_speaker = speaker;
@@ -697,23 +798,51 @@ mod paragraphs {
             current_chars += text.chars().count() + 1;
             sentence_count += count_sentence_ends(text);
             ends_sentence_flag = ends_sentence(text);
-            let end = if seg.end_time != 0.0 {
-                seg.end_time
-            } else {
-                seg.start_time
-            };
-            last_end = last_end.max(end);
+            last_end = last_end.max(seg_end(seg));
         }
 
         if !current_words.is_empty() {
             paragraphs.push(Paragraph {
                 timestamp: current_timestamp,
+                start_time: current_start,
                 text: current_words.join(" "),
                 speaker: current_speaker,
             });
         }
 
         paragraphs
+    }
+
+    /// Group segments into flowing paragraphs with a leading timestamp. See
+    /// `groupIntoParagraphs` in `src/lib/utils/paragraphs.ts` for the
+    /// authoritative rule set. Diarized meetings cluster into per-speaker
+    /// turns (emission order within a lane), split each turn into readable
+    /// paragraphs, then order those paragraphs by start time.
+    pub fn group_into_paragraphs(
+        segments: &[TranscriptionSegment],
+        pause_threshold: f64,
+    ) -> Vec<Paragraph> {
+        if segments.is_empty() {
+            return Vec::new();
+        }
+
+        let diarized = segments.iter().any(|s| s.speaker.is_some());
+        if !diarized {
+            let refs: Vec<&TranscriptionSegment> = segments.iter().collect();
+            return paragraphs_from_refs(&refs, pause_threshold, false);
+        }
+
+        let turns = cluster_into_turns(segments, pause_threshold);
+        let mut pieces: Vec<Paragraph> = Vec::new();
+        for turn in &turns {
+            pieces.extend(paragraphs_from_refs(&turn.segments, pause_threshold, false));
+        }
+        pieces.sort_by(|a, b| {
+            a.start_time
+                .partial_cmp(&b.start_time)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        pieces
     }
 }
 
@@ -1268,6 +1397,46 @@ mod tests {
                     Some(Speaker::Me),
                     "about moving the launch date to next quarter"
                 ),
+            ]
+        );
+    }
+
+    #[test]
+    fn same_speaker_keeps_emission_order_when_timestamps_jitter() {
+        let segments = vec![
+            diarized_segment("Je", 19.28, 19.38, Speaker::Them),
+            diarized_segment("vous", 19.28, 19.38, Speaker::Them),
+            diarized_segment("la", 19.30, 19.40, Speaker::Them),
+            diarized_segment("mets", 19.29, 19.39, Speaker::Them),
+            diarized_segment("dans", 19.32, 19.42, Speaker::Them),
+            diarized_segment("le", 19.31, 19.41, Speaker::Them),
+            diarized_segment("chat", 19.34, 19.44, Speaker::Them),
+        ];
+        let result = paragraphs::group_into_paragraphs(&segments, 1.5);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].text, "Je vous la mets dans le chat");
+    }
+
+    #[test]
+    fn unpunctuated_overlap_closes_after_interrupt_hold() {
+        let segments = vec![
+            diarized_segment("aaaaaaaaaa", 0.0, 0.5, Speaker::Them),
+            diarized_segment("bbbbbbbbbb", 0.4, 0.9, Speaker::Them),
+            diarized_segment("interrupt", 0.5, 1.0, Speaker::Me),
+            diarized_segment("cccccccccc", 0.8, 1.3, Speaker::Them),
+            diarized_segment("dddddddddd", 1.6, 2.1, Speaker::Them),
+        ];
+        let result = paragraphs::group_into_paragraphs(&segments, 1.5);
+        let texts: Vec<(Option<Speaker>, &str)> = result
+            .iter()
+            .map(|p| (p.speaker, p.text.as_str()))
+            .collect();
+        assert_eq!(
+            texts,
+            vec![
+                (Some(Speaker::Them), "aaaaaaaaaa bbbbbbbbbb cccccccccc"),
+                (Some(Speaker::Me), "interrupt"),
+                (Some(Speaker::Them), "dddddddddd"),
             ]
         );
     }

--- a/src-tauri/tests/fixtures/paragraph_grouping.json
+++ b/src-tauri/tests/fixtures/paragraph_grouping.json
@@ -305,6 +305,52 @@
           "speaker": null
         }
       ]
+    },
+    {
+      "name": "same_speaker_timestamp_jitter",
+      "segments": [
+        { "text": "Je", "start_time": 19.28, "end_time": 19.38, "speaker": "them" },
+        { "text": "vous", "start_time": 19.28, "end_time": 19.38, "speaker": "them" },
+        { "text": "la", "start_time": 19.30, "end_time": 19.40, "speaker": "them" },
+        { "text": "mets", "start_time": 19.29, "end_time": 19.39, "speaker": "them" },
+        { "text": "dans", "start_time": 19.32, "end_time": 19.42, "speaker": "them" },
+        { "text": "le", "start_time": 19.31, "end_time": 19.41, "speaker": "them" },
+        { "text": "chat", "start_time": 19.34, "end_time": 19.44, "speaker": "them" }
+      ],
+      "expected": [
+        {
+          "timestamp": "0:19",
+          "text": "Je vous la mets dans le chat",
+          "speaker": "them"
+        }
+      ]
+    },
+    {
+      "name": "unpunctuated_interrupt_hold",
+      "segments": [
+        { "text": "aaaaaaaaaa", "start_time": 0.0, "end_time": 0.5, "speaker": "them" },
+        { "text": "bbbbbbbbbb", "start_time": 0.4, "end_time": 0.9, "speaker": "them" },
+        { "text": "interrupt", "start_time": 0.5, "end_time": 1.0, "speaker": "me" },
+        { "text": "cccccccccc", "start_time": 0.8, "end_time": 1.3, "speaker": "them" },
+        { "text": "dddddddddd", "start_time": 1.6, "end_time": 2.1, "speaker": "them" }
+      ],
+      "expected": [
+        {
+          "timestamp": "0:00",
+          "text": "aaaaaaaaaa bbbbbbbbbb cccccccccc",
+          "speaker": "them"
+        },
+        {
+          "timestamp": "0:00",
+          "text": "interrupt",
+          "speaker": "me"
+        },
+        {
+          "timestamp": "0:01",
+          "text": "dddddddddd",
+          "speaker": "them"
+        }
+      ]
     }
   ]
 }

--- a/src/lib/features/meeting/live-transcript.svelte.test.ts
+++ b/src/lib/features/meeting/live-transcript.svelte.test.ts
@@ -63,9 +63,10 @@ describe("createLiveTranscript equivalence", () => {
     expect(all).toEqual(groupIntoParagraphs(segments, PAUSE_THRESHOLD));
   });
 
-  it("matches batch grouping for diarized alternating speakers with slight interleave", () => {
+    it("matches batch grouping for diarized alternating speakers with slight interleave", () => {
     // Mic and system audio lanes arrive close together but not perfectly
-    // ordered; the grouper still sorts by start_time before grouping.
+    // ordered; the batch grouper merges lanes without time-sorting within one
+    // speaker, then orders the resulting paragraphs by start.
     const segments = [
       dseg("hi there", 0, "me"),
       dseg("hello back", 2.1, "them"),
@@ -83,31 +84,30 @@ describe("createLiveTranscript equivalence", () => {
     expect(all).toEqual(groupIntoParagraphs(segments, PAUSE_THRESHOLD));
   });
 
-  it("commits paragraphs to `committed` once more than 2 paragraphs are open", () => {
-    const segments = [
-      seg("First paragraph.", 0),
-      seg("Second paragraph.", 2.0),
-      seg("Third paragraph.", 4.0),
-      seg("Fourth paragraph.", 6.0),
-    ];
+  it("commits paragraphs once they fall outside the trailing time window", () => {
+    // 2s gaps: pause break every sentence. Latest start is 12s; horizon is
+    // 12 - 8 = 4s, so paragraphs ending before 4s freeze, later ones stay in
+    // the tail (and the last paragraph is always kept open).
+    const segments = Array.from({ length: 7 }, (_, i) =>
+      seg(`Sentence number ${i + 1}.`, i * 2.0),
+    );
     const live = createLiveTranscript(PAUSE_THRESHOLD);
     feedSegments(live, segments);
 
-    expect(live.tail.length).toBeLessThanOrEqual(2);
-    expect(live.committed.length + live.tail.length).toBe(4);
     expect(live.committed.length).toBeGreaterThan(0);
+    expect(live.tail.length).toBeGreaterThan(0);
+    expect(live.committed.length + live.tail.length).toBe(7);
+    expect(live.committed[live.committed.length - 1].startTime).toBeLessThan(
+      live.tail[0].startTime,
+    );
   });
 });
 
 describe("createLiveTranscript committed immutability", () => {
   it("never mutates a committed paragraph after it is committed", () => {
-    const segments = [
-      seg("First paragraph.", 0),
-      seg("Second paragraph.", 2.0),
-      seg("Third paragraph.", 4.0),
-      seg("Fourth paragraph.", 6.0),
-      seg("Fifth paragraph.", 8.0),
-    ];
+    const segments = Array.from({ length: 8 }, (_, i) =>
+      seg(`Sentence number ${i + 1}.`, i * 2.0),
+    );
     const live = createLiveTranscript(PAUSE_THRESHOLD);
     feedSegments(live, segments);
 
@@ -116,8 +116,8 @@ describe("createLiveTranscript committed immutability", () => {
 
     // Append more segments; already-committed paragraphs must stay identical.
     feedSegments(live, [
-      seg("Sixth paragraph.", 10.0),
-      seg("Seventh paragraph.", 12.0),
+      seg("Ninth paragraph.", 16.0),
+      seg("Tenth paragraph.", 18.0),
     ]);
 
     for (const { ref, copy } of snapshot) {
@@ -221,18 +221,49 @@ describe("createLiveTranscript segment ranges and live edits", () => {
 
   it("editParagraph updates committed text without resetting the stream", () => {
     const live = createLiveTranscript(PAUSE_THRESHOLD);
-    feedSegments(live, [
-      seg("hello", 0),
-      seg("world", 1),
-      seg("First paragraph.", 2.0),
-      seg("Second paragraph.", 4.0),
-      seg("Third paragraph.", 6.0),
-    ]);
+    feedSegments(live, Array.from({ length: 8 }, (_, i) =>
+      seg(`Sentence number ${i + 1}.`, i * 2.0),
+    ));
 
     expect(live.committed.length).toBeGreaterThan(0);
     const target = live.committed[0];
     const updated = live.editParagraph(target.id, "hello universe");
     expect(updated?.text).toBe("hello universe");
     expect(live.committed[0].text).toBe("hello universe");
+  });
+});
+
+describe("createLiveTranscript diarized tail window", () => {
+  it("places a late Me segment by timestamp inside the still-open tail", () => {
+    const live = createLiveTranscript(PAUSE_THRESHOLD);
+    feedSegments(live, [
+      dseg("Them first.", 10.0, "them"),
+      dseg("Them second.", 12.0, "them"),
+    ]);
+    live.append(dseg("Me interruption.", 11.0, "me"), 2);
+
+    const all = [...live.committed, ...live.tail];
+    expect(all.map((p) => ({ speaker: p.speaker, text: p.text }))).toEqual([
+      { speaker: "them", text: "Them first." },
+      { speaker: "me", text: "Me interruption." },
+      { speaker: "them", text: "Them second." },
+    ]);
+  });
+
+  it("does not zipper same-speaker words that arrive with overlapping timestamps", () => {
+    const live = createLiveTranscript(PAUSE_THRESHOLD);
+    feedSegments(live, [
+      dseg("Je", 19.28, "them"),
+      dseg("vous", 19.28, "them"),
+      dseg("la", 19.30, "them"),
+      dseg("mets", 19.29, "them"),
+      dseg("dans", 19.32, "them"),
+      dseg("le", 19.31, "them"),
+      dseg("chat", 19.34, "them"),
+    ]);
+
+    const all = [...live.committed, ...live.tail];
+    expect(all).toHaveLength(1);
+    expect(all[0].text).toBe("Je vous la mets dans le chat");
   });
 });

--- a/src/lib/features/meeting/live-transcript.svelte.ts
+++ b/src/lib/features/meeting/live-transcript.svelte.ts
@@ -14,33 +14,46 @@ export type LiveParagraph = Paragraph & {
 
 type IndexedSegment = { segment: TranscriptionSegment; index: number };
 
+/** Keep paragraphs whose last word is newer than this many seconds before
+ * the latest segment. Covers dual-lane ASR delay so a late Me word can
+ * still land between Them paragraphs instead of freezing at the tail. */
+const TAIL_WINDOW_S = 8;
+/** Safety cap so a burst of tiny fragments cannot keep the tail unbounded. */
+const MAX_TAIL_PARAGRAPHS = 16;
+
+function segEnd(seg: TranscriptionSegment): number {
+  return seg.end_time || seg.start_time;
+}
+
+function paragraphEndTime(
+  ordered: TranscriptionSegment[],
+  range: ParagraphRange,
+): number {
+  let end = 0;
+  for (let i = range.start; i < range.end; i++) {
+    end = Math.max(end, segEnd(ordered[i]));
+  }
+  return end;
+}
+
 /**
  * Incremental paragraph grouper for a live transcript stream.
  *
  * Batch grouping (`groupIntoParagraphs`) re-scans every segment on every
  * call, which is O(n) per call and O(n^2) over a whole meeting. This grouper
- * instead freezes paragraphs as soon as a later segment proves they are
- * closed (a new paragraph started after them) and only re-groups the small
- * "tail" of still-open paragraphs on each `append`.
+ * instead freezes paragraphs once they sit outside a trailing time window
+ * (and only re-groups the small "tail" of still-open paragraphs on each
+ * `append`).
  *
- * Correctness: paragraph state (sentence count, char count, pause gap) only
- * ever depends on segments at or after the paragraph's own start, so once a
- * later paragraph has started, earlier paragraphs can never change. For an
- * in-order stream this makes `[...committed, ...tail]` byte-identical to
- * `groupIntoParagraphs(allSegments, pauseThreshold)`.
+ * Correctness: for an in-order stream this makes `[...committed, ...tail]`
+ * byte-identical to `groupIntoParagraphs(allSegments, pauseThreshold)`.
  *
- * The one caveat is diarization: mic and system audio are transcribed on
- * independent lanes and merged by timestamp, so a final segment can arrive
- * slightly out of order relative to a lane that's already been committed. In
- * that rare case the late segment is simply inserted at the tail (bounded
- * staleness) rather than reopening an already-frozen paragraph. This is
- * acceptable for the live view; the post-stop transcript regroups everything
- * from the database, so nothing is lost.
+ * Diarization: mic and system audio are transcribed on independent lanes.
+ * Segments are kept in emission order (the batch grouper owns lane merge);
+ * the time window, not a 2-paragraph cap, is what keeps a late lane from
+ * landing after already-frozen speech.
  */
 export function createLiveTranscript(pauseThreshold: number) {
-  /** At most this many trailing paragraphs are kept open (not yet frozen). */
-  const MAX_TAIL_PARAGRAPHS = 2;
-
   let committed = $state<LiveParagraph[]>([]);
   let tail = $state<LiveParagraph[]>([]);
   let tentative = $state("");
@@ -52,66 +65,75 @@ export function createLiveTranscript(pauseThreshold: number) {
   let tailSegments: IndexedSegment[] = [];
   let nextParagraphId = 0;
 
-  function insertByStartTime(entry: IndexedSegment) {
-    const seg = entry.segment;
-    if (
-      tailSegments.length === 0
-      || seg.start_time >= tailSegments[tailSegments.length - 1].segment.start_time
-    ) {
-      tailSegments.push(entry);
-      return;
+  function globalRange(
+    range: ParagraphRange,
+    ordered: TranscriptionSegment[],
+  ): ParagraphRange {
+    const indices: number[] = [];
+    for (let i = range.start; i < range.end; i++) {
+      const found = tailSegments.find((item) => item.segment === ordered[i]);
+      if (found) indices.push(found.index);
     }
-    let lo = 0;
-    let hi = tailSegments.length;
-    while (lo < hi) {
-      const mid = (lo + hi) >>> 1;
-      if (tailSegments[mid].segment.start_time <= seg.start_time) lo = mid + 1;
-      else hi = mid;
+    if (indices.length === 0) {
+      return range;
     }
-    tailSegments.splice(lo, 0, entry);
+    return { start: Math.min(...indices), end: Math.max(...indices) + 1 };
   }
 
-  function globalRange(range: ParagraphRange): ParagraphRange {
-    const startIndex = tailSegments[range.start]?.index;
-    const endIndex = tailSegments[range.end - 1]?.index;
-    return {
-      start: startIndex ?? range.start,
-      end: endIndex == null ? range.end : endIndex + 1,
-    };
+  function assignIds(paragraphs: Paragraph[], prev: LiveParagraph[]): number[] {
+    const unused = [...prev];
+    return paragraphs.map((paragraph) => {
+      const matchAt = unused.findIndex(
+        (old) =>
+          old.speaker === paragraph.speaker
+          && Math.abs(old.startTime - paragraph.startTime) < 0.05,
+      );
+      if (matchAt >= 0) {
+        const [match] = unused.splice(matchAt, 1);
+        return match.id;
+      }
+      return nextParagraphId++;
+    });
   }
 
   function regroupTail() {
-    const ordered = tailSegments.map((entry) => entry.segment);
-    const { paragraphs, ranges } = groupIntoParagraphsWithRanges(ordered, pauseThreshold);
+    const input = tailSegments.map((entry) => entry.segment);
+    const { paragraphs, ranges, ordered } = groupIntoParagraphsWithRanges(input, pauseThreshold);
     const prevTail = tail;
-    const numToCommit = Math.max(0, paragraphs.length - MAX_TAIL_PARAGRAPHS);
+
+    const latestStart = input.reduce((max, seg) => Math.max(max, seg.start_time), 0);
+    const horizon = latestStart - TAIL_WINDOW_S;
+    let numToCommit = 0;
+    for (let i = 0; i < paragraphs.length; i++) {
+      if (paragraphEndTime(ordered, ranges[i]) < horizon) numToCommit = i + 1;
+      else break;
+    }
+    numToCommit = Math.max(numToCommit, paragraphs.length - MAX_TAIL_PARAGRAPHS);
+    if (numToCommit === paragraphs.length && paragraphs.length > 0) {
+      numToCommit -= 1;
+    }
+
+    const ids = assignIds(paragraphs, prevTail);
 
     for (let i = 0; i < numToCommit; i++) {
-      const id = i < prevTail.length ? prevTail[i].id : nextParagraphId++;
       committed.push({
         ...paragraphs[i],
-        id,
-        segmentRange: globalRange(ranges[i]),
+        id: ids[i],
+        segmentRange: globalRange(ranges[i], ordered),
       });
     }
     if (numToCommit > 0) {
-      const cutIndex = ranges[numToCommit - 1].end;
-      tailSegments = tailSegments.slice(cutIndex);
+      const consumed = new Set(ordered.slice(0, ranges[numToCommit - 1].end));
+      tailSegments = tailSegments.filter((entry) => !consumed.has(entry.segment));
     }
 
     const remaining = paragraphs.slice(numToCommit);
     const remainingRanges = ranges.slice(numToCommit);
-    const survivingOldCount = Math.max(0, prevTail.length - numToCommit);
-    tail = remaining.map((paragraph, i) => {
-      const id = i < survivingOldCount
-        ? prevTail[numToCommit + i].id
-        : nextParagraphId++;
-      return {
-        ...paragraph,
-        id,
-        segmentRange: globalRange(remainingRanges[i]),
-      };
-    });
+    tail = remaining.map((paragraph, i) => ({
+      ...paragraph,
+      id: ids[numToCommit + i],
+      segmentRange: globalRange(remainingRanges[i], ordered),
+    }));
   }
 
   function append(segment: TranscriptionSegment, segmentIndex: number) {
@@ -122,12 +144,7 @@ export function createLiveTranscript(pauseThreshold: number) {
     tentative = "";
     segmentCount++;
 
-    const entry = { segment, index: segmentIndex };
-    const diarizedSoFar =
-      segment.speaker != null || tailSegments.some((item) => item.segment.speaker != null);
-    if (diarizedSoFar) insertByStartTime(entry);
-    else tailSegments.push(entry);
-
+    tailSegments.push({ segment, index: segmentIndex });
     regroupTail();
   }
 

--- a/src/lib/test-helpers/paragraph-grouping.fixture.json
+++ b/src/lib/test-helpers/paragraph-grouping.fixture.json
@@ -305,6 +305,52 @@
           "speaker": null
         }
       ]
+    },
+    {
+      "name": "same_speaker_timestamp_jitter",
+      "segments": [
+        { "text": "Je", "start_time": 19.28, "end_time": 19.38, "speaker": "them" },
+        { "text": "vous", "start_time": 19.28, "end_time": 19.38, "speaker": "them" },
+        { "text": "la", "start_time": 19.30, "end_time": 19.40, "speaker": "them" },
+        { "text": "mets", "start_time": 19.29, "end_time": 19.39, "speaker": "them" },
+        { "text": "dans", "start_time": 19.32, "end_time": 19.42, "speaker": "them" },
+        { "text": "le", "start_time": 19.31, "end_time": 19.41, "speaker": "them" },
+        { "text": "chat", "start_time": 19.34, "end_time": 19.44, "speaker": "them" }
+      ],
+      "expected": [
+        {
+          "timestamp": "0:19",
+          "text": "Je vous la mets dans le chat",
+          "speaker": "them"
+        }
+      ]
+    },
+    {
+      "name": "unpunctuated_interrupt_hold",
+      "segments": [
+        { "text": "aaaaaaaaaa", "start_time": 0.0, "end_time": 0.5, "speaker": "them" },
+        { "text": "bbbbbbbbbb", "start_time": 0.4, "end_time": 0.9, "speaker": "them" },
+        { "text": "interrupt", "start_time": 0.5, "end_time": 1.0, "speaker": "me" },
+        { "text": "cccccccccc", "start_time": 0.8, "end_time": 1.3, "speaker": "them" },
+        { "text": "dddddddddd", "start_time": 1.6, "end_time": 2.1, "speaker": "them" }
+      ],
+      "expected": [
+        {
+          "timestamp": "0:00",
+          "text": "aaaaaaaaaa bbbbbbbbbb cccccccccc",
+          "speaker": "them"
+        },
+        {
+          "timestamp": "0:00",
+          "text": "interrupt",
+          "speaker": "me"
+        },
+        {
+          "timestamp": "0:01",
+          "text": "dddddddddd",
+          "speaker": "them"
+        }
+      ]
     }
   ]
 }

--- a/src/lib/utils/paragraphs.test.ts
+++ b/src/lib/utils/paragraphs.test.ts
@@ -163,6 +163,62 @@ describe('groupIntoParagraphs diarization', () => {
       { speaker: 'me', text: 'Great to hear.' },
     ]);
   });
+
+  it('keeps same-speaker emission order when timestamps overlap or go backwards', () => {
+    // Kyutai KV-refresh can emit a later hypothesis with an earlier or equal
+    // timestamp. Time-sorting the lane would zipper "Je vous la mets dans le
+    // chat" with "En octobre on va commencer".
+    const segments = [
+      dseg('Je', 19.28, 'them'),
+      dseg('vous', 19.28, 'them'),
+      dseg('la', 19.30, 'them'),
+      dseg('mets', 19.29, 'them'),
+      dseg('dans', 19.32, 'them'),
+      dseg('le', 19.31, 'them'),
+      dseg('chat', 19.34, 'them'),
+    ];
+    const result = groupIntoParagraphs(segments, 1.5);
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe('Je vous la mets dans le chat');
+  });
+
+  it('closes an unpunctuated overlapping turn after the interrupt hold, so the interruption sorts between the two halves', () => {
+    const segments = [
+      dseg('aaaaaaaaaa', 0.0, 'them'),
+      dseg('bbbbbbbbbb', 0.4, 'them'),
+      dseg('interrupt', 0.5, 'me'),
+      dseg('cccccccccc', 0.8, 'them'),
+      dseg('dddddddddd', 1.6, 'them'),
+    ];
+    const result = groupIntoParagraphs(segments, 1.5);
+    expect(result.map((p) => ({ speaker: p.speaker, text: p.text }))).toEqual([
+      { speaker: 'them', text: 'aaaaaaaaaa bbbbbbbbbb cccccccccc' },
+      { speaker: 'me', text: 'interrupt' },
+      { speaker: 'them', text: 'dddddddddd' },
+    ]);
+  });
+
+  it('interleaves an interruption between length-split paragraphs of a long turn', () => {
+    // One Them turn long enough to split at the soft cap, Me starting during
+    // the first half. Display order is by paragraph start, not "entire turn
+    // then the interrupter".
+    const longSentence = `${'word '.repeat(100).trim()}.`; // ~500 chars
+    const segments = [
+      dseg(longSentence, 0, 'them'),
+      dseg('Short follow-up.', 0.5, 'them'),
+      dseg('quick correction', 0.3, 'me'),
+      dseg('And more after that.', 1.0, 'them'),
+    ];
+    const result = groupIntoParagraphs(segments, 1.5);
+    const speakers = result.map((p) => p.speaker);
+    const meAt = speakers.indexOf('me');
+    expect(meAt).toBeGreaterThan(0);
+    expect(meAt).toBeLessThan(speakers.length - 1);
+    expect(result[meAt].text).toBe('quick correction');
+    expect(result[0].speaker).toBe('them');
+    expect(result[0].startTime).toBeLessThan(result[meAt].startTime);
+    expect(result[meAt].startTime).toBeLessThan(result[result.length - 1].startTime);
+  });
 });
 
 describe('groupIntoParagraphs', () => {

--- a/src/lib/utils/paragraphs.ts
+++ b/src/lib/utils/paragraphs.ts
@@ -28,6 +28,17 @@ const SOFT_MAX_CHARS = 480;
 /** Absolute ceiling for streams with no punctuation at all. */
 const HARD_MAX_CHARS = 700;
 
+/** Gap after which a new speaker is treated as a handoff, not crosstalk. */
+const HANDOFF_GAP_S = 0.35;
+/** Overlapping speech closes the interrupted turn this long after the
+ * interrupter started, even without a sentence end. Only applied when the
+ * interrupted turn is long enough to be a monologue — short simultaneous
+ * phrases stay intact. */
+const INTERRUPT_HOLD_S = 1.0;
+/** Turns shorter than this are treated as phrases, not monologues, so a
+ * 1s hold must not peel the last word off word-level crosstalk. */
+const MONOLOGUE_MIN_S = 2.0;
+
 /** Sentence-ending punctuation, allowing closing quotes/brackets after it. */
 const SENTENCE_END = /[.!?…]["»”')\]]*\s*$/;
 
@@ -35,126 +46,191 @@ function countSentenceEnds(text: string): number {
   return (text.match(/[.!?…]+(?=["»”')\]]*(\s|$))/g) ?? []).length;
 }
 
+function segEnd(seg: TranscriptionSegment): number {
+  return seg.end_time || seg.start_time;
+}
+
 /** Half-open index range `[start, end)` into the ordered segment array that a
  * paragraph was built from. */
 export type ParagraphRange = { start: number; end: number };
 
-/**
- * Cluster time-sorted diarized segments into per-speaker turns, then emit
- * them ordered by each turn's start time (turn segments stay contiguous and
- * chronological internally). A segment joins its speaker's currently open
- * turn if the gap since that turn's last segment is under `pauseThreshold`;
- * otherwise that speaker's turn closes and a new one opens.
- *
- * Mic (Me) and system audio (Them) are transcribed on independent lanes, so
- * during crosstalk a naive time-sort interleaves them word by word. Turn
- * clustering keeps each speaker's own words together (one turn = one
- * speaker's contiguous phrase) even while both are talking over each other,
- * so the paragraph loop below breaks on turn boundaries instead of on every
- * single word.
- *
- * Without a pause, a monologue would otherwise absorb everything indefinitely,
- * so a second speaker's interjection would render far below the point in the
- * monologue it actually responded to. Opening a new turn for speaker B:
- * - If B starts clearly after A's last end (sequential handoff, >= 350ms),
- *   A's turn closes immediately so A's later speech opens a fresh line below.
- *   This matters for unpunctuated word streams (Kyutai) that never hit a
- *   sentence end.
- * - If B overlaps A or starts within 350ms (true crosstalk / tight
- *   interjection), A is marked interrupted and keeps absorbing until a
- *   sentence end, so word-level interleaving stays readable as two phrases.
- */
-function clusterIntoTurns(sorted: TranscriptionSegment[], pauseThreshold: number): TranscriptionSegment[] {
-  /** Gap after which a new speaker is treated as a handoff, not crosstalk. */
-  const HANDOFF_GAP_S = 0.35;
-  type Turn = { start: number; lastEnd: number; segments: TranscriptionSegment[]; interrupted: boolean };
-  const openTurns = new Map<Speaker, Turn>();
-  const turns: Turn[] = [];
+type Turn = {
+  start: number;
+  lastEnd: number;
+  speaker: Speaker | null;
+  segments: TranscriptionSegment[];
+};
 
-  for (const seg of sorted) {
+/**
+ * Cluster diarized segments into per-speaker turns.
+ *
+ * Mic (Me) and system audio (Them) are transcribed on independent lanes.
+ * Within a lane, emission order is kept (timestamps can jitter or overlap
+ * after a KV refresh; time-sorting the same speaker zippers two hypotheses
+ * into word salad). Lanes are pause-split, then overlapping turns from
+ * another speaker split the interrupted turn so the interruption can sort
+ * between the two halves:
+ * - Sequential handoff (>= 350ms after the other speaker's last end): close
+ *   immediately.
+ * - Overlap / tight interjection: close at the earlier of the next sentence
+ *   end or `INTERRUPT_HOLD_S` after the interrupter started.
+ */
+function clusterIntoTurns(segments: TranscriptionSegment[], pauseThreshold: number): Turn[] {
+  const lanes = new Map<Speaker, TranscriptionSegment[]>();
+  const untagged: TranscriptionSegment[] = [];
+
+  for (const seg of segments) {
     const speaker = seg.speaker;
     if (speaker == null) {
-      // Non-diarized segment inside an otherwise-diarized stream (shouldn't
-      // normally happen): keep it as its own single-segment turn in place.
-      turns.push({ start: seg.start_time, lastEnd: seg.end_time || seg.start_time, segments: [seg], interrupted: false });
+      untagged.push(seg);
       continue;
     }
-    const open = openTurns.get(speaker);
-    if (open && seg.start_time - open.lastEnd < pauseThreshold) {
-      open.segments.push(seg);
-      open.lastEnd = Math.max(open.lastEnd, seg.end_time || seg.start_time);
-      if (open.interrupted && SENTENCE_END.test(seg.text.trim())) {
-        // First sentence end at or after the interruption: close now so the
-        // speaker's next segment starts a fresh, later-sorting turn.
-        openTurns.delete(speaker);
-      }
-    } else {
-      const turn: Turn = { start: seg.start_time, lastEnd: seg.end_time || seg.start_time, segments: [seg], interrupted: false };
-      turns.push(turn);
-      openTurns.set(speaker, turn);
-      for (const [otherSpeaker, otherTurn] of [...openTurns.entries()]) {
-        if (otherSpeaker === speaker) continue;
-        if (turn.start >= otherTurn.lastEnd + HANDOFF_GAP_S) {
-          // Sequential handoff: close now so later speech from that speaker
-          // opens a new line below instead of editing the earlier monologue.
-          openTurns.delete(otherSpeaker);
-        } else {
-          otherTurn.interrupted = true;
-        }
-      }
-    }
+    const lane = lanes.get(speaker);
+    if (lane) lane.push(seg);
+    else lanes.set(speaker, [seg]);
   }
 
-  turns.sort((a, b) => a.start - b.start);
-  return turns.flatMap((t) => t.segments);
+  const turns: Turn[] = [];
+  for (const [speaker, segs] of lanes) {
+    turns.push(...pauseSplitLane(segs, speaker, pauseThreshold));
+  }
+  for (const seg of untagged) {
+    turns.push({
+      start: seg.start_time,
+      lastEnd: segEnd(seg),
+      speaker: null,
+      segments: [seg],
+    });
+  }
+
+  return splitInterruptedTurns(turns);
+}
+
+function pauseSplitLane(
+  segs: TranscriptionSegment[],
+  speaker: Speaker,
+  pauseThreshold: number,
+): Turn[] {
+  const turns: Turn[] = [];
+  let current: Turn | null = null;
+  for (const seg of segs) {
+    if (current && seg.start_time - current.lastEnd < pauseThreshold) {
+      current.segments.push(seg);
+      current.lastEnd = Math.max(current.lastEnd, segEnd(seg));
+    } else {
+      current = {
+        start: seg.start_time,
+        lastEnd: segEnd(seg),
+        speaker,
+        segments: [seg],
+      };
+      turns.push(current);
+    }
+  }
+  return turns;
+}
+
+/** Index at which `turn` should split so `interrupter` can sort between the
+ * two halves. `null` when the overlap is too short / has no split point. */
+function interruptSplitIndex(turn: Turn, interrupter: Turn): number | null {
+  const spokenBefore = turn.segments.findIndex((s) => s.start_time >= interrupter.start);
+  const headLen = spokenBefore === -1 ? turn.segments.length : spokenBefore;
+  const lastBeforeEnd = headLen > 0 ? segEnd(turn.segments[headLen - 1]) : turn.start;
+
+  if (interrupter.start >= lastBeforeEnd + HANDOFF_GAP_S) {
+    return headLen > 0 && headLen < turn.segments.length ? headLen : null;
+  }
+
+  const holdAt = interrupter.start + INTERRUPT_HOLD_S;
+  const applyHold = turn.lastEnd - turn.start >= MONOLOGUE_MIN_S;
+  for (let i = headLen; i < turn.segments.length; i++) {
+    const seg = turn.segments[i];
+    if (SENTENCE_END.test(seg.text.trim())) return i + 1;
+    if (applyHold && seg.start_time >= holdAt) return i;
+  }
+  return null;
+}
+
+function splitInterruptedTurns(turns: Turn[]): Turn[] {
+  const remaining = [...turns];
+  const out: Turn[] = [];
+
+  while (remaining.length > 0) {
+    remaining.sort((a, b) => a.start - b.start);
+    const turn = remaining.shift()!;
+    if (turn.speaker == null || turn.segments.length === 0) {
+      out.push(turn);
+      continue;
+    }
+
+    const interrupter = remaining.find(
+      (other) =>
+        other.speaker != null
+        && other.speaker !== turn.speaker
+        && other.start < turn.lastEnd
+        && other.start >= turn.start,
+    );
+
+    if (!interrupter) {
+      out.push(turn);
+      continue;
+    }
+
+    const splitAt = interruptSplitIndex(turn, interrupter);
+    if (splitAt == null || splitAt <= 0 || splitAt >= turn.segments.length) {
+      out.push(turn);
+      continue;
+    }
+
+    const headSegs = turn.segments.slice(0, splitAt);
+    const tailSegs = turn.segments.slice(splitAt);
+    out.push({
+      start: turn.start,
+      lastEnd: Math.max(...headSegs.map(segEnd)),
+      speaker: turn.speaker,
+      segments: headSegs,
+    });
+    remaining.push({
+      start: tailSegs[0].start_time,
+      lastEnd: Math.max(...tailSegs.map(segEnd)),
+      speaker: turn.speaker,
+      segments: tailSegs,
+    });
+  }
+
+  return out;
 }
 
 /**
- * Group segments into flowing paragraphs with a leading timestamp, also
- * returning the source index range (into the returned `ordered` array) each
- * paragraph consumed. Callers that need incremental/streaming regrouping use
- * the ranges to know which segments a completed paragraph consumed, without
- * duplicating the break rules below.
- *
+ * Split a homogeneous (or non-diarized) segment stream into paragraphs.
  * Paragraphs only break at sentence boundaries, triggered by any of:
+ * - a speaker change when `breakOnSpeakerChange` is set
  * - a pause ≥ `pauseThreshold` seconds before the next segment
  * - the paragraph already holds MAX_SENTENCES_PER_PARAGRAPH sentences
  * - the paragraph exceeds SOFT_MAX_CHARS
- * So continuous speech without pauses still yields readable paragraphs.
  * Streams with no punctuation at all fall back to a hard length cap.
  *
- * Works across engines: Kyutai emits one segment per word, Whisper and
- * Parakeet emit sentence/window segments. Negative gaps (legacy data with
- * window-relative timestamps) never trigger a pause break.
+ * Negative gaps (legacy data with window-relative timestamps) never trigger
+ * a pause break.
  */
-export function groupIntoParagraphsWithRanges(
+function paragraphsFromSegments(
   segments: TranscriptionSegment[],
   pauseThreshold: number,
-): { paragraphs: Paragraph[]; ranges: ParagraphRange[]; ordered: TranscriptionSegment[] } {
-  if (segments.length === 0) return { paragraphs: [], ranges: [], ordered: segments };
-
-  // Diarized meetings tag each segment with a speaker. Mic (Me) and system
-  // audio (Them) are transcribed independently, so order by time first, then
-  // cluster into per-speaker turns so crosstalk reads as flowing phrases
-  // instead of breaking on every speaker change. Non-diarized streams are
-  // left exactly as emitted (legacy window-relative timestamps must not be
-  // reordered).
-  const diarized = segments.some((s) => s.speaker != null);
-  const ordered = diarized
-    ? clusterIntoTurns([...segments].sort((a, b) => a.start_time - b.start_time), pauseThreshold)
-    : segments;
+  breakOnSpeakerChange: boolean,
+): { paragraphs: Paragraph[]; ranges: ParagraphRange[] } {
+  if (segments.length === 0) return { paragraphs: [], ranges: [] };
 
   const paragraphs: Paragraph[] = [];
   const ranges: ParagraphRange[] = [];
   let rangeStart = 0;
-  let currentTimestamp = formatTimestamp(ordered[0].start_time);
-  let currentStartTime = ordered[0].start_time;
-  let currentSpeaker: Speaker | null = ordered[0].speaker ?? null;
+  let currentTimestamp = formatTimestamp(segments[0].start_time);
+  let currentStartTime = segments[0].start_time;
+  let currentSpeaker: Speaker | null = segments[0].speaker ?? null;
   let currentWords: string[] = [];
   let currentChars = 0;
   let sentenceCount = 0;
   let endsSentence = false;
-  let lastEnd = ordered[0].start_time;
+  let lastEnd = segments[0].start_time;
 
   const flush = (boundaryIndex: number, nextStart: number, nextSpeaker: Speaker | null) => {
     paragraphs.push({
@@ -174,8 +250,8 @@ export function groupIntoParagraphsWithRanges(
     endsSentence = false;
   };
 
-  for (let i = 0; i < ordered.length; i++) {
-    const seg = ordered[i];
+  for (let i = 0; i < segments.length; i++) {
+    const seg = segments[i];
     const text = seg.text.trim();
     // An empty segment carries no text but still occupies an index; it stays
     // part of whichever paragraph range is currently open (or the next one,
@@ -184,8 +260,7 @@ export function groupIntoParagraphsWithRanges(
     const speaker = seg.speaker ?? null;
 
     if (currentWords.length > 0) {
-      // A speaker change always starts a new paragraph (even mid-sentence).
-      if (diarized && speaker !== currentSpeaker) {
+      if (breakOnSpeakerChange && speaker !== currentSpeaker) {
         flush(i, seg.start_time, speaker);
       } else {
         const gap = seg.start_time - lastEnd;
@@ -208,7 +283,7 @@ export function groupIntoParagraphsWithRanges(
     currentChars += text.length + 1;
     sentenceCount += countSentenceEnds(text);
     endsSentence = SENTENCE_END.test(text);
-    lastEnd = Math.max(lastEnd, seg.end_time || seg.start_time);
+    lastEnd = Math.max(lastEnd, segEnd(seg));
   }
 
   if (currentWords.length > 0) {
@@ -218,7 +293,61 @@ export function groupIntoParagraphsWithRanges(
       text: currentWords.join(" "),
       speaker: currentSpeaker,
     });
-    ranges.push({ start: rangeStart, end: ordered.length });
+    ranges.push({ start: rangeStart, end: segments.length });
+  }
+
+  return { paragraphs, ranges };
+}
+
+/**
+ * Group segments into flowing paragraphs with a leading timestamp, also
+ * returning the source index range (into the returned `ordered` array) each
+ * paragraph consumed. Callers that need incremental/streaming regrouping use
+ * the ranges to know which segments a completed paragraph consumed, without
+ * duplicating the break rules below.
+ *
+ * Diarized meetings: cluster into per-speaker turns (keeping emission order
+ * within a lane), split each turn into readable paragraphs, then order those
+ * paragraphs by start time so an interruption lands between the two halves
+ * of a long turn instead of after every length-split of it.
+ *
+ * Non-diarized streams are left exactly as emitted (legacy window-relative
+ * timestamps must not be reordered).
+ */
+export function groupIntoParagraphsWithRanges(
+  segments: TranscriptionSegment[],
+  pauseThreshold: number,
+): { paragraphs: Paragraph[]; ranges: ParagraphRange[]; ordered: TranscriptionSegment[] } {
+  if (segments.length === 0) return { paragraphs: [], ranges: [], ordered: segments };
+
+  const diarized = segments.some((s) => s.speaker != null);
+  if (!diarized) {
+    const split = paragraphsFromSegments(segments, pauseThreshold, false);
+    return { ...split, ordered: segments };
+  }
+
+  const turns = clusterIntoTurns(segments, pauseThreshold);
+  const pieces: { paragraph: Paragraph; segs: TranscriptionSegment[] }[] = [];
+  for (const turn of turns) {
+    const split = paragraphsFromSegments(turn.segments, pauseThreshold, false);
+    for (let i = 0; i < split.paragraphs.length; i++) {
+      pieces.push({
+        paragraph: split.paragraphs[i],
+        segs: turn.segments.slice(split.ranges[i].start, split.ranges[i].end),
+      });
+    }
+  }
+
+  pieces.sort((a, b) => a.paragraph.startTime - b.paragraph.startTime);
+
+  const paragraphs: Paragraph[] = [];
+  const ranges: ParagraphRange[] = [];
+  const ordered: TranscriptionSegment[] = [];
+  for (const piece of pieces) {
+    const start = ordered.length;
+    ordered.push(...piece.segs);
+    paragraphs.push(piece.paragraph);
+    ranges.push({ start, end: ordered.length });
   }
 
   return { paragraphs, ranges, ordered };


### PR DESCRIPTION
A whole speaker turn was flattened before it was split into paragraphs, so an interruption landed after the rest of that turn. Words from the same person were also sorted by timestamp, which zippered overlapping fragments into salad.

## What this changes

- Each turn splits into paragraphs first; those paragraphs then sort by start time, so an interruption sits where it was spoken.
- A speaker's own words keep arrival order. Across speakers, overlapping talk still merges.
- An interrupted monologue closes at the next sentence end or after a second of overlap, but only if that turn has already lasted two seconds (short crosstalk stays one paragraph).
- Live transcript follows an eight-second window instead of freezing after two paragraphs.
- Kyutai waits for `EndWord` so pause gaps are real instead of start-to-start.

## Test plan

- [x] Vitest: paragraph grouping + live transcript
- [x] `cargo test --lib export::tests` and `engine::kyutai::tests`
- [x] Local meeting: interrupted speaker lands in time order, not after the whole monologue
- [ ] Same-speaker overlapping fragments stay in speaking order (no zipper salad)
- [ ] Sequential handoff still splits around 350ms