### PR TITLE
Fix the last svelte-check errors in test files

### DIFF
--- a/src/lib/features/audio/mic-toast.svelte.ts
+++ b/src/lib/features/audio/mic-toast.svelte.ts
@@ -8,7 +8,7 @@ export type MicToastCopy = {
   hint: string;
 };
 
-type Translate = (key: string, options?: { values?: Record<string, string | number> }) => string;
+export type Translate = (key: string, options?: { values?: Record<string, string | number> }) => string;
 
 export function micToastCopy(notice: InputRouteNotice, t: Translate): MicToastCopy {
   switch (notice.reason) {

--- a/src/lib/features/audio/mic-toast.test.ts
+++ b/src/lib/features/audio/mic-toast.test.ts
@@ -2,10 +2,9 @@ import { describe, expect, it, vi, afterEach } from "vitest";
 import { get } from "svelte/store";
 import { t } from "svelte-i18n";
 import type { InputRouteNotice } from "../../types";
-import { createMicToast, micToastCopy } from "./mic-toast.svelte";
+import { createMicToast, micToastCopy, type Translate } from "./mic-toast.svelte";
 
-const translate = (key: string, options?: { values?: Record<string, string> }) =>
-  get(t)(key, options);
+const translate: Translate = (key, options) => get(t)(key, options);
 
 function notice(partial: Partial<InputRouteNotice> & Pick<InputRouteNotice, "reason">): InputRouteNotice {
   return {

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -475,7 +475,7 @@ describe("transcription controller", () => {
     expect(mockInvoke).toHaveBeenCalledWith("read_selected_text");
 
     simulateRecordingStarted(ctrl.app);
-    transcriptionChannel?.onmessage?.({
+    (transcriptionChannel as { onmessage: ((msg: unknown) => void) | null } | null)?.onmessage?.({
       text: "hello world",
       is_final: true,
       start_ms: 0,
@@ -514,7 +514,7 @@ describe("transcription controller", () => {
     expect(mockInvoke).not.toHaveBeenCalledWith("read_selected_text");
 
     simulateRecordingStarted(ctrl.app);
-    transcriptionChannel?.onmessage?.({
+    (transcriptionChannel as { onmessage: ((msg: unknown) => void) | null } | null)?.onmessage?.({
       text: "hello world",
       is_final: true,
       start_ms: 0,
@@ -554,7 +554,7 @@ describe("transcription controller", () => {
 
       await ctrl.toggleRecording(true);
       simulateRecordingStarted(ctrl.app);
-      transcriptionChannel?.onmessage?.({
+      (transcriptionChannel as { onmessage: ((msg: unknown) => void) | null } | null)?.onmessage?.({
         text: "hello world",
         is_final: true,
         start_ms: 0,


### PR DESCRIPTION
Stacked on #97.

## Summary
- `mic-toast.test.ts` redeclared a local `Translate` type narrower than the one `mic-toast.svelte.ts` expects (`Record<string, string>` vs `Record<string, string | number>`). Exported the real `Translate` type and reused it in the test instead of duplicating it.
- `transcription/controller.svelte.test.ts` read the mocked channel through a plain optional chain (`transcriptionChannel?.onmessage`) that TS narrowed to `never` at three call sites. Cast it explicitly, matching the pattern already used elsewhere in the same file.

## Test plan
- [x] `svelte-check` — 0 errors (down from 6)
- [x] `vitest run` — 319/319 passing