### PR TITLE
Add first-run setup wizard

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "generate:types": "cargo test export_typescript_bindings --manifest-path src-tauri/Cargo.toml -- --nocapture",
     "check:generated-types": "npm run generate:types && git diff --exit-code src/lib/types/generated.ts src/lib/api/generated.ts",
     "tauri": "tauri",
+    "dev:fresh": "./scripts/dev-fresh.sh",
     "test": "vitest run",
     "test:e2e": "playwright test"
   },

--- a/scripts/dev-fresh.sh
+++ b/scripts/dev-fresh.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Wipe Soufflé local state and start the dev app (first-run wizard).
+set -euo pipefail
+
+DATA_DIR="${HOME}/Library/Application Support/com.souffle.desktop"
+LEGACY_DIR="${HOME}/Library/Application Support/com.souffle.app"
+WEBKIT_DIR="${HOME}/Library/WebKit/com.souffle.desktop"
+
+echo "Removing app data:"
+for dir in "$DATA_DIR" "$LEGACY_DIR" "$WEBKIT_DIR"; do
+  if [[ -d "$dir" ]]; then
+    echo "  $dir"
+    rm -rf "$dir"
+  fi
+done
+
+echo "Starting Tauri dev (first launch)…"
+exec npm run tauri dev

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -13,9 +13,7 @@
   import { bootstrapAppState } from "./lib/bootstrap";
   import { getSelectedTranscriptionModel } from "./lib/features/transcription/catalog";
   import OnboardingView from "./lib/features/onboarding/OnboardingView.svelte";
-  import PermissionsOnboarding from "./lib/features/onboarding/PermissionsOnboarding.svelte";
   import WhatsNewDialog from "./lib/features/onboarding/WhatsNewDialog.svelte";
-  import UpdateAvailableDialog from "./lib/features/onboarding/UpdateAvailableDialog.svelte";
   import {
     notifyMeetingAborted,
     notifyMeetingFinalized,
@@ -30,6 +28,7 @@
   import { getAppState } from "./lib/stores/app.svelte";
   import { applyTheme, errorMessage } from "./lib/utils";
   import { micToast, micToastCopy } from "./lib/features/audio/mic-toast.svelte";
+  import { decideShowSetupWizard, readSetupFlags } from "./lib/features/onboarding/setup";
 
   const app = getAppState();
   // Mounted app-level so the global dictation shortcut works whatever view
@@ -37,7 +36,6 @@
   const transcription = createTranscriptionController();
 
   let unlistenNav: (() => void) | null = null;
-  let unlistenUpdate: (() => void) | null = null;
   let unlistenState: (() => void) | null = null;
   let unlistenHealth: (() => void) | null = null;
   let unlistenPipelineError: (() => void) | null = null;
@@ -60,13 +58,7 @@
   const routeToast = $derived(micToast.current);
   const routeToastCopy = $derived(routeToast ? micToastCopy(routeToast, $t) : null);
   let isRecovering = $state(false);
-  let showPermissions = $state(false);
   let whatsNew = $state<{ version: string; releaseNotes: string } | null>(null);
-  let updateAvailable = $state<{
-    version: string;
-    releaseNotes: string | null;
-    releaseUrl: string | null;
-  } | null>(null);
   let modelLabel = $state("");
 
   const isLightTheme = $derived(
@@ -123,7 +115,10 @@
           });
         }
       } catch {
-        // First run, no settings yet.
+        // First run, no settings yet — still offer the setup wizard.
+        if (decideShowSetupWizard("download_required", readSetupFlags())) {
+          app.showOnboarding = true;
+        }
       }
       cleanupTranscription = (await transcription.mount()) ?? (() => {});
       try {
@@ -137,26 +132,6 @@
         // Header chip simply omits the model name.
       }
     })();
-
-    // First-run permissions walkthrough (mic, system audio, accessibility) so
-    // the user grants everything up front instead of hitting prompts piecemeal.
-    try {
-      showPermissions = localStorage.getItem("permissionsOnboarded") !== "1";
-    } catch {
-      showPermissions = false;
-    }
-
-    events.updateAvailable.listen((event) => {
-      // The backend emits at most once per launch per version, so this never
-      // reopens a dialog the user has dismissed.
-      updateAvailable = {
-        version: event.payload.latest_version,
-        releaseNotes: event.payload.release_notes,
-        releaseUrl: event.payload.release_url,
-      };
-    }).then((fn) => {
-      unlistenUpdate = fn;
-    });
 
     events.navigate.listen((event) => {
       if (event.payload === "settings") {
@@ -247,7 +222,6 @@
     return () => {
       cleanupTranscription();
       unlistenNav?.();
-      unlistenUpdate?.();
       unlistenState?.();
       unlistenHealth?.();
       unlistenPipelineError?.();
@@ -402,24 +376,11 @@
 
 {/if}
 
-{#if showPermissions}
-  <PermissionsOnboarding onClose={() => (showPermissions = false)} />
-{/if}
-
-{#if whatsNew}
+{#if whatsNew && !app.showOnboarding}
   <WhatsNewDialog
     version={whatsNew.version}
     releaseNotes={whatsNew.releaseNotes}
     onDismiss={dismissWhatsNew}
-  />
-{/if}
-
-{#if updateAvailable}
-  <UpdateAvailableDialog
-    version={updateAvailable.version}
-    releaseNotes={updateAvailable.releaseNotes}
-    releaseUrl={updateAvailable.releaseUrl}
-    onDismiss={() => (updateAvailable = null)}
   />
 {/if}
 

--- a/src/lib/bootstrap.test.ts
+++ b/src/lib/bootstrap.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getSettings, saveSettings, getAppVersion, runStartupModelFlow } = vi.hoisted(() => ({
+  getSettings: vi.fn(),
+  saveSettings: vi.fn(),
+  getAppVersion: vi.fn(),
+  runStartupModelFlow: vi.fn(),
+}));
+
+vi.mock("./api/settings", () => ({
+  getSettings,
+  saveSettings,
+  selectAudioDevice: vi.fn(),
+}));
+vi.mock("./api/diagnostics", () => ({
+  getAppVersion,
+}));
+vi.mock("./api/transcription", () => ({
+  getMachineState: vi.fn().mockResolvedValue({ state: "idle" }),
+}));
+vi.mock("./features/transcription/runtime", () => ({
+  runStartupModelFlow,
+}));
+vi.mock("./utils/theme", () => ({
+  applyTheme: vi.fn(),
+}));
+
+import { bootstrapAppState } from "./bootstrap";
+import { getAppState } from "./stores/app.svelte";
+import { mockSettings } from "./test-helpers/fixtures";
+import { SETUP_STORAGE_KEY } from "./features/onboarding/setup";
+
+describe("bootstrapAppState what's new", () => {
+  const app = getAppState();
+
+  beforeEach(() => {
+    localStorage.clear();
+    app.settings = { ...mockSettings };
+    app.showOnboarding = false;
+    getSettings.mockResolvedValue({ ...mockSettings });
+    saveSettings.mockResolvedValue(undefined);
+    getAppVersion.mockResolvedValue("0.4.0");
+    runStartupModelFlow.mockResolvedValue(undefined);
+  });
+
+  it("never shows the changelog on a first launch", async () => {
+    const result = await bootstrapAppState(app);
+    expect(result.whatsNew).toBeNull();
+    expect(saveSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ last_seen_version: "0.4.0" }),
+    );
+  });
+
+  it("never shows the changelog while setup is unfinished, even after a version bump", async () => {
+    getSettings.mockResolvedValue({ ...mockSettings, last_seen_version: "0.3.0" });
+    getAppVersion.mockResolvedValue("0.4.0");
+
+    const result = await bootstrapAppState(app);
+    expect(result.whatsNew).toBeNull();
+    expect(saveSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ last_seen_version: "0.4.0" }),
+    );
+  });
+
+  it("shows the changelog after setup when the version changed", async () => {
+    localStorage.setItem(SETUP_STORAGE_KEY, "1");
+    getSettings.mockResolvedValue({ ...mockSettings, last_seen_version: "0.3.0" });
+    getAppVersion.mockResolvedValue("0.4.0");
+
+    const result = await bootstrapAppState(app);
+    expect(result.whatsNew).toEqual({
+      version: "0.4.0",
+      releaseNotes: "Updated to v0.4.0.",
+    });
+  });
+
+  it("does not show the changelog when setup is done and the version is unchanged", async () => {
+    localStorage.setItem(SETUP_STORAGE_KEY, "1");
+    getSettings.mockResolvedValue({ ...mockSettings, last_seen_version: "0.4.0" });
+
+    const result = await bootstrapAppState(app);
+    expect(result.whatsNew).toBeNull();
+  });
+});

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -2,6 +2,7 @@ import { getSettings, saveSettings, selectAudioDevice } from "./api/settings";
 import { getAppVersion } from "./api/diagnostics";
 import { getMachineState } from "./api/transcription";
 import { runStartupModelFlow } from "./features/transcription/runtime";
+import { readSetupFlags } from "./features/onboarding/setup";
 import { setLocale } from "./i18n";
 import { getAppState } from "./stores/app.svelte";
 import { applyTheme } from "./utils/theme";
@@ -35,17 +36,22 @@ export async function bootstrapAppState(
   }
 
   // Zero-ceremony startup: auto-load the last-selected model, or show
-  // first-run onboarding when no model is downloaded yet.
+  // the first-run setup wizard when the user hasn't finished onboarding
+  // (or when no model is downloaded yet).
   await runStartupModelFlow(app);
 
   const currentVersion = await getAppVersion();
-  const previousVersion = settings.last_seen_version.trim();
+  const previousVersion = app.settings.last_seen_version.trim();
+  const setupDone = readSetupFlags().setupDone;
 
-  if (!previousVersion) {
-    // Brand-new install: record version silently, no What's New dialog.
-    if (settings.last_seen_version !== currentVersion) {
-      await saveSettings({ ...settings, last_seen_version: currentVersion });
-      app.settings = { ...app.settings, last_seen_version: currentVersion };
+  // First launch and unfinished setup: stamp the version silently so the
+  // changelog never stacks on the wizard, and so finishing setup doesn't
+  // immediately pop it either.
+  if (!previousVersion || !setupDone) {
+    if (app.settings.last_seen_version !== currentVersion) {
+      const next = { ...app.settings, last_seen_version: currentVersion };
+      await saveSettings(next);
+      app.settings = next;
     }
     return { whatsNew: null };
   }

--- a/src/lib/features/onboarding/OnboardingView.svelte
+++ b/src/lib/features/onboarding/OnboardingView.svelte
@@ -1,34 +1,58 @@
 <script lang="ts">
+  import { Download, Keyboard, Lock, Mic, RefreshCw } from "@lucide/svelte";
   import { onMount } from "svelte";
-  import { Download, Lock } from "@lucide/svelte";
-  import { t } from "svelte-i18n";
+  import { locale, t } from "svelte-i18n";
   import ProgressBar from "../../components/ui/ProgressBar.svelte";
   import Spinner from "../../components/ui/Spinner.svelte";
   import StatusBanner from "../../components/ui/StatusBanner.svelte";
+  import { SUPPORTED_LOCALES } from "../../i18n";
   import { createOnboardingController } from "./controller.svelte";
+  import PermissionsStep from "./PermissionsStep.svelte";
 
   const controller = createOnboardingController();
   const app = controller.app;
 
-  const isDownloading = $derived(app.transcriptionModelOperationState === "downloading");
-  const isLoading = $derived(app.transcriptionModelOperationState === "loading");
-  const busy = $derived(controller.isStarting || isDownloading || isLoading);
+  const titles = {
+    permissions: "permissions.title",
+    microphone: "onboarding.mic_title",
+    model: "onboarding.model_title",
+    shortcut: "onboarding.shortcut_title",
+  } as const;
 
-  // The model is ready: onboarding is done.
-  $effect(() => {
-    if (app.transcriptionRuntimePhase === "ready") {
-      app.showOnboarding = false;
+  const subtitles = {
+    permissions: "permissions.subtitle",
+    microphone: "onboarding.mic_subtitle",
+    model: "onboarding.model_hint",
+    shortcut: "onboarding.shortcut_subtitle",
+  } as const;
+
+  const continueLabel = $derived(
+    controller.stepIndex === controller.steps.length - 1
+      && (controller.step !== "model" || controller.modelReady)
+      ? $t("onboarding.finish")
+      : controller.step === "model" && !controller.modelReady
+        ? $t("onboarding.start_button")
+        : $t("onboarding.continue"),
+  );
+
+  function onContinue() {
+    if (controller.step === "model" && !controller.modelReady) {
+      void controller.beginDownload();
+      return;
     }
-  });
+    void controller.goNext();
+  }
 
   onMount(() => {
     void controller.mount();
   });
 </script>
 
+<svelte:window onkeydown={(event) => controller.handleKeyDown(event)} />
+
 <div class="flex h-screen items-center justify-center p-8">
-  <div class="surface-card flex w-full max-w-md flex-col gap-6 p-8 text-center">
-    <div class="flex flex-col items-center gap-3">
+  <div class="surface-card flex w-full max-w-lg flex-col gap-6 p-8">
+    <div class="flex flex-col items-center gap-3 text-center">
       <img src="/favicon.svg" alt="" class="h-16 w-16 rounded-2xl" aria-hidden="true" />
       <h1 class="font-heading text-2xl font-bold">Soufflé</h1>
       <p class="text-text-secondary text-sm">{$t("onboarding.tagline")}</p>
@@ -36,53 +60,177 @@
         <Lock size={12} aria-hidden="true" />
         {$t("onboarding.local_note")}
       </p>
+      <div class="flex gap-1" role="group" aria-label={$t("settings_interface.language")}>
+        {#each SUPPORTED_LOCALES as loc}
+          <button
+            type="button"
+            class={`btn px-2.5 py-1 text-xs ${$locale === loc.id ? "btn-active" : ""}`}
+            onclick={() => void controller.onLocaleChange(loc.id)}
+          >
+            {loc.label}
+          </button>
+        {/each}
+      </div>
+    </div>
+
+    {#if controller.steps.length > 1}
+      <div
+        class="flex justify-center gap-1.5"
+        role="progressbar"
+        aria-valuemin={1}
+        aria-valuemax={controller.steps.length}
+        aria-valuenow={controller.stepIndex + 1}
+        aria-label={$t("onboarding.step_progress", {
+          values: { current: controller.stepIndex + 1, total: controller.steps.length },
+        })}
+      >
+        {#each controller.steps as _, i}
+          <span
+            class={`h-1.5 w-6 rounded-full ${i === controller.stepIndex ? "bg-accent" : "bg-surface-3"}`}
+          ></span>
+        {/each}
+      </div>
+    {/if}
+
+    <div class="flex flex-col gap-1 text-left">
+      <h2 class="font-heading text-lg font-semibold">{$t(titles[controller.step])}</h2>
+      <p class="text-sm text-text-muted">{$t(subtitles[controller.step])}</p>
     </div>
 
     {#if controller.statusMessage}
       <StatusBanner message={controller.statusMessage} variant="warning" />
     {/if}
 
-    {#if isDownloading}
-      <div class="flex flex-col gap-2 text-left">
-        <p class="text-sm text-text-secondary">{$t("onboarding.downloading")}</p>
-        <ProgressBar
-          value={app.downloadedBytes}
-          max={app.downloadTotalBytes ?? Math.max(app.downloadedBytes, 1)}
-          label={$t("onboarding.downloading")}
-        />
-        {#if app.downloadFile}
-          <p class="truncate text-xs text-text-muted">{app.downloadFile}</p>
-        {/if}
+    {#if controller.step === "permissions"}
+      <PermissionsStep />
+    {:else if controller.step === "microphone"}
+      <div class="flex flex-col gap-3 text-left">
+        <div class="flex items-center gap-2">
+          <Mic size={16} class="shrink-0 text-text-muted" aria-hidden="true" />
+          <select
+            id="onboarding-mic"
+            class="field-select min-w-0 flex-1"
+            value={controller.selectedDevice}
+            onchange={(event) => void controller.onDeviceChange(event)}
+          >
+            <option value="">{$t("settings_audio.input_device_automatic")}</option>
+            {#each controller.audioDevices as device}
+              <option value={device.uid}>
+                {device.name}{device.is_default ? ` ${$t("settings_audio.device_default_suffix")}` : ""}
+              </option>
+            {/each}
+          </select>
+          <button
+            type="button"
+            class="btn btn-icon"
+            aria-label={$t("settings_audio.refresh_devices")}
+            onclick={() => void controller.refreshDevices()}
+          >
+            <RefreshCw size={16} />
+          </button>
+        </div>
+        <p class="text-xs text-text-muted">{$t("onboarding.mic_hint")}</p>
       </div>
-    {:else if isLoading}
-      <div class="flex items-center justify-center gap-2 text-sm text-text-secondary">
-        <Spinner />
-        {$t("onboarding.loading")}
-      </div>
+    {:else if controller.step === "model"}
+      {#if controller.isDownloading}
+        <div class="flex flex-col gap-2 text-left">
+          <p class="text-sm text-text-secondary">{$t("onboarding.downloading")}</p>
+          <ProgressBar
+            value={app.downloadedBytes}
+            max={app.downloadTotalBytes ?? Math.max(app.downloadedBytes, 1)}
+            label={$t("onboarding.downloading")}
+          />
+          {#if app.downloadFile}
+            <p class="truncate text-xs text-text-muted">{app.downloadFile}</p>
+          {/if}
+        </div>
+      {:else if controller.isLoading}
+        <div class="flex items-center justify-center gap-2 text-sm text-text-secondary">
+          <Spinner />
+          {$t("onboarding.loading")}
+        </div>
+      {:else if controller.modelReady}
+        <p class="text-sm text-text-secondary">{$t("onboarding.model_ready")}</p>
+      {:else}
+        <div class="flex flex-col gap-2 text-left">
+          <label for="onboarding-model" class="field-label">{$t("onboarding.model_label")}</label>
+          <select
+            id="onboarding-model"
+            class="field-select"
+            bind:value={controller.selectedKey}
+            disabled={controller.busy}
+          >
+            {#each controller.options as option}
+              <option value={option.key}>{option.label}</option>
+            {/each}
+          </select>
+        </div>
+      {/if}
     {:else}
-      <div class="flex flex-col gap-2 text-left">
-        <label for="onboarding-model" class="field-label">{$t("onboarding.model_label")}</label>
-        <select
-          id="onboarding-model"
-          class="field-select"
-          bind:value={controller.selectedKey}
-          disabled={busy}
-        >
-          {#each controller.options as option}
-            <option value={option.key}>{option.label}</option>
-          {/each}
-        </select>
-        <p class="text-xs text-text-muted">{$t("onboarding.model_hint")}</p>
+      <div class="flex flex-col gap-4 text-left">
+        <div class="flex items-center gap-3">
+          <Keyboard size={16} class="shrink-0 text-text-muted" aria-hidden="true" />
+          <button
+            type="button"
+            class="shortcut-button flex-1"
+            class:is-recording={controller.recordingShortcut}
+            onclick={() => controller.startShortcutRecording()}
+          >
+            {controller.recordingShortcut
+              ? $t("settings_interface.press_keys")
+              : controller.formatShortcut(controller.toggleShortcut) || $t("onboarding.shortcut_unset")}
+          </button>
+        </div>
+        <p class="text-xs text-text-muted">{$t("onboarding.shortcut_hint")}</p>
+        {#if controller.shortcutError}
+          <StatusBanner message={$t("onboarding.shortcut_needs_modifier")} variant="danger" />
+        {/if}
+        <label class="flex items-start justify-between gap-4">
+          <span class="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span class="setting-label">{$t("settings_interface.auto_paste")}</span>
+            <span class="setting-desc">{$t("onboarding.auto_paste_desc")}</span>
+          </span>
+          <input
+            type="checkbox"
+            class="switch"
+            checked={controller.autoPaste}
+            onchange={(event) => {
+              controller.autoPaste = (event.currentTarget as HTMLInputElement).checked;
+            }}
+            aria-label={$t("settings_interface.auto_paste")}
+          />
+        </label>
       </div>
+    {/if}
+
+    <div class="flex items-center gap-3">
+      {#if controller.stepIndex > 0}
+        <button
+          type="button"
+          class="btn btn-ghost"
+          disabled={controller.busy}
+          onclick={() => controller.goBack()}
+        >
+          {$t("onboarding.back")}
+        </button>
+      {:else if controller.step === "permissions"}
+        <span class="text-xs text-text-muted">{$t("permissions.skip_hint")}</span>
+      {/if}
 
       <button
-        class="btn btn-primary justify-center gap-2"
-        disabled={busy || !controller.selectedKey}
-        onclick={() => void controller.begin()}
+        type="button"
+        class="btn btn-primary ml-auto justify-center gap-2"
+        disabled={controller.busy || (controller.step === "model" && !controller.modelReady && !controller.selectedKey)}
+        onclick={onContinue}
       >
-        <Download size={16} aria-hidden="true" />
-        {$t("onboarding.start_button")}
+        {#if controller.step === "model" && !controller.modelReady && !controller.isDownloading && !controller.isLoading}
+          <Download size={16} aria-hidden="true" />
+        {/if}
+        {#if controller.busy && controller.step === "model"}
+          <Spinner />
+        {/if}
+        {continueLabel}
       </button>
-    {/if}
+    </div>
   </div>
 </div>

--- a/src/lib/features/onboarding/PermissionsOnboarding.svelte
+++ b/src/lib/features/onboarding/PermissionsOnboarding.svelte
@@ -1,124 +1,14 @@
 <script lang="ts">
-  import { Accessibility, Check, Mic, Volume2 } from "@lucide/svelte";
-  import { onMount } from "svelte";
   import { t } from "svelte-i18n";
-  import Spinner from "../../components/ui/Spinner.svelte";
-  import {
-    getPermissionStatus,
-    repairAccessibilityPermission,
-    requestPermission,
-    type PermissionKind,
-  } from "../../api/permissions";
-  import type { PermissionStatus, PermState } from "../../types";
-  import { errorMessage } from "../../utils";
+  import PermissionsStep from "./PermissionsStep.svelte";
+  import { markPermissionsDone } from "./setup";
 
   let { onClose }: { onClose: () => void } = $props();
 
-  let status = $state<PermissionStatus>({
-    microphone: "unknown",
-    system_audio: "unknown",
-    accessibility: "unknown",
-    calendar: "unknown",
-  });
-  let busy = $state<PermissionKind | null>(null);
-  let error = $state("");
-  let repairing = $state(false);
-
-  type Row = {
-    kind: PermissionKind;
-    icon: typeof Mic;
-    label: string;
-    desc: string;
-    action: string;
-  };
-
-  const rows = $derived<Row[]>([
-    {
-      kind: "microphone",
-      icon: Mic,
-      label: $t("permissions.mic_label"),
-      desc: $t("permissions.mic_desc"),
-      action: $t("permissions.grant"),
-    },
-    {
-      kind: "system_audio",
-      icon: Volume2,
-      label: $t("permissions.system_label"),
-      desc: $t("permissions.system_desc"),
-      action: $t("permissions.grant"),
-    },
-    {
-      kind: "accessibility",
-      icon: Accessibility,
-      label: $t("permissions.accessibility_label"),
-      desc: $t("permissions.accessibility_desc"),
-      action: $t("permissions.open_settings"),
-    },
-  ]);
-
-  function stateOf(kind: PermissionKind): PermState {
-    return status[kind];
-  }
-
-  async function refreshAll() {
-    try {
-      status = await getPermissionStatus();
-    } catch (e) {
-      error = errorMessage(e);
-    }
-  }
-
-  async function grant(kind: PermissionKind) {
-    busy = kind;
-    error = "";
-    try {
-      const next = await requestPermission(kind);
-      status = { ...status, [kind]: next };
-    } catch (e) {
-      error = errorMessage(e);
-    } finally {
-      busy = null;
-    }
-  }
-
-  async function repairAccessibility() {
-    repairing = true;
-    error = "";
-    try {
-      const next = await repairAccessibilityPermission();
-      status = { ...status, accessibility: next };
-    } catch (e) {
-      error = errorMessage(e);
-    } finally {
-      repairing = false;
-    }
-  }
-
   function finish() {
-    try {
-      localStorage.setItem("permissionsOnboarded", "1");
-    } catch {
-      // Private mode / storage disabled — onboarding just shows again next time.
-    }
+    markPermissionsDone();
     onClose();
   }
-
-  onMount(() => {
-    void refreshAll();
-    // Accessibility is granted in System Settings (not via an in-app prompt),
-    // so re-check it whenever the window regains focus. Microphone and system
-    // audio keep their probed result — re-snapshotting would reset them to
-    // "unknown" since snapshot() deliberately doesn't probe.
-    const onFocus = () => {
-      void getPermissionStatus()
-        .then((s) => {
-          status = { ...status, accessibility: s.accessibility };
-        })
-        .catch(() => {});
-    };
-    window.addEventListener("focus", onFocus);
-    return () => window.removeEventListener("focus", onFocus);
-  });
 </script>
 
 <div
@@ -133,64 +23,7 @@
       <p class="text-sm text-text-muted">{$t("permissions.subtitle")}</p>
     </div>
 
-    <div class="flex flex-col gap-2">
-      {#each rows as row (row.kind)}
-        {@const s = stateOf(row.kind)}
-        <div class="flex flex-col gap-2 rounded-lg bg-surface-1/70 p-3">
-          <div class="flex items-center gap-3">
-            <row.icon size={20} class="shrink-0 text-text-muted" aria-hidden="true" />
-            <div class="min-w-0 flex-1">
-              <div class="text-sm font-medium text-text-primary">{row.label}</div>
-              <div class="text-xs text-text-muted">{row.desc}</div>
-            </div>
-
-            {#if s === "granted"}
-              <span class="pill pill-accent inline-flex items-center gap-1">
-                <Check size={13} aria-hidden="true" />
-                {$t("permissions.granted")}
-              </span>
-            {:else if s === "unsupported"}
-              <span class="pill pill-muted">{$t("permissions.not_supported")}</span>
-            {:else}
-              <button
-                class="btn btn-primary shrink-0 gap-1.5"
-                disabled={busy !== null}
-                onclick={() => grant(row.kind)}
-              >
-                {#if busy === row.kind}
-                  <Spinner />
-                  {$t("permissions.checking")}
-                {:else}
-                  {row.action}
-                {/if}
-              </button>
-            {/if}
-          </div>
-
-          {#if row.kind === "accessibility" && s === "denied"}
-            <div class="flex items-center justify-between gap-3 pl-8">
-              <p class="text-xs text-text-muted">{$t("permissions.accessibility_stale_hint")}</p>
-              <button
-                class="btn btn-ghost shrink-0 gap-1.5"
-                disabled={repairing || busy !== null}
-                onclick={repairAccessibility}
-              >
-                {#if repairing}
-                  <Spinner />
-                  {$t("permissions.checking")}
-                {:else}
-                  {$t("permissions.repair")}
-                {/if}
-              </button>
-            </div>
-          {/if}
-        </div>
-      {/each}
-    </div>
-
-    {#if error}
-      <p class="text-sm text-red-400">{error}</p>
-    {/if}
+    <PermissionsStep />
 
     <div class="flex items-center justify-between gap-3">
       <span class="text-xs text-text-muted">{$t("permissions.skip_hint")}</span>

--- a/src/lib/features/onboarding/PermissionsStep.svelte
+++ b/src/lib/features/onboarding/PermissionsStep.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+  import { Accessibility, Check, Mic, Volume2 } from "@lucide/svelte";
+  import { onMount } from "svelte";
+  import { t } from "svelte-i18n";
+  import Spinner from "../../components/ui/Spinner.svelte";
+  import {
+    getPermissionStatus,
+    repairAccessibilityPermission,
+    requestPermission,
+    type PermissionKind,
+  } from "../../api/permissions";
+  import type { PermissionStatus, PermState } from "../../types";
+  import { errorMessage } from "../../utils";
+
+  let status = $state<PermissionStatus>({
+    microphone: "unknown",
+    system_audio: "unknown",
+    accessibility: "unknown",
+    calendar: "unknown",
+  });
+  let busy = $state<PermissionKind | null>(null);
+  let error = $state("");
+  let repairing = $state(false);
+
+  type Row = {
+    kind: PermissionKind;
+    icon: typeof Mic;
+    label: string;
+    desc: string;
+    action: string;
+  };
+
+  const rows = $derived<Row[]>([
+    {
+      kind: "microphone",
+      icon: Mic,
+      label: $t("permissions.mic_label"),
+      desc: $t("permissions.mic_desc"),
+      action: $t("permissions.grant"),
+    },
+    {
+      kind: "system_audio",
+      icon: Volume2,
+      label: $t("permissions.system_label"),
+      desc: $t("permissions.system_desc"),
+      action: $t("permissions.grant"),
+    },
+    {
+      kind: "accessibility",
+      icon: Accessibility,
+      label: $t("permissions.accessibility_label"),
+      desc: $t("permissions.accessibility_desc"),
+      action: $t("permissions.open_settings"),
+    },
+  ]);
+
+  function stateOf(kind: PermissionKind): PermState {
+    return status[kind];
+  }
+
+  async function refreshAll() {
+    try {
+      status = await getPermissionStatus();
+    } catch (e) {
+      error = errorMessage(e);
+    }
+  }
+
+  async function grant(kind: PermissionKind) {
+    busy = kind;
+    error = "";
+    try {
+      const next = await requestPermission(kind);
+      status = { ...status, [kind]: next };
+    } catch (e) {
+      error = errorMessage(e);
+    } finally {
+      busy = null;
+    }
+  }
+
+  async function repairAccessibility() {
+    repairing = true;
+    error = "";
+    try {
+      const next = await repairAccessibilityPermission();
+      status = { ...status, accessibility: next };
+    } catch (e) {
+      error = errorMessage(e);
+    } finally {
+      repairing = false;
+    }
+  }
+
+  onMount(() => {
+    void refreshAll();
+    // Accessibility is granted in System Settings (not via an in-app prompt),
+    // so re-check it whenever the window regains focus. Microphone and system
+    // audio keep their probed result — re-snapshotting would reset them to
+    // "unknown" since snapshot() deliberately doesn't probe.
+    const onFocus = () => {
+      void getPermissionStatus()
+        .then((s) => {
+          status = { ...status, accessibility: s.accessibility };
+        })
+        .catch(() => {});
+    };
+    window.addEventListener("focus", onFocus);
+    return () => window.removeEventListener("focus", onFocus);
+  });
+</script>
+
+<div class="flex flex-col gap-2">
+  {#each rows as row (row.kind)}
+    {@const s = stateOf(row.kind)}
+    <div class="flex flex-col gap-2 rounded-lg bg-surface-1/70 p-3">
+      <div class="flex items-center gap-3">
+        <row.icon size={20} class="shrink-0 text-text-muted" aria-hidden="true" />
+        <div class="min-w-0 flex-1">
+          <div class="text-sm font-medium text-text-primary">{row.label}</div>
+          <div class="text-xs text-text-muted">{row.desc}</div>
+        </div>
+
+        {#if s === "granted"}
+          <span class="pill pill-accent inline-flex items-center gap-1">
+            <Check size={13} aria-hidden="true" />
+            {$t("permissions.granted")}
+          </span>
+        {:else if s === "unsupported"}
+          <span class="pill pill-muted">{$t("permissions.not_supported")}</span>
+        {:else}
+          <button
+            class="btn btn-primary shrink-0 gap-1.5"
+            disabled={busy !== null}
+            onclick={() => grant(row.kind)}
+          >
+            {#if busy === row.kind}
+              <Spinner />
+              {$t("permissions.checking")}
+            {:else}
+              {row.action}
+            {/if}
+          </button>
+        {/if}
+      </div>
+
+      {#if row.kind === "accessibility" && s === "denied"}
+        <div class="flex items-center justify-between gap-3 pl-8">
+          <p class="text-xs text-text-muted">{$t("permissions.accessibility_stale_hint")}</p>
+          <button
+            class="btn btn-ghost shrink-0 gap-1.5"
+            disabled={repairing || busy !== null}
+            onclick={repairAccessibility}
+          >
+            {#if repairing}
+              <Spinner />
+              {$t("permissions.checking")}
+            {:else}
+              {$t("permissions.repair")}
+            {/if}
+          </button>
+        </div>
+      {/if}
+    </div>
+  {/each}
+</div>
+
+{#if error}
+  <p class="text-sm text-red-400">{error}</p>
+{/if}

--- a/src/lib/features/onboarding/controller.svelte.test.ts
+++ b/src/lib/features/onboarding/controller.svelte.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { transcriptionApi, settingsApi, startDownload } = vi.hoisted(() => ({
+  transcriptionApi: {
+    getTranscriptionCatalog: vi.fn(),
+  },
+  settingsApi: {
+    getSettings: vi.fn(),
+    saveSettings: vi.fn(),
+    getShortcuts: vi.fn(),
+    saveShortcuts: vi.fn(),
+    listAudioDevices: vi.fn(),
+    selectAudioDevice: vi.fn(),
+  },
+  startDownload: vi.fn(),
+}));
+
+vi.mock("../../api/transcription", () => transcriptionApi);
+vi.mock("../../api/settings", () => settingsApi);
+vi.mock("../transcription/runtime", () => ({
+  resetTranscriptionRuntimeState: vi.fn(),
+  startTranscriptionModelDownload: startDownload,
+}));
+
+import { createOnboardingController } from "./controller.svelte";
+import { getAppState } from "../../stores/app.svelte";
+import { mockCatalog, mockSettings, mockShortcuts } from "../../test-helpers/fixtures";
+import { PERMISSIONS_STORAGE_KEY, SETUP_STORAGE_KEY } from "./setup";
+
+const fakeDevices = [
+  { uid: "builtin-mic", name: "Built-in Microphone", transport: "built_in" as const, is_default: true },
+  { uid: "usb-mic", name: "External USB Mic", transport: "usb" as const, is_default: false },
+];
+
+describe("createOnboardingController", () => {
+  const app = getAppState();
+
+  beforeEach(() => {
+    localStorage.clear();
+    app.showOnboarding = true;
+    app.settings = { ...mockSettings };
+    app.selectedDevice = "";
+    app.transcriptionRuntimePhase = "download_required";
+    app.machineState = { state: "idle" };
+
+    transcriptionApi.getTranscriptionCatalog.mockResolvedValue(mockCatalog);
+    settingsApi.saveSettings.mockResolvedValue(undefined);
+    settingsApi.getShortcuts.mockResolvedValue({ ...mockShortcuts });
+    settingsApi.saveShortcuts.mockResolvedValue(undefined);
+    settingsApi.listAudioDevices.mockResolvedValue(fakeDevices);
+    settingsApi.selectAudioDevice.mockResolvedValue(undefined);
+    startDownload.mockResolvedValue(undefined);
+  });
+
+  it("starts on permissions and walks to shortcut", async () => {
+    const ctrl = createOnboardingController();
+    await ctrl.mount();
+
+    expect(ctrl.steps).toEqual(["permissions", "microphone", "model", "shortcut"]);
+    expect(ctrl.step).toBe("permissions");
+
+    await ctrl.goNext();
+    expect(localStorage.getItem(PERMISSIONS_STORAGE_KEY)).toBeNull();
+    expect(ctrl.step).toBe("microphone");
+
+    await ctrl.goNext();
+    expect(ctrl.step).toBe("model");
+  });
+
+  it("resumes at microphone when permissions were already granted", async () => {
+    localStorage.setItem(PERMISSIONS_STORAGE_KEY, "1");
+    const ctrl = createOnboardingController();
+    await ctrl.mount();
+    expect(ctrl.steps).toEqual(["microphone", "model", "shortcut"]);
+    expect(ctrl.step).toBe("microphone");
+  });
+
+  it("pins a microphone and persists it", async () => {
+    localStorage.setItem(PERMISSIONS_STORAGE_KEY, "1");
+    const ctrl = createOnboardingController();
+    await ctrl.mount();
+    expect(ctrl.audioDevices).toEqual(fakeDevices);
+
+    await ctrl.onDeviceChange({
+      currentTarget: { value: "usb-mic" },
+    } as unknown as Event);
+
+    expect(settingsApi.selectAudioDevice).toHaveBeenCalledWith("usb-mic");
+    expect(app.selectedDevice).toBe("usb-mic");
+    expect(settingsApi.saveSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ audio_device: "usb-mic" }),
+    );
+  });
+
+  it("starts the model download from the selected catalog option", async () => {
+    const ctrl = createOnboardingController();
+    await ctrl.mount();
+    expect(ctrl.selectedKey).toBe("kyutai:stt-1b-en_fr");
+
+    await ctrl.beginDownload();
+
+    expect(settingsApi.saveSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transcription_engine_id: "kyutai",
+        transcription_model_id: "stt-1b-en_fr",
+        transcription_backend_id: "candle",
+      }),
+    );
+    expect(startDownload).toHaveBeenCalled();
+  });
+
+  it("records a toggle shortcut", async () => {
+    const ctrl = createOnboardingController();
+    await ctrl.mount();
+    expect(ctrl.toggleShortcut).toBe("CommandOrControl+Shift+S");
+
+    ctrl.startShortcutRecording();
+    const event = new KeyboardEvent("keydown", {
+      key: " ",
+      code: "Space",
+      metaKey: true,
+      shiftKey: true,
+    });
+    Object.defineProperty(event, "preventDefault", { value: vi.fn() });
+    Object.defineProperty(event, "stopPropagation", { value: vi.fn() });
+    ctrl.handleKeyDown(event);
+
+    await vi.waitFor(() => {
+      expect(settingsApi.saveShortcuts).toHaveBeenCalledWith({
+        toggle: "CommandOrControl+Shift+Space",
+        push_to_talk: mockShortcuts.push_to_talk,
+        rewrite: mockShortcuts.rewrite,
+      });
+    });
+    expect(ctrl.recordingShortcut).toBe(false);
+  });
+
+  it("finishes by enabling auto-paste and marking setup complete", async () => {
+    localStorage.setItem(PERMISSIONS_STORAGE_KEY, "1");
+    const ctrl = createOnboardingController();
+    await ctrl.mount();
+    ctrl.autoPaste = true;
+
+    // Skip to shortcut: mic → model → shortcut would require model ready.
+    await ctrl.finish();
+
+    expect(settingsApi.saveSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ auto_paste: true }),
+    );
+    expect(localStorage.getItem(SETUP_STORAGE_KEY)).toBe("1");
+    expect(localStorage.getItem(PERMISSIONS_STORAGE_KEY)).toBe("1");
+    expect(app.showOnboarding).toBe(false);
+  });
+
+  it("blocks continue on the model step until the model is ready", async () => {
+    localStorage.setItem(PERMISSIONS_STORAGE_KEY, "1");
+    const ctrl = createOnboardingController();
+    await ctrl.mount();
+    await ctrl.goNext(); // microphone → model
+    expect(ctrl.step).toBe("model");
+    expect(ctrl.canContinue).toBe(false);
+
+    app.transcriptionRuntimePhase = "ready";
+    expect(ctrl.canContinue).toBe(true);
+  });
+});

--- a/src/lib/features/onboarding/controller.svelte.ts
+++ b/src/lib/features/onboarding/controller.svelte.ts
@@ -1,13 +1,27 @@
 import { getAppState } from "../../stores/app.svelte";
 import { getTranscriptionCatalog } from "../../api/transcription";
-import { saveSettings } from "../../api/settings";
-import type { AppSettings, TranscriptionCatalog } from "../../types";
-import { errorMessage } from "../../utils";
+import {
+  getShortcuts,
+  listAudioDevices,
+  saveSettings,
+  saveShortcuts,
+  selectAudioDevice,
+} from "../../api/settings";
+import { setLocale } from "../../i18n";
+import type { AppSettings, AudioInputDevice, TranscriptionCatalog } from "../../types";
+import { errorMessage, formatShortcutLabel } from "../../utils";
+import { keyEventToShortcut, shortcutMissingModifier } from "../../utils/shortcut";
 import { listAvailableModelOptions } from "../transcription/catalog";
 import {
   resetTranscriptionRuntimeState,
   startTranscriptionModelDownload,
 } from "../transcription/runtime";
+import {
+  markSetupComplete,
+  readSetupFlags,
+  wizardSteps,
+  type SetupStep,
+} from "./setup";
 
 export function createOnboardingController() {
   const app = getAppState();
@@ -17,9 +31,53 @@ export function createOnboardingController() {
   let statusMessage = $state("");
   let isStarting = $state(false);
 
+  let steps = $state<SetupStep[]>(wizardSteps(readSetupFlags()));
+  let stepIndex = $state(0);
+  let recoveryOnly = $state(readSetupFlags().setupDone);
+
+  let audioDevices = $state<AudioInputDevice[]>([]);
+  let selectedDevice = $state("");
+
+  let toggleShortcut = $state("CommandOrControl+Shift+Space");
+  let pushToTalk = $state("");
+  let rewrite = $state("");
+  let recordingShortcut = $state(false);
+  let shortcutError = $state("");
+  let autoPaste = $state(true);
+
   const options = $derived(listAvailableModelOptions(catalog));
+  const step = $derived(steps[stepIndex] ?? "permissions");
+  const isDownloading = $derived(app.transcriptionModelOperationState === "downloading");
+  const isLoading = $derived(app.transcriptionModelOperationState === "loading");
+  const modelReady = $derived(app.transcriptionRuntimePhase === "ready");
+  const busy = $derived(isStarting || isDownloading || isLoading);
+
+  const canContinue = $derived.by(() => {
+    switch (step) {
+      case "permissions":
+      case "microphone":
+      case "shortcut":
+        return true;
+      case "model":
+        return modelReady && !busy;
+    }
+  });
+
+  async function persistSettings(updater: (settings: AppSettings) => void) {
+    const nextSettings: AppSettings = { ...app.settings };
+    updater(nextSettings);
+    await saveSettings(nextSettings);
+    app.settings = nextSettings;
+  }
 
   async function mount() {
+    const flags = readSetupFlags();
+    recoveryOnly = flags.setupDone;
+    steps = wizardSteps(flags);
+    stepIndex = 0;
+    selectedDevice = app.selectedDevice;
+    autoPaste = true;
+
     try {
       catalog = await getTranscriptionCatalog();
       selectedKey = `${catalog.selected_engine_id}:${catalog.selected_model_id}`;
@@ -29,24 +87,73 @@ export function createOnboardingController() {
     } catch (e) {
       statusMessage = errorMessage(e);
     }
+
+    try {
+      audioDevices = await listAudioDevices();
+    } catch (e) {
+      statusMessage = errorMessage(e);
+    }
+
+    try {
+      const shortcuts = await getShortcuts();
+      toggleShortcut = shortcuts.toggle || "CommandOrControl+Shift+Space";
+      pushToTalk = shortcuts.push_to_talk;
+      rewrite = shortcuts.rewrite;
+    } catch {
+      // Keep the built-in default.
+    }
+  }
+
+  async function persistDevice(uid: string) {
+    try {
+      await selectAudioDevice(uid);
+      app.selectedDevice = uid;
+      await persistSettings((settings) => {
+        settings.audio_device = uid || null;
+      });
+    } catch (e) {
+      statusMessage = errorMessage(e);
+    }
+  }
+
+  async function onDeviceChange(event: Event) {
+    const uid = (event.currentTarget as HTMLSelectElement).value;
+    selectedDevice = uid;
+    await persistDevice(uid);
+  }
+
+  async function refreshDevices() {
+    try {
+      audioDevices = await listAudioDevices();
+    } catch (e) {
+      statusMessage = errorMessage(e);
+    }
+  }
+
+  async function onLocaleChange(locale: string) {
+    setLocale(locale);
+    try {
+      await persistSettings((settings) => {
+        settings.locale = locale;
+      });
+    } catch (e) {
+      statusMessage = errorMessage(e);
+    }
   }
 
   /** Persist the chosen model, then download and load it in one go. */
-  async function begin() {
+  async function beginDownload() {
     const option = options.find((candidate) => candidate.key === selectedKey);
-    if (!option || isStarting) return;
+    if (!option || isStarting || busy) return;
 
     isStarting = true;
     statusMessage = "";
     try {
-      const nextSettings: AppSettings = {
-        ...app.settings,
-        transcription_engine_id: option.engineId,
-        transcription_model_id: option.modelId,
-        transcription_backend_id: option.backendId,
-      };
-      await saveSettings(nextSettings);
-      app.settings = nextSettings;
+      await persistSettings((settings) => {
+        settings.transcription_engine_id = option.engineId;
+        settings.transcription_model_id = option.modelId;
+        settings.transcription_backend_id = option.backendId;
+      });
       resetTranscriptionRuntimeState(app);
 
       await startTranscriptionModelDownload(
@@ -59,8 +166,91 @@ export function createOnboardingController() {
       );
     } catch (e) {
       statusMessage = errorMessage(e);
+    } finally {
       isStarting = false;
     }
+  }
+
+  function startShortcutRecording() {
+    recordingShortcut = true;
+    shortcutError = "";
+  }
+
+  async function persistToggleShortcut(value: string) {
+    shortcutError = "";
+    toggleShortcut = value;
+    try {
+      await saveShortcuts({
+        toggle: value,
+        push_to_talk: pushToTalk,
+        rewrite,
+      });
+    } catch (e) {
+      shortcutError = errorMessage(e);
+    }
+  }
+
+  function handleKeyDown(event: KeyboardEvent) {
+    if (!recordingShortcut) return;
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (event.key === "Escape") {
+      recordingShortcut = false;
+      return;
+    }
+
+    if (event.key === "Backspace" || event.key === "Delete") {
+      recordingShortcut = false;
+      void persistToggleShortcut("");
+      return;
+    }
+
+    const shortcut = keyEventToShortcut(event);
+    if (!shortcut) return;
+
+    if (shortcutMissingModifier(event)) {
+      shortcutError = "modifier";
+      return;
+    }
+
+    recordingShortcut = false;
+    void persistToggleShortcut(shortcut);
+  }
+
+  async function goNext() {
+    if (!canContinue) return;
+    if (stepIndex >= steps.length - 1) {
+      await finish();
+      return;
+    }
+    stepIndex += 1;
+  }
+
+  function goBack() {
+    if (stepIndex === 0) return;
+    recordingShortcut = false;
+    stepIndex -= 1;
+  }
+
+  async function finish() {
+    try {
+      if (!recoveryOnly) {
+        await persistSettings((settings) => {
+          settings.auto_paste = autoPaste;
+          settings.audio_device = selectedDevice || null;
+        });
+      }
+    } catch (e) {
+      statusMessage = errorMessage(e);
+      return;
+    }
+    markSetupComplete();
+    app.showOnboarding = false;
+  }
+
+  function formatShortcut(shortcut: string): string {
+    return formatShortcutLabel(shortcut);
   }
 
   return {
@@ -70,7 +260,32 @@ export function createOnboardingController() {
     set selectedKey(key: string) { selectedKey = key; },
     get statusMessage() { return statusMessage; },
     get isStarting() { return isStarting; },
+    get steps() { return steps; },
+    get step() { return step; },
+    get stepIndex() { return stepIndex; },
+    get recoveryOnly() { return recoveryOnly; },
+    get audioDevices() { return audioDevices; },
+    get selectedDevice() { return selectedDevice; },
+    get toggleShortcut() { return toggleShortcut; },
+    get recordingShortcut() { return recordingShortcut; },
+    get shortcutError() { return shortcutError; },
+    get autoPaste() { return autoPaste; },
+    set autoPaste(value: boolean) { autoPaste = value; },
+    get busy() { return busy; },
+    get isDownloading() { return isDownloading; },
+    get isLoading() { return isLoading; },
+    get modelReady() { return modelReady; },
+    get canContinue() { return canContinue; },
     mount,
-    begin,
+    beginDownload,
+    onDeviceChange,
+    refreshDevices,
+    onLocaleChange,
+    startShortcutRecording,
+    handleKeyDown,
+    goNext,
+    goBack,
+    finish,
+    formatShortcut,
   };
 }

--- a/src/lib/features/onboarding/setup.test.ts
+++ b/src/lib/features/onboarding/setup.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  SETUP_STORAGE_KEY,
+  PERMISSIONS_STORAGE_KEY,
+  decideShowSetupWizard,
+  markPermissionsDone,
+  markSetupComplete,
+  readSetupFlags,
+  shouldMigrateSetupComplete,
+  wizardSteps,
+} from "./setup";
+
+describe("setup flags", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("starts unset", () => {
+    expect(readSetupFlags()).toEqual({ permissionsDone: false, setupDone: false });
+  });
+
+  it("markPermissionsDone is independent of setupDone", () => {
+    markPermissionsDone();
+    expect(readSetupFlags()).toEqual({ permissionsDone: true, setupDone: false });
+  });
+
+  it("markSetupComplete sets both flags", () => {
+    markSetupComplete();
+    expect(localStorage.getItem(PERMISSIONS_STORAGE_KEY)).toBe("1");
+    expect(localStorage.getItem(SETUP_STORAGE_KEY)).toBe("1");
+    expect(readSetupFlags()).toEqual({ permissionsDone: true, setupDone: true });
+  });
+});
+
+describe("shouldMigrateSetupComplete", () => {
+  it("migrates pre-wizard users who already finished permissions and have a model", () => {
+    expect(
+      shouldMigrateSetupComplete("ready", { permissionsDone: true, setupDone: false }),
+    ).toBe(true);
+  });
+
+  it("does not migrate a first-run still missing a model", () => {
+    expect(
+      shouldMigrateSetupComplete("download_required", {
+        permissionsDone: true,
+        setupDone: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not migrate when setup is already complete", () => {
+    expect(
+      shouldMigrateSetupComplete("ready", { permissionsDone: true, setupDone: true }),
+    ).toBe(false);
+  });
+});
+
+describe("decideShowSetupWizard", () => {
+  it("shows the full wizard on a brand-new install", () => {
+    expect(
+      decideShowSetupWizard("download_required", {
+        permissionsDone: false,
+        setupDone: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps showing after the model is ready until the wizard is finished", () => {
+    expect(
+      decideShowSetupWizard("ready", { permissionsDone: false, setupDone: false }),
+    ).toBe(true);
+  });
+
+  it("keeps showing after permissions if the model is still missing", () => {
+    expect(
+      decideShowSetupWizard("download_required", {
+        permissionsDone: true,
+        setupDone: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("hides for migrated existing users", () => {
+    expect(
+      decideShowSetupWizard("ready", { permissionsDone: true, setupDone: true }),
+    ).toBe(false);
+  });
+
+  it("reopens on a model-only recovery after the user deleted the files", () => {
+    expect(
+      decideShowSetupWizard("download_required", {
+        permissionsDone: true,
+        setupDone: true,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("wizardSteps", () => {
+  it("starts at permissions for a new user", () => {
+    expect(wizardSteps({ permissionsDone: false, setupDone: false })).toEqual([
+      "permissions",
+      "microphone",
+      "model",
+      "shortcut",
+    ]);
+  });
+
+  it("resumes at microphone after permissions were granted", () => {
+    expect(wizardSteps({ permissionsDone: true, setupDone: false })).toEqual([
+      "microphone",
+      "model",
+      "shortcut",
+    ]);
+  });
+
+  it("is model-only when setup was already completed", () => {
+    expect(wizardSteps({ permissionsDone: true, setupDone: true })).toEqual(["model"]);
+  });
+});

--- a/src/lib/features/onboarding/setup.ts
+++ b/src/lib/features/onboarding/setup.ts
@@ -1,0 +1,72 @@
+import type { TranscriptionRuntimePhase } from "../../types";
+
+export const PERMISSIONS_STORAGE_KEY = "permissionsOnboarded";
+export const SETUP_STORAGE_KEY = "setupOnboarded";
+
+export type SetupStep = "permissions" | "microphone" | "model" | "shortcut";
+
+export type SetupFlags = {
+  permissionsDone: boolean;
+  setupDone: boolean;
+};
+
+function readFlag(key: string): boolean {
+  try {
+    return localStorage.getItem(key) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function writeFlag(key: string, value: boolean): void {
+  try {
+    if (value) localStorage.setItem(key, "1");
+    else localStorage.removeItem(key);
+  } catch {
+    // Private mode / storage disabled — wizard just shows again next time.
+  }
+}
+
+export function readSetupFlags(): SetupFlags {
+  return {
+    permissionsDone: readFlag(PERMISSIONS_STORAGE_KEY),
+    setupDone: readFlag(SETUP_STORAGE_KEY),
+  };
+}
+
+export function markPermissionsDone(): void {
+  writeFlag(PERMISSIONS_STORAGE_KEY, true);
+}
+
+export function markSetupComplete(): void {
+  writeFlag(PERMISSIONS_STORAGE_KEY, true);
+  writeFlag(SETUP_STORAGE_KEY, true);
+}
+
+/** Pre-wizard installs already granted permissions and have a model on disk.
+ * Treat them as fully set up so the new mic/shortcut steps don't reappear. */
+export function shouldMigrateSetupComplete(
+  phase: TranscriptionRuntimePhase,
+  flags: SetupFlags,
+): boolean {
+  return !flags.setupDone && flags.permissionsDone && phase !== "download_required";
+}
+
+export function decideShowSetupWizard(
+  phase: TranscriptionRuntimePhase,
+  flags: SetupFlags,
+): boolean {
+  if (flags.setupDone) return phase === "download_required";
+  if (flags.permissionsDone && phase !== "download_required") return false;
+  return true;
+}
+
+/** First-run walks permissions (if needed) → mic → model → shortcut.
+ * Re-download after a deleted model is model-only. */
+export function wizardSteps(flags: SetupFlags): SetupStep[] {
+  if (flags.setupDone) return ["model"];
+  const steps: SetupStep[] = [];
+  if (!flags.permissionsDone) steps.push("permissions");
+  steps.push("microphone", "model", "shortcut");
+  return steps;
+}

--- a/src/lib/features/settings/controller.svelte.ts
+++ b/src/lib/features/settings/controller.svelte.ts
@@ -29,12 +29,11 @@ import type {
   DictionaryEntry,
   PermState,
   SummaryModelDescriptor,
-  SummaryProviderChoice,
   ShortcutSettings,
   Theme,
   TranscriptionCatalog,
 } from "../../types";
-import { applyTheme, errorMessage, formatShortcutLabel } from "../../utils";
+import { applyTheme, errorMessage, formatShortcutLabel, keyEventToShortcut, shortcutMissingModifier } from "../../utils";
 import {
   buildMicrophoneList,
   reorderMicrophoneList,
@@ -420,13 +419,6 @@ export function createSettingsController() {
     });
   }
 
-  function onAutoUpdateCheckChange(event: Event) {
-    const checked = (event.target as HTMLInputElement).checked;
-    void persistSettings((settings) => {
-      settings.auto_update_check_enabled = checked;
-    });
-  }
-
   function onDictationPolishEnabledChange(event: Event) {
     const checked = (event.target as HTMLInputElement).checked;
     void persistSettings((settings) => {
@@ -542,13 +534,6 @@ export function createSettingsController() {
     const value = (event.target as HTMLSelectElement).value;
     void persistSettings((settings) => {
       settings.ollama_model = value;
-    });
-  }
-
-  function onSummaryProviderChange(event: Event) {
-    const value = (event.target as HTMLSelectElement).value as SummaryProviderChoice;
-    void persistSettings((settings) => {
-      settings.summary_provider = value;
     });
   }
 
@@ -738,34 +723,6 @@ export function createSettingsController() {
     dictionaryEntries = dictionaryEntries.filter((e) => e.id !== id);
   }
 
-  function keyEventToShortcut(event: KeyboardEvent): string | null {
-    if (["Control", "Shift", "Alt", "Meta"].includes(event.key)) return null;
-    const parts: string[] = [];
-    if (event.metaKey || event.ctrlKey) parts.push("CommandOrControl");
-    if (event.shiftKey) parts.push("Shift");
-    if (event.altKey) parts.push("Alt");
-    const key = mapKey(event.code, event.key);
-    if (!key) return null;
-    parts.push(key);
-    return parts.join("+");
-  }
-
-  function mapKey(code: string, key: string): string | null {
-    if (/^F\d{1,2}$/.test(key)) return key;
-    if (code.startsWith("Key")) return code.slice(3);
-    if (code.startsWith("Digit")) return code.slice(5);
-    const keyMap: Record<string, string> = {
-      Space: "Space", Enter: "Enter", Escape: "Escape", Backspace: "Backspace",
-      Tab: "Tab", ArrowUp: "ArrowUp", ArrowDown: "ArrowDown", ArrowLeft: "ArrowLeft",
-      ArrowRight: "ArrowRight", Delete: "Delete", Home: "Home", End: "End",
-      PageUp: "PageUp", PageDown: "PageDown", Backquote: "Backquote", Minus: "Minus",
-      Equal: "Equal", BracketLeft: "BracketLeft", BracketRight: "BracketRight",
-      Backslash: "Backslash", Semicolon: "Semicolon", Quote: "Quote",
-      Comma: "Comma", Period: "Period", Slash: "Slash",
-    };
-    return keyMap[code] || null;
-  }
-
   function formatShortcut(shortcut: string): string {
     return formatShortcutLabel(shortcut) || "Not set";
   }
@@ -801,7 +758,7 @@ export function createSettingsController() {
     const shortcut = keyEventToShortcut(event);
     if (!shortcut) return;
 
-    if (!event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey && !/^F\d{1,2}$/.test(event.key)) {
+    if (shortcutMissingModifier(event)) {
       shortcutError = "Shortcut must include a modifier key (Cmd, Ctrl, Shift, Alt) or be a function key";
       return;
     }
@@ -885,7 +842,6 @@ export function createSettingsController() {
     onLocaleChange,
     onAutoPasteChange,
     onLearnFromEditChange,
-    onAutoUpdateCheckChange,
     onDictationPolishEnabledChange,
     onDictationPolishTemplateChange,
     onDictationPolishPromptChange,
@@ -900,7 +856,6 @@ export function createSettingsController() {
     onLogLevelChange,
     onOllamaUrlChange,
     onOllamaModelChange,
-    onSummaryProviderChange,
     get systemAudioSupported() { return systemAudioSupported; },
     get isLaptop() { return isLaptop; },
     onCaptureSystemAudioChange,

--- a/src/lib/features/transcription/runtime.ts
+++ b/src/lib/features/transcription/runtime.ts
@@ -8,6 +8,12 @@ import {
 import type { DownloadProgress, TranscriptionCatalog } from "../../types";
 import { errorMessage } from "../../utils";
 import { toSelectedTranscriptionProfileSelection } from "./catalog";
+import {
+  decideShowSetupWizard,
+  markSetupComplete,
+  readSetupFlags,
+  shouldMigrateSetupComplete,
+} from "../onboarding/setup";
 
 type AppState = ReturnType<typeof getAppState>;
 
@@ -118,6 +124,14 @@ export function decideStartupModelAction(
   return "none";
 }
 
+function applySetupWizardVisibility(app: AppState): void {
+  const flags = readSetupFlags();
+  if (shouldMigrateSetupComplete(app.transcriptionRuntimePhase, flags)) {
+    markSetupComplete();
+  }
+  app.showOnboarding = decideShowSetupWizard(app.transcriptionRuntimePhase, readSetupFlags());
+}
+
 /** Startup flow: auto-load the last-selected model, or surface onboarding
  * when nothing is downloaded yet. Fire-and-forget from bootstrap; progress
  * reaches the UI through StateChanged events. */
@@ -126,6 +140,7 @@ export async function runStartupModelFlow(app: AppState): Promise<void> {
   try {
     catalog = await getTranscriptionCatalog();
   } catch {
+    applySetupWizardVisibility(app);
     return; // Backend unavailable; StateChanged events will catch us up.
   }
   app.settings = {
@@ -138,19 +153,20 @@ export async function runStartupModelFlow(app: AppState): Promise<void> {
   try {
     await refreshTranscriptionRuntimeStatus(app, catalog);
   } catch {
+    applySetupWizardVisibility(app);
     return;
   }
 
   switch (decideStartupModelAction(app.transcriptionRuntimePhase, app.machineState.state)) {
-    case "onboarding":
-      app.showOnboarding = true;
-      break;
     case "load":
       void startTranscriptionModelLoad(app, catalog, () => {});
       break;
+    case "onboarding":
     case "none":
       break;
   }
+
+  applySetupWizardVisibility(app);
 }
 
 // Indirection so TypeScript re-reads the getter after the `await` below

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -144,13 +144,6 @@
   "settings_intelligence": {
     "title": "Summarization",
     "description": "Summaries use Apple Intelligence on supported Macs, or a local Ollama server.",
-    "provider": "Provider",
-    "provider_desc": "Which engine writes summaries and cleans up dictation.",
-    "provider_auto": "Automatic",
-    "provider_ollama": "Ollama",
-    "provider_apple_unusable": "Apple Intelligence is selected but not available on this Mac, so summaries and dictation polish will not run.",
-    "provider_ollama_unusable": "Ollama is selected but has no usable model installed, so summaries and dictation polish will not run. Install a chat model such as qwen2.5:7b-instruct.",
-    "provider_none_usable": "No provider is available: Apple Intelligence is unavailable and Ollama has no usable model. Summaries and dictation polish will not run.",
     "apple_intelligence": "Apple Intelligence",
     "apple_intelligence_desc": "On-device summaries on Apple Silicon with macOS 26+ and Apple Intelligence enabled.",
     "apple_available": "Available",
@@ -170,7 +163,6 @@
     "not_available": "Not available",
     "retry": "Retry",
     "summary_model": "Summarization model",
-    "no_model_installed": "Ollama is running but has no model installed. Download the recommended one below, or install your own with ollama pull.",
     "no_compatible_model": "No compatible model found. Install a model like Llama or Mistral to enable summaries.",
     "download_recommended": "Download {model}",
     "download_recommended_desc": "Recommended for summaries and dictation polish (~4.7 GB).",
@@ -240,9 +232,7 @@
     "checking": "Checking…",
     "up_to_date": "You're on the latest release.",
     "update_available": "Version {version} is available.",
-    "download_update": "Download on GitHub",
-    "auto_check": "Check daily for updates",
-    "auto_check_desc": "Ask GitHub once a day whether a newer version exists, and show a dialog when there is one. Nothing is downloaded or installed."
+    "download_update": "Download on GitHub"
   },
   "whats_new": {
     "title": "What's New",
@@ -265,8 +255,7 @@
     "export_markdown": "Markdown (.md)",
     "export_json": "JSON (.json)",
     "export_srt": "Subtitles (.srt)",
-    "export_vtt": "Subtitles (.vtt)",
-    "export_audio": "Audio (.ogg)"
+    "export_vtt": "Subtitles (.vtt)"
   },
   "meeting_transcript": {
     "title": "Transcript",
@@ -374,11 +363,26 @@
   "onboarding": {
     "tagline": "Local speech-to-text for dictation and meetings.",
     "local_note": "100% local — nothing ever leaves your Mac. No account, no cloud.",
+    "model_title": "Download the transcription model",
     "model_label": "Transcription model",
     "model_hint": "Downloaded once (1–2 GB), then everything runs offline. You can switch models later in Settings.",
-    "start_button": "Download and get started",
+    "model_ready": "The model is ready to use.",
+    "start_button": "Download and continue",
     "downloading": "Downloading the model…",
-    "loading": "Loading the model…"
+    "loading": "Loading the model…",
+    "mic_title": "Choose your microphone",
+    "mic_subtitle": "Soufflé listens to this input for dictation and meetings. Automatic follows macOS.",
+    "mic_hint": "You can reorder devices and allow Bluetooth mics later in Settings.",
+    "shortcut_title": "Quick dictation shortcut",
+    "shortcut_subtitle": "Press this from any app to start or stop dictation.",
+    "shortcut_hint": "Click the shortcut, then press the keys you want. Escape cancels.",
+    "shortcut_unset": "Not set",
+    "shortcut_needs_modifier": "Shortcut must include a modifier key (⌘, Ctrl, Shift, Option) or be a function key.",
+    "auto_paste_desc": "When you stop, paste the transcript into the app you were using. Needs Accessibility.",
+    "continue": "Continue",
+    "back": "Back",
+    "finish": "Get started",
+    "step_progress": "Step {current} of {total}"
   },
   "status_chip": {
     "ready": "Ready",
@@ -499,11 +503,5 @@
     "starts_in_minutes": "Starts in {minutes} min",
     "started_system_audio": "Meeting started — system audio active",
     "dismiss": "Dismiss"
-  },
-  "update_available": {
-    "title": "Update available",
-    "subtitle": "Soufflé v{version} is out.",
-    "later": "Later",
-    "download": "Download"
   }
 }

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -144,13 +144,6 @@
   "settings_intelligence": {
     "title": "Résumés",
     "description": "Les résumés utilisent Apple Intelligence sur les Mac compatibles, ou un serveur Ollama local.",
-    "provider": "Moteur",
-    "provider_desc": "Le moteur qui rédige les résumés et nettoie la dictée.",
-    "provider_auto": "Automatique",
-    "provider_ollama": "Ollama",
-    "provider_apple_unusable": "Apple Intelligence est sélectionné mais indisponible sur ce Mac : les résumés et le nettoyage de la dictée ne s'exécuteront pas.",
-    "provider_ollama_unusable": "Ollama est sélectionné mais aucun modèle utilisable n'est installé : les résumés et le nettoyage de la dictée ne s'exécuteront pas. Installez un modèle de conversation, par exemple qwen2.5:7b-instruct.",
-    "provider_none_usable": "Aucun moteur disponible : Apple Intelligence est indisponible et Ollama n'a aucun modèle utilisable. Les résumés et le nettoyage de la dictée ne s'exécuteront pas.",
     "apple_intelligence": "Apple Intelligence",
     "apple_intelligence_desc": "Résumés on-device sur Apple Silicon avec macOS 26+ et Apple Intelligence activé.",
     "apple_available": "Disponible",
@@ -170,7 +163,6 @@
     "not_available": "Non disponible",
     "retry": "Réessayer",
     "summary_model": "Modèle de résumé",
-    "no_model_installed": "Ollama tourne mais aucun modèle n'est installé. Téléchargez le modèle recommandé ci-dessous, ou installez le vôtre avec ollama pull.",
     "no_compatible_model": "Aucun modèle compatible trouvé. Installez un modèle comme Llama ou Mistral pour activer les résumés.",
     "download_recommended": "Télécharger {model}",
     "download_recommended_desc": "Recommandé pour les résumés et le polish de dictée (~4,7 Go).",
@@ -240,9 +232,7 @@
     "checking": "Vérification…",
     "up_to_date": "Vous utilisez la dernière version.",
     "update_available": "La version {version} est disponible.",
-    "download_update": "Télécharger sur GitHub",
-    "auto_check": "Vérifier les mises à jour chaque jour",
-    "auto_check_desc": "Demande à GitHub une fois par jour si une version plus récente existe, et affiche une fenêtre le cas échéant. Rien n'est téléchargé ni installé."
+    "download_update": "Télécharger sur GitHub"
   },
   "whats_new": {
     "title": "Nouveautés",
@@ -265,8 +255,7 @@
     "export_markdown": "Markdown (.md)",
     "export_json": "JSON (.json)",
     "export_srt": "Sous-titres (.srt)",
-    "export_vtt": "Sous-titres (.vtt)",
-    "export_audio": "Audio (.ogg)"
+    "export_vtt": "Sous-titres (.vtt)"
   },
   "meeting_transcript": {
     "title": "Transcription",
@@ -374,11 +363,26 @@
   "onboarding": {
     "tagline": "Transcription vocale locale pour la dictée et les meetings.",
     "local_note": "100 % local — rien ne quitte votre Mac. Pas de compte, pas de cloud.",
+    "model_title": "Télécharger le modèle de transcription",
     "model_label": "Modèle de transcription",
     "model_hint": "Téléchargé une seule fois (1–2 Go), puis tout fonctionne hors ligne. Changeable plus tard dans les réglages.",
-    "start_button": "Télécharger et commencer",
+    "model_ready": "Le modèle est prêt à l'emploi.",
+    "start_button": "Télécharger et continuer",
     "downloading": "Téléchargement du modèle…",
-    "loading": "Chargement du modèle…"
+    "loading": "Chargement du modèle…",
+    "mic_title": "Choisir le microphone",
+    "mic_subtitle": "Soufflé écoute cette entrée pour la dictée et les meetings. Automatique suit macOS.",
+    "mic_hint": "Vous pourrez réordonner les appareils et autoriser les micros Bluetooth plus tard dans les réglages.",
+    "shortcut_title": "Raccourci de dictée rapide",
+    "shortcut_subtitle": "Appuyez dessus depuis n'importe quelle app pour démarrer ou arrêter la dictée.",
+    "shortcut_hint": "Cliquez sur le raccourci, puis appuyez sur les touches voulues. Échap annule.",
+    "shortcut_unset": "Non défini",
+    "shortcut_needs_modifier": "Le raccourci doit inclure une touche modificatrice (⌘, Ctrl, Shift, Option) ou être une touche de fonction.",
+    "auto_paste_desc": "À l'arrêt, colle la transcription dans l'app que vous utilisiez. Nécessite Accessibilité.",
+    "continue": "Continuer",
+    "back": "Retour",
+    "finish": "Commencer",
+    "step_progress": "Étape {current} sur {total}"
   },
   "status_chip": {
     "ready": "Prêt",
@@ -499,11 +503,5 @@
     "starts_in_minutes": "Commence dans {minutes} min",
     "started_system_audio": "Réunion commencée — audio système actif",
     "dismiss": "Ignorer"
-  },
-  "update_available": {
-    "title": "Mise à jour disponible",
-    "subtitle": "Soufflé v{version} est disponible.",
-    "later": "Plus tard",
-    "download": "Télécharger"
   }
 }

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -36,7 +36,7 @@ let systemAudioStatus = $state<SystemAudioStatus | null>(null);
 // Calendar reminder awaiting the user's decision (drives the home banner)
 let upcomingMeeting = $state<UpcomingMeeting | null>(null);
 
-// First-run onboarding (model not downloaded yet) — derived at bootstrap
+// First-run setup wizard (permissions, mic, model, shortcut)
 let showOnboarding = $state(false);
 
 // Last pipeline error surfaced by the backend (dismissable)
@@ -57,7 +57,6 @@ let settings = $state<AppSettings>({
   paste_delay_ms: 100,
   paste_method: "clipboard",
   ollama_url: "http://localhost:11434",
-  summary_provider: "auto",
   ollama_model: "",
   debug_transcription: false,
   log_level: "info",
@@ -79,7 +78,7 @@ let settings = $state<AppSettings>({
   calendar_autostart_enabled: true,
   feedback_sounds_enabled: true,
   feedback_sounds_volume: 70,
-  model_unload_timeout_minutes: 60,
+  model_unload_timeout_minutes: 0,
   meeting_autostop_enabled: true,
   meeting_autostop_minutes: 10,
   meeting_max_duration_minutes: 240,
@@ -93,7 +92,6 @@ let settings = $state<AppSettings>({
     { id: "bullets", label: "Bullet points", prompt: "Use bullets." },
     { id: "no_fillers", label: "Remove fillers", prompt: "Remove fillers." },
   ],
-  auto_update_check_enabled: true,
   dictation_learn_from_edit: true,
   default_summary_template_id: "default",
   summary_templates: [

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,4 +1,5 @@
 export { formatTimestamp, formatDate, formatDuration, formatShortcutLabel, formatBytes } from "./format";
+export { keyEventToShortcut, shortcutMissingModifier } from "./shortcut";
 export { applyTheme } from "./theme";
 export { buildMeetingTranscriptBlocks, groupIntoParagraphs } from "./paragraphs";
 export type { Paragraph, TranscriptBlock } from "./paragraphs";

--- a/src/lib/utils/shortcut.test.ts
+++ b/src/lib/utils/shortcut.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { keyEventToShortcut, shortcutMissingModifier } from "./shortcut";
+
+function key(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent("keydown", init);
+}
+
+describe("keyEventToShortcut", () => {
+  it("ignores modifier-only keydowns", () => {
+    expect(keyEventToShortcut(key({ key: "Meta", metaKey: true }))).toBeNull();
+    expect(keyEventToShortcut(key({ key: "Shift", shiftKey: true }))).toBeNull();
+  });
+
+  it("maps cmd-shift-space to the stored accelerator", () => {
+    expect(
+      keyEventToShortcut(key({ key: " ", code: "Space", metaKey: true, shiftKey: true })),
+    ).toBe("CommandOrControl+Shift+Space");
+  });
+
+  it("treats ctrl like cmd on the stored form", () => {
+    expect(
+      keyEventToShortcut(key({ key: "s", code: "KeyS", ctrlKey: true })),
+    ).toBe("CommandOrControl+S");
+  });
+
+  it("maps function keys without a modifier", () => {
+    expect(keyEventToShortcut(key({ key: "F6", code: "F6" }))).toBe("F6");
+  });
+});
+
+describe("shortcutMissingModifier", () => {
+  it("rejects a bare letter", () => {
+    expect(shortcutMissingModifier(key({ key: "a", code: "KeyA" }))).toBe(true);
+  });
+
+  it("accepts F-keys and modified keys", () => {
+    expect(shortcutMissingModifier(key({ key: "F8", code: "F8" }))).toBe(false);
+    expect(shortcutMissingModifier(key({ key: "a", code: "KeyA", metaKey: true }))).toBe(false);
+  });
+});

--- a/src/lib/utils/shortcut.ts
+++ b/src/lib/utils/shortcut.ts
@@ -1,0 +1,59 @@
+/** Map a keydown event to the accelerator string the backend stores
+ * (`CommandOrControl+Shift+Space`). Returns null for modifier-only or
+ * unmapped keys. */
+export function keyEventToShortcut(event: KeyboardEvent): string | null {
+  if (["Control", "Shift", "Alt", "Meta"].includes(event.key)) return null;
+  const parts: string[] = [];
+  if (event.metaKey || event.ctrlKey) parts.push("CommandOrControl");
+  if (event.shiftKey) parts.push("Shift");
+  if (event.altKey) parts.push("Alt");
+  const key = mapKey(event.code, event.key);
+  if (!key) return null;
+  parts.push(key);
+  return parts.join("+");
+}
+
+/** Bare letter/digit/symbol keys need a modifier (or to be an F-key). */
+export function shortcutMissingModifier(event: KeyboardEvent): boolean {
+  return (
+    !event.metaKey
+    && !event.ctrlKey
+    && !event.shiftKey
+    && !event.altKey
+    && !/^F\d{1,2}$/.test(event.key)
+  );
+}
+
+function mapKey(code: string, key: string): string | null {
+  if (/^F\d{1,2}$/.test(key)) return key;
+  if (code.startsWith("Key")) return code.slice(3);
+  if (code.startsWith("Digit")) return code.slice(5);
+  const keyMap: Record<string, string> = {
+    Space: "Space",
+    Enter: "Enter",
+    Escape: "Escape",
+    Backspace: "Backspace",
+    Tab: "Tab",
+    ArrowUp: "ArrowUp",
+    ArrowDown: "ArrowDown",
+    ArrowLeft: "ArrowLeft",
+    ArrowRight: "ArrowRight",
+    Delete: "Delete",
+    Home: "Home",
+    End: "End",
+    PageUp: "PageUp",
+    PageDown: "PageDown",
+    Backquote: "Backquote",
+    Minus: "Minus",
+    Equal: "Equal",
+    BracketLeft: "BracketLeft",
+    BracketRight: "BracketRight",
+    Backslash: "Backslash",
+    Semicolon: "Semicolon",
+    Quote: "Quote",
+    Comma: "Comma",
+    Period: "Period",
+    Slash: "Slash",
+  };
+  return keyMap[code] || null;
+}

--- a/tests/e2e/tauri-stub.ts
+++ b/tests/e2e/tauri-stub.ts
@@ -57,6 +57,7 @@ export const DEFAULT_RESPONSES: Record<string, unknown> = {
   list_dictionary: [],
   get_data_stats: { meetings_count: 0, dictation_entries_count: 0, database_bytes: 0 },
   recover_state: { state: "ready", data: { profile: mockRuntimeStatus.profile } },
+  list_audio_devices: [],
   // Recording lifecycle — overridden per test where the flow matters.
   start_meeting_recording: null,
   resume_meeting_recording: null,
@@ -77,12 +78,12 @@ export interface TauriStubOptions {
 export async function installTauriStub(page: Page, options: TauriStubOptions = {}): Promise<void> {
   const responses = { ...DEFAULT_RESPONSES, ...options.responses };
 
-  // Skip the first-run "grant permissions" walkthrough (App.svelte gates it
-  // on this key) — it's a modal overlay unrelated to the flows under test
-  // and would otherwise block every click.
+  // Skip the first-run setup wizard (App.svelte gates it on these keys
+  // plus model status) — it's unrelated to the flows under test.
   await page.addInitScript(() => {
     try {
       window.localStorage.setItem("permissionsOnboarded", "1");
+      window.localStorage.setItem("setupOnboarded", "1");
     } catch {
       // Storage may be unavailable in some contexts; the dialog just shows.
     }


### PR DESCRIPTION
## Summary
- Unified first-run wizard: permissions → microphone → model download → dictation shortcut
- Auto-paste enabled by default at the end of setup; What's New suppressed until setup completes
- `npm run dev:fresh` script to wipe local state and test the wizard

## Test plan
- [x] Vitest: onboarding controller, setup flags, bootstrap What's New gating, shortcut util
- [x] Manual: release build (`Soufflé.app`) — wizard completes and transcription works with real TCC permissions

