### PR TITLE
Stop the Kyutai model-dir copy bomb, and cut Whisper/Parakeet on silence

### DIFF
--- a/src-tauri/src/engine/batch_windows.rs
+++ b/src-tauri/src/engine/batch_windows.rs
@@ -1,0 +1,174 @@
+//! Shared batch-window cutting for Whisper and Parakeet.
+//!
+//! Both engines are stateless per window. Fixed 5 s non-overlapping cuts
+//! split words at the boundary (`data | platform`, `Snow | flake`) and
+//! push Parakeet into inventing a completion (`The next one is the same
+//! thing.`). Cut on a silence gap in [4 s, 7 s] instead; if none, cut at
+//! 7 s. The advertised pipeline hop stays 5 s — leftover samples sit in
+//! the engine buffer.
+
+/// Whisper / Parakeet sample rate.
+pub const SAMPLE_RATE: u32 = 16_000;
+
+/// Pipeline hop advertised as `chunk_size_samples`. Actor and CLI still
+/// deliver this many samples per `transcribe` call.
+pub const CHUNK_SAMPLES: usize = SAMPLE_RATE as usize * 5;
+
+const MIN_CUT_SAMPLES: usize = SAMPLE_RATE as usize * 4;
+const MAX_CUT_SAMPLES: usize = SAMPLE_RATE as usize * 7;
+
+/// 10 ms frames at 16 kHz.
+const FRAME_SAMPLES: usize = SAMPLE_RATE as usize / 100;
+/// RMS below this in a 10 ms frame counts as silence.
+const SILENCE_FRAME_RMS: f32 = 0.01;
+/// Need this many consecutive silent frames (200 ms) to accept a gap.
+const MIN_GAP_FRAMES: usize = 20;
+
+pub fn pcm_rms(pcm: &[f32]) -> f32 {
+    if pcm.is_empty() {
+        return 0.0;
+    }
+    let sum: f32 = pcm.iter().map(|s| s * s).sum();
+    (sum / pcm.len() as f32).sqrt()
+}
+
+fn frame_rms(frame: &[f32]) -> f32 {
+    pcm_rms(frame)
+}
+
+/// How many samples to take from the front of `pcm` for the next inference
+/// window. `None` = wait for more audio (buffer is short and has no gap).
+pub fn find_cut_samples(pcm: &[f32]) -> Option<usize> {
+    if pcm.len() < MIN_CUT_SAMPLES {
+        return None;
+    }
+
+    let search_end = pcm.len().min(MAX_CUT_SAMPLES);
+    if let Some(cut) = find_silence_cut(pcm, MIN_CUT_SAMPLES, search_end) {
+        return Some(cut);
+    }
+
+    if pcm.len() >= MAX_CUT_SAMPLES {
+        return Some(MAX_CUT_SAMPLES);
+    }
+
+    None
+}
+
+/// First 200 ms silence run whose start sits in `[search_start, search_end)`.
+/// Returns the sample index at the start of the gap.
+fn find_silence_cut(pcm: &[f32], search_start: usize, search_end: usize) -> Option<usize> {
+    if FRAME_SAMPLES == 0 || search_end <= search_start {
+        return None;
+    }
+
+    let mut run = 0usize;
+    let mut run_start = search_start;
+    let mut i = search_start;
+
+    while i + FRAME_SAMPLES <= search_end {
+        let frame = &pcm[i..i + FRAME_SAMPLES];
+        if frame_rms(frame) < SILENCE_FRAME_RMS {
+            if run == 0 {
+                run_start = i;
+            }
+            run += 1;
+            if run >= MIN_GAP_FRAMES {
+                return Some(run_start.max(1));
+            }
+        } else {
+            run = 0;
+        }
+        i += FRAME_SAMPLES;
+    }
+
+    None
+}
+
+/// Drain every ready inference window from the front of `buffer`.
+pub fn drain_ready_windows(buffer: &mut Vec<f32>) -> Vec<Vec<f32>> {
+    let mut windows = Vec::new();
+    while let Some(cut) = find_cut_samples(buffer) {
+        let cut = cut.min(buffer.len());
+        if cut == 0 {
+            break;
+        }
+        windows.push(buffer.drain(..cut).collect());
+    }
+    windows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sine(seconds: f64, amplitude: f32) -> Vec<f32> {
+        let n = (seconds * SAMPLE_RATE as f64).round() as usize;
+        (0..n)
+            .map(|i| {
+                let t = i as f32 / SAMPLE_RATE as f32;
+                (t * 440.0 * 2.0 * std::f32::consts::PI).sin() * amplitude
+            })
+            .collect()
+    }
+
+    fn silence(seconds: f64) -> Vec<f32> {
+        vec![0.0; (seconds * SAMPLE_RATE as f64).round() as usize]
+    }
+
+    #[test]
+    fn continuous_speech_does_not_cut_at_five_seconds() {
+        let pcm = sine(5.0, 0.3);
+        assert_eq!(
+            find_cut_samples(&pcm),
+            None,
+            "5 s of speech with no gap must wait — cutting here splits data|platform"
+        );
+    }
+
+    #[test]
+    fn continuous_speech_hard_caps_at_seven_seconds() {
+        let pcm = sine(8.0, 0.3);
+        assert_eq!(find_cut_samples(&pcm), Some(MAX_CUT_SAMPLES));
+        let mut buf = pcm;
+        let windows = drain_ready_windows(&mut buf);
+        assert_eq!(windows.len(), 1);
+        assert_eq!(windows[0].len(), MAX_CUT_SAMPLES);
+        assert_eq!(buf.len(), SAMPLE_RATE as usize); // 1 s leftover
+    }
+
+    #[test]
+    fn silence_gap_in_four_to_seven_is_preferred_cut() {
+        let mut pcm = sine(4.5, 0.3);
+        pcm.extend(silence(0.4));
+        pcm.extend(sine(2.0, 0.3));
+        let cut = find_cut_samples(&pcm).expect("gap at 4.5 s");
+        let start = (4.5 * SAMPLE_RATE as f64) as usize;
+        let end = (4.9 * SAMPLE_RATE as f64) as usize;
+        assert!(
+            (start..end).contains(&cut),
+            "cut {cut} should sit in the 4.5–4.9 s gap"
+        );
+    }
+
+    #[test]
+    fn short_buffer_waits() {
+        let pcm = sine(3.5, 0.3);
+        assert_eq!(find_cut_samples(&pcm), None);
+        assert!(drain_ready_windows(&mut pcm.clone()).is_empty());
+    }
+
+    #[test]
+    fn five_second_boundary_stays_inside_one_window() {
+        // Speech through the old 5 s knife-edge, then a gap at 6 s.
+        let mut pcm = sine(6.0, 0.3);
+        pcm.extend(silence(0.3));
+        pcm.extend(sine(1.5, 0.3));
+        let cut = find_cut_samples(&pcm).expect("gap at 6 s");
+        let five = CHUNK_SAMPLES;
+        assert!(
+            cut > five,
+            "cut {cut} must keep the ~5 s boundary (data platform / Snowflake / next checkpoint) intact"
+        );
+    }
+}

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -1,3 +1,4 @@
+pub mod batch_windows;
 pub mod kyutai;
 pub mod parakeet;
 pub mod whisper;
@@ -247,7 +248,11 @@ pub trait TranscriptionEngine {
 
     /// Heuristic meeting-language prior for LID and lane resets (Kyutai only).
     /// Never passed to the engine as a forced decode language.
-    fn set_meeting_language_prior(&mut self, _prior: crate::settings::MeetingTranscriptionLanguage) {}
+    fn set_meeting_language_prior(
+        &mut self,
+        _prior: crate::settings::MeetingTranscriptionLanguage,
+    ) {
+    }
 
     /// Transcribe one paired frame from both streams (mic = Me, system = Them),
     /// returning segments already tagged with their speaker. Only valid after

--- a/src-tauri/src/engine/parakeet.rs
+++ b/src-tauri/src/engine/parakeet.rs
@@ -3,24 +3,20 @@ use std::path::Path;
 use parakeet_rs::{ParakeetTDT, TimestampMode, Transcriber};
 use tracing::{debug, info};
 
+use super::batch_windows::{
+    CHUNK_SAMPLES, SAMPLE_RATE as PARAKEET_SAMPLE_RATE, drain_ready_windows,
+};
 use super::{
     AudioInputRequirements, EngineError, TranscriptionEngine, TranscriptionSegment,
     collapse_whitespace,
 };
 
-/// Parakeet sample rate: 16kHz mono f32 (fixed by the model's mel frontend)
-const PARAKEET_SAMPLE_RATE: u32 = 16_000;
-
-/// Chunk size for pipeline delivery: 5 seconds at 16kHz.
-/// Non-overlapping windows, same shape as the Whisper engine — the model
-/// transcribes each window independently (TDT inference is stateless).
-const CHUNK_SAMPLES: usize = PARAKEET_SAMPLE_RATE as usize * 5;
-
 /// Minimum audio worth an inference pass on flush (0.5 second).
 const MIN_INFERENCE_SAMPLES: usize = PARAKEET_SAMPLE_RATE as usize / 2;
 
 /// NVIDIA Parakeet TDT engine via parakeet-rs (ONNX Runtime, CPU).
-/// Batch-oriented: accumulates audio, runs inference every CHUNK_SAMPLES.
+/// Batch-oriented: same silence-gap windows as Whisper ([4 s, 7 s], else 7 s).
+/// Pipeline hop stays [`CHUNK_SAMPLES`] (5 s).
 ///
 /// Uses the bundled ONNX Runtime dylib through ort's load-dynamic mode —
 /// see `crate::ort_runtime` for why static linking is forbidden here.
@@ -148,14 +144,14 @@ impl TranscriptionEngine for ParakeetEngine {
 
         self.audio_buffer.extend_from_slice(audio);
 
-        if self.audio_buffer.len() < CHUNK_SAMPLES {
-            return Ok(vec![]);
+        let mut all_segments = Vec::new();
+        let windows = drain_ready_windows(&mut self.audio_buffer);
+        for to_process in windows {
+            let offset = self.take_window_offset(to_process.len());
+            let model = self.model.as_mut().ok_or(EngineError::NotInitialized)?;
+            all_segments.extend(Self::run_inference(model, to_process, offset)?);
         }
-
-        let to_process: Vec<f32> = self.audio_buffer.drain(..).collect();
-        let offset = self.take_window_offset(to_process.len());
-        let model = self.model.as_mut().ok_or(EngineError::NotInitialized)?;
-        Self::run_inference(model, to_process, offset)
+        Ok(all_segments)
     }
 
     fn flush(&mut self) -> Result<Vec<TranscriptionSegment>, EngineError> {
@@ -223,6 +219,26 @@ mod tests {
         assert_eq!(reqs.sample_rate_hz, 16_000);
         assert_eq!(reqs.channels, 1);
         assert_eq!(reqs.chunk_size_samples, 80_000);
+    }
+
+    #[test]
+    fn five_second_boundary_does_not_cut_mid_phrase() {
+        // Continuous speech through 5 s — the old knife-edge that split
+        // "The next | checkpoint" and made TDT invent a completion.
+        let pcm: Vec<f32> = (0..CHUNK_SAMPLES)
+            .map(|i| (i as f32 * 0.02).sin() * 0.3)
+            .collect();
+        assert_eq!(
+            crate::engine::batch_windows::find_cut_samples(&pcm),
+            None,
+            "must wait past 5 s so 'next checkpoint' stays in one window"
+        );
+
+        let mut longer = pcm;
+        longer.extend((0..CHUNK_SAMPLES).map(|i| (i as f32 * 0.02).sin() * 0.3));
+        let cut = crate::engine::batch_windows::find_cut_samples(&longer).unwrap();
+        assert!(cut > CHUNK_SAMPLES);
+        assert_eq!(cut, 16_000 * 7);
     }
 
     /// End-to-end inference against the real downloaded model. Run with:

--- a/src-tauri/src/engine/whisper.rs
+++ b/src-tauri/src/engine/whisper.rs
@@ -71,17 +71,28 @@ fn hallucination_key(text: &str) -> String {
 }
 
 /// True when `text` is *only* a known Whisper hallucination, not real
-/// speech that happens to include "thank you".
+/// speech that happens to include "thank you" or mention Amara.
 fn is_known_hallucination(text: &str) -> bool {
     let key = hallucination_key(text);
     if key.is_empty() {
         return false;
     }
-    matches!(key.as_str(), "thank you" | "thank you thank you" | "merci")
-        || key.contains("amara")
-        || text.to_lowercase().contains("sous-titres")
-        || key.contains("subtitles by")
-        || key.contains("subtitles made")
+    matches!(
+        key.as_str(),
+        "thank you" | "thank you thank you" | "merci" | "amara" | "amara org"
+    ) || is_subtitle_credit(&key)
+}
+
+/// Whole-utterance subtitle watermarks. Prefixes, not substrings, so
+/// "I spoke to Amara yesterday" / "the subtitles are ready" survive.
+fn is_subtitle_credit(key: &str) -> bool {
+    const CREDIT_PREFIXES: &[&str] = &[
+        "sous titres réalisés par",
+        "sous titres par amara",
+        "subtitles by",
+        "subtitles made",
+    ];
+    CREDIT_PREFIXES.iter().any(|prefix| key.starts_with(prefix))
 }
 
 /// Drop a window that is digital silence, or whose sole segment is a
@@ -239,6 +250,24 @@ impl WhisperEngine {
     }
 }
 
+/// Cache auto-detected language only from a window that kept real speech.
+/// A filtered leading hallucination must not lock the session to the
+/// wrong language for later windows.
+fn remember_detected_language(
+    cached: &mut Option<String>,
+    requested: Option<&str>,
+    detected: Option<String>,
+    surviving_segments: &[TranscriptionSegment],
+) {
+    if requested.is_some() || cached.is_some() || surviving_segments.is_empty() {
+        return;
+    }
+    if let Some(lang) = detected {
+        info!(language = %lang, "Whisper auto-detected language, caching for session");
+        *cached = Some(lang);
+    }
+}
+
 impl TranscriptionEngine for WhisperEngine {
     fn load_model(&mut self, model_path: &Path) -> Result<(), EngineError> {
         let bin_path = if model_path.extension().is_some_and(|ext| ext == "bin") {
@@ -317,16 +346,13 @@ impl TranscriptionEngine for WhisperEngine {
                 seg.start_time += offset;
                 seg.end_time += offset;
             }
+            remember_detected_language(
+                &mut self.detected_language,
+                language,
+                detected,
+                &segments,
+            );
             all_segments.extend(segments);
-
-            // Cache detected language from first successful auto-detect
-            if language.is_none()
-                && let Some(ref lang) = detected
-                && self.detected_language.is_none()
-            {
-                info!(language = %lang, "Whisper auto-detected language, caching for session");
-                self.detected_language = Some(lang.clone());
-            }
         }
 
         Ok(all_segments)
@@ -433,6 +459,43 @@ mod tests {
         assert!(!is_known_hallucination("Thank you for the update."));
         assert!(!is_known_hallucination("Please thank you later today"));
         assert!(!is_known_hallucination("Merci beaucoup à toute l'équipe"));
+        assert!(!is_known_hallucination("I spoke to Amara yesterday"));
+        assert!(!is_known_hallucination("The subtitles are ready"));
+    }
+
+    #[test]
+    fn filtered_leading_window_does_not_cache_language() {
+        let mut cached = None;
+        remember_detected_language(&mut cached, None, Some("en".into()), &[]);
+        assert!(cached.is_none(), "hallucinated window must not lock language");
+
+        let speech = [TranscriptionSegment {
+            text: "Bonjour à tous".into(),
+            start_time: 0.0,
+            end_time: 1.0,
+            is_final: true,
+            language: Some("fr".into()),
+            confidence: Some(0.9),
+            speaker: None,
+        }];
+        remember_detected_language(&mut cached, None, Some("fr".into()), &speech);
+        assert_eq!(cached.as_deref(), Some("fr"));
+    }
+
+    #[test]
+    fn explicit_language_is_not_overwritten_by_detect() {
+        let mut cached = None;
+        let speech = [TranscriptionSegment {
+            text: "Hello".into(),
+            start_time: 0.0,
+            end_time: 1.0,
+            is_final: true,
+            language: Some("en".into()),
+            confidence: Some(0.9),
+            speaker: None,
+        }];
+        remember_detected_language(&mut cached, Some("fr"), Some("en".into()), &speech);
+        assert!(cached.is_none());
     }
 
     #[test]

--- a/src-tauri/src/engine/whisper.rs
+++ b/src-tauri/src/engine/whisper.rs
@@ -3,26 +3,26 @@ use std::path::{Path, PathBuf};
 use tracing::{debug, info};
 use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
 
+use super::batch_windows::{
+    CHUNK_SAMPLES, SAMPLE_RATE as WHISPER_SAMPLE_RATE, drain_ready_windows, pcm_rms,
+};
 use super::{
     AudioInputRequirements, EngineError, TranscriptionEngine, TranscriptionSegment,
     collapse_whitespace,
 };
 
-/// Whisper sample rate: 16kHz mono f32 (required by whisper.cpp)
-const WHISPER_SAMPLE_RATE: u32 = 16_000;
-
 /// Number of CPU threads for whisper.cpp inference.
 const WHISPER_N_THREADS: i32 = 4;
-
-/// Chunk size for pipeline delivery: 5 seconds at 16kHz.
-/// Non-overlapping chunks avoid duplicate text from sliding windows.
-const CHUNK_SAMPLES: usize = WHISPER_SAMPLE_RATE as usize * 5;
 
 /// Minimum audio for meaningful inference (1 second).
 const MIN_INFERENCE_SAMPLES: usize = WHISPER_SAMPLE_RATE as usize;
 
 /// Segments with no-speech probability above this are discarded.
 const NO_SPEECH_PROB_THRESHOLD: f32 = 0.6;
+
+/// Digital-silence / near-zero RMS. Room tone sits well above this; those
+/// windows are dropped via [`is_known_hallucination`] instead.
+const SILENCE_RMS_FLOOR: f32 = 5e-4;
 
 /// Strip whisper special tokens: [_BEG_], [_TT_xxx], [_SOT_], [_EOT_], [_LANG_xx], etc.
 fn strip_special_tokens(text: &str) -> String {
@@ -59,6 +59,46 @@ fn strip_special_tokens(text: &str) -> String {
     collapse_whitespace(&result)
 }
 
+/// Alphanumeric-only lowercase key so `"Thank you."` / `". . Thank you."`
+/// collapse to the same token.
+fn hallucination_key(text: &str) -> String {
+    let lowered = text.to_lowercase();
+    let spaced: String = lowered
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { ' ' })
+        .collect();
+    collapse_whitespace(&spaced)
+}
+
+/// True when `text` is *only* a known Whisper hallucination, not real
+/// speech that happens to include "thank you".
+fn is_known_hallucination(text: &str) -> bool {
+    let key = hallucination_key(text);
+    if key.is_empty() {
+        return false;
+    }
+    matches!(key.as_str(), "thank you" | "thank you thank you" | "merci")
+        || key.contains("amara")
+        || text.to_lowercase().contains("sous-titres")
+        || key.contains("subtitles by")
+        || key.contains("subtitles made")
+}
+
+/// Drop a window that is digital silence, or whose sole segment is a
+/// known hallucination. Real speech that mentions "thank you" is kept.
+fn drop_silent_or_hallucinated_window(
+    segments: Vec<TranscriptionSegment>,
+    audio: &[f32],
+) -> Vec<TranscriptionSegment> {
+    if pcm_rms(audio) < SILENCE_RMS_FLOOR {
+        return Vec::new();
+    }
+    if segments.len() == 1 && is_known_hallucination(&segments[0].text) {
+        return Vec::new();
+    }
+    segments
+}
+
 struct LoadedWhisperModel {
     ctx: WhisperContext,
     #[allow(dead_code)]
@@ -66,7 +106,8 @@ struct LoadedWhisperModel {
 }
 
 /// Whisper STT engine via whisper-rs (whisper.cpp bindings).
-/// Batch-oriented: accumulates audio, triggers inference every CHUNK_SAMPLES.
+/// Batch-oriented: accumulates audio, cuts on a silence gap in [4 s, 7 s]
+/// (else 7 s). Pipeline hop stays [`CHUNK_SAMPLES`] (5 s).
 pub struct WhisperEngine {
     model: Option<LoadedWhisperModel>,
     /// Audio buffer — accumulates until chunk threshold
@@ -192,6 +233,8 @@ impl WhisperEngine {
             });
         }
 
+        segments = drop_silent_or_hallucinated_window(segments, audio);
+
         Ok((segments, detected_lang))
     }
 }
@@ -252,41 +295,41 @@ impl TranscriptionEngine for WhisperEngine {
 
         self.audio_buffer.extend_from_slice(audio);
 
-        if self.audio_buffer.len() < CHUNK_SAMPLES {
-            return Ok(vec![]);
+        let mut all_segments = Vec::new();
+        let windows = drain_ready_windows(&mut self.audio_buffer);
+
+        for to_process in windows {
+            let offset = self.take_window_offset(to_process.len());
+            let effective_lang = if language.is_some() {
+                language.map(String::from)
+            } else {
+                self.detected_language.clone()
+            };
+            let (mut segments, detected) = {
+                let loaded = self.model.as_ref().ok_or(EngineError::NotInitialized)?;
+                Self::run_inference(
+                    &loaded.ctx,
+                    &to_process,
+                    effective_lang.as_deref().or(language),
+                )?
+            };
+            for seg in &mut segments {
+                seg.start_time += offset;
+                seg.end_time += offset;
+            }
+            all_segments.extend(segments);
+
+            // Cache detected language from first successful auto-detect
+            if language.is_none()
+                && let Some(ref lang) = detected
+                && self.detected_language.is_none()
+            {
+                info!(language = %lang, "Whisper auto-detected language, caching for session");
+                self.detected_language = Some(lang.clone());
+            }
         }
 
-        let to_process: Vec<f32> = self.audio_buffer.drain(..).collect();
-        let offset = self.take_window_offset(to_process.len());
-        let loaded = self.model.as_ref().ok_or(EngineError::NotInitialized)?;
-
-        // Use cached language if available, otherwise auto-detect
-        let effective_lang = if language.is_some() {
-            language.map(String::from)
-        } else {
-            self.detected_language.clone()
-        };
-
-        let (mut segments, detected) = Self::run_inference(
-            &loaded.ctx,
-            &to_process,
-            effective_lang.as_deref().or(language),
-        )?;
-        for seg in &mut segments {
-            seg.start_time += offset;
-            seg.end_time += offset;
-        }
-
-        // Cache detected language from first successful auto-detect
-        if language.is_none()
-            && let Some(ref lang) = detected
-            && self.detected_language.is_none()
-        {
-            info!(language = %lang, "Whisper auto-detected language, caching for session");
-            self.detected_language = Some(lang.clone());
-        }
-
-        Ok(segments)
+        Ok(all_segments)
     }
 
     fn flush(&mut self) -> Result<Vec<TranscriptionSegment>, EngineError> {
@@ -367,5 +410,100 @@ mod tests {
     fn strip_special_tokens_cleans_extra_spaces() {
         let input = "[_BEG_]  Hello  [_TT_100]  world  [_TT_200]";
         assert_eq!(strip_special_tokens(input), "Hello world");
+    }
+
+    #[test]
+    fn known_hallucinations_are_dropped() {
+        for text in [
+            "Thank you.",
+            "Thank you. Thank you.",
+            ". . Thank you.",
+            "Merci.",
+            "Sous-titres réalisés par Amara.org",
+        ] {
+            assert!(
+                is_known_hallucination(text),
+                "expected hallucination: {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn real_speech_with_thank_you_is_kept() {
+        assert!(!is_known_hallucination("Thank you for the update."));
+        assert!(!is_known_hallucination("Please thank you later today"));
+        assert!(!is_known_hallucination("Merci beaucoup à toute l'équipe"));
+    }
+
+    #[test]
+    fn silent_buffer_drops_any_segment() {
+        let silent = vec![0.0f32; 16_000];
+        assert!(pcm_rms(&silent) < SILENCE_RMS_FLOOR);
+        let segs = vec![TranscriptionSegment {
+            text: "Hello".into(),
+            start_time: 0.0,
+            end_time: 1.0,
+            is_final: true,
+            language: Some("en".into()),
+            confidence: Some(0.9),
+            speaker: None,
+        }];
+        assert!(drop_silent_or_hallucinated_window(segs, &silent).is_empty());
+    }
+
+    #[test]
+    fn sole_thank_you_on_room_tone_is_dropped() {
+        // Brown-ish noise above the digital-silence floor.
+        let room: Vec<f32> = (0..16_000)
+            .map(|i| ((i % 17) as f32 / 17.0 - 0.5) * 0.04)
+            .collect();
+        assert!(pcm_rms(&room) >= SILENCE_RMS_FLOOR);
+        let segs = vec![TranscriptionSegment {
+            text: "Thank you.".into(),
+            start_time: 0.0,
+            end_time: 1.0,
+            is_final: true,
+            language: Some("en".into()),
+            confidence: Some(0.4),
+            speaker: None,
+        }];
+        assert!(drop_silent_or_hallucinated_window(segs, &room).is_empty());
+    }
+
+    #[test]
+    fn speech_window_with_thank_you_in_a_sentence_is_kept() {
+        let speech: Vec<f32> = (0..16_000).map(|i| (i as f32 * 0.05).sin() * 0.3).collect();
+        let segs = vec![TranscriptionSegment {
+            text: "Thank you for joining the call.".into(),
+            start_time: 0.0,
+            end_time: 1.0,
+            is_final: true,
+            language: Some("en".into()),
+            confidence: Some(0.9),
+            speaker: None,
+        }];
+        let kept = drop_silent_or_hallucinated_window(segs, &speech);
+        assert_eq!(kept.len(), 1);
+        assert!(kept[0].text.contains("joining"));
+    }
+
+    #[test]
+    fn audio_requirements_keep_5s_pipeline_hop() {
+        let engine = WhisperEngine::new();
+        let reqs = engine.audio_requirements();
+        assert_eq!(reqs.sample_rate_hz, 16_000);
+        assert_eq!(reqs.chunk_size_samples, CHUNK_SAMPLES as u32);
+    }
+
+    #[test]
+    fn five_second_speech_waits_for_gap_or_seven() {
+        let pcm: Vec<f32> = (0..CHUNK_SAMPLES)
+            .map(|i| (i as f32 * 0.02).sin() * 0.3)
+            .collect();
+        assert_eq!(
+            crate::engine::batch_windows::find_cut_samples(&pcm),
+            None,
+            "must not knife-cut at 5 s (data|platform / Snowflake)"
+        );
     }
 }

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -49,14 +49,33 @@ fn ensure_model_layout(profile: &TranscriptionProfile) -> Result<(), String> {
         return Ok(());
     }
 
-    if let Some(parent) = target_dir.parent() {
+    relocate_model_directory(&legacy_dir, &target_dir)
+}
+
+/// Move a legacy model directory to `target`.
+///
+/// Kyutai's candle layout is `…/stt-1b-en_fr/candle`, i.e. a *child* of the
+/// legacy dir `…/stt-1b-en_fr`. `rename(legacy, legacy/candle)` is EINVAL, and
+/// a naive recursive copy then copies the target into itself
+/// (`candle/candle/…`). Never rename or recurse a directory into its own
+/// descendant — lift files instead.
+fn relocate_model_directory(source: &Path, target: &Path) -> Result<(), String> {
+    if source == target {
+        return Ok(());
+    }
+
+    if let Some(parent) = target.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|e| format!("Failed to create model parent directory: {e}"))?;
     }
 
-    match std::fs::rename(&legacy_dir, &target_dir) {
+    if target.starts_with(source) {
+        return copy_directory_contents(source, target);
+    }
+
+    match std::fs::rename(source, target) {
         Ok(()) => Ok(()),
-        Err(_) => copy_directory_contents(&legacy_dir, &target_dir),
+        Err(_) => copy_directory_contents(source, target),
     }
 }
 
@@ -77,6 +96,10 @@ fn legacy_model_dir(profile: &TranscriptionProfile) -> Option<PathBuf> {
 }
 
 fn copy_directory_contents(source: &Path, target: &Path) -> Result<(), String> {
+    if source == target {
+        return Ok(());
+    }
+
     std::fs::create_dir_all(target).map_err(|e| format!("Failed to create target dir: {e}"))?;
 
     for entry in std::fs::read_dir(source).map_err(|e| format!("Failed to read source dir: {e}"))? {
@@ -85,6 +108,14 @@ fn copy_directory_contents(source: &Path, target: &Path) -> Result<(), String> {
             .file_type()
             .map_err(|e| format!("Failed to inspect source entry type: {e}"))?;
         let source_path = entry.path();
+
+        // Target may be a child of source (legacy Kyutai → `…/candle`).
+        // Creating `target` first would otherwise make `read_dir` see it and
+        // recurse `candle/candle/…` without bound.
+        if source_path == target || source_path.starts_with(target) {
+            continue;
+        }
+
         let target_path = target.join(entry.file_name());
 
         if entry_type.is_dir() {
@@ -92,9 +123,103 @@ fn copy_directory_contents(source: &Path, target: &Path) -> Result<(), String> {
             continue;
         }
 
-        std::fs::copy(&source_path, &target_path)
-            .map_err(|e| format!("Failed to copy model file '{}': {e}", source_path.display()))?;
+        match std::fs::rename(&source_path, &target_path) {
+            Ok(()) => {}
+            Err(_) => {
+                std::fs::copy(&source_path, &target_path).map_err(|e| {
+                    format!("Failed to copy model file '{}': {e}", source_path.display())
+                })?;
+            }
+        }
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn count_files(dir: &Path) -> usize {
+        if !dir.is_dir() {
+            return usize::from(dir.is_file());
+        }
+        let mut n = 0;
+        for entry in fs::read_dir(dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                n += count_files(&path);
+            } else {
+                n += 1;
+            }
+        }
+        n
+    }
+
+    fn max_candle_depth(dir: &Path) -> usize {
+        let mut depth = 0;
+        let mut cursor = dir.to_path_buf();
+        while cursor.join("candle").is_dir() {
+            depth += 1;
+            cursor = cursor.join("candle");
+        }
+        depth
+    }
+
+    #[test]
+    fn relocate_into_own_child_does_not_nest_candle() {
+        let tmp = TempDir::new().unwrap();
+        let legacy = tmp.path().join("kyutai").join("stt-1b-en_fr");
+        fs::create_dir_all(&legacy).unwrap();
+        fs::write(legacy.join("config.json"), "{\"dim\":1}").unwrap();
+        fs::write(legacy.join("model.safetensors"), b"weights").unwrap();
+        // Pre-existing child — the layout that made the old copy explode.
+        fs::create_dir_all(legacy.join("candle")).unwrap();
+        fs::write(legacy.join("candle").join("already.txt"), "keep").unwrap();
+
+        let target = legacy.join("candle");
+        relocate_model_directory(&legacy, &target).unwrap();
+
+        assert!(target.join("config.json").is_file());
+        assert!(target.join("model.safetensors").is_file());
+        assert!(target.join("already.txt").is_file());
+        assert!(!target.join("candle").exists(), "nested candle/candle");
+        assert_eq!(max_candle_depth(&legacy), 1);
+        assert!(
+            count_files(tmp.path()) <= 4,
+            "unbounded copy: {} files",
+            count_files(tmp.path())
+        );
+    }
+
+    #[test]
+    fn relocate_creates_child_target_without_recursing() {
+        let tmp = TempDir::new().unwrap();
+        let legacy = tmp.path().join("stt-1b-en_fr");
+        fs::create_dir_all(&legacy).unwrap();
+        fs::write(legacy.join("config.json"), "{}").unwrap();
+        fs::write(legacy.join("model.safetensors"), b"w").unwrap();
+
+        let target = legacy.join("candle");
+        relocate_model_directory(&legacy, &target).unwrap();
+
+        assert!(target.join("config.json").is_file());
+        assert!(target.join("model.safetensors").is_file());
+        assert!(!target.join("candle").exists());
+        assert_eq!(count_files(&target), 2);
+    }
+
+    #[test]
+    fn relocate_same_path_is_noop() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("model");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("config.json"), "{}").unwrap();
+        relocate_model_directory(&dir, &dir).unwrap();
+        assert!(dir.join("config.json").is_file());
+        assert_eq!(count_files(&dir), 1);
+    }
 }

--- a/src-tauri/src/models/mod.rs
+++ b/src-tauri/src/models/mod.rs
@@ -37,19 +37,25 @@ pub fn download_model(
 }
 
 fn ensure_model_layout(profile: &TranscriptionProfile) -> Result<(), String> {
-    let target_dir = model_dir(profile);
-    if target_dir.exists() {
+    ensure_layout(&model_dir(profile), legacy_model_dir(profile).as_deref())
+}
+
+/// Relocate unless `target` already exists *outside* the legacy dir.
+/// An existing nested target (`legacy/candle`) still needs files lifted
+/// out of `legacy`, otherwise `model_exists` sees an incomplete child.
+fn ensure_layout(target_dir: &Path, legacy_dir: Option<&Path>) -> Result<(), String> {
+    if target_dir.exists() && !legacy_dir.is_some_and(|legacy| target_dir.starts_with(legacy)) {
         return Ok(());
     }
 
-    let Some(legacy_dir) = legacy_model_dir(profile) else {
+    let Some(legacy_dir) = legacy_dir else {
         return Ok(());
     };
     if !legacy_dir.exists() {
         return Ok(());
     }
 
-    relocate_model_directory(&legacy_dir, &target_dir)
+    relocate_model_directory(legacy_dir, target_dir)
 }
 
 /// Move a legacy model directory to `target`.
@@ -210,6 +216,38 @@ mod tests {
         assert!(target.join("model.safetensors").is_file());
         assert!(!target.join("candle").exists());
         assert_eq!(count_files(&target), 2);
+    }
+
+    #[test]
+    fn nested_target_still_lifts_legacy_files() {
+        let tmp = TempDir::new().unwrap();
+        let legacy = tmp.path().join("kyutai").join("stt-1b-en_fr");
+        let target = legacy.join("candle");
+        fs::create_dir_all(&target).unwrap();
+        fs::write(legacy.join("config.json"), "{}").unwrap();
+        fs::write(legacy.join("model.safetensors"), b"w").unwrap();
+
+        ensure_layout(&target, Some(&legacy)).unwrap();
+
+        assert!(target.join("config.json").is_file());
+        assert!(target.join("model.safetensors").is_file());
+        assert!(!target.join("candle").exists());
+    }
+
+    #[test]
+    fn existing_target_outside_legacy_is_left_alone() {
+        let tmp = TempDir::new().unwrap();
+        let legacy = tmp.path().join("legacy");
+        let target = tmp.path().join("models").join("candle");
+        fs::create_dir_all(&legacy).unwrap();
+        fs::create_dir_all(&target).unwrap();
+        fs::write(legacy.join("config.json"), "legacy").unwrap();
+        fs::write(target.join("config.json"), "target").unwrap();
+
+        ensure_layout(&target, Some(&legacy)).unwrap();
+
+        assert_eq!(fs::read_to_string(target.join("config.json")).unwrap(), "target");
+        assert!(legacy.join("config.json").is_file());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Legacy Kyutai layout migration targeted `…/stt-1b-en_fr/candle`, a child of the source dir. `rename` failed and the fallback recursive copy nested `candle/candle/…` until `du` showed hundreds of GB. Migration now lifts files and skips the nested `candle/` child.
- Whisper and Parakeet no longer hop on a hard 5s boundary (that split `data|platform`, `Snow|flake`, and let Parakeet invent `The next one is the same thing.`). They cut on a ≥200 ms silence gap in [4s, 7s], else at 7s, while keeping the advertised 5s hop. Whisper also drops digital-silence windows and sole-segment hallucinations (`Thank you.`, `Merci.`, Amara / sous-titres). Kyutai is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved transcription batching to preserve continuous speech across processing boundaries.
  * Audio is now split more naturally at pauses, while longer continuous speech is handled without premature cuts.
  * Reduced spurious transcription output from digital silence and hallucination-only audio while preserving genuine speech.
  * Maintained transcription timing and language-detection behavior across batches.

* **Bug Fixes**
  * Improved legacy model relocation for nested folders, existing directories, and same-location operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->