### PR TITLE
Add a home screen type filter and a calendar setup CTA

### DIFF
--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -145,6 +145,20 @@
         />
       </label>
 
+      <div class="flex items-center gap-1.5 px-0.5" role="group" aria-label={$t("home.filter_label")}>
+        {#each (["all", "meeting", "dictation"] as const) as kind (kind)}
+          <button
+            type="button"
+            class="btn btn-sm btn-ghost"
+            class:btn-active={timeline.kindFilter === kind}
+            aria-pressed={timeline.kindFilter === kind}
+            onclick={() => { timeline.kindFilter = kind; }}
+          >
+            {$t(`home.filter_${kind}`)}
+          </button>
+        {/each}
+      </div>
+
       {#if timeline.statusMessage}
         <StatusBanner message={timeline.statusMessage} />
       {/if}
@@ -157,6 +171,12 @@
         upcoming={calendar.events}
         canStartEvent={modelReady}
         onStartEvent={(event) => void calendar.startFromEvent(event)}
+        calendarEnabled={calendar.enabled}
+        calendarPermission={calendar.permission}
+        onSetupCalendar={() => {
+          app.settingsInitialTab = "meetings";
+          app.settingsOpen = true;
+        }}
       />
     {:else}
       <!-- During a live session, the session card is the only focus. -->

--- a/src/lib/components/SettingsView.svelte
+++ b/src/lib/components/SettingsView.svelte
@@ -32,7 +32,11 @@
   ];
 
   const controller = createSettingsController();
-  let activeTab = $state<SettingsTab>("transcription");
+  let activeTab = $state<SettingsTab>(
+    (controller.app.settingsInitialTab as SettingsTab | null) ?? "transcription",
+  );
+  // Deep-link is one-shot: don't stick future normal opens to this tab.
+  controller.app.settingsInitialTab = null;
 
   let selectedTranscriptionLabel = $derived(
     formatSelectedTranscriptionLabel(

--- a/src/lib/features/timeline/components/TimelineSection.svelte
+++ b/src/lib/features/timeline/components/TimelineSection.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { CalendarClock, Play, Users } from "@lucide/svelte";
+  import { CalendarClock, CalendarPlus, Play, Users } from "@lucide/svelte";
   import { t } from "svelte-i18n";
   import EmptyState from "../../../components/ui/EmptyState.svelte";
-  import type { CalendarEvent } from "../../../types";
+  import type { CalendarEvent, PermState } from "../../../types";
   import type { createTimelineController } from "../controller.svelte";
   import TimelineItem from "./TimelineItem.svelte";
 
@@ -11,13 +11,26 @@
     upcoming = [],
     canStartEvent = false,
     onStartEvent,
+    calendarEnabled = false,
+    calendarPermission = "unknown",
+    onSetupCalendar,
   }: {
     controller: ReturnType<typeof createTimelineController>;
     /** Today's calendar events, in start order. */
     upcoming?: CalendarEvent[];
     canStartEvent?: boolean;
     onStartEvent?: (event: CalendarEvent) => void;
+    calendarEnabled?: boolean;
+    calendarPermission?: PermState;
+    onSetupCalendar?: () => void;
   } = $props();
+
+  // Show the CTA when nothing today's calendar section could show:
+  // integration off, or on but macOS hasn't granted access.
+  const showCalendarSetupCta = $derived(
+    upcoming.length === 0
+      && (!calendarEnabled || calendarPermission === "denied"),
+  );
 
   // Drives the now/next/past styling of today's events.
   let now = $state(Date.now());
@@ -111,6 +124,21 @@
         {/each}
       </div>
     </section>
+  {:else if showCalendarSetupCta && onSetupCalendar}
+    <button
+      type="button"
+      onclick={onSetupCalendar}
+      class="surface-card flex items-center gap-3 !p-3 text-left transition-colors hover:bg-surface-2"
+    >
+      <span class="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-[9px] bg-secondary/12 text-secondary" aria-hidden="true">
+        <CalendarPlus size={15} />
+      </span>
+      <span class="min-w-0 flex-1">
+        <span class="block truncate text-[13.5px] text-text-primary">{$t("calendar.setup_cta_title")}</span>
+        <span class="block truncate text-xs text-text-muted">{$t("calendar.setup_cta_desc")}</span>
+      </span>
+      <span class="shrink-0 text-xs font-semibold text-accent">{$t("calendar.setup_cta_action")}</span>
+    </button>
   {/if}
 
   {#if controller.isEmpty}

--- a/src/lib/features/timeline/controller.svelte.ts
+++ b/src/lib/features/timeline/controller.svelte.ts
@@ -77,6 +77,8 @@ export function groupByDay(items: TimelineItem[]): TimelineGroup[] {
   return groups;
 }
 
+export type TimelineKindFilter = "all" | "meeting" | "dictation";
+
 function createTimelineControllerInstance() {
   const app = getAppState();
 
@@ -84,6 +86,7 @@ function createTimelineControllerInstance() {
   let meetings = $state<MeetingListItem[]>([]);
   let statusMessage = $state("");
   let searchQuery = $state("");
+  let kindFilter = $state<TimelineKindFilter>("all");
   let expandedDictationId = $state<string | null>(null);
   const search = createDebouncedSearch(250, 40);
 
@@ -91,12 +94,16 @@ function createTimelineControllerInstance() {
 
   const filteredItems = $derived.by(() => {
     const query = searchQuery.trim().toLowerCase();
-    if (!query) return items;
+    const byKind = kindFilter === "all"
+      ? items
+      : items.filter((item) => item.kind === kindFilter);
+
+    if (!query) return byKind;
 
     if (search.results.length > 0) {
       const matchedDictations = matchedIdsForType(search.results, "dictation");
       const matchedMeetings = matchedIdsForType(search.results, "meeting");
-      return items.filter((item) =>
+      return byKind.filter((item) =>
         item.kind === "dictation"
           ? matchedDictations.has(item.id)
           : matchedMeetings.has(item.id),
@@ -104,7 +111,7 @@ function createTimelineControllerInstance() {
     }
 
     // Local fallback while the FTS query is in flight.
-    return items.filter((item) => item.title.toLowerCase().includes(query));
+    return byKind.filter((item) => item.title.toLowerCase().includes(query));
   });
 
   const groups = $derived(groupByDay(filteredItems));
@@ -162,6 +169,8 @@ function createTimelineControllerInstance() {
     get hasMatches() { return filteredItems.length > 0; },
     get searchQuery() { return searchQuery; },
     set searchQuery(value: string) { onSearchQueryChange(value); },
+    get kindFilter() { return kindFilter; },
+    set kindFilter(value: TimelineKindFilter) { kindFilter = value; },
     get searchResults() { return search.results; },
     get isSearching() { return search.isSearching; },
     get expandedDictationId() { return expandedDictationId; },

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -459,6 +459,10 @@
     "stopping": "Finishing…",
     "listening": "Listening…",
     "search_placeholder": "Search transcripts and meetings",
+    "filter_label": "Filter by type",
+    "filter_all": "All",
+    "filter_meeting": "Meetings",
+    "filter_dictation": "Dictations",
     "press": "Press",
     "autopaste_hint": "Auto-pastes into your last app when you stop",
     "live_transcript": "Live transcript",
@@ -513,7 +517,10 @@
     "you": "you",
     "starts_in_minutes": "Starts in {minutes} min",
     "started_system_audio": "Meeting started — system audio active",
-    "dismiss": "Dismiss"
+    "dismiss": "Dismiss",
+    "setup_cta_title": "See today's meetings here",
+    "setup_cta_desc": "Connect the macOS Calendar to get reminders and one-click start.",
+    "setup_cta_action": "Set up"
   },
   "update_available": {
     "title": "Update available",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -459,6 +459,10 @@
     "stopping": "Finalisation…",
     "listening": "À l'écoute…",
     "search_placeholder": "Rechercher transcriptions et réunions",
+    "filter_label": "Filtrer par type",
+    "filter_all": "Tout",
+    "filter_meeting": "Réunions",
+    "filter_dictation": "Dictées",
     "press": "Appuyez sur",
     "autopaste_hint": "Collé automatiquement dans votre dernière app à l’arrêt",
     "live_transcript": "Transcription en direct",
@@ -513,7 +517,10 @@
     "you": "vous",
     "starts_in_minutes": "Commence dans {minutes} min",
     "started_system_audio": "Réunion commencée — audio système actif",
-    "dismiss": "Ignorer"
+    "dismiss": "Ignorer",
+    "setup_cta_title": "Affichez vos réunions du jour ici",
+    "setup_cta_desc": "Connectez le calendrier macOS pour des rappels et un démarrage en un clic.",
+    "setup_cta_action": "Configurer"
   },
   "update_available": {
     "title": "Mise à jour disponible",

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -12,6 +12,10 @@ import type { TranscriptionModelOperationState } from "../features/transcription
 // Settings sheet visibility (the app is otherwise a single home surface)
 let settingsOpen = $state(false);
 
+// Tab to land on the next time settings opens (e.g. a "set up calendar" CTA
+// deep-linking into the meetings tab). Consumed once by SettingsView.
+let settingsInitialTab = $state<string | null>(null);
+
 // Current meeting ID (when viewing a specific meeting)
 let currentMeetingId = $state<string | null>(null);
 
@@ -153,6 +157,9 @@ export function getAppState() {
   return {
     get settingsOpen() { return settingsOpen; },
     set settingsOpen(v: boolean) { settingsOpen = v; },
+
+    get settingsInitialTab() { return settingsInitialTab; },
+    set settingsInitialTab(v: string | null) { settingsInitialTab = v; },
 
     get currentMeetingId() { return currentMeetingId; },
     set currentMeetingId(id: string | null) { currentMeetingId = id; },


### PR DESCRIPTION
## Summary
- Add a discreet All/Meetings/Dictations filter next to the home screen search box (default: all).
- Show a small CTA in the "coming up today" calendar area when the calendar integration isn't set up (or macOS denied access), deep-linking into Settings > Meetings.

## Test plan
- [x] `vitest run` — 319/319 passing
- [x] `svelte-check` — no new errors introduced
- [ ] Manual check in the app: toggle the filter pills, and open the CTA link to confirm it lands on the Meetings settings tab