### PR TITLE
Make model switching apply, and unstick downloads after a failure

### DIFF
--- a/src-tauri/src/commands/model.rs
+++ b/src-tauri/src/commands/model.rs
@@ -111,13 +111,21 @@ pub fn download_model(
         return Ok(());
     }
 
-    // Switching to a different, not-yet-downloaded model while one is loaded:
-    // drop the current engine first so the state machine can move out of
-    // Ready (it tracks a single profile through download → load → ready).
     let machine = state.current_machine_state()?;
     if machine.is_recording() {
         return Err("Cannot switch models while recording".into());
     }
+
+    // Auto-recover from a previous failure so picking another model works
+    // without restarting the app (mirrors `load_model`).
+    if matches!(machine, AppStateMachine::Error { .. }) {
+        state.apply_transition(StateAction::Recover)?;
+    }
+
+    // Switching to a different, not-yet-downloaded model while one is loaded:
+    // drop the current engine first so the state machine can move out of
+    // Ready (it tracks a single profile through download → load → ready).
+    let machine = state.current_machine_state()?;
     if machine.is_model_ready() && machine.active_profile() != Some(&profile) {
         state.apply_transition(StateAction::Unload { next_profile: None })?;
         state.engine_actor.unload_model()?;
@@ -232,7 +240,9 @@ pub fn load_model(
             state.apply_transition(StateAction::DownloadComplete)?;
         }
 
-        state.apply_transition(StateAction::StartLoad)?;
+        state.apply_transition(StateAction::StartLoad {
+            profile: profile.clone(),
+        })?;
     }
 
     info!(path = %model_dir.display(), "Loading model");

--- a/src-tauri/src/commands/model.rs
+++ b/src-tauri/src/commands/model.rs
@@ -88,6 +88,16 @@ pub fn download_model(
     channel: Channel<models::DownloadProgress>,
 ) -> Result<(), String> {
     let profile = resolve_transcription_selection(&selection)?;
+
+    // Auto-recover from a previous failure so picking another model works
+    // without restarting the app (mirrors `load_model`). Must run before
+    // the existing-model fast path, otherwise Error + files on disk
+    // reports Complete while the machine stays wedged.
+    let machine = state.current_machine_state()?;
+    if matches!(machine, AppStateMachine::Error { .. }) {
+        state.apply_transition(StateAction::Recover)?;
+    }
+
     if models::model_exists(&profile) {
         // Ensure machine reflects downloaded state
         let machine = state.current_machine_state()?;
@@ -114,12 +124,6 @@ pub fn download_model(
     let machine = state.current_machine_state()?;
     if machine.is_recording() {
         return Err("Cannot switch models while recording".into());
-    }
-
-    // Auto-recover from a previous failure so picking another model works
-    // without restarting the app (mirrors `load_model`).
-    if matches!(machine, AppStateMachine::Error { .. }) {
-        state.apply_transition(StateAction::Recover)?;
     }
 
     // Switching to a different, not-yet-downloaded model while one is loaded:

--- a/src-tauri/src/state_machine.rs
+++ b/src-tauri/src/state_machine.rs
@@ -66,7 +66,9 @@ pub enum StateAction {
         profile: TranscriptionProfile,
     },
     DownloadComplete,
-    StartLoad,
+    StartLoad {
+        profile: TranscriptionProfile,
+    },
     LoadComplete,
     StartDictation {
         session_id: u64,
@@ -107,9 +109,10 @@ impl AppStateMachine {
             }),
 
             // --- Load transitions ---
-            (Downloaded { profile }, StartLoad) => Ok(Loading {
-                profile: profile.clone(),
-            }),
+            // The profile being loaded is the caller's, not the one the
+            // machine last downloaded: switching to an already-downloaded
+            // model from `Downloaded` must not keep the previous profile.
+            (Downloaded { .. }, StartLoad { profile }) => Ok(Loading { profile }),
             (Loading { profile }, LoadComplete) => Ok(Ready { profile }),
             (Loading { profile }, Fail { message }) => Ok(Error {
                 message,
@@ -339,10 +342,29 @@ mod tests {
         let state = AppStateMachine::Downloaded {
             profile: test_profile(),
         };
-        let state = state.transition(StateAction::StartLoad).unwrap();
+        let state = state
+            .transition(StateAction::StartLoad {
+                profile: test_profile(),
+            })
+            .unwrap();
         assert!(matches!(state, AppStateMachine::Loading { .. }));
         let state = state.transition(StateAction::LoadComplete).unwrap();
         assert!(matches!(state, AppStateMachine::Ready { .. }));
+    }
+
+    #[test]
+    fn downloaded_can_load_a_different_downloaded_model() {
+        let state = AppStateMachine::Downloaded {
+            profile: test_profile(),
+        };
+        let state = state
+            .transition(StateAction::StartLoad {
+                profile: other_profile(),
+            })
+            .unwrap();
+        assert_eq!(state.active_profile(), Some(&other_profile()));
+        let state = state.transition(StateAction::LoadComplete).unwrap();
+        assert_eq!(state.active_profile(), Some(&other_profile()));
     }
 
     #[test]
@@ -518,7 +540,13 @@ mod tests {
     #[test]
     fn idle_cannot_start_load() {
         let state = AppStateMachine::Idle;
-        assert!(state.transition(StateAction::StartLoad).is_err());
+        assert!(
+            state
+                .transition(StateAction::StartLoad {
+                    profile: test_profile(),
+                })
+                .is_err()
+        );
     }
 
     #[test]
@@ -699,7 +727,11 @@ mod tests {
             })
             .unwrap();
         let state = state.transition(StateAction::DownloadComplete).unwrap();
-        let state = state.transition(StateAction::StartLoad).unwrap();
+        let state = state
+            .transition(StateAction::StartLoad {
+                profile: profile.clone(),
+            })
+            .unwrap();
         let state = state.transition(StateAction::LoadComplete).unwrap();
         assert!(matches!(state, AppStateMachine::Ready { .. }));
     }
@@ -710,6 +742,12 @@ mod tests {
             message: "oops".into(),
             recovery: ErrorRecovery::RetryFromIdle,
         };
-        assert!(state.transition(StateAction::StartLoad).is_err());
+        assert!(
+            state
+                .transition(StateAction::StartLoad {
+                    profile: test_profile(),
+                })
+                .is_err()
+        );
     }
 }

--- a/src-tauri/tests/app_flows.rs
+++ b/src-tauri/tests/app_flows.rs
@@ -94,7 +94,11 @@ fn bring_to_ready(state: &AppState, actor: &EngineActorHandle) {
     state
         .apply_transition(StateAction::DownloadComplete)
         .unwrap();
-    state.apply_transition(StateAction::StartLoad).unwrap();
+    state
+        .apply_transition(StateAction::StartLoad {
+            profile: profile.clone(),
+        })
+        .unwrap();
     state.apply_transition(StateAction::LoadComplete).unwrap();
 }
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -11,7 +11,7 @@
   import { getTranscriptionCatalog, recoverState } from "./lib/api/transcription";
   import { getReleaseNotesForVersion } from "./lib/api/diagnostics";
   import { bootstrapAppState } from "./lib/bootstrap";
-  import { getSelectedTranscriptionModel } from "./lib/features/transcription/catalog";
+  import { findTranscriptionModel } from "./lib/features/transcription/catalog";
   import OnboardingView from "./lib/features/onboarding/OnboardingView.svelte";
   import WhatsNewDialog from "./lib/features/onboarding/WhatsNewDialog.svelte";
   import UpdateAvailableDialog from "./lib/features/onboarding/UpdateAvailableDialog.svelte";
@@ -72,7 +72,7 @@
   let transcriptionCatalog = $state<TranscriptionCatalog | null>(null);
   const modelLabel = $derived(
     app.settings.transcription_model_id
-      ? getSelectedTranscriptionModel(
+      ? findTranscriptionModel(
           transcriptionCatalog,
           app.settings.transcription_engine_id,
           app.settings.transcription_model_id,

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -30,6 +30,7 @@
   import { applyTheme, errorMessage } from "./lib/utils";
   import { micToast, micToastCopy } from "./lib/features/audio/mic-toast.svelte";
   import { decideShowSetupWizard, readSetupFlags } from "./lib/features/onboarding/setup";
+  import type { TranscriptionCatalog } from "./lib/types";
 
   const app = getAppState();
   // Mounted app-level so the global dictation shortcut works whatever view
@@ -66,7 +67,18 @@
     releaseNotes: string | null;
     releaseUrl: string | null;
   } | null>(null);
-  let modelLabel = $state("");
+  // Catalog is static; the label follows the *current* selection so the chip
+  // updates as soon as the user switches model (no app restart needed).
+  let transcriptionCatalog = $state<TranscriptionCatalog | null>(null);
+  const modelLabel = $derived(
+    app.settings.transcription_model_id
+      ? getSelectedTranscriptionModel(
+          transcriptionCatalog,
+          app.settings.transcription_engine_id,
+          app.settings.transcription_model_id,
+        )?.label ?? ""
+      : "",
+  );
 
   const isLightTheme = $derived(
     app.settings.theme === "light" ||
@@ -129,12 +141,7 @@
       }
       cleanupTranscription = (await transcription.mount()) ?? (() => {});
       try {
-        const catalog = await getTranscriptionCatalog();
-        modelLabel = getSelectedTranscriptionModel(
-          catalog,
-          app.settings.transcription_engine_id,
-          app.settings.transcription_model_id,
-        )?.label ?? "";
+        transcriptionCatalog = await getTranscriptionCatalog();
       } catch {
         // Header chip simply omits the model name.
       }

--- a/src/lib/features/settings/controller.svelte.test.ts
+++ b/src/lib/features/settings/controller.svelte.test.ts
@@ -402,6 +402,57 @@ describe("settings controller", () => {
     );
   });
 
+  it("selectModelOption loads a model that is already downloaded", async () => {
+    let currentModelId = "stt-1b-en_fr";
+    mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      switch (cmd) {
+        case "save_settings":
+          currentModelId = (args?.settings as AppSettings).transcription_model_id;
+          return Promise.resolve(null);
+        case "get_transcription_catalog":
+          return Promise.resolve({ ...fakeCatalog, selected_model_id: currentModelId });
+        case "get_model_status":
+          return Promise.resolve(
+            currentModelId === "stt-1b-en_fr"
+              ? { ...fakeStatus, phase: "ready" }
+              : {
+                  ...fakeStatus,
+                  profile: { ...fakeStatus.profile, model_id: "stt-2.6b-en", model_label: "STT 2.6B" },
+                  // Already on disk from a previous run: only a load is needed.
+                  phase: "load_required",
+                },
+          );
+        default:
+          return defaultInvoke(cmd, args);
+      }
+    });
+
+    const ctrl = createSettingsController();
+    await ctrl.mount();
+
+    // The backend is still Ready with the previously selected model.
+    ctrl.app.machineState = {
+      state: "ready",
+      data: {
+        profile: {
+          engine_id: "kyutai",
+          engine_label: "Kyutai",
+          model_id: "stt-1b-en_fr",
+          model_label: "STT 1B",
+          backend_id: "candle",
+          backend_label: "Candle",
+        },
+      },
+    };
+
+    await ctrl.selectModelOption("kyutai:stt-2.6b-en");
+
+    expect(mockInvoke).toHaveBeenCalledWith("load_model", {
+      selection: { engine_id: "kyutai", model_id: "stt-2.6b-en", backend_id: "candle" },
+    });
+    expect(mockInvoke).not.toHaveBeenCalledWith("download_model", expect.anything());
+  });
+
   it("shortcut recording flow", async () => {
     const ctrl = createSettingsController();
     await ctrl.mount();

--- a/src/lib/features/settings/controller.svelte.ts
+++ b/src/lib/features/settings/controller.svelte.ts
@@ -133,9 +133,10 @@ export function createSettingsController() {
 
   async function refreshRuntimeStatus() {
     try {
-      await refreshTranscriptionRuntimeStatus(app, catalog);
+      return await refreshTranscriptionRuntimeStatus(app, catalog);
     } catch (e) {
       statusMessage = errorMessage(e);
+      return null;
     }
   }
 
@@ -323,14 +324,19 @@ export function createSettingsController() {
       settings.transcription_backend_id = option.backendId;
     });
 
-    if (app.transcriptionRuntimePhase === "download_required") {
+    // Branch on the phase the backend just reported for the newly selected
+    // model, never on stored state a StateChanged event may have overwritten
+    // with the previous model's phase.
+    const phase = await refreshRuntimeStatus();
+
+    if (phase === "download_required") {
       await startTranscriptionModelDownload(
         app,
         catalog,
         (message) => { statusMessage = message; },
         { autoLoad: true },
       );
-    } else if (app.transcriptionRuntimePhase === "load_required") {
+    } else if (phase === "load_required") {
       await startTranscriptionModelLoad(app, catalog, (message) => {
         statusMessage = message;
       });

--- a/src/lib/features/transcription/catalog.test.ts
+++ b/src/lib/features/transcription/catalog.test.ts
@@ -4,6 +4,7 @@ import {
   getSelectedTranscriptionBackend,
   getSelectedTranscriptionEngine,
   getSelectedTranscriptionModel,
+  findTranscriptionModel,
   toSelectedTranscriptionProfile,
   toSelectedTranscriptionProfileSelection,
   formatSelectedTranscriptionLabel,
@@ -105,6 +106,21 @@ describe('getSelectedTranscriptionModel', () => {
     const model = getSelectedTranscriptionModel(catalog, 'kyutai', 'nonexistent');
     expect(model).not.toBeNull();
     expect(model!.id).toBe('stt-1b-en_fr');
+  });
+});
+
+describe('findTranscriptionModel', () => {
+  it('returns the exact model when present', () => {
+    const model = findTranscriptionModel(catalog, 'kyutai', 'stt-small');
+    expect(model?.id).toBe('stt-small');
+  });
+
+  it('returns null for a stale or unsupported model id', () => {
+    expect(findTranscriptionModel(catalog, 'kyutai', 'nonexistent')).toBeNull();
+  });
+
+  it('returns null when the engine id does not match', () => {
+    expect(findTranscriptionModel(catalog, 'whisper', 'stt-small')).toBeNull();
   });
 });
 

--- a/src/lib/features/transcription/catalog.ts
+++ b/src/lib/features/transcription/catalog.ts
@@ -50,6 +50,17 @@ export function getSelectedTranscriptionEngine(
   );
 }
 
+/** Exact engine/model lookup. Unlike `getSelectedTranscriptionModel`, this
+ * does not fall back to the first catalog entry when the id is unknown. */
+export function findTranscriptionModel(
+  catalog: TranscriptionCatalog | null,
+  engineId: string,
+  modelId: string,
+): TranscriptionModelDescriptor | null {
+  const engine = catalog?.engines.find((engine) => engine.id === engineId);
+  return engine?.models.find((model) => model.id === modelId) ?? null;
+}
+
 export function getSelectedTranscriptionModel(
   catalog: TranscriptionCatalog | null,
   engineId: string,

--- a/src/lib/features/transcription/runtime.ts
+++ b/src/lib/features/transcription/runtime.ts
@@ -5,7 +5,11 @@ import {
   getTranscriptionCatalog,
   loadModel,
 } from "../../api/transcription";
-import type { DownloadProgress, TranscriptionCatalog } from "../../types";
+import type {
+  DownloadProgress,
+  TranscriptionCatalog,
+  TranscriptionRuntimePhase,
+} from "../../types";
 import { errorMessage } from "../../utils";
 import { toSelectedTranscriptionProfileSelection } from "./catalog";
 import {
@@ -38,10 +42,13 @@ export function currentTranscriptionSelection(
   );
 }
 
+/** Refresh the phase of the *selected* profile and return it, so callers can
+ * act on the fresh value instead of re-reading state a later event may have
+ * moved on. */
 export async function refreshTranscriptionRuntimeStatus(
   app: AppState,
   catalog: TranscriptionCatalog | null,
-) {
+): Promise<TranscriptionRuntimePhase> {
   const status = await getModelStatus(currentTranscriptionSelection(app, catalog));
   app.transcriptionRuntimePhase = status.phase;
   app.settings = {
@@ -50,6 +57,7 @@ export async function refreshTranscriptionRuntimeStatus(
     transcription_model_id: status.profile.model_id,
     transcription_backend_id: status.profile.backend_id ?? app.settings.transcription_backend_id,
   };
+  return status.phase;
 }
 
 export async function startTranscriptionModelDownload(

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -57,6 +57,32 @@ describe('app store', () => {
     expect(state.settings.transcription_engine_id).toBe('whisper');
   });
 
+  it('only syncs the runtime phase from machine states about the selected model', () => {
+    const state = getAppState();
+    const profile = (modelId: string) => ({
+      engine_id: 'kyutai',
+      engine_label: 'Kyutai',
+      model_id: modelId,
+      model_label: modelId,
+      backend_id: 'candle',
+      backend_label: 'Candle',
+    });
+
+    state.settings = { ...mockSettings, transcription_model_id: 'stt-2.6b-en' };
+    state.transcriptionRuntimePhase = 'download_required';
+
+    // Old model still loaded in the backend: its "ready" must not be read as
+    // the newly selected model being ready.
+    state.machineState = { state: 'ready', data: { profile: profile('stt-1b-en_fr') } };
+    expect(state.transcriptionRuntimePhase).toBe('download_required');
+
+    state.machineState = { state: 'ready', data: { profile: profile('stt-2.6b-en') } };
+    expect(state.transcriptionRuntimePhase).toBe('ready');
+
+    state.machineState = { state: 'idle' };
+    expect(state.transcriptionRuntimePhase).toBe('ready');
+  });
+
   it('recordingMode is derived from machineState', () => {
     const state = getAppState();
     state.machineState = { state: "recording_meeting", data: { profile: { engine_id: "", engine_label: "", model_id: "", model_label: "", backend_id: "", backend_label: "" }, session_id: 1, meeting_id: "m1" } };

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -4,6 +4,7 @@ import type {
   PipelineError,
   SystemAudioStatus,
   TranscriptionHealth,
+  TranscriptionProfile,
   TranscriptionRuntimePhase,
   UpcomingMeeting,
 } from "../types";
@@ -145,6 +146,43 @@ function deriveRuntimePhase(state: AppStateMachine): TranscriptionRuntimePhase {
   }
 }
 
+/** The profile the backend is currently busy with, when it tracks one. */
+export function machineProfile(state: AppStateMachine): TranscriptionProfile | null {
+  switch (state.state) {
+    case "idle":
+      return null;
+    case "error": {
+      const recovery = state.data.recovery;
+      if (typeof recovery === "object") {
+        if ("retry_from_downloaded" in recovery) return recovery.retry_from_downloaded.profile;
+        if ("retry_from_ready" in recovery) return recovery.retry_from_ready.profile;
+      }
+      return null;
+    }
+    default:
+      return state.data.profile;
+  }
+}
+
+/** Whether the machine is talking about the model the user has selected.
+ * After a model switch the two diverge (machine still Ready with the old
+ * profile), and the machine's phase must not be applied to the new one. */
+export function machineMatchesSelection(
+  state: AppStateMachine,
+  selection: Pick<
+    AppSettings,
+    "transcription_engine_id" | "transcription_model_id" | "transcription_backend_id"
+  >,
+): boolean {
+  const profile = machineProfile(state);
+  if (!profile) return false;
+  return (
+    profile.engine_id === selection.transcription_engine_id
+    && profile.model_id === selection.transcription_model_id
+    && profile.backend_id === selection.transcription_backend_id
+  );
+}
+
 function deriveModelOperationState(state: AppStateMachine): TranscriptionModelOperationState {
   switch (state.state) {
     case "downloading": return "downloading";
@@ -175,7 +213,10 @@ export function getAppState() {
       machineState = s;
       // Sync runtime phase from machine when no model operation is in progress.
       // During download/load the phase is managed by runtime.ts callbacks.
-      if (deriveModelOperationState(s) === "idle") {
+      // Only when the machine is talking about the selected model: otherwise a
+      // stray event would report the *old* model's phase (e.g. "ready") for a
+      // model the user just picked and that still needs a download or a load.
+      if (deriveModelOperationState(s) === "idle" && machineMatchesSelection(s, settings)) {
         transcriptionRuntimePhase = deriveRuntimePhase(s);
       }
       // Health snapshots only make sense while recording


### PR DESCRIPTION
Two symptoms reported: switching model in settings did not seem to apply (the header status chip never changed, so the app had to be restarted to be sure), and some models picked in the dropdown did not start downloading at all.

Four independent causes:

### The header chip never updated
`modelLabel` in `App.svelte` was a `$state` filled once in `onMount` from the catalog. Nothing recomputed it when the selection changed. It is now derived from the (static) catalog and the current selection.

### The runtime phase was overwritten by the previous model
The `machineState` setter recomputed `transcriptionRuntimePhase` from the state machine on every `StateChanged` event, without checking that the machine was talking about the *selected* profile — even though the file's own comment noted that the two diverge right after a switch. An event about the still-loaded old model repainted the chip as "ready" while the newly selected model was neither downloaded nor loaded. The phase is now only synced when the machine's profile matches the selection.

### The backend recorded the wrong active profile
`StateAction::StartLoad` carried no profile, and the transition was `(Downloaded { profile }, StartLoad) => Loading { profile }`, keeping the *previous* profile. After the idle timer unloads model A (machine `Downloaded{A}`), selecting B loaded B in the engine but left the machine in `Ready{A}`. `get_model_status(B)` then answered `load_required` forever (chip stuck), and re-selecting A was treated as already-ready, so nothing was reloaded while the engine was still running B. `StartLoad` now carries the requested profile.

### A model that would never download
`load_model` auto-recovers from `Error`, `download_model` did not. After any failure (failed download, pipeline error during a recording) the machine stayed in `Error` and every `StartDownload` failed with "Invalid state transition" — selecting a model did nothing, no download, no load, until the app was restarted. Same auto-recover added.

Also: `selectModelOption` now branches on the phase `get_model_status` just returned rather than re-reading store state an event may have overwritten.

## Tests

- `npm run check`: clean. `npm test`: 321 passing (2 added — phase-sync guard in the store, loading an already-downloaded model).
- `cargo test`: 660 passing (1 added — `Downloaded{A} + StartLoad{B}` → `Loading{B}`).
- Not verified against a running build: exercising the switches by hand needs several GB of downloaded models. The fixes are backed by tests and by reading the flow, not by a visual run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Switching between downloaded transcription models now loads the selected model correctly.
  * The app header displays the exact currently selected transcription model.

* **Bug Fixes**
  * Model selection now accurately determines whether a model needs downloading or loading.
  * Runtime status no longer reflects readiness from a previously selected model.
  * Model changes recover more reliably from prior error states and recording activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->