### PR TITLE
Keep meetings recording when the mic dies, and abort silent sessions

### DIFF
--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -60,8 +60,15 @@ const LEVEL_EMIT_INTERVAL: Duration = Duration::from_millis(66);
 /// Consecutive rebuild failures after which a dictation session (mic is the
 /// only source) gives up and ends itself, rather than retrying forever
 /// while the UI still claims to be recording. ~10s at the `MIC_CHECK_INTERVAL`
-/// cadence.
+/// cadence — failures closer together than that interval do not increment
+/// the counter (a BT/dock DeviceList burst must not burn the 5 slots in ms
+/// and then kill the capture thread for the process lifetime).
 const DICTATION_ABORT_AFTER_FAILURES: u32 = 5;
+
+/// `spawn_tap` can block this thread for up to 5s. A missing tap is retried
+/// on the next mic rebuild, but not more often than this, so a flapping
+/// mic does not stall the mixer every `MIC_CHECK_INTERVAL`.
+const TAP_RETRY_INTERVAL: Duration = Duration::from_secs(15);
 
 /// Decision for one mic-loss episode in `check_mic_health`, given how many
 /// rebuilds have failed in a row, whether the session has another audio
@@ -139,12 +146,35 @@ fn should_rebuild_mic(
 /// Tearing them down first meant a failed reopen also killed system audio,
 /// after which the `capture_system_audio` *setting* still counted as a
 /// fallback and the session recorded silence.
+///
+/// `tap_owned` is a live `TapHandle`, not the setting. A `MeetingState`
+/// whose `spawn_tap` failed (`tap: None`) must fall through and retry —
+/// unless `tap_retry_ready` is false, which rate-limits the 5s spawn.
 fn should_reuse_meeting(
     existing_session: Option<u64>,
     new_session: u64,
     capture_system_audio: bool,
+    tap_owned: bool,
+    tap_retry_ready: bool,
 ) -> bool {
-    capture_system_audio && existing_session == Some(new_session)
+    if !(capture_system_audio && existing_session == Some(new_session)) {
+        return false;
+    }
+    tap_owned || !tap_retry_ready
+}
+
+/// Count a rebuild failure only when `min_interval` has elapsed since the
+/// last counted one. Returns the new (count, timestamp-of-this-count).
+fn count_rebuild_failure(
+    failures: u32,
+    last_counted: Option<Instant>,
+    now: Instant,
+    min_interval: Duration,
+) -> (u32, Instant) {
+    match last_counted {
+        Some(t) if now.saturating_duration_since(t) < min_interval => (failures, t),
+        _ => (failures.saturating_add(1), now),
+    }
 }
 
 /// The mic-loss ladder's "other source" is a tap that is actually running,
@@ -256,16 +286,50 @@ mod mic_loss_tests {
 
     #[test]
     fn reuses_meeting_only_for_same_session_with_system_audio() {
-        assert!(should_reuse_meeting(Some(7), 7, true));
+        assert!(should_reuse_meeting(Some(7), 7, true, true, false));
         assert!(
-            !should_reuse_meeting(Some(7), 8, true),
+            !should_reuse_meeting(Some(7), 8, true, true, false),
             "a new session must tear the old tap down"
         );
         assert!(
-            !should_reuse_meeting(Some(7), 7, false),
+            !should_reuse_meeting(Some(7), 7, false, true, false),
             "dictation must not keep a leftover meeting tap"
         );
-        assert!(!should_reuse_meeting(None, 7, true));
+        assert!(!should_reuse_meeting(None, 7, true, true, false));
+    }
+
+    #[test]
+    fn missing_tap_is_retried_once_the_window_opens() {
+        assert!(
+            should_reuse_meeting(Some(7), 7, true, false, false),
+            "a just-failed spawn_tap must not be retried on the next 2s tick"
+        );
+        assert!(
+            !should_reuse_meeting(Some(7), 7, true, false, true),
+            "a MeetingState with tap: None must fall through to spawn_tap"
+        );
+        assert!(
+            should_reuse_meeting(Some(7), 7, true, true, true),
+            "an owned tap is never torn down just because the retry window opened"
+        );
+    }
+
+    #[test]
+    fn rebuild_failures_are_not_counted_inside_the_check_interval() {
+        let t0 = Instant::now();
+        let (n1, t1) = count_rebuild_failure(0, None, t0, MIC_CHECK_INTERVAL);
+        assert_eq!(n1, 1);
+        let (n2, t2) = count_rebuild_failure(
+            n1,
+            Some(t1),
+            t0 + Duration::from_millis(10),
+            MIC_CHECK_INTERVAL,
+        );
+        assert_eq!(n2, 1, "a DeviceList burst must not burn the abort ladder");
+        assert_eq!(t2, t1);
+        let (n3, _) =
+            count_rebuild_failure(n2, Some(t1), t0 + MIC_CHECK_INTERVAL, MIC_CHECK_INTERVAL);
+        assert_eq!(n3, 2);
     }
 
     #[test]
@@ -398,6 +462,9 @@ struct MeetingState {
     /// instead of one mixed stream.
     diarize: bool,
     ticks: u32,
+    /// Last `spawn_tap` attempt (success or fail). Caps retries so a
+    /// flapping mic rebuild cannot block this thread for 5s every 2s.
+    last_tap_attempt: Instant,
 }
 
 impl MeetingState {
@@ -605,6 +672,10 @@ pub struct AudioCapture {
     /// Whether the current mic-loss episode already surfaced its one-time
     /// warning (meeting mode only); re-armed on the next successful rebuild.
     mic_loss_warned: bool,
+    /// When the last rebuild failure was counted toward `mic_rebuild_failures`.
+    /// Bursts of CoreAudio DeviceList / DefaultInput notifications must not
+    /// increment the counter faster than `MIC_CHECK_INTERVAL`.
+    last_counted_failure: Option<Instant>,
     /// Shared with the engine actor. Set right before this thread exits
     /// after giving up on an unrecoverable microphone, so the actor's
     /// AudioGone handler can surface a mic-specific message instead of its
@@ -660,6 +731,7 @@ impl AudioCapture {
                     level_throttle: AudioLevelThrottle::new(),
                     mic_rebuild_failures: 0,
                     mic_loss_warned: false,
+                    last_counted_failure: None,
                     audio_gone_reason,
                 };
 
@@ -866,6 +938,8 @@ impl AudioCapture {
             self.meeting.as_ref().map(|m| m.session_id),
             session_id,
             capture_system_audio,
+            self.tap_owned_for_reuse(),
+            self.tap_retry_ready(),
         ) {
             self.meeting.take();
         }
@@ -1228,6 +1302,7 @@ impl AudioCapture {
             aec_active,
             diarize,
             ticks: 0,
+            last_tap_attempt: Instant::now(),
         });
 
         info!("Meeting audio capture started (mic + system audio)");
@@ -1308,6 +1383,7 @@ impl AudioCapture {
         ) {
             Ok(()) => {
                 self.mic_rebuild_failures = 0;
+                self.last_counted_failure = None;
                 self.mic_loss_warned = false;
                 if resolved_changed && resolved != self.mic_device_uid {
                     warn!(
@@ -1320,7 +1396,14 @@ impl AudioCapture {
                 false
             }
             Err(e) => {
-                self.mic_rebuild_failures += 1;
+                let (n, counted_at) = count_rebuild_failure(
+                    self.mic_rebuild_failures,
+                    self.last_counted_failure,
+                    Instant::now(),
+                    MIC_CHECK_INTERVAL,
+                );
+                self.mic_rebuild_failures = n;
+                self.last_counted_failure = Some(counted_at);
                 warn!(
                     "Capture rebuild failed ({} in a row): {e}",
                     self.mic_rebuild_failures
@@ -1377,10 +1460,40 @@ impl AudioCapture {
 
     /// A process tap that is still owned by this session. The system-audio
     /// *setting* is not enough: a rebuild may have already dropped the tap.
+    /// Ownership, not IOProc liveness — a zombie handle still counts.
     fn tap_is_live(&self) -> bool {
         #[cfg(target_os = "macos")]
         {
             self.meeting.as_ref().is_some_and(|m| m.tap.is_some())
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            false
+        }
+    }
+
+    /// Whether `should_reuse_meeting` may keep the current mixer. On macOS
+    /// this is a tap handle; elsewhere there is nothing to recover so a
+    /// same-session meeting mixer is always reusable.
+    fn tap_owned_for_reuse(&self) -> bool {
+        #[cfg(target_os = "macos")]
+        {
+            self.tap_is_live()
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            self.meeting.is_some()
+        }
+    }
+
+    /// Missing tap + retry window elapsed. `spawn_tap` blocks up to 5s, so
+    /// this must stay false on the 2s health cadence after a failed spawn.
+    fn tap_retry_ready(&self) -> bool {
+        #[cfg(target_os = "macos")]
+        {
+            self.meeting.as_ref().is_some_and(|m| {
+                m.tap.is_none() && m.last_tap_attempt.elapsed() >= TAP_RETRY_INTERVAL
+            })
         }
         #[cfg(not(target_os = "macos"))]
         {

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -135,6 +135,25 @@ fn should_rebuild_mic(
     stream_failed || callbacks_stale || device_replaced || device_not_alive || resolved_changed
 }
 
+/// Keep the meeting tap/mixer across a mic rebuild of the same session.
+/// Tearing them down first meant a failed reopen also killed system audio,
+/// after which the `capture_system_audio` *setting* still counted as a
+/// fallback and the session recorded silence.
+fn should_reuse_meeting(
+    existing_session: Option<u64>,
+    new_session: u64,
+    capture_system_audio: bool,
+) -> bool {
+    capture_system_audio && existing_session == Some(new_session)
+}
+
+/// The mic-loss ladder's "other source" is a tap that is actually running,
+/// not the user's setting. A meeting that requested system audio but never
+/// got a tap (or lost it) is dictation: abort rather than fake-record.
+fn has_fallback_audio(tap_live: bool) -> bool {
+    tap_live
+}
+
 #[cfg(test)]
 mod mic_loss_tests {
     use super::*;
@@ -233,6 +252,47 @@ mod mic_loss_tests {
         );
         assert!(should_rebuild_mic(true, false, false, false, false));
         assert!(should_rebuild_mic(false, false, false, false, true));
+    }
+
+    #[test]
+    fn reuses_meeting_only_for_same_session_with_system_audio() {
+        assert!(should_reuse_meeting(Some(7), 7, true));
+        assert!(
+            !should_reuse_meeting(Some(7), 8, true),
+            "a new session must tear the old tap down"
+        );
+        assert!(
+            !should_reuse_meeting(Some(7), 7, false),
+            "dictation must not keep a leftover meeting tap"
+        );
+        assert!(!should_reuse_meeting(None, 7, true));
+    }
+
+    #[test]
+    fn fallback_is_a_live_tap_not_the_system_audio_setting() {
+        // The setting alone used to keep a meeting alive after a rebuild
+        // had already dropped the tap — UI still "recording", no audio.
+        assert!(
+            !has_fallback_audio(false),
+            "tap missing → abort like dictation"
+        );
+        assert!(has_fallback_audio(true));
+        assert_eq!(
+            decide_mic_loss(
+                DICTATION_ABORT_AFTER_FAILURES,
+                has_fallback_audio(false),
+                false
+            ),
+            MicLossAction::Abort
+        );
+        assert_eq!(
+            decide_mic_loss(
+                DICTATION_ABORT_AFTER_FAILURES,
+                has_fallback_audio(true),
+                false
+            ),
+            MicLossAction::WarnOnce
+        );
     }
 }
 
@@ -685,7 +745,9 @@ impl AudioCapture {
                                 info!("Selected input device UID: {uid}");
                                 capture.selected_device = Some(uid);
                             }
-                            capture.refresh_input_route();
+                            if capture.refresh_input_route() {
+                                break;
+                            }
                         }
                         AudioCommand::SetClamshellDevice(uid) => {
                             if let Some(ref uid) = uid {
@@ -694,7 +756,9 @@ impl AudioCapture {
                                 info!("Clamshell-mode microphone preference cleared");
                             }
                             capture.clamshell_device = uid;
-                            capture.refresh_input_route();
+                            if capture.refresh_input_route() {
+                                break;
+                            }
                         }
                         AudioCommand::SetInputPolicy {
                             priority,
@@ -702,13 +766,17 @@ impl AudioCapture {
                         } => {
                             capture.input_priority = priority;
                             capture.allow_bluetooth_mic = allow_bluetooth_mic;
-                            capture.refresh_input_route();
+                            if capture.refresh_input_route() {
+                                break;
+                            }
                         }
                         AudioCommand::AttachApp(app) => {
                             capture.app = Some(app);
                         }
                         AudioCommand::RefreshInputRoute => {
-                            capture.refresh_input_route();
+                            if capture.refresh_input_route() {
+                                break;
+                            }
                         }
                     }
                 }
@@ -787,13 +855,20 @@ impl AudioCapture {
         diarize: bool,
         record_path: Option<PathBuf>,
     ) -> Result<(), String> {
-        // Ensure any previous callback stops emitting immediately, and tear
-        // down any leftover meeting state (tap included). The recorder is
-        // NOT torn down here; see `sync_recorder`, so a mid-session mic
-        // rebuild (same session_id) keeps recording to the same file.
+        // Ensure any previous callback stops emitting immediately. The
+        // recorder is NOT torn down here; see `sync_recorder`, so a
+        // mid-session mic rebuild (same session_id) keeps recording to the
+        // same file. The meeting tap/mixer stay too: dropping them here
+        // made a failed mic reopen also lose system audio.
         self.active_session_id.store(0, Ordering::Release);
         self.release_capture_stream();
-        self.meeting.take();
+        if !should_reuse_meeting(
+            self.meeting.as_ref().map(|m| m.session_id),
+            session_id,
+            capture_system_audio,
+        ) {
+            self.meeting.take();
+        }
         self.sync_recorder(session_id, record_path.as_deref(), target_sample_rate);
 
         // Stored before any fallible step so a failed (re)build is retried
@@ -852,6 +927,9 @@ impl AudioCapture {
                 diarize,
             );
         }
+
+        // Dictation: never keep a leftover meeting tap from a prior session.
+        self.meeting.take();
 
         let resampler = Arc::new(Mutex::new(Resampler::new(
             sample_rate,
@@ -1038,10 +1116,9 @@ impl AudioCapture {
         let sample_rate = config.sample_rate;
         let channels = config.channels;
 
-        // ~2s of headroom per ring; the 5ms tick drains far faster.
+        // ~2s of headroom per ring; the 20ms tick drains far faster.
         let mic_capacity = (sample_rate as usize * channels as usize) * 2;
         let (mut mic_prod, mic_cons) = HeapRb::<f32>::new(mic_capacity).split();
-        let (tap_prod, tap_cons) = HeapRb::<f32>::new(super::mixer::MIX_RATE as usize * 2).split();
 
         // Mic stream first: it's the session's pacing clock and must never
         // be held hostage by tap startup (see system_tap.rs module docs).
@@ -1082,6 +1159,19 @@ impl AudioCapture {
         // bounds how much of a slow tap's wait it can retain, but that beats
         // discarding all of it outright.
         self.active_session_id.store(session_id, Ordering::Release);
+
+        if let Some(meeting) = self.meeting.as_mut() {
+            meeting
+                .mixer
+                .replace_mic(mic_cons, sample_rate, channels, mic_gain);
+            meeting.session_id = session_id;
+            meeting.diarize = diarize;
+            self.stream = Some(stream);
+            info!("Meeting microphone rebuilt; system-audio tap kept");
+            return Ok(());
+        }
+
+        let (tap_prod, tap_cons) = HeapRb::<f32>::new(super::mixer::MIX_RATE as usize * 2).split();
 
         #[cfg(target_os = "macos")]
         let (tap, tap_rate) = match super::system_tap::spawn_tap(tap_prod, Duration::from_secs(5)) {
@@ -1237,7 +1327,7 @@ impl AudioCapture {
                 );
                 match decide_mic_loss(
                     self.mic_rebuild_failures,
-                    params.capture_system_audio,
+                    has_fallback_audio(self.tap_is_live()),
                     self.mic_loss_warned,
                 ) {
                     MicLossAction::KeepRetrying => false,
@@ -1265,7 +1355,13 @@ impl AudioCapture {
     /// Called on explicit route events (device pick, policy change, CoreAudio
     /// device-list or default-input change), so a previously non-converged
     /// target is fair game again.
-    fn refresh_input_route(&mut self) {
+    ///
+    /// Returns `true` when the microphone is unrecoverable and the session
+    /// has been torn down: the caller must break the audio thread so the
+    /// actor observes AudioGone. Returning without exiting left the actor
+    /// waiting on a channel that never closed, and `Stop` could no longer
+    /// send EndOfStream (`active_params` was already cleared).
+    fn refresh_input_route(&mut self) -> bool {
         self.route_attempt_uid = None;
         if self.active_params.is_some() {
             self.last_mic_check = Instant::now();
@@ -1273,7 +1369,22 @@ impl AudioCapture {
                 tracing::error!(
                     "Microphone unrecoverable after input route change; ending session"
                 );
+                return true;
             }
+        }
+        false
+    }
+
+    /// A process tap that is still owned by this session. The system-audio
+    /// *setting* is not enough: a rebuild may have already dropped the tap.
+    fn tap_is_live(&self) -> bool {
+        #[cfg(target_os = "macos")]
+        {
+            self.meeting.as_ref().is_some_and(|m| m.tap.is_some())
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            false
         }
     }
 
@@ -1281,6 +1392,7 @@ impl AudioCapture {
     fn meeting_tick(&mut self) {
         // Do all mixer work inside this borrow, then release it before calling
         // &self/&mut self helpers (sending, RMS) to satisfy the borrow checker.
+        let tap_clock = self.stream.is_none();
         let (session_id, diarize, mixed, me, them) = {
             let Some(meeting) = self.meeting.as_mut() else {
                 return;
@@ -1290,10 +1402,18 @@ impl AudioCapture {
                 meeting.check_output_route(self.app.as_ref());
             }
             if meeting.diarize {
-                let (me, them) = meeting.mixer.tick_split();
+                let (me, them) = if tap_clock {
+                    meeting.mixer.tick_split_on_tap_clock()
+                } else {
+                    meeting.mixer.tick_split()
+                };
                 (meeting.session_id, true, Vec::new(), me, them)
             } else {
-                let mixed = meeting.mixer.tick();
+                let mixed = if tap_clock {
+                    meeting.mixer.tick_on_tap_clock()
+                } else {
+                    meeting.mixer.tick()
+                };
                 (meeting.session_id, false, mixed, Vec::new(), Vec::new())
             }
         };

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -177,6 +177,19 @@ fn count_rebuild_failure(
     }
 }
 
+/// The abort ladder is per-session. A meeting that KeepRetrying-ed on a
+/// live tap can leave the counter at 50; the next dictation must not
+/// Abort on its first transient SetInputPolicy.
+fn reset_mic_loss_ladder(
+    failures: &mut u32,
+    last_counted: &mut Option<Instant>,
+    warned: &mut bool,
+) {
+    *failures = 0;
+    *last_counted = None;
+    *warned = false;
+}
+
 /// The mic-loss ladder's "other source" is a tap that is actually running,
 /// not the user's setting. A meeting that requested system audio but never
 /// got a tap (or lost it) is dictation: abort rather than fake-record.
@@ -330,6 +343,24 @@ mod mic_loss_tests {
         let (n3, _) =
             count_rebuild_failure(n2, Some(t1), t0 + MIC_CHECK_INTERVAL, MIC_CHECK_INTERVAL);
         assert_eq!(n3, 2);
+    }
+
+    #[test]
+    fn mic_loss_ladder_resets_between_sessions() {
+        let mut failures = 50;
+        let mut last = Some(Instant::now());
+        let mut warned = true;
+        reset_mic_loss_ladder(&mut failures, &mut last, &mut warned);
+        assert_eq!(failures, 0);
+        assert_eq!(last, None);
+        assert!(!warned);
+        let (n, _) = count_rebuild_failure(failures, last, Instant::now(), MIC_CHECK_INTERVAL);
+        assert_eq!(n, 1, "first failure of the new session counts from zero");
+        assert_eq!(
+            decide_mic_loss(n, false, false),
+            MicLossAction::KeepRetrying,
+            "a leftover meeting counter must not abort the next dictation"
+        );
     }
 
     #[test]
@@ -927,6 +958,13 @@ impl AudioCapture {
         diarize: bool,
         record_path: Option<PathBuf>,
     ) -> Result<(), String> {
+        let is_new_session = self
+            .active_params
+            .as_ref()
+            .is_none_or(|p| p.session_id != session_id);
+        if is_new_session {
+            self.clear_mic_loss_ladder();
+        }
         // Ensure any previous callback stops emitting immediately. The
         // recorder is NOT torn down here; see `sync_recorder`, so a
         // mid-session mic rebuild (same session_id) keeps recording to the
@@ -1382,9 +1420,7 @@ impl AudioCapture {
             params.record_path.clone(),
         ) {
             Ok(()) => {
-                self.mic_rebuild_failures = 0;
-                self.last_counted_failure = None;
-                self.mic_loss_warned = false;
+                self.clear_mic_loss_ladder();
                 if resolved_changed && resolved != self.mic_device_uid {
                     warn!(
                         "Input route did not converge on the resolved device \
@@ -1456,6 +1492,14 @@ impl AudioCapture {
             }
         }
         false
+    }
+
+    fn clear_mic_loss_ladder(&mut self) {
+        reset_mic_loss_ladder(
+            &mut self.mic_rebuild_failures,
+            &mut self.last_counted_failure,
+            &mut self.mic_loss_warned,
+        );
     }
 
     /// A process tap that is still owned by this session. The system-audio
@@ -1654,6 +1698,7 @@ impl AudioCapture {
         self.finish_recording();
         self.emit_audio_level(0.0);
         self.level_throttle.reset();
+        self.clear_mic_loss_ladder();
     }
 
     fn abort_after_panic(&mut self) {
@@ -1715,6 +1760,7 @@ impl AudioCapture {
         self.last_mic_callback_ms.store(0, Ordering::Relaxed);
         self.emit_audio_level(0.0);
         self.level_throttle.reset();
+        self.clear_mic_loss_ladder();
 
         // Stop IO and dispose the AudioUnit — after this, no callback runs
         // and a Bluetooth headset can leave HFP/mono for A2DP stereo.

--- a/src-tauri/src/audio/mixer.rs
+++ b/src-tauri/src/audio/mixer.rs
@@ -380,6 +380,20 @@ mod tests {
     }
 
     #[test]
+    fn tap_clock_does_not_discard_lead_when_mic_is_empty() {
+        let (_mic, mut tap, mut mixer) = make_mixer(48_000, 48_000, 16_000);
+        // More than MAX_TAP_LEAD_SAMPLES (12_000): mic-clock ingest would drop it.
+        tap.push_slice(&vec![0.4f32; 24_000]);
+        let out = mixer.tick_on_tap_clock();
+        assert!(!out.is_empty());
+        assert_eq!(
+            mixer.tap_discarded(),
+            0,
+            "a dead mic must not treat the live tap as clock-drift lead"
+        );
+    }
+
+    #[test]
     fn tap_clock_split_puts_system_audio_on_them_only() {
         let (_mic, mut tap, mut mixer) = make_mixer(48_000, 48_000, 16_000);
 

--- a/src-tauri/src/audio/mixer.rs
+++ b/src-tauri/src/audio/mixer.rs
@@ -78,15 +78,46 @@ impl MeetingMixer {
         self.aec = aec;
     }
 
+    /// Swap the microphone ring after a mid-session rebuild. The tap ring,
+    /// its resampler, and AEC stay put so a USB/BT mic flip does not tear
+    /// down a live process tap (and lose system audio if the new tap fails).
+    pub fn replace_mic(
+        &mut self,
+        mic: HeapCons<f32>,
+        mic_rate: u32,
+        mic_channels: u16,
+        mic_gain: f32,
+    ) {
+        self.mic = mic;
+        self.mic_to_mix = Resampler::new(mic_rate, mic_channels, MIX_RATE, mic_gain);
+        self.mic_fifo.clear();
+    }
+
     /// Drain both rings, mix every complete 10ms frame, and return the
     /// resulting engine-rate samples (possibly empty).
     pub fn tick(&mut self) -> Vec<f32> {
-        self.ingest();
+        self.tick_inner(false)
+    }
+
+    /// Like [`tick`], but when the mic fifo has no full frame, pace on the
+    /// tap so a dead mic does not discard system audio as "lead".
+    pub fn tick_on_tap_clock(&mut self) -> Vec<f32> {
+        self.tick_inner(true)
+    }
+
+    fn tick_inner(&mut self, tap_clock: bool) -> Vec<f32> {
+        self.ingest(!tap_clock);
 
         let mut out = Vec::new();
         while self.mic_fifo.len() >= FRAME_SAMPLES {
             let frame = self.mix_frame(FRAME_SAMPLES);
             out.extend(self.to_engine.process(&frame));
+        }
+        if tap_clock {
+            while self.tap_fifo.len() >= FRAME_SAMPLES {
+                let frame = self.tap_only_frame(FRAME_SAMPLES);
+                out.extend(self.to_engine.process(&frame));
+            }
         }
         out
     }
@@ -94,7 +125,7 @@ impl MeetingMixer {
     /// Final drain when the session stops: both producers are gone, so
     /// everything left in the rings, FIFOs, and resampler tails comes out.
     pub fn flush(&mut self) -> Vec<f32> {
-        let mut out = self.tick();
+        let mut out = self.tick_on_tap_clock();
 
         let mic_tail = self.mic_to_mix.flush();
         self.mic_fifo.extend(mic_tail);
@@ -122,7 +153,16 @@ impl MeetingMixer {
     /// system audio). Each leg has its own engine resampler so their stream
     /// states don't interfere.
     pub fn tick_split(&mut self) -> (Vec<f32>, Vec<f32>) {
-        self.ingest();
+        self.tick_split_inner(false)
+    }
+
+    /// Diarized counterpart of [`tick_on_tap_clock`].
+    pub fn tick_split_on_tap_clock(&mut self) -> (Vec<f32>, Vec<f32>) {
+        self.tick_split_inner(true)
+    }
+
+    fn tick_split_inner(&mut self, tap_clock: bool) -> (Vec<f32>, Vec<f32>) {
+        self.ingest(!tap_clock);
 
         let (mut me, mut them) = (Vec::new(), Vec::new());
         while self.mic_fifo.len() >= FRAME_SAMPLES {
@@ -130,12 +170,18 @@ impl MeetingMixer {
             me.extend(self.to_engine.process(&mic));
             them.extend(self.tap_to_engine.process(&tap));
         }
+        if tap_clock {
+            while self.tap_fifo.len() >= FRAME_SAMPLES {
+                let tap: Vec<f32> = self.tap_fifo.drain(..FRAME_SAMPLES).collect();
+                them.extend(self.tap_to_engine.process(&tap));
+            }
+        }
         (me, them)
     }
 
     /// Diarized counterpart of `flush`.
     pub fn flush_split(&mut self) -> (Vec<f32>, Vec<f32>) {
-        let (mut me, mut them) = self.tick_split();
+        let (mut me, mut them) = self.tick_split_on_tap_clock();
 
         let mic_tail = self.mic_to_mix.flush();
         self.mic_fifo.extend(mic_tail);
@@ -164,7 +210,7 @@ impl MeetingMixer {
         self.tap_discarded
     }
 
-    fn ingest(&mut self) {
+    fn ingest(&mut self, bound_tap_lead: bool) {
         loop {
             let n = self.mic.pop_slice(&mut self.scratch);
             if n == 0 {
@@ -182,13 +228,16 @@ impl MeetingMixer {
             self.tap_fifo.extend(resampled);
         }
 
-        // Bound how far the tap leg can run ahead of the mic (clock drift,
-        // or a stalled mic device): drop the oldest excess.
-        let max_len = self.mic_fifo.len() + MAX_TAP_LEAD_SAMPLES;
-        if self.tap_fifo.len() > max_len {
-            let excess = self.tap_fifo.len() - max_len;
-            self.tap_fifo.drain(..excess);
-            self.tap_discarded += excess as u64;
+        // Bound how far the tap leg can run ahead of the mic (clock drift).
+        // Skip this when pacing on the tap: a dead mic would otherwise make
+        // us discard the only remaining source as "lead".
+        if bound_tap_lead {
+            let max_len = self.mic_fifo.len() + MAX_TAP_LEAD_SAMPLES;
+            if self.tap_fifo.len() > max_len {
+                let excess = self.tap_fifo.len() - max_len;
+                self.tap_fifo.drain(..excess);
+                self.tap_discarded += excess as u64;
+            }
         }
     }
 
@@ -201,6 +250,15 @@ impl MeetingMixer {
             *sample = (*sample + *tap).clamp(-1.0, 1.0);
         }
         mic
+    }
+
+    /// System-audio frame with no mic to pair. Used when the mic stream is
+    /// down and the tap is the session's only live source.
+    fn tap_only_frame(&mut self, n: usize) -> Vec<f32> {
+        let tap_n = n.min(self.tap_fifo.len());
+        let mut tap: Vec<f32> = self.tap_fifo.drain(..tap_n).collect();
+        tap.resize(n, 0.0);
+        tap
     }
 
     /// Drain one frame from each leg and echo-cancel the mic, but return the
@@ -301,6 +359,59 @@ mod tests {
             "excess tap lead should be dropped"
         );
         assert!(mixer.tap_fifo.len() <= MAX_TAP_LEAD_SAMPLES + FRAME_SAMPLES);
+    }
+
+    #[test]
+    fn tap_clock_emits_system_audio_when_mic_is_empty() {
+        let (_mic, mut tap, mut mixer) = make_mixer(48_000, 48_000, 16_000);
+
+        tap.push_slice(&vec![0.4f32; 4_800]);
+        assert!(
+            mixer.tick().is_empty(),
+            "mic clock must not invent frames from tap alone"
+        );
+        let out = mixer.tick_on_tap_clock();
+        assert!(
+            !out.is_empty(),
+            "a dead mic must still deliver the live tap, not discard it as lead"
+        );
+        let mid = out[out.len() / 2];
+        assert!((mid - 0.4).abs() < 0.05, "expected ~0.4, got {mid}");
+    }
+
+    #[test]
+    fn tap_clock_split_puts_system_audio_on_them_only() {
+        let (_mic, mut tap, mut mixer) = make_mixer(48_000, 48_000, 16_000);
+
+        tap.push_slice(&vec![0.3f32; 4_800]);
+        let (me, them) = mixer.tick_split_on_tap_clock();
+        assert!(me.is_empty(), "no mic frames to emit");
+        assert!(!them.is_empty(), "them must carry the tap");
+        let mid = them[them.len() / 2];
+        assert!((mid - 0.3).abs() < 0.05, "expected ~0.3, got {mid}");
+    }
+
+    #[test]
+    fn replace_mic_keeps_buffered_tap() {
+        let (old_mic, mut tap, mut mixer) = make_mixer(48_000, 48_000, 16_000);
+        tap.push_slice(&vec![0.2f32; FRAME_SAMPLES]);
+        // Ingest the tap into the fifo without a mic frame so it stays put.
+        assert!(mixer.tick().is_empty());
+        drop(old_mic);
+
+        let (mut new_mic, new_cons) = HeapRb::<f32>::new(48_000 * 2).split();
+        mixer.replace_mic(new_cons, 48_000, 1, 1.0);
+        new_mic.push_slice(&vec![0.1f32; FRAME_SAMPLES]);
+        let mut out = mixer.tick();
+        out.extend(mixer.flush());
+
+        assert!(!out.is_empty());
+        // Cross-rate FFT buffering plus the flush pad means the mix may not
+        // sit at the midpoint; any sample near 0.3 proves the tap survived.
+        assert!(
+            out.iter().any(|s| (*s - 0.3).abs() < 0.05),
+            "replaced mic must still mix with the tap that survived the rebuild"
+        );
     }
 
     #[test]
@@ -409,7 +520,13 @@ mod aec_bench {
     /// Sum of sinusoids at `freqs` plus a touch of low-pass-filtered noise,
     /// so the signal has broadband content like real speech/video audio
     /// rather than a single tone.
-    fn synth_wideband(len: usize, sample_rate: u32, freqs: &[(f32, f32)], noise_amp: f32, seed: u64) -> Vec<f32> {
+    fn synth_wideband(
+        len: usize,
+        sample_rate: u32,
+        freqs: &[(f32, f32)],
+        noise_amp: f32,
+        seed: u64,
+    ) -> Vec<f32> {
         let mut rng = Xorshift(seed);
         let mut noise_state = 0.0f32;
         (0..len)
@@ -471,7 +588,15 @@ mod aec_bench {
         let (mut tap_prod, tap_cons) = HeapRb::<f32>::new(sample_rate as usize).split();
         // engine_rate == MIX_RATE: no cross-resampling, so the bench measures
         // the AEC's contribution in isolation from resampler artifacts.
-        let mut mixer = MeetingMixer::new(mic_cons, sample_rate, 1, 1.0, tap_cons, sample_rate, sample_rate);
+        let mut mixer = MeetingMixer::new(
+            mic_cons,
+            sample_rate,
+            1,
+            1.0,
+            tap_cons,
+            sample_rate,
+            sample_rate,
+        );
         let mut aec = Aec::new(sample_rate);
         if let Some(hint) = expected_delay_hint_ms {
             aec.set_expected_delay_ms(hint);
@@ -523,7 +648,9 @@ mod aec_bench {
         let mut converge_frame = None;
         for i in 0..n_frames.saturating_sub(sustain_frames) {
             let window_pre: f32 = echo_energy_per_frame[i..i + sustain_frames].iter().sum();
-            let window_post: f32 = residual_energy_per_frame[i..i + sustain_frames].iter().sum();
+            let window_post: f32 = residual_energy_per_frame[i..i + sustain_frames]
+                .iter()
+                .sum();
             if window_post < window_pre * 0.1 {
                 converge_frame = Some(i);
                 break;
@@ -553,7 +680,9 @@ mod aec_bench {
         println!(
             "AEC bench (no stream_delay_ms hint, 50ms acoustic delay): ERLE post-convergence = \
              {erle_db:.1} dB, convergence at ~{}ms",
-            converge_frame.map(|f| f * 10).map_or("never".to_string(), |ms| ms.to_string())
+            converge_frame
+                .map(|f| f * 10)
+                .map_or("never".to_string(), |ms| ms.to_string())
         );
         assert!(
             erle_db > DOUBLE_TALK_ERLE_FLOOR_DB,
@@ -568,7 +697,9 @@ mod aec_bench {
         println!(
             "AEC bench (50ms stream_delay_ms hint, 50ms acoustic delay): ERLE post-convergence = \
              {erle_db:.1} dB, convergence at ~{}ms",
-            converge_frame.map(|f| f * 10).map_or("never".to_string(), |ms| ms.to_string())
+            converge_frame
+                .map(|f| f * 10)
+                .map_or("never".to_string(), |ms| ms.to_string())
         );
         assert!(
             erle_db > DOUBLE_TALK_ERLE_FLOOR_DB,
@@ -587,8 +718,9 @@ mod aec_bench {
         println!(
             "AEC bench (echo only, no voice, 50ms hint, 50ms acoustic delay): ERLE \
              post-convergence = {erle_db:.1} dB, convergence at ~{}ms",
-            converge_frame.map(|f| f * 10).map_or("never".to_string(), |ms| ms.to_string())
+            converge_frame
+                .map(|f| f * 10)
+                .map_or("never".to_string(), |ms| ms.to_string())
         );
     }
-
 }

--- a/src-tauri/src/audio/recorder.rs
+++ b/src-tauri/src/audio/recorder.rs
@@ -282,16 +282,23 @@ impl MeetingRecorder {
                     .then(|| super::resampler::Resampler::new(sample_rate, 1, encode_rate, 1.0));
 
                 while let Ok(RecorderMsg::Chunk(samples)) = rx.recv() {
-                    let owned;
-                    let encode_samples: &[f32] = match resampler.as_mut() {
-                        Some(r) => {
-                            owned = r.process(&samples);
-                            &owned
-                        }
-                        None => &samples,
-                    };
-                    if let Err(e) = writer.write_chunk(encode_samples) {
-                        tracing::warn!("Meeting recorder encode error: {e}");
+                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        let owned;
+                        let encode_samples: &[f32] = match resampler.as_mut() {
+                            Some(r) => {
+                                owned = r.process(&samples);
+                                &owned
+                            }
+                            None => &samples,
+                        };
+                        writer.write_chunk(encode_samples)
+                    }));
+                    match result {
+                        Ok(Ok(())) => {}
+                        Ok(Err(e)) => tracing::warn!("Meeting recorder encode error: {e}"),
+                        Err(_) => tracing::warn!(
+                            "Meeting recorder panicked on a chunk; skipping it and keeping the file"
+                        ),
                     }
                 }
 

--- a/src-tauri/src/audio/recorder.rs
+++ b/src-tauri/src/audio/recorder.rs
@@ -247,6 +247,42 @@ enum RecorderMsg {
     Chunk(Vec<f32>),
 }
 
+/// Flush then finish, each under `catch_unwind`, so a poisoned resampler
+/// cannot skip the Ogg EndStream page.
+#[cfg(test)]
+fn run_guarded_finalize(flush: impl FnOnce(), finish: impl FnOnce()) {
+    if std::panic::catch_unwind(std::panic::AssertUnwindSafe(flush)).is_err() {
+        tracing::warn!("Meeting recorder panicked on resampler flush; still finalizing the file");
+    }
+    if std::panic::catch_unwind(std::panic::AssertUnwindSafe(finish)).is_err() {
+        tracing::warn!("Meeting recorder panicked while finishing the file");
+    }
+}
+
+fn finalize_recorder_writer<W: Write>(
+    resampler: &mut Option<super::resampler::Resampler>,
+    writer: &mut OggOpusWriter<W>,
+) {
+    if let Some(r) = resampler.as_mut() {
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| r.flush())) {
+            Ok(tail) if !tail.is_empty() => {
+                if let Err(e) = writer.write_chunk(&tail) {
+                    tracing::warn!("Meeting recorder tail flush error: {e}");
+                }
+            }
+            Ok(_) => {}
+            Err(_) => tracing::warn!(
+                "Meeting recorder panicked on resampler flush; still finalizing the file"
+            ),
+        }
+    }
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| writer.finish())) {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => tracing::warn!("Meeting recorder finalize error: {e}"),
+        Err(_) => tracing::warn!("Meeting recorder panicked while finishing the file"),
+    }
+}
+
 /// Feeds mono f32 PCM to a background writer thread that encodes it to an
 /// Ogg Opus file. One instance per recording session (see
 /// `capture::AudioCapture`'s recorder field — it survives mid-session
@@ -302,17 +338,7 @@ impl MeetingRecorder {
                     }
                 }
 
-                if let Some(r) = resampler.as_mut() {
-                    let tail = r.flush();
-                    if !tail.is_empty()
-                        && let Err(e) = writer.write_chunk(&tail)
-                    {
-                        tracing::warn!("Meeting recorder tail flush error: {e}");
-                    }
-                }
-                if let Err(e) = writer.finish() {
-                    tracing::warn!("Meeting recorder finalize error: {e}");
-                }
+                finalize_recorder_writer(&mut resampler, &mut writer);
             })
             .map_err(|e| format!("Spawn meeting recorder thread: {e}"))?;
 
@@ -425,6 +451,20 @@ mod tests {
         assert_eq!(&bytes[0..4], b"OggS", "file must start with an Ogg page");
         // Granule position should reflect ~2s at 48kHz-equivalent samples.
         assert!(writer.granule_position >= 95_000 && writer.granule_position <= 97_000);
+    }
+
+    #[test]
+    fn finalize_still_runs_after_flush_panic() {
+        use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+        let finished = AtomicBool::new(false);
+        run_guarded_finalize(
+            || panic!("poisoned resampler"),
+            || finished.store(true, AtomicOrdering::Relaxed),
+        );
+        assert!(
+            finished.load(AtomicOrdering::Relaxed),
+            "EndStream must still run after a flush panic"
+        );
     }
 
     #[test]

--- a/src-tauri/src/audio/system_tap.rs
+++ b/src-tauri/src/audio/system_tap.rs
@@ -230,7 +230,10 @@ impl SystemTap {
                   _input_time: NonNull<AudioTimeStamp>,
                   _output_data: NonNull<AudioBufferList>,
                   _output_time: NonNull<AudioTimeStamp>| {
-                forward_input(&block_shared, input_data);
+                // Unwinding across the HAL C boundary is UB. A bad buffer
+                // or a poisoned-then-recovered producer must not take the
+                // process down; the mixer treats a silent tap as zeros.
+                swallow_io_panic(|| forward_input(&block_shared, input_data));
             },
         );
 
@@ -346,6 +349,10 @@ impl Drop for SystemTap {
         LIVE_TAPS.fetch_sub(1, Ordering::Relaxed);
         info!("System audio tap stopped");
     }
+}
+
+fn swallow_io_panic(f: impl FnOnce()) {
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
 }
 
 /// Forward the tap's input buffers into the ring buffer. Runs on the tap's
@@ -496,6 +503,11 @@ mod tests {
     /// The sweep destroys every Souffle aggregate it finds, so it must stay
     /// out of the way while a tap is running: a rebuild mid-meeting spawns a
     /// new tap while the old one is still tearing down.
+    #[test]
+    fn io_callback_panic_must_not_propagate() {
+        swallow_io_panic(|| panic!("malformed AudioBufferList"));
+    }
+
     #[test]
     fn no_sweep_while_a_tap_is_alive() {
         TEARDOWN_SUSPECT.store(true, Ordering::Relaxed);


### PR DESCRIPTION
## Summary
- A failed dock/BT mic rebuild used to tear down the process tap, then treat the `capture_system_audio` *setting* as a live fallback. Meetings kept "recording" silence. Same-session rebuilds now keep the tap (`replace_mic`); fallback is a tap handle that actually exists; a dead mic paces the mixer on the tap instead of discarding system audio as lead.
- Abort via route change (`SelectDevice` / clamshell / policy / CoreAudio notify) now exits the capture thread so the actor sees `AudioGone`. `spawn_tap` is retried after an initial timeout (rate-limited to 15s). The 5-failure abort ladder has a 2s floor (DeviceList bursts) and resets at session boundaries (a meeting that KeepRetrying-ed at 50 no longer kills the next dictation).
- Panic in the tap IOProc or the Opus writer no longer unwinds into the HAL or skips the Ogg EndStream page.

## Test plan
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml --lib audio` (125 passed, 6 ignored locally)
- [ ] Meeting + unplug USB/BT mic: toast "still recording system audio", Them keeps moving, tap is not torn down
- [ ] Meeting started just after wake if system audio fails: plugging a headset later retries the tap (after 15s), not mic-only forever
- [ ] Dictation after a long meeting-with-mic-down: a single CoreAudio notify must not abort / kill capture for the rest of the process
- [ ] Stop a meeting after mic-loss fallback: actor still gets EOS, audio file finalizes
- [ ] Lid / dock DeviceList burst while dictating: must not burn the abort ladder in milliseconds