### PR TITLE
Stop the dictation paste from inserting an older clipboard entry

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -1,3 +1,4 @@
+use std::sync::Mutex;
 use std::thread;
 use std::time::Duration;
 
@@ -86,7 +87,9 @@ fn holds_text(current: Option<&str>, expected: &str) -> bool {
 }
 
 fn verify_poll_attempts(timeout: Duration, interval: Duration) -> u32 {
-    let attempts = timeout.as_millis() / interval.as_millis().max(1);
+    let interval_ms = interval.as_millis().max(1);
+    // Inclusive of the timeout boundary: 250 ms / 10 ms reads at 0, 10, …, 250.
+    let attempts = timeout.as_millis() / interval_ms + 1;
     u32::try_from(attempts).unwrap_or(u32::MAX).max(1)
 }
 
@@ -117,6 +120,7 @@ fn paste_via_cmd_v(text: &str, delay_ms: u64, enigo: &mut Enigo) -> Result<(), S
             timeout_ms = CLIPBOARD_VERIFY_TIMEOUT.as_millis(),
             "Clipboard did not serve the transcription in time; skipping paste"
         );
+        spawn_restore(previous, text.to_string());
         return Err(
             "Clipboard write did not take effect. Paste skipped so an older clipboard entry is not pasted instead."
                 .to_string(),
@@ -125,6 +129,14 @@ fn paste_via_cmd_v(text: &str, delay_ms: u64, enigo: &mut Enigo) -> Result<(), S
 
     thread::sleep(Duration::from_millis(delay_ms));
 
+    let paste_result = send_paste_keys(enigo);
+    // The pasteboard already holds the transcription, whether ⌘V landed or
+    // not. Restore either way so a key error does not leave it there.
+    spawn_restore(previous, text.to_string());
+    paste_result
+}
+
+fn send_paste_keys(enigo: &mut Enigo) -> Result<(), String> {
     enigo
         .key(Key::Meta, Direction::Press)
         .map_err(|e| format!("Key press Meta: {e}"))?;
@@ -133,34 +145,73 @@ fn paste_via_cmd_v(text: &str, delay_ms: u64, enigo: &mut Enigo) -> Result<(), S
         .map_err(|e| format!("Key click V: {e}"))?;
     enigo
         .key(Key::Meta, Direction::Release)
-        .map_err(|e| format!("Key release Meta: {e}"))?;
+        .map_err(|e| format!("Key release Meta: {e}"))
+}
 
-    spawn_restore(previous, text.to_string());
-    Ok(())
+/// Snapshot of the clipboard from before the first paste in an overlapping
+/// burst. Only the newest generation restores it; older restores no-op so a
+/// second paste within `CLIPBOARD_RESTORE_DELAY` cannot write the first
+/// transcription back as if it were the user's original contents.
+struct RestoreBurst {
+    generation: u64,
+    original: Option<String>,
+}
+
+impl RestoreBurst {
+    const fn new() -> Self {
+        Self {
+            generation: 0,
+            original: None,
+        }
+    }
+
+    fn begin(&mut self, previous: Option<String>) -> (u64, bool) {
+        self.generation = self.generation.wrapping_add(1);
+        if self.original.is_none() {
+            self.original = previous;
+        }
+        (self.generation, self.original.is_some())
+    }
+
+    /// `None` means a newer paste owns the restore. `Some(snapshot)` is the
+    /// pre-burst clipboard, which may itself be `None`.
+    fn take_if_current(&mut self, generation: u64) -> Option<Option<String>> {
+        if generation != self.generation {
+            return None;
+        }
+        Some(self.original.take())
+    }
+}
+
+static RESTORE: Mutex<RestoreBurst> = Mutex::new(RestoreBurst::new());
+
+fn lock_restore() -> std::sync::MutexGuard<'static, RestoreBurst> {
+    RESTORE.lock().unwrap_or_else(|p| p.into_inner())
 }
 
 /// The restore waits out `CLIPBOARD_RESTORE_DELAY`, and `paste_text` is a
 /// synchronous Tauri command, so it runs on the main thread. Detach it rather
 /// than freezing the UI for the whole wait; nothing downstream depends on it.
 fn spawn_restore(previous: Option<String>, ours: String) {
-    if previous.is_none() {
+    let (generation, has_snapshot) = lock_restore().begin(previous);
+    if !has_snapshot {
         return;
     }
-    thread::spawn(move || restore_clipboard(previous, &ours));
+    thread::spawn(move || restore_clipboard(generation, &ours));
 }
 
-/// Put `previous` back after a delay long enough for ⌘V to land, and only if
-/// the pasteboard still holds `ours`: anything else means another app or the
-/// user wrote in the meantime and the restore would clobber it. No-op when
-/// there was no previous text. Restore failures are ignored.
+/// Put the pre-burst clipboard back after a delay long enough for ⌘V to land,
+/// and only if this generation is still current and the pasteboard still holds
+/// `ours`. Anything else means another paste, app, or the user wrote in the
+/// meantime. No-op when there was no previous text.
 ///
 /// Returns whether a restore was attempted (for unit tests; real AX is not
 /// exercised in CI).
-fn restore_clipboard(previous: Option<String>, ours: &str) -> bool {
-    let Some(previous) = previous else {
+fn restore_clipboard(generation: u64, ours: &str) -> bool {
+    thread::sleep(CLIPBOARD_RESTORE_DELAY);
+    let Some(Some(previous)) = lock_restore().take_if_current(generation) else {
         return false;
     };
-    thread::sleep(CLIPBOARD_RESTORE_DELAY);
     let Ok(mut clipboard) = Clipboard::new() else {
         return false;
     };
@@ -194,11 +245,6 @@ mod tests {
         assert!(ax_set_applied(&Ok(true)));
         assert!(!ax_set_applied(&Ok(false)));
         assert!(!ax_set_applied(&Err("nope".into())));
-    }
-
-    #[test]
-    fn restore_clipboard_skips_when_no_previous() {
-        assert!(!restore_clipboard(None, "text"));
     }
 
     #[test]
@@ -243,7 +289,7 @@ mod tests {
     fn verify_poll_attempts_fit_the_timeout() {
         assert_eq!(
             verify_poll_attempts(Duration::from_millis(250), Duration::from_millis(10)),
-            25
+            26
         );
         assert_eq!(
             verify_poll_attempts(Duration::from_millis(5), Duration::from_millis(10)),
@@ -251,7 +297,7 @@ mod tests {
         );
         assert_eq!(
             verify_poll_attempts(Duration::from_millis(250), Duration::ZERO),
-            250
+            251
         );
     }
 
@@ -259,5 +305,39 @@ mod tests {
     fn verify_timeout_stays_short_enough_to_not_stall_dictation() {
         assert!(CLIPBOARD_VERIFY_TIMEOUT <= Duration::from_millis(250));
         assert!(CLIPBOARD_VERIFY_INTERVAL < CLIPBOARD_VERIFY_TIMEOUT);
+    }
+
+    #[test]
+    fn overlapping_pastes_restore_the_pre_burst_clipboard() {
+        let mut burst = RestoreBurst::new();
+        let (first, _) = burst.begin(Some("notes".into()));
+        let (second, has_snapshot) = burst.begin(Some("first transcription".into()));
+        assert!(has_snapshot);
+        assert!(
+            burst.take_if_current(first).is_none(),
+            "the older restore must not run once a newer paste owns the burst"
+        );
+        assert_eq!(
+            burst.take_if_current(second),
+            Some(Some("notes".into())),
+            "the newest restore puts back what was there before either paste"
+        );
+    }
+
+    #[test]
+    fn a_failed_read_on_the_second_paste_still_keeps_the_original() {
+        let mut burst = RestoreBurst::new();
+        burst.begin(Some("notes".into()));
+        let (second, has_snapshot) = burst.begin(None);
+        assert!(has_snapshot);
+        assert_eq!(burst.take_if_current(second), Some(Some("notes".into())));
+    }
+
+    #[test]
+    fn first_paste_without_a_previous_value_has_nothing_to_restore() {
+        let mut burst = RestoreBurst::new();
+        let (generation, has_snapshot) = burst.begin(None);
+        assert!(!has_snapshot);
+        assert_eq!(burst.take_if_current(generation), Some(None));
     }
 }

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -12,13 +12,28 @@ use crate::settings::PasteMethod;
 /// instead of just relaying a raw OS error string.
 pub const ACCESSIBILITY_STALE_ERROR: &str = "Accessibility permission missing. If Souffle is already listed and checked in System Settings > Privacy & Security > Accessibility, this is usually a stale entry left by an app update: remove Souffle with the minus button and re-add it, or use Repair permission in Souffle's Settings > Advanced > Permissions.";
 
-/// Wait for ⌘V to land in the target app before putting the previous
-/// clipboard contents back.
-const CLIPBOARD_RESTORE_DELAY: Duration = Duration::from_millis(75);
+/// The synthetic ⌘V is asynchronous: the target app reads the pasteboard from
+/// its own run loop, and a busy app, an Electron one, or one that was just
+/// launched can take a few hundred milliseconds to get there. Restoring
+/// earlier races that read and the app pastes the previous clipboard contents
+/// instead of the transcription.
+const CLIPBOARD_RESTORE_DELAY: Duration = Duration::from_millis(400);
+
+/// `set_text` can return before the pasteboard actually serves the new value,
+/// so the write is read back before ⌘V is sent. Bounded low enough that a
+/// failing pasteboard does not stall dictation.
+const CLIPBOARD_VERIFY_TIMEOUT: Duration = Duration::from_millis(250);
+const CLIPBOARD_VERIFY_INTERVAL: Duration = Duration::from_millis(10);
 
 /// Insert text into the active application after `delay_ms`, using either
 /// clipboard+Cmd+V or simulated keystrokes (for apps that reject synthetic paste).
 pub fn paste_text(text: &str, delay_ms: u64, method: PasteMethod) -> Result<(), String> {
+    // Nothing to insert: leave the user's clipboard and their frontmost app
+    // untouched rather than firing a ⌘V that pastes whatever was there.
+    if is_blank(text) {
+        return Ok(());
+    }
+
     if !permissions::accessibility_granted() {
         return Err(ACCESSIBILITY_STALE_ERROR.to_string());
     }
@@ -55,8 +70,39 @@ pub fn paste_text(text: &str, delay_ms: u64, method: PasteMethod) -> Result<(), 
     Ok(())
 }
 
+fn is_blank(text: &str) -> bool {
+    text.trim().is_empty()
+}
+
 fn ax_set_applied(result: &Result<bool, String>) -> bool {
     matches!(result, Ok(true))
+}
+
+/// Whether the pasteboard currently serves exactly what we put there. Used
+/// both to confirm our write before ⌘V and to decide whether the restore is
+/// still ours to make.
+fn holds_text(current: Option<&str>, expected: &str) -> bool {
+    current == Some(expected)
+}
+
+fn verify_poll_attempts(timeout: Duration, interval: Duration) -> u32 {
+    let attempts = timeout.as_millis() / interval.as_millis().max(1);
+    u32::try_from(attempts).unwrap_or(u32::MAX).max(1)
+}
+
+/// Poll the pasteboard until it serves `text`, so ⌘V is never sent against a
+/// write that has not landed.
+fn wait_for_clipboard(clipboard: &mut Clipboard, text: &str) -> bool {
+    let attempts = verify_poll_attempts(CLIPBOARD_VERIFY_TIMEOUT, CLIPBOARD_VERIFY_INTERVAL);
+    for attempt in 0..attempts {
+        if holds_text(clipboard.get_text().ok().as_deref(), text) {
+            return true;
+        }
+        if attempt + 1 < attempts {
+            thread::sleep(CLIPBOARD_VERIFY_INTERVAL);
+        }
+    }
+    false
 }
 
 fn paste_via_cmd_v(text: &str, delay_ms: u64, enigo: &mut Enigo) -> Result<(), String> {
@@ -65,6 +111,17 @@ fn paste_via_cmd_v(text: &str, delay_ms: u64, enigo: &mut Enigo) -> Result<(), S
     clipboard
         .set_text(text)
         .map_err(|e| format!("Clipboard set: {e}"))?;
+
+    if !wait_for_clipboard(&mut clipboard, text) {
+        tracing::warn!(
+            timeout_ms = CLIPBOARD_VERIFY_TIMEOUT.as_millis(),
+            "Clipboard did not serve the transcription in time; skipping paste"
+        );
+        return Err(
+            "Clipboard write did not take effect. Paste skipped so an older clipboard entry is not pasted instead."
+                .to_string(),
+        );
+    }
 
     thread::sleep(Duration::from_millis(delay_ms));
 
@@ -78,23 +135,40 @@ fn paste_via_cmd_v(text: &str, delay_ms: u64, enigo: &mut Enigo) -> Result<(), S
         .key(Key::Meta, Direction::Release)
         .map_err(|e| format!("Key release Meta: {e}"))?;
 
-    restore_clipboard(previous);
+    spawn_restore(previous, text.to_string());
     Ok(())
 }
 
-/// Put `previous` back after a short delay so ⌘V can complete. No-op when
+/// The restore waits out `CLIPBOARD_RESTORE_DELAY`, and `paste_text` is a
+/// synchronous Tauri command, so it runs on the main thread. Detach it rather
+/// than freezing the UI for the whole wait; nothing downstream depends on it.
+fn spawn_restore(previous: Option<String>, ours: String) {
+    if previous.is_none() {
+        return;
+    }
+    thread::spawn(move || restore_clipboard(previous, &ours));
+}
+
+/// Put `previous` back after a delay long enough for ⌘V to land, and only if
+/// the pasteboard still holds `ours`: anything else means another app or the
+/// user wrote in the meantime and the restore would clobber it. No-op when
 /// there was no previous text. Restore failures are ignored.
 ///
 /// Returns whether a restore was attempted (for unit tests; real AX is not
 /// exercised in CI).
-fn restore_clipboard(previous: Option<String>) -> bool {
+fn restore_clipboard(previous: Option<String>, ours: &str) -> bool {
     let Some(previous) = previous else {
         return false;
     };
     thread::sleep(CLIPBOARD_RESTORE_DELAY);
-    if let Ok(mut clipboard) = Clipboard::new() {
-        let _ = clipboard.set_text(&previous);
+    let Ok(mut clipboard) = Clipboard::new() else {
+        return false;
+    };
+    if !holds_text(clipboard.get_text().ok().as_deref(), ours) {
+        tracing::warn!("Clipboard changed after paste; leaving the new contents in place");
+        return false;
     }
+    let _ = clipboard.set_text(&previous);
     true
 }
 
@@ -124,12 +198,66 @@ mod tests {
 
     #[test]
     fn restore_clipboard_skips_when_no_previous() {
-        assert!(!restore_clipboard(None));
+        assert!(!restore_clipboard(None, "text"));
     }
 
     #[test]
-    fn clipboard_restore_delay_allows_paste_to_complete() {
-        assert!(CLIPBOARD_RESTORE_DELAY >= Duration::from_millis(50));
-        assert!(CLIPBOARD_RESTORE_DELAY <= Duration::from_millis(100));
+    fn spawn_restore_does_not_block_on_a_missing_previous() {
+        let started = std::time::Instant::now();
+        spawn_restore(None, "text".to_string());
+        assert!(started.elapsed() < CLIPBOARD_RESTORE_DELAY);
+    }
+
+    #[test]
+    fn clipboard_restore_delay_covers_slow_apps() {
+        assert!(CLIPBOARD_RESTORE_DELAY >= Duration::from_millis(300));
+        assert!(CLIPBOARD_RESTORE_DELAY <= Duration::from_millis(1000));
+    }
+
+    #[test]
+    fn blank_text_is_not_pasted() {
+        assert!(is_blank(""));
+        assert!(is_blank("   "));
+        assert!(is_blank("\n\t "));
+        assert!(!is_blank("hi"));
+        assert!(!is_blank(" hi "));
+    }
+
+    #[test]
+    fn paste_text_is_a_no_op_for_blank_text() {
+        // Runs without Accessibility in CI: the blank guard returns before
+        // any permission check or Enigo init.
+        assert_eq!(paste_text("   ", 0, PasteMethod::Clipboard), Ok(()));
+        assert_eq!(paste_text("", 0, PasteMethod::Type), Ok(()));
+    }
+
+    #[test]
+    fn holds_text_requires_an_exact_match() {
+        assert!(holds_text(Some("hello"), "hello"));
+        assert!(!holds_text(Some("hello "), "hello"));
+        assert!(!holds_text(Some("something else"), "hello"));
+        assert!(!holds_text(None, "hello"));
+    }
+
+    #[test]
+    fn verify_poll_attempts_fit_the_timeout() {
+        assert_eq!(
+            verify_poll_attempts(Duration::from_millis(250), Duration::from_millis(10)),
+            25
+        );
+        assert_eq!(
+            verify_poll_attempts(Duration::from_millis(5), Duration::from_millis(10)),
+            1
+        );
+        assert_eq!(
+            verify_poll_attempts(Duration::from_millis(250), Duration::ZERO),
+            250
+        );
+    }
+
+    #[test]
+    fn verify_timeout_stays_short_enough_to_not_stall_dictation() {
+        assert!(CLIPBOARD_VERIFY_TIMEOUT <= Duration::from_millis(250));
+        assert!(CLIPBOARD_VERIFY_INTERVAL < CLIPBOARD_VERIFY_TIMEOUT);
     }
 }


### PR DESCRIPTION
Fixes the intermittent bug where a dictation triggered by the global shortcut pastes a **previous clipboard entry** instead of the transcription (ticket SOU-010).

## Cause

`paste_via_cmd_v` wrote the text, sent the synthetic ⌘V, then `restore_clipboard` slept a fixed **75 ms** and put the previous clipboard contents back.

The ⌘V is asynchronous: the target app reads the pasteboard from its own run loop. Any app slower than 75 ms (Electron, a busy app, a cold start) reads *after* the restore and pastes the old contents. That fixed delay explains the intermittency on its own, without any race on the write side.

The restore was also unconditional, so it clobbered the pasteboard even if something else had written to it meanwhile.

## Changes

All in `src-tauri/src/clipboard.rs`.

- **Verify before pasting.** After `set_text`, poll `get_text()` (10 ms interval, 250 ms budget) until the pasteboard serves our text. On timeout, log and return an error instead of sending ⌘V. Pasting nothing beats pasting an arbitrary older clipboard entry into whatever app is frontmost.
- **Guard the restore.** Delay raised to 400 ms, and the previous contents are only written back if the pasteboard still holds what we wrote.
- **Blank text is a no-op.** No clipboard write, no ⌘V. The frontend already guards empty text, so this is defense in depth for whitespace-only transcriptions and for the exposed `paste_text` command in general.
- **The restore is detached.** `paste_text` is a synchronous Tauri command, so it runs on the main thread (see the note in `commands/pill.rs:14`). Waiting out 400 ms inline would have taken the main-thread block from ~175 ms to ~510 ms. Detaching it puts the block *below* what it is today: only `paste_delay_ms` plus the readback remain.

`PasteMethod::Ax` and `PasteMethod::Type` keep their behavior apart from the blank guard. The `Ax` fallback goes through `paste_via_cmd_v`, so it inherits the verify and the guarded restore, which is intended.

## Tests

`cargo test --lib clipboard`: 11 passed. New coverage on `is_blank`, `holds_text`, `verify_poll_attempts`, the blank no-op through the real `paste_text` entry point, and the detached restore.

`clipboard_restore_delay_allows_paste_to_complete` asserted `<= 100 ms`, in other words it encoded the bug, so it was replaced by `clipboard_restore_delay_covers_slow_apps`.

## QA

Needs a real check on device, since none of this is exercisable in CI:

1. Copy a distinctive string, then dictate into Slack or VS Code. The transcription must land, and the copied string must come back to the clipboard right after.
2. Same thing against an app that was just launched (the slow case that used to fail).
3. Dictate silence: nothing should be pasted and the clipboard must be untouched.

## Not addressed

The ticket also mentions an in-app alert along the lines of "insecure content...". Grepping the Rust, TS and Svelte sources for that wording turns up nothing that the app itself emits, so it most likely comes from macOS or the target app. Left open in the ticket.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Clipboard verification now continues polling through the timeout boundary.
  - Clipboard contents are restored when verification fails.
  - Overlapping paste operations now coordinate restoration to preserve the latest clipboard contents.
  - Improved handling for failed clipboard reads and cases where clipboard contents are unavailable.
  - Clipboard restoration avoids overwriting newer clipboard content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->