### PR TITLE
Publish the CI build cache on develop so PRs stop rebuilding from scratch

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -3,8 +3,14 @@ name: Contracts
 on:
   push:
     branches:
+      - develop
       - master
   pull_request:
+
+# A new push to a PR makes the in-flight run obsolete; don't pay for it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   generated-contracts:
@@ -15,9 +21,16 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      # Only the default branch writes the cache. GitHub scopes a cache to the
+      # ref that created it, and a run can read only its own ref, its base, and
+      # the default branch: never a sibling. Saving from PR runs therefore piled
+      # up ~1 GB entries per PR that no other run could reach, against a 10 GB
+      # repo-wide budget that GitHub reclaims by evicting the least recently
+      # used entry.
       - uses: Swatinem/rust-cache@v2.9.1
         with:
           workspaces: src-tauri -> target
+          save-if: ${{ github.ref == 'refs/heads/develop' }}
 
       - uses: actions/setup-node@v6.1.0
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,8 +3,13 @@ name: E2E
 on:
   push:
     branches:
+      - develop
       - master
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   playwright:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,10 +118,20 @@ jobs:
       # cmake builds the sentencepiece tokenizer; it's preinstalled on
       # GitHub's macOS runner images, so no separate setup step is needed.
 
+      # Restore only. GitHub never lets one tag read another tag's cache, and
+      # this job only ever runs on tags, so the ~900 MB it used to save was
+      # unreachable to every later release while still counting against the
+      # 10 GB repo budget. Restoring is kept because a hit on the default
+      # branch's entry is still possible and costs nothing when it misses.
+      # A cache that actually hits here would need a release-profile
+      # `--target aarch64-apple-darwin` warm-up build on develop; the Contracts
+      # entry cannot serve it, since `--target` writes to a different target
+      # subdirectory than the host builds Contracts caches.
       - name: Rust cache
         uses: Swatinem/rust-cache@v2.9.1
         with:
           workspaces: "./src-tauri -> target"
+          save-if: false
 
       - name: Install frontend dependencies
         run: npm ci


### PR DESCRIPTION
## The problem

Contracts and E2E only ran on `push: master`. When `develop` became the default branch today, nothing was left writing a cache to the one ref every run is guaranteed to be able to read, so PR runs went cold.

It shows up sharply in the last 20 Contracts runs, measured on the `check:generated-types` step:

| Runs | Base | Build step | Job total |
|---|---|---|---|
| 16 runs up to 17:23 | `master` | 57-105s | ~3 min |
| 3 runs after 20:30 | `develop` chain | **415-458s** | **~10 min** |

The three slow ones all log `No cache found.` and recompile 580 crates. That is not a blip, it is the steady state for every PR from here on.

Meanwhile each PR run still *saved* ~1 GB under `refs/pull/N/merge`, which nothing else can read. The repo sat at 7.8 GB of its 10 GB cache budget across 16 entries, 3 of them 907 MB release-tag entries that no later tag can read either.

## The fix

- Add `develop` to the push triggers on Contracts and E2E, so the default branch publishes the cache. This is the bulk of the win: ~10 min back down to ~3 min per PR.
- `save-if: refs/heads/develop` on the Contracts Rust cache, so PRs restore without writing. Drops 1 GB of dead weight and ~45s of post-step per PR.
- `save-if: false` on the release job. A tag can never read another tag's cache ([caching docs](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching)), so its ~900 MB per release was pure waste. Frees ~2.7 GB. Restoring stays on, since it costs nothing when it misses.
- `concurrency` with `cancel-in-progress` on PR runs.

## Considered and left out

- **Playwright browser cache.** 30s on a 53s job, part of it non-cacheable `apt --with-deps` work, and it would compete for budget the Rust cache needs.
- **`shared-key` between Contracts and release.** The release build uses `--target aarch64-apple-darwin`, so its artifacts land in a different `target/` subdirectory than the host builds Contracts caches. Restoring 1 GB to reuse only the registry is roughly a wash. A real release cache would need a release-profile warm-up build on develop; noted in a comment.
- **The MCP sidecar build** (45-95s) stays. `tauri-build` only validates that the `externalBin` file exists, so a stub might do, but that is unverified and touches the release path.

## Notes

The first push to `develop` after this merges will still be a cold ~10 min build, and will populate the cache that every later PR reads.

Optionally, to purge the unreachable entries now rather than waiting for LRU eviction:

```bash
gh api "repos/damione1/souffle/actions/caches?per_page=100" \
  --jq '.actions_caches[]|select(.ref|test("refs/pull/|refs/tags/")).id' \
  | xargs -I{} gh api -X DELETE repos/damione1/souffle/actions/caches/{}
```