### PR TITLE
Fix stale site assets, the overlay window's square corners, and the missing mobile nav

### DIFF
--- a/site/eleventy.config.js
+++ b/site/eleventy.config.js
@@ -4,6 +4,13 @@
  * Output is plain static files — no server, nothing to configure on
  * Cloudflare Pages beyond "run npm run build, publish _site".
  */
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const srcDir = join(dirname(fileURLToPath(import.meta.url)), "src");
+
 export default function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy({ "src/css": "css" });
   eleventyConfig.addPassthroughCopy({ "src/js": "js" });
@@ -13,6 +20,14 @@ export default function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy({ "src/og-fr.png": "og-fr.png" });
   eleventyConfig.addPassthroughCopy({ "src/_headers": "_headers" });
   eleventyConfig.addPassthroughCopy({ "src/robots.txt": "robots.txt" });
+
+  // CSS and JS keep stable filenames, so a deploy would otherwise serve fresh
+  // HTML against whatever stylesheet the visitor still had cached. Stamping a
+  // content hash onto the URL makes each build a distinct cache entry.
+  eleventyConfig.addFilter("bust", (url) => {
+    const digest = createHash("sha256").update(readFileSync(join(srcDir, url))).digest("hex");
+    return `${url}?v=${digest.slice(0, 8)}`;
+  });
 
   // `t.some.key` inside a template, resolved against the page's locale bundle.
   eleventyConfig.addFilter("get", (obj, path) =>

--- a/site/src/_data/en.json
+++ b/site/src/_data/en.json
@@ -13,7 +13,8 @@
     "github": "GitHub",
     "home": "Home",
     "releases": "Releases",
-    "download": "Download"
+    "download": "Download",
+    "menu": "Menu"
   },
   "hero": {
     "badge": "macOS 13+ · APPLE SILICON",

--- a/site/src/_data/fr.json
+++ b/site/src/_data/fr.json
@@ -13,7 +13,8 @@
     "github": "GitHub",
     "home": "Accueil",
     "releases": "Versions",
-    "download": "Télécharger"
+    "download": "Télécharger",
+    "menu": "Menu"
   },
   "hero": {
     "badge": "macOS 13+ · APPLE SILICON",

--- a/site/src/_headers
+++ b/site/src/_headers
@@ -7,7 +7,7 @@
   Cache-Control: public, max-age=31536000, immutable
 
 /css/*
-  Cache-Control: public, max-age=3600
+  Cache-Control: public, max-age=31536000, immutable
 
 /js/*
-  Cache-Control: public, max-age=3600
+  Cache-Control: public, max-age=31536000, immutable

--- a/site/src/_includes/icons.njk
+++ b/site/src/_includes/icons.njk
@@ -2,6 +2,10 @@
 {% macro icon(name, size = 16, stroke = 2) %}
 {%- if name == "download" -%}
 <svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="{{ stroke }}" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 3v13"/><path d="M7 12l5 5 5-5"/><path d="M4 21h16"/></svg>
+{%- elif name == "menu" -%}
+<svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="{{ stroke }}" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M4 6h16"/><path d="M4 12h16"/><path d="M4 18h16"/></svg>
+{%- elif name == "close" -%}
+<svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="{{ stroke }}" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 6l12 12"/><path d="M18 6L6 18"/></svg>
 {%- elif name == "clock" -%}
 <svg width="{{ size }}" height="{{ size }}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="{{ stroke }}" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 8v4l3 2"/></svg>
 {%- elif name == "server" -%}

--- a/site/src/_includes/layouts/base.njk
+++ b/site/src/_includes/layouts/base.njk
@@ -6,8 +6,8 @@
   <title>{{ pageTitle or t.meta.title }}</title>
   <meta name="description" content="{{ t.meta.description }}">
   <link rel="icon" href="/souffle-logo.svg" type="image/svg+xml">
-  <link rel="stylesheet" href="/css/site.css">
-  <link rel="stylesheet" href="/css/mocks.css">
+  <link rel="stylesheet" href="{{ '/css/site.css' | bust }}">
+  <link rel="stylesheet" href="{{ '/css/mocks.css' | bust }}">
   {% set altEn = "/docs/" if isDocs else "/" %}
   {% set altFr = "/fr/docs/" if isDocs else "/fr/" %}
   <link rel="canonical" href="{{ site.url }}{{ page.url }}">
@@ -48,7 +48,7 @@
   {% include "partials/nav.njk" %}
   <main>{{ content | safe }}</main>
   {% include "partials/footer.njk" %}
-  <script src="/js/site.js" defer></script>
-  <script src="/js/mocks.js" defer></script>
+  <script src="{{ '/js/site.js' | bust }}" defer></script>
+  <script src="{{ '/js/mocks.js' | bust }}" defer></script>
 </body>
 </html>

--- a/site/src/_includes/mocks/mocks.njk
+++ b/site/src/_includes/mocks/mocks.njk
@@ -172,7 +172,7 @@
 <div class="overlay-stage" data-mock="overlay" data-polishing="{{ t.mock.pillPolishing }}"
      data-me="{{ c.me.name }}" data-me-initials="{{ c.me.initials }}"
      data-me-colour="{{ c.me.colour }}" data-me-at="{{ c.me.at }}">
-  <div class="mock chat-win">
+  <div class="mock win chat-win">
     <div class="win-bar chat-bar">
       <span class="win-dot red"></span><span class="win-dot amber"></span><span class="win-dot green"></span>
       <span class="win-title">{{ c.app }}</span>

--- a/site/src/_includes/partials/nav.njk
+++ b/site/src/_includes/partials/nav.njk
@@ -3,7 +3,7 @@
 {% set docs = "/docs/" if loc.code == "en" else "/fr/docs/" %}
 <nav class="nav">
   <a class="brand" href="{{ home }}">{{ logo(34) }}<span>{{ site.name }}</span></a>
-  <div class="nav-links">
+  <div class="nav-links" id="nav-links">
     {% if isDocs %}
       <a href="{{ home }}">{{ t.nav.home }}</a>
       <a href="{{ site.releases }}">{{ t.nav.releases }}</a>
@@ -21,5 +21,9 @@
       <a href="{{ "/fr/docs/" if isDocs else "/fr/" }}" aria-current="{{ "true" if loc.code == "fr" }}">FR</a>
     </div>
     <a class="btn-nav" href="{{ "#download" if not isDocs else site.latest }}">{{ icon("download", 15) }}{{ t.nav.download }}</a>
+    <button class="nav-toggle" type="button" aria-controls="nav-links" aria-expanded="false" aria-label="{{ t.nav.menu }}">
+      <span class="nav-toggle-open">{{ icon("menu", 20) }}</span>
+      <span class="nav-toggle-close">{{ icon("close", 20) }}</span>
+    </button>
   </div>
 </nav>

--- a/site/src/css/site.css
+++ b/site/src/css/site.css
@@ -102,6 +102,16 @@ button { font: inherit; border: 0; background: none; color: inherit; }
 .nav-links { display: flex; align-items: center; gap: 30px; }
 .nav-links a { font-size: 14px; color: var(--t3); }
 .nav-links a:hover { color: var(--t1); }
+.nav-toggle {
+  display: none; align-items: center; justify-content: center;
+  width: 36px; height: 36px; padding: 0;
+  border: 0; border-radius: 10px; cursor: pointer;
+  background: var(--surface-2); outline: 1px solid var(--ghost); color: var(--t2);
+}
+.nav-toggle-open, .nav-toggle-close { display: flex; }
+.nav-toggle-close { display: none; }
+.nav-toggle[aria-expanded="true"] .nav-toggle-open { display: none; }
+.nav-toggle[aria-expanded="true"] .nav-toggle-close { display: flex; }
 .brand { display: flex; align-items: center; gap: 11px; }
 .brand span {
   font-family: var(--font-heading); font-size: 19px; font-weight: 600;
@@ -285,7 +295,23 @@ button { font: inherit; border: 0; background: none; color: inherit; }
   .feature.is-flipped > div:first-child { order: 2; }
 }
 @media (max-width: 860px) {
-  .nav-links { display: none; }
+  .nav-toggle { display: inline-flex; }
+  /* The links move out of the bar into a panel hanging under it, so a
+     phone still reaches every section the desktop nav offers. */
+  .nav-links {
+    display: none; position: absolute; top: 100%; left: 0; right: 0;
+    flex-direction: column; align-items: stretch; gap: 0;
+    padding: 6px 12px 12px;
+    /* Opaque, not the bar's --glass: the nav's own backdrop-filter is a
+       backdrop root, so a nested blur samples nothing and the page would
+       read straight through the panel. */
+    background: var(--surface-1);
+    border-bottom: 1px solid var(--ghost);
+    box-shadow: 0 24px 40px -20px rgba(0, 0, 0, 0.7);
+  }
+  .nav-links.is-open { display: flex; }
+  .nav-links a { padding: 13px 12px; border-radius: 10px; font-size: 15px; color: var(--t2); }
+  .nav-links a:active { background: var(--surface-2); }
   .hero { padding-top: 56px; }
   .hero h1 { font-size: 40px; letter-spacing: -0.03em; }
   .hero-sub { font-size: 16px; }
@@ -299,9 +325,6 @@ button { font: inherit; border: 0; background: none; color: inherit; }
   .btn { width: 100%; }
   .copy { width: 100%; }
   .copy code { font-size: 12px; }
-}
-
-
 }
 
 /* The nav is sticky, so anchored sections need to stop below it. */

--- a/site/src/js/site.js
+++ b/site/src/js/site.js
@@ -61,3 +61,37 @@
   }, { rootMargin: "-96px 0px -70% 0px" });
   sections.forEach(function (s) { io.observe(s); });
 })();
+
+/* Mobile nav: the links live in a panel under the bar, opened by the
+   hamburger. The panel is CSS-hidden above 860px, so the desktop nav is
+   unaffected and the class left behind by a resize costs nothing. */
+(function () {
+  "use strict";
+  var toggle = document.querySelector(".nav-toggle");
+  var panel = document.getElementById("nav-links");
+  if (!toggle || !panel) return;
+
+  var close = function () {
+    panel.classList.remove("is-open");
+    toggle.setAttribute("aria-expanded", "false");
+  };
+
+  toggle.addEventListener("click", function () {
+    var open = panel.classList.toggle("is-open");
+    toggle.setAttribute("aria-expanded", open ? "true" : "false");
+  });
+
+  panel.addEventListener("click", function (e) {
+    if (e.target.closest("a")) close();
+  });
+
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape") close();
+  });
+
+  document.addEventListener("click", function (e) {
+    if (!e.target.closest(".nav")) close();
+  });
+
+  window.matchMedia("(min-width: 861px)").addEventListener("change", close);
+})();


### PR DESCRIPTION
Three fixes to the landing page, all found after #107 went live.

## The header cluster rendered unstyled

The model status pill, theme toggle and settings button added in #107 showed up as raw text and stacked icons on the live site. The CSS was correct and deployed; the problem is that `/css/mocks.css` keeps the same URL across deploys, so returning visitors got the new HTML against a stylesheet they already had cached. Cloudflare was serving it with `max-age=14400`, giving a four-hour window after every deploy where the markup is new and its CSS is not.

A `bust` filter now stamps a short content hash onto the four CSS/JS URLs at build time, so a changed file is a different URL. With the URLs versioned, `_headers` moves `/css/*` and `/js/*` from `max-age=3600` to `max-age=31536000, immutable`, matching `/fonts/*`: unchanged assets stay on the CDN edge and in the browser indefinitely, changed ones arrive immediately rather than on expiry.

## The overlay demo's chat window had square corners

`.chat-win` was `class="mock chat-win"` and never carried `win`, so it inherited none of the shared window chrome: no `border-radius: 14px`, no `overflow: hidden`, no outline or shadow. The dead `.chat-win { outline-color }` rule shows `win` was meant to be there. Present since the original landing page PR.

## Mobile portrait had no way to reach the nav links

Below 860px `.nav-links` was `display: none` with nothing in its place, so a phone had no route to Features, Models, Privacy, Docs or GitHub (Home/Releases/GitHub on the docs page). The links now collapse into a panel under the bar, opened by a hamburger placed after the download button; it closes on link tap, Escape, a tap outside the nav, and when the viewport crosses back above the breakpoint.

The panel is painted opaque rather than with the bar's translucent `--glass`, because `.nav` sets `backdrop-filter` and is therefore a backdrop root: a nested blur samples nothing and the page read straight through the panel.

Also removes a stray `}` left after the mobile media block.

## Test plan

Verified in headless Chrome against the built `_site`:

- Header cluster renders as a rounded status pill plus two icon buttons in a row
- Chat window: `border-radius: 14px`, `overflow: hidden`, cool grey outline; all four corners confirmed round in screenshots
- Nav at 1440 / 1000 / 861 / 860 / 768 / 430 / 375 / 320px: the toggle appears exactly at 860 and below, the links stay inline above it, no horizontal overflow at any width
- Panel opens with the right links on the landing page (5), docs (3) and FR (5, translated); closes on link click and outside click; `aria-expanded` tracks state; no console errors
- Desktop nav pixel-unchanged
- `en.json` / `fr.json` key parity checked with the script in `site/README.md`