### PR TITLE
Stop re-rating the shared input device, which blocked Teams from starting

### DIFF
--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -1,5 +1,5 @@
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-use cpal::{Device, SampleFormat, Stream, StreamConfig};
+use cpal::{Device, SampleFormat, Stream, StreamConfig, SupportedStreamConfigRange};
 use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
 use ringbuf::HeapRb;
 use ringbuf::traits::{Producer, Split};
@@ -219,6 +219,33 @@ fn choose_input_sample_rate(current: Option<u32>, min: u32, max: u32) -> u32 {
     }
 }
 
+/// Prefer an F32 range that already covers `current`, so we don't fall back
+/// and re-rate the device just because the first listed range is narrower.
+fn pick_input_config_range(
+    supported: &[SupportedStreamConfigRange],
+    current: Option<u32>,
+) -> Option<SupportedStreamConfigRange> {
+    let f32_ranges: Vec<_> = supported
+        .iter()
+        .filter(|c| c.sample_format() == SampleFormat::F32)
+        .cloned()
+        .collect();
+    let candidates: &[SupportedStreamConfigRange] = if f32_ranges.is_empty() {
+        supported
+    } else {
+        &f32_ranges
+    };
+
+    if let Some(rate) = current
+        && let Some(range) = candidates
+            .iter()
+            .find(|c| (c.min_sample_rate()..=c.max_sample_rate()).contains(&rate))
+    {
+        return Some(range.clone());
+    }
+    candidates.first().cloned()
+}
+
 #[cfg(test)]
 mod input_rate_tests {
     use super::*;
@@ -259,6 +286,46 @@ mod input_rate_tests {
     fn clamps_the_fallback_into_a_narrow_range() {
         assert_eq!(choose_input_sample_rate(None, 16_000, 16_000), 16_000);
         assert_eq!(choose_input_sample_rate(None, 88_200, 192_000), 88_200);
+    }
+
+    fn f32_range(min: u32, max: u32) -> SupportedStreamConfigRange {
+        SupportedStreamConfigRange::new(
+            1,
+            min,
+            max,
+            cpal::SupportedBufferSize::Unknown,
+            SampleFormat::F32,
+        )
+    }
+
+    #[test]
+    fn picks_later_f32_range_that_covers_current() {
+        let ranges = vec![f32_range(8_000, 44_100), f32_range(48_000, 96_000)];
+        let picked = pick_input_config_range(&ranges, Some(48_000)).unwrap();
+        assert_eq!(picked.min_sample_rate(), 48_000);
+        assert_eq!(picked.max_sample_rate(), 96_000);
+        let rate = choose_input_sample_rate(
+            Some(48_000),
+            picked.min_sample_rate(),
+            picked.max_sample_rate(),
+        );
+        assert_eq!(rate, 48_000);
+    }
+
+    #[test]
+    fn first_f32_range_still_wins_when_it_covers_current() {
+        let ranges = vec![f32_range(8_000, 96_000), f32_range(48_000, 48_000)];
+        let picked = pick_input_config_range(&ranges, Some(48_000)).unwrap();
+        assert_eq!(picked.min_sample_rate(), 8_000);
+        assert_eq!(picked.max_sample_rate(), 96_000);
+    }
+
+    #[test]
+    fn falls_back_to_first_f32_when_current_fits_none() {
+        let ranges = vec![f32_range(8_000, 16_000), f32_range(44_100, 44_100)];
+        let picked = pick_input_config_range(&ranges, Some(48_000)).unwrap();
+        assert_eq!(picked.min_sample_rate(), 8_000);
+        assert_eq!(picked.max_sample_rate(), 16_000);
     }
 }
 
@@ -1947,24 +2014,18 @@ impl AudioCapture {
     }
 
     fn preferred_config(device: &Device) -> Result<StreamConfig, String> {
-        let mut supported = device
+        let supported: Vec<_> = device
             .supported_input_configs()
-            .map_err(|e| format!("Failed to get supported configs: {e}"))?;
-
-        let config = supported
-            .find(|c| c.sample_format() == SampleFormat::F32)
-            .or_else(|| {
-                device
-                    .supported_input_configs()
-                    .ok()
-                    .and_then(|mut c| c.next())
-            })
-            .ok_or_else(|| "No supported input config found".to_string())?;
+            .map_err(|e| format!("Failed to get supported configs: {e}"))?
+            .collect();
 
         // `default_input_config` reads the device's *current* stream format,
         // which is the one rate that opens without re-rating the hardware for
         // every other process on the machine.
         let current = device.default_input_config().ok().map(|c| c.sample_rate());
+        let config = pick_input_config_range(&supported, current)
+            .ok_or_else(|| "No supported input config found".to_string())?;
+
         let rate =
             choose_input_sample_rate(current, config.min_sample_rate(), config.max_sample_rate());
         if current != Some(rate) {

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -197,6 +197,71 @@ fn has_fallback_audio(tap_live: bool) -> bool {
     tap_live
 }
 
+/// Fallback rate when the device's current one can't be read. 48 kHz is what
+/// every conferencing stack negotiates; the device maximum is not, and picking
+/// it is what broke other apps.
+const FALLBACK_INPUT_SAMPLE_RATE: u32 = 48_000;
+
+/// Rate to open a shared input device at.
+///
+/// cpal writes `kAudioDevicePropertyNominalSampleRate` from
+/// `build_input_stream` whenever the requested rate differs from the device's
+/// current one, and that property is machine-wide: opening the built-in mic at
+/// its 96 kHz maximum re-rates it for every other client. Meeting apps that
+/// bring up their own pipeline afterwards (Teams) fail to start on a mic above
+/// 48 kHz, so keep whatever rate the device is already on and let CoreAudio
+/// stay untouched. Souffle resamples to the engine rate regardless, so a
+/// higher device rate buys nothing.
+fn choose_input_sample_rate(current: Option<u32>, min: u32, max: u32) -> u32 {
+    match current {
+        Some(rate) if (min..=max).contains(&rate) => rate,
+        _ => FALLBACK_INPUT_SAMPLE_RATE.clamp(min, max),
+    }
+}
+
+#[cfg(test)]
+mod input_rate_tests {
+    use super::*;
+
+    /// The whole point: never move a rate another app may depend on.
+    #[test]
+    fn keeps_the_rate_the_device_already_runs_at() {
+        assert_eq!(
+            choose_input_sample_rate(Some(96_000), 8_000, 96_000),
+            96_000
+        );
+        assert_eq!(
+            choose_input_sample_rate(Some(48_000), 8_000, 96_000),
+            48_000
+        );
+        assert_eq!(
+            choose_input_sample_rate(Some(16_000), 8_000, 96_000),
+            16_000
+        );
+    }
+
+    #[test]
+    fn falls_back_to_48k_when_the_current_rate_is_unknown() {
+        assert_eq!(choose_input_sample_rate(None, 8_000, 96_000), 48_000);
+    }
+
+    /// A stale reading from another device, or a rate the range no longer
+    /// covers, must not be requested: cpal would reject the whole stream.
+    #[test]
+    fn ignores_a_current_rate_outside_the_supported_range() {
+        assert_eq!(
+            choose_input_sample_rate(Some(192_000), 8_000, 96_000),
+            48_000
+        );
+    }
+
+    #[test]
+    fn clamps_the_fallback_into_a_narrow_range() {
+        assert_eq!(choose_input_sample_rate(None, 16_000, 16_000), 16_000);
+        assert_eq!(choose_input_sample_rate(None, 88_200, 192_000), 88_200);
+    }
+}
+
 #[cfg(test)]
 mod mic_loss_tests {
     use super::*;
@@ -1043,6 +1108,14 @@ impl AudioCapture {
         // Dictation: never keep a leftover meeting tap from a prior session.
         self.meeting.take();
 
+        // The stream that fed the outgoing resampler is already released, so
+        // its buffered chunk can be emitted without racing samples that came
+        // after it. Only for a rebuild of the running session: a new one must
+        // not inherit the previous session's audio.
+        if !is_new_session {
+            self.emit_resampler_tail(session_id);
+        }
+
         let resampler = Arc::new(Mutex::new(Resampler::new(
             sample_rate,
             channels,
@@ -1722,6 +1795,38 @@ impl AudioCapture {
         self.teardown_session_state();
     }
 
+    /// Emit what the mic resampler still holds before a rebuild replaces it,
+    /// mirroring the flush `stop` does at session end. Without this the
+    /// partial FFT chunk (~20ms of speech) dies with the old stream, on top
+    /// of the gap the teardown already costs.
+    ///
+    /// Callers must have released the capture stream first, so no callback
+    /// can push samples that would end up ordered before this tail.
+    fn emit_resampler_tail(&mut self, session_id: u64) {
+        let Some(resampler) = self.resampler.take() else {
+            return;
+        };
+        let Ok(mut r) = resampler.lock() else {
+            return;
+        };
+        let tail = r.flush();
+        if tail.is_empty() {
+            return;
+        }
+        if self
+            .audio_sender
+            .try_send(AudioMessage::Chunk(AudioChunk {
+                session_id,
+                samples: tail,
+                captured_at: Instant::now(),
+                speaker: None,
+            }))
+            .is_err()
+        {
+            debug!("Dropped the resampler tail on mic rebuild (channel full)");
+        }
+    }
+
     /// Stop IO and dispose the capture AudioUnit.
     ///
     /// On macOS, a Bluetooth headset cannot run A2DP stereo output and HFP
@@ -1856,6 +1961,19 @@ impl AudioCapture {
             })
             .ok_or_else(|| "No supported input config found".to_string())?;
 
-        Ok(config.with_max_sample_rate().into())
+        // `default_input_config` reads the device's *current* stream format,
+        // which is the one rate that opens without re-rating the hardware for
+        // every other process on the machine.
+        let current = device.default_input_config().ok().map(|c| c.sample_rate());
+        let rate =
+            choose_input_sample_rate(current, config.min_sample_rate(), config.max_sample_rate());
+        if current != Some(rate) {
+            warn!(
+                "Input device current rate unreadable or unsupported ({current:?}); \
+                 opening at {rate}Hz, which re-rates the device system-wide"
+            );
+        }
+
+        Ok(config.with_sample_rate(rate).into())
     }
 }

--- a/src-tauri/src/audio/mixer.rs
+++ b/src-tauri/src/audio/mixer.rs
@@ -88,9 +88,15 @@ impl MeetingMixer {
         mic_channels: u16,
         mic_gain: f32,
     ) {
+        // Carry the outgoing resampler's buffered chunk into the fifo instead
+        // of dropping it, the same way `flush` does at session end: a rebuild
+        // already costs the teardown gap, and this is another ~20ms of speech
+        // on top. What stays in the fifo is sub-frame, so tap pairing and the
+        // drift bound are unaffected.
+        let tail = self.mic_to_mix.flush();
+        self.mic_fifo.extend(tail);
         self.mic = mic;
         self.mic_to_mix = Resampler::new(mic_rate, mic_channels, MIX_RATE, mic_gain);
-        self.mic_fifo.clear();
     }
 
     /// Drain both rings, mix every complete 10ms frame, and return the
@@ -403,6 +409,38 @@ mod tests {
         assert!(!them.is_empty(), "them must carry the tap");
         let mid = them[them.len() / 2];
         assert!((mid - 0.3).abs() < 0.05, "expected ~0.3, got {mid}");
+    }
+
+    /// A mid-session rebuild must not swallow the speech the mic resampler
+    /// had accumulated but not yet converted.
+    #[test]
+    fn replace_mic_keeps_the_partial_mic_chunk() {
+        // 44.1kHz -> 48kHz needs 1029 input frames per FFT chunk, so 1000
+        // samples sit entirely inside the resampler with nothing emitted.
+        let (mut mic, _tap, mut mixer) = make_mixer(44_100, 48_000, 16_000);
+        mic.push_slice(&vec![0.4f32; 1_000]);
+        assert!(
+            mixer.tick().is_empty(),
+            "a partial chunk must not produce a frame yet"
+        );
+        drop(mic);
+
+        let (_new_mic, new_cons) = HeapRb::<f32>::new(44_100 * 2).split();
+        mixer.replace_mic(new_cons, 44_100, 1, 1.0);
+
+        // No new mic samples: whatever comes out now is the rescued tail.
+        // It still has to clear the engine resampler's own chunking, hence
+        // the flush.
+        let mut out = mixer.tick();
+        out.extend(mixer.flush());
+        assert!(
+            !out.is_empty(),
+            "the buffered chunk must survive the mic rebuild"
+        );
+        assert!(
+            out.iter().any(|s| (*s - 0.4).abs() < 0.05),
+            "the rescued samples must be the ones that were buffered"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## The bug

Starting a Souffle transcription *before* joining a Teams call stopped Teams from opening its audio pipeline: the call would not start at all. The workaround was to stop Souffle, restart Teams, join the call, and only then start transcribing.

It is not a lock or an exclusive claim on the microphone (macOS allows several input clients on one device). It is a global side effect.

`AudioCapture::preferred_config` opened the mic with `with_max_sample_rate()`. cpal collapses a device's discrete rates into a single range (`min=8000, max=96000` for the built-in mic), so that resolved to **96 kHz**. And cpal writes `kAudioDevicePropertyNominalSampleRate` from `build_input_stream` whenever the requested rate differs from the device's current one ([`cpal-0.17.3/src/host/coreaudio/macos/device.rs:53`](https://github.com/RustAudio/cpal/blob/master/src/host/coreaudio/macos/device.rs) and `:751`). That property is **machine-wide, not per process**.

Evidence, with Souffle not even running:

```
$ system_profiler SPAudioDataType
MacBook Pro Microphone:
  Current SampleRate: 96000     # should be 48000
```

cpal never restores the rate, so it outlives the session. And Teams breaks above 48 kHz, which Microsoft documents ([Q&A: works at 48 kHz, anything above causes the issue](https://learn.microsoft.com/en-us/answers/questions/4443650/audio-issues-on-mac-with-audio-interface-high-samp), [crash when HD audio is enabled](https://learn.microsoft.com/en-us/answers/questions/4420455/teams-crashes-on-macos-14-3-1-when-high-definition)).

That explains the ordering asymmetry: Souffle first means Teams initialises VoiceProcessingIO on a 96 kHz mic and fails; Teams first means its pipeline is already negotiated when Souffle flips the rate, and it survives.

Aggravating factor: `check_mic_health` rebuilds the mic leg on device-list and default-input changes. Teams creates its own `Microsoft Teams Audio` virtual device when a call starts, which triggers a rebuild, which re-wrote 96 kHz in the middle of Teams' negotiation.

## The fix

Open at whatever rate the device already runs, read from `default_input_config` (the device's current stream format), so cpal finds nothing to change and touches no shared state. Fallback is 48 kHz clamped into the supported range when the current rate is unreadable, never the maximum. Souffle resamples to the engine rate regardless, so the higher device rate bought nothing but CPU.

Side benefit: this removes the up-to-1s stall inside cpal's `set_sample_rate` (it waits on a property listener for the change to land) from every mic rebuild.

## Non-destructive rebuilds

Rebuilds are rare, but they were lossy beyond the unavoidable teardown gap: both legs dropped the mic resampler mid-chunk, losing ~20-30 ms of speech.

- `MeetingMixer::replace_mic` carried out `self.mic_fifo.clear()` and discarded the resampler's buffered FFT chunk. It now flushes that chunk into the fifo first, the same way `flush()` already does at session end. What remains in the fifo is sub-frame, so tap pairing and `MAX_TAP_LEAD_SAMPLES` are unaffected.
- The dictation path overwrote `self.resampler` without draining it. New `emit_resampler_tail()` sends the remainder as a normal chunk, guarded twice: it runs after `release_capture_stream()` so the old callback is dead and ordering holds, and only when `!is_new_session` so a fresh session never inherits the previous one's audio.

## Tests

- 4 unit tests on `choose_input_sample_rate` (keeps the current rate, falls back to 48 kHz, rejects a rate outside the supported range, clamps into a narrow range).
- `replace_mic_keeps_the_partial_mic_chunk`: 1000 samples at 44.1 kHz sit entirely inside the resampler (its FFT chunk is 1029 frames), the mic is rebuilt, and the samples still come out with the right amplitude. Verified to fail against the old `clear()`, so it is not vacuous.

`cargo test --lib`: 660 passed, 0 failed. Clippy unchanged (the only warning is the pre-existing `contains_key`/`insert` in `export.rs`).

## Manual step for anyone already affected

The fix stops Souffle from moving the rate, but a mic already stuck at 96 kHz stays there. Audio MIDI Setup, `MacBook Pro Microphone`, set the format back to 48 000 Hz once.

Souffle deliberately does not force 48 kHz at startup: that would be the same mistake in the other direction (writing a shared property) and would disrupt a DAW running at 96 kHz.

## Not confirmed

The global CoreAudio process tap in `system_tap.rs` remains a secondary suspect. It is correctly private (`kAudioAggregateDeviceIsPrivateKey`) so Teams cannot see it, and the orphan sweep is properly scoped to the Souffle UID prefix, so it destroys nothing belonging to Teams. There is a known Teams/CATap bug but in the other direction (a tapped Teams yields silent buffers, [meeting-transcriber#79](https://github.com/pasrom/meeting-transcriber/issues/79)), not "Teams will not start". If the symptom survives resetting the mic to 48 kHz, that is where to dig next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved microphone and dictation session transitions by preserving buffered audio instead of dropping partial samples.
  - Improved input device sample-rate handling by selecting a supported rate matching the device when available, with a compatible fallback otherwise.
  - Reduced audio interruptions and potential artifacts when rebuilding or switching microphone input during an active session.
  - Improved continuity for in-progress recordings by ensuring buffered microphone audio reaches output after input replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->