### PR TITLE
Anchor the live elapsed counter to the wall clock

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -1,3 +1,4 @@
+use std::sync::Mutex;
 use std::thread;
 use std::time::Duration;
 
@@ -86,7 +87,9 @@ fn holds_text(current: Option<&str>, expected: &str) -> bool {
 }
 
 fn verify_poll_attempts(timeout: Duration, interval: Duration) -> u32 {
-    let attempts = timeout.as_millis() / interval.as_millis().max(1);
+    let interval_ms = interval.as_millis().max(1);
+    // Inclusive of the timeout boundary: 250 ms / 10 ms reads at 0, 10, …, 250.
+    let attempts = timeout.as_millis() / interval_ms + 1;
     u32::try_from(attempts).unwrap_or(u32::MAX).max(1)
 }
 
@@ -117,6 +120,7 @@ fn paste_via_cmd_v(text: &str, delay_ms: u64, enigo: &mut Enigo) -> Result<(), S
             timeout_ms = CLIPBOARD_VERIFY_TIMEOUT.as_millis(),
             "Clipboard did not serve the transcription in time; skipping paste"
         );
+        spawn_restore(previous, text.to_string());
         return Err(
             "Clipboard write did not take effect. Paste skipped so an older clipboard entry is not pasted instead."
                 .to_string(),
@@ -125,6 +129,14 @@ fn paste_via_cmd_v(text: &str, delay_ms: u64, enigo: &mut Enigo) -> Result<(), S
 
     thread::sleep(Duration::from_millis(delay_ms));
 
+    let paste_result = send_paste_keys(enigo);
+    // The pasteboard already holds the transcription, whether ⌘V landed or
+    // not. Restore either way so a key error does not leave it there.
+    spawn_restore(previous, text.to_string());
+    paste_result
+}
+
+fn send_paste_keys(enigo: &mut Enigo) -> Result<(), String> {
     enigo
         .key(Key::Meta, Direction::Press)
         .map_err(|e| format!("Key press Meta: {e}"))?;
@@ -133,34 +145,73 @@ fn paste_via_cmd_v(text: &str, delay_ms: u64, enigo: &mut Enigo) -> Result<(), S
         .map_err(|e| format!("Key click V: {e}"))?;
     enigo
         .key(Key::Meta, Direction::Release)
-        .map_err(|e| format!("Key release Meta: {e}"))?;
+        .map_err(|e| format!("Key release Meta: {e}"))
+}
 
-    spawn_restore(previous, text.to_string());
-    Ok(())
+/// Snapshot of the clipboard from before the first paste in an overlapping
+/// burst. Only the newest generation restores it; older restores no-op so a
+/// second paste within `CLIPBOARD_RESTORE_DELAY` cannot write the first
+/// transcription back as if it were the user's original contents.
+struct RestoreBurst {
+    generation: u64,
+    original: Option<String>,
+}
+
+impl RestoreBurst {
+    const fn new() -> Self {
+        Self {
+            generation: 0,
+            original: None,
+        }
+    }
+
+    fn begin(&mut self, previous: Option<String>) -> (u64, bool) {
+        self.generation = self.generation.wrapping_add(1);
+        if self.original.is_none() {
+            self.original = previous;
+        }
+        (self.generation, self.original.is_some())
+    }
+
+    /// `None` means a newer paste owns the restore. `Some(snapshot)` is the
+    /// pre-burst clipboard, which may itself be `None`.
+    fn take_if_current(&mut self, generation: u64) -> Option<Option<String>> {
+        if generation != self.generation {
+            return None;
+        }
+        Some(self.original.take())
+    }
+}
+
+static RESTORE: Mutex<RestoreBurst> = Mutex::new(RestoreBurst::new());
+
+fn lock_restore() -> std::sync::MutexGuard<'static, RestoreBurst> {
+    RESTORE.lock().unwrap_or_else(|p| p.into_inner())
 }
 
 /// The restore waits out `CLIPBOARD_RESTORE_DELAY`, and `paste_text` is a
 /// synchronous Tauri command, so it runs on the main thread. Detach it rather
 /// than freezing the UI for the whole wait; nothing downstream depends on it.
 fn spawn_restore(previous: Option<String>, ours: String) {
-    if previous.is_none() {
+    let (generation, has_snapshot) = lock_restore().begin(previous);
+    if !has_snapshot {
         return;
     }
-    thread::spawn(move || restore_clipboard(previous, &ours));
+    thread::spawn(move || restore_clipboard(generation, &ours));
 }
 
-/// Put `previous` back after a delay long enough for ⌘V to land, and only if
-/// the pasteboard still holds `ours`: anything else means another app or the
-/// user wrote in the meantime and the restore would clobber it. No-op when
-/// there was no previous text. Restore failures are ignored.
+/// Put the pre-burst clipboard back after a delay long enough for ⌘V to land,
+/// and only if this generation is still current and the pasteboard still holds
+/// `ours`. Anything else means another paste, app, or the user wrote in the
+/// meantime. No-op when there was no previous text.
 ///
 /// Returns whether a restore was attempted (for unit tests; real AX is not
 /// exercised in CI).
-fn restore_clipboard(previous: Option<String>, ours: &str) -> bool {
-    let Some(previous) = previous else {
+fn restore_clipboard(generation: u64, ours: &str) -> bool {
+    thread::sleep(CLIPBOARD_RESTORE_DELAY);
+    let Some(Some(previous)) = lock_restore().take_if_current(generation) else {
         return false;
     };
-    thread::sleep(CLIPBOARD_RESTORE_DELAY);
     let Ok(mut clipboard) = Clipboard::new() else {
         return false;
     };
@@ -194,11 +245,6 @@ mod tests {
         assert!(ax_set_applied(&Ok(true)));
         assert!(!ax_set_applied(&Ok(false)));
         assert!(!ax_set_applied(&Err("nope".into())));
-    }
-
-    #[test]
-    fn restore_clipboard_skips_when_no_previous() {
-        assert!(!restore_clipboard(None, "text"));
     }
 
     #[test]
@@ -243,7 +289,7 @@ mod tests {
     fn verify_poll_attempts_fit_the_timeout() {
         assert_eq!(
             verify_poll_attempts(Duration::from_millis(250), Duration::from_millis(10)),
-            25
+            26
         );
         assert_eq!(
             verify_poll_attempts(Duration::from_millis(5), Duration::from_millis(10)),
@@ -251,7 +297,7 @@ mod tests {
         );
         assert_eq!(
             verify_poll_attempts(Duration::from_millis(250), Duration::ZERO),
-            250
+            251
         );
     }
 
@@ -259,5 +305,39 @@ mod tests {
     fn verify_timeout_stays_short_enough_to_not_stall_dictation() {
         assert!(CLIPBOARD_VERIFY_TIMEOUT <= Duration::from_millis(250));
         assert!(CLIPBOARD_VERIFY_INTERVAL < CLIPBOARD_VERIFY_TIMEOUT);
+    }
+
+    #[test]
+    fn overlapping_pastes_restore_the_pre_burst_clipboard() {
+        let mut burst = RestoreBurst::new();
+        let (first, _) = burst.begin(Some("notes".into()));
+        let (second, has_snapshot) = burst.begin(Some("first transcription".into()));
+        assert!(has_snapshot);
+        assert!(
+            burst.take_if_current(first).is_none(),
+            "the older restore must not run once a newer paste owns the burst"
+        );
+        assert_eq!(
+            burst.take_if_current(second),
+            Some(Some("notes".into())),
+            "the newest restore puts back what was there before either paste"
+        );
+    }
+
+    #[test]
+    fn a_failed_read_on_the_second_paste_still_keeps_the_original() {
+        let mut burst = RestoreBurst::new();
+        burst.begin(Some("notes".into()));
+        let (second, has_snapshot) = burst.begin(None);
+        assert!(has_snapshot);
+        assert_eq!(burst.take_if_current(second), Some(Some("notes".into())));
+    }
+
+    #[test]
+    fn first_paste_without_a_previous_value_has_nothing_to_restore() {
+        let mut burst = RestoreBurst::new();
+        let (generation, has_snapshot) = burst.begin(None);
+        assert!(!has_snapshot);
+        assert_eq!(burst.take_if_current(generation), Some(None));
     }
 }

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -12,13 +12,28 @@ use crate::settings::PasteMethod;
 /// instead of just relaying a raw OS error string.
 pub const ACCESSIBILITY_STALE_ERROR: &str = "Accessibility permission missing. If Souffle is already listed and checked in System Settings > Privacy & Security > Accessibility, this is usually a stale entry left by an app update: remove Souffle with the minus button and re-add it, or use Repair permission in Souffle's Settings > Advanced > Permissions.";
 
-/// Wait for ⌘V to land in the target app before putting the previous
-/// clipboard contents back.
-const CLIPBOARD_RESTORE_DELAY: Duration = Duration::from_millis(75);
+/// The synthetic ⌘V is asynchronous: the target app reads the pasteboard from
+/// its own run loop, and a busy app, an Electron one, or one that was just
+/// launched can take a few hundred milliseconds to get there. Restoring
+/// earlier races that read and the app pastes the previous clipboard contents
+/// instead of the transcription.
+const CLIPBOARD_RESTORE_DELAY: Duration = Duration::from_millis(400);
+
+/// `set_text` can return before the pasteboard actually serves the new value,
+/// so the write is read back before ⌘V is sent. Bounded low enough that a
+/// failing pasteboard does not stall dictation.
+const CLIPBOARD_VERIFY_TIMEOUT: Duration = Duration::from_millis(250);
+const CLIPBOARD_VERIFY_INTERVAL: Duration = Duration::from_millis(10);
 
 /// Insert text into the active application after `delay_ms`, using either
 /// clipboard+Cmd+V or simulated keystrokes (for apps that reject synthetic paste).
 pub fn paste_text(text: &str, delay_ms: u64, method: PasteMethod) -> Result<(), String> {
+    // Nothing to insert: leave the user's clipboard and their frontmost app
+    // untouched rather than firing a ⌘V that pastes whatever was there.
+    if is_blank(text) {
+        return Ok(());
+    }
+
     if !permissions::accessibility_granted() {
         return Err(ACCESSIBILITY_STALE_ERROR.to_string());
     }
@@ -55,8 +70,39 @@ pub fn paste_text(text: &str, delay_ms: u64, method: PasteMethod) -> Result<(), 
     Ok(())
 }
 
+fn is_blank(text: &str) -> bool {
+    text.trim().is_empty()
+}
+
 fn ax_set_applied(result: &Result<bool, String>) -> bool {
     matches!(result, Ok(true))
+}
+
+/// Whether the pasteboard currently serves exactly what we put there. Used
+/// both to confirm our write before ⌘V and to decide whether the restore is
+/// still ours to make.
+fn holds_text(current: Option<&str>, expected: &str) -> bool {
+    current == Some(expected)
+}
+
+fn verify_poll_attempts(timeout: Duration, interval: Duration) -> u32 {
+    let attempts = timeout.as_millis() / interval.as_millis().max(1);
+    u32::try_from(attempts).unwrap_or(u32::MAX).max(1)
+}
+
+/// Poll the pasteboard until it serves `text`, so ⌘V is never sent against a
+/// write that has not landed.
+fn wait_for_clipboard(clipboard: &mut Clipboard, text: &str) -> bool {
+    let attempts = verify_poll_attempts(CLIPBOARD_VERIFY_TIMEOUT, CLIPBOARD_VERIFY_INTERVAL);
+    for attempt in 0..attempts {
+        if holds_text(clipboard.get_text().ok().as_deref(), text) {
+            return true;
+        }
+        if attempt + 1 < attempts {
+            thread::sleep(CLIPBOARD_VERIFY_INTERVAL);
+        }
+    }
+    false
 }
 
 fn paste_via_cmd_v(text: &str, delay_ms: u64, enigo: &mut Enigo) -> Result<(), String> {
@@ -65,6 +111,17 @@ fn paste_via_cmd_v(text: &str, delay_ms: u64, enigo: &mut Enigo) -> Result<(), S
     clipboard
         .set_text(text)
         .map_err(|e| format!("Clipboard set: {e}"))?;
+
+    if !wait_for_clipboard(&mut clipboard, text) {
+        tracing::warn!(
+            timeout_ms = CLIPBOARD_VERIFY_TIMEOUT.as_millis(),
+            "Clipboard did not serve the transcription in time; skipping paste"
+        );
+        return Err(
+            "Clipboard write did not take effect. Paste skipped so an older clipboard entry is not pasted instead."
+                .to_string(),
+        );
+    }
 
     thread::sleep(Duration::from_millis(delay_ms));
 
@@ -78,23 +135,40 @@ fn paste_via_cmd_v(text: &str, delay_ms: u64, enigo: &mut Enigo) -> Result<(), S
         .key(Key::Meta, Direction::Release)
         .map_err(|e| format!("Key release Meta: {e}"))?;
 
-    restore_clipboard(previous);
+    spawn_restore(previous, text.to_string());
     Ok(())
 }
 
-/// Put `previous` back after a short delay so ⌘V can complete. No-op when
+/// The restore waits out `CLIPBOARD_RESTORE_DELAY`, and `paste_text` is a
+/// synchronous Tauri command, so it runs on the main thread. Detach it rather
+/// than freezing the UI for the whole wait; nothing downstream depends on it.
+fn spawn_restore(previous: Option<String>, ours: String) {
+    if previous.is_none() {
+        return;
+    }
+    thread::spawn(move || restore_clipboard(previous, &ours));
+}
+
+/// Put `previous` back after a delay long enough for ⌘V to land, and only if
+/// the pasteboard still holds `ours`: anything else means another app or the
+/// user wrote in the meantime and the restore would clobber it. No-op when
 /// there was no previous text. Restore failures are ignored.
 ///
 /// Returns whether a restore was attempted (for unit tests; real AX is not
 /// exercised in CI).
-fn restore_clipboard(previous: Option<String>) -> bool {
+fn restore_clipboard(previous: Option<String>, ours: &str) -> bool {
     let Some(previous) = previous else {
         return false;
     };
     thread::sleep(CLIPBOARD_RESTORE_DELAY);
-    if let Ok(mut clipboard) = Clipboard::new() {
-        let _ = clipboard.set_text(&previous);
+    let Ok(mut clipboard) = Clipboard::new() else {
+        return false;
+    };
+    if !holds_text(clipboard.get_text().ok().as_deref(), ours) {
+        tracing::warn!("Clipboard changed after paste; leaving the new contents in place");
+        return false;
     }
+    let _ = clipboard.set_text(&previous);
     true
 }
 
@@ -124,12 +198,66 @@ mod tests {
 
     #[test]
     fn restore_clipboard_skips_when_no_previous() {
-        assert!(!restore_clipboard(None));
+        assert!(!restore_clipboard(None, "text"));
     }
 
     #[test]
-    fn clipboard_restore_delay_allows_paste_to_complete() {
-        assert!(CLIPBOARD_RESTORE_DELAY >= Duration::from_millis(50));
-        assert!(CLIPBOARD_RESTORE_DELAY <= Duration::from_millis(100));
+    fn spawn_restore_does_not_block_on_a_missing_previous() {
+        let started = std::time::Instant::now();
+        spawn_restore(None, "text".to_string());
+        assert!(started.elapsed() < CLIPBOARD_RESTORE_DELAY);
+    }
+
+    #[test]
+    fn clipboard_restore_delay_covers_slow_apps() {
+        assert!(CLIPBOARD_RESTORE_DELAY >= Duration::from_millis(300));
+        assert!(CLIPBOARD_RESTORE_DELAY <= Duration::from_millis(1000));
+    }
+
+    #[test]
+    fn blank_text_is_not_pasted() {
+        assert!(is_blank(""));
+        assert!(is_blank("   "));
+        assert!(is_blank("\n\t "));
+        assert!(!is_blank("hi"));
+        assert!(!is_blank(" hi "));
+    }
+
+    #[test]
+    fn paste_text_is_a_no_op_for_blank_text() {
+        // Runs without Accessibility in CI: the blank guard returns before
+        // any permission check or Enigo init.
+        assert_eq!(paste_text("   ", 0, PasteMethod::Clipboard), Ok(()));
+        assert_eq!(paste_text("", 0, PasteMethod::Type), Ok(()));
+    }
+
+    #[test]
+    fn holds_text_requires_an_exact_match() {
+        assert!(holds_text(Some("hello"), "hello"));
+        assert!(!holds_text(Some("hello "), "hello"));
+        assert!(!holds_text(Some("something else"), "hello"));
+        assert!(!holds_text(None, "hello"));
+    }
+
+    #[test]
+    fn verify_poll_attempts_fit_the_timeout() {
+        assert_eq!(
+            verify_poll_attempts(Duration::from_millis(250), Duration::from_millis(10)),
+            25
+        );
+        assert_eq!(
+            verify_poll_attempts(Duration::from_millis(5), Duration::from_millis(10)),
+            1
+        );
+        assert_eq!(
+            verify_poll_attempts(Duration::from_millis(250), Duration::ZERO),
+            250
+        );
+    }
+
+    #[test]
+    fn verify_timeout_stays_short_enough_to_not_stall_dictation() {
+        assert!(CLIPBOARD_VERIFY_TIMEOUT <= Duration::from_millis(250));
+        assert!(CLIPBOARD_VERIFY_INTERVAL < CLIPBOARD_VERIFY_TIMEOUT);
     }
 }

--- a/src/lib/features/home/LiveSessionCard.svelte
+++ b/src/lib/features/home/LiveSessionCard.svelte
@@ -142,10 +142,20 @@
   });
 
   onMount(() => {
-    const timer = setInterval(() => {
+    const tick = () => {
       nowMs = Date.now();
-    }, 1000);
-    return () => clearInterval(timer);
+    };
+    const timer = setInterval(tick, 1000);
+    // WebKit pauses the interval while the window is occluded; the displayed
+    // value is derived from the wall clock, so one catch-up on return is enough.
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") tick();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => {
+      clearInterval(timer);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
   });
 
   onDestroy(() => {

--- a/src/lib/features/home/LiveSessionCard.svelte
+++ b/src/lib/features/home/LiveSessionCard.svelte
@@ -9,7 +9,7 @@
   import type { LiveParagraph } from "../meeting/live-transcript.svelte";
   import type { createMeetingController } from "../meeting/controller.svelte";
   import type { createTranscriptionController } from "../transcription/controller.svelte";
-  import { resolveSpeakerLabel } from "../../utils";
+  import { elapsedSecondsSince, formatDuration, resolveSpeakerLabel } from "../../utils";
 
   let {
     mode,
@@ -27,7 +27,11 @@
   /** Auto-scroll only kicks in when already within this many px of the bottom. */
   const NEAR_BOTTOM_PX = 40;
 
-  let elapsedSeconds = $state(0);
+  // Repaint driver only. The displayed value is always recomputed from the
+  // wall clock below, so ticks dropped by WebKit's background throttling cost
+  // nothing but refresh smoothness. A counter incremented per tick would
+  // instead lose that time for good.
+  let nowMs = $state(Date.now());
   let transcriptEl: HTMLDivElement | undefined = $state();
   let editingParagraphId = $state<number | null>(null);
   let editDraft = $state("");
@@ -48,7 +52,7 @@
   );
 
   const elapsed = $derived(
-    `${Math.floor(elapsedSeconds / 60)}:${`${elapsedSeconds % 60}`.padStart(2, "0")}`,
+    formatDuration(elapsedSecondsSince(meeting.app.recordingStartedAtMs, nowMs)),
   );
 
   const stopping = $derived(
@@ -139,7 +143,7 @@
 
   onMount(() => {
     const timer = setInterval(() => {
-      elapsedSeconds += 1;
+      nowMs = Date.now();
     }, 1000);
     return () => clearInterval(timer);
   });

--- a/src/lib/features/meeting/components/MeetingAudioPlayerSection.svelte
+++ b/src/lib/features/meeting/components/MeetingAudioPlayerSection.svelte
@@ -4,7 +4,7 @@
   import { t } from "svelte-i18n";
   import { defaultAudioTarget, buildPlayCommand, type AudioSeekTarget } from "../audio-map";
   import type { MeetingAudioSession } from "../../../types";
-  import { formatDuration } from "../../../utils";
+  import { formatTimestamp } from "../../../utils";
 
   let {
     audioSessions,
@@ -88,7 +88,7 @@
         <Play size={16} />
       {/if}
     </button>
-    <span class="w-10 shrink-0 text-right font-mono text-[11px] text-text-muted">{formatDuration(currentTime)}</span>
+    <span class="w-10 shrink-0 text-right font-mono text-[11px] text-text-muted">{formatTimestamp(currentTime)}</span>
     <input
       type="range"
       class="flex-1"
@@ -98,6 +98,6 @@
       oninput={onScrub}
       aria-label={$t("meeting_audio.scrubber")}
     />
-    <span class="w-10 shrink-0 font-mono text-[11px] text-text-muted">{formatDuration(duration)}</span>
+    <span class="w-10 shrink-0 font-mono text-[11px] text-text-muted">{formatTimestamp(duration)}</span>
   </section>
 {/if}

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { getAppState } from './app.svelte';
 import { mockSettings } from '../test-helpers/fixtures';
+
+const profile = {
+  engine_id: "", engine_label: "", model_id: "", model_label: "", backend_id: "", backend_label: "",
+};
 
 describe('app store', () => {
   it('has correct initial state defaults', () => {
@@ -55,6 +59,43 @@ describe('app store', () => {
     expect(state.settings.debug_transcription).toBe(true);
     expect(state.settings.audio_device).toBe('mic-1');
     expect(state.settings.transcription_engine_id).toBe('whisper');
+  });
+
+  it('anchors the recording start clock while a session is live', () => {
+    const state = getAppState();
+    state.machineState = { state: "ready", data: { profile } };
+    expect(state.recordingStartedAtMs).toBeNull();
+
+    const before = Date.now();
+    state.machineState = { state: "recording_meeting", data: { profile, session_id: 1, meeting_id: "m1" } };
+    const anchor = state.recordingStartedAtMs;
+    expect(anchor).not.toBeNull();
+    expect(anchor as number).toBeGreaterThanOrEqual(before);
+
+    // Stopping still shows the live card, so the anchor must survive it.
+    state.machineState = { state: "stopping", data: { profile, was_recording: { meeting: { meeting_id: "m1" } } } };
+    expect(state.recordingStartedAtMs).toBe(anchor);
+
+    state.machineState = { state: "ready", data: { profile } };
+    expect(state.recordingStartedAtMs).toBeNull();
+  });
+
+  it('re-anchors when a meeting is resumed as a new recording session', () => {
+    const state = getAppState();
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-01-01T09:00:00Z'));
+      state.machineState = { state: "recording_meeting", data: { profile, session_id: 1, meeting_id: "m1" } };
+      expect(state.recordingStartedAtMs).toBe(Date.UTC(2026, 0, 1, 9, 0, 0));
+
+      state.machineState = { state: "ready", data: { profile } };
+      vi.setSystemTime(new Date('2026-01-01T09:20:00Z'));
+      state.machineState = { state: "recording_meeting", data: { profile, session_id: 2, meeting_id: "m1" } };
+      expect(state.recordingStartedAtMs).toBe(Date.UTC(2026, 0, 1, 9, 20, 0));
+    } finally {
+      vi.useRealTimers();
+    }
+    state.machineState = { state: "idle" };
   });
 
   it('recordingMode is derived from machineState', () => {

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -80,6 +80,22 @@ describe('app store', () => {
     expect(state.recordingStartedAtMs).toBeNull();
   });
 
+  it('anchors dictation the same way as a meeting', () => {
+    const state = getAppState();
+    state.machineState = { state: "ready", data: { profile } };
+    expect(state.recordingStartedAtMs).toBeNull();
+
+    state.machineState = { state: "recording_dictation", data: { profile, session_id: 1 } };
+    const anchor = state.recordingStartedAtMs;
+    expect(anchor).not.toBeNull();
+
+    state.machineState = { state: "stopping", data: { profile, was_recording: "dictation" } };
+    expect(state.recordingStartedAtMs).toBe(anchor);
+
+    state.machineState = { state: "ready", data: { profile } };
+    expect(state.recordingStartedAtMs).toBeNull();
+  });
+
   it('re-anchors when a meeting is resumed as a new recording session', () => {
     const state = getAppState();
     vi.useFakeTimers();

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -34,6 +34,13 @@ let transcriptionRuntimePhase = $state<TranscriptionRuntimePhase>("download_requ
 // Latest pipeline health snapshot while recording (cleared when recording ends)
 let transcriptionHealth = $state<TranscriptionHealth | null>(null);
 
+// Wall-clock start of the current recording session (dictation or meeting),
+// captured when the backend machine enters a recording state. The live
+// elapsed counter derives from this instead of counting timer ticks, which
+// WebKit drops while the window sits in the background during a meeting.
+// Module-level, so it also survives a remount of the live session card.
+let recordingStartedAtMs = $state<number | null>(null);
+
 // System-audio capture status for the current meeting session
 let systemAudioStatus = $state<SystemAudioStatus | null>(null);
 
@@ -172,7 +179,13 @@ export function getAppState() {
 
     get machineState() { return machineState; },
     set machineState(s: AppStateMachine) {
+      const wasRecording = deriveRecordingMode(machineState) !== "idle";
       machineState = s;
+      // A resumed meeting re-enters recording from a non-recording state, so
+      // the counter restarts at zero for the new recording session.
+      if (!wasRecording && deriveRecordingMode(s) !== "idle") {
+        recordingStartedAtMs = Date.now();
+      }
       // Sync runtime phase from machine when no model operation is in progress.
       // During download/load the phase is managed by runtime.ts callbacks.
       if (deriveModelOperationState(s) === "idle") {
@@ -182,11 +195,14 @@ export function getAppState() {
       if (deriveRecordingMode(s) === "idle") {
         transcriptionHealth = null;
         systemAudioStatus = null;
+        recordingStartedAtMs = null;
       }
     },
 
     get transcriptionHealth() { return transcriptionHealth; },
     set transcriptionHealth(h: TranscriptionHealth | null) { transcriptionHealth = h; },
+
+    get recordingStartedAtMs() { return recordingStartedAtMs; },
 
     get systemAudioStatus() { return systemAudioStatus; },
     set systemAudioStatus(s: SystemAudioStatus | null) { systemAudioStatus = s; },

--- a/src/lib/utils/elapsed.test.ts
+++ b/src/lib/utils/elapsed.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { elapsedSecondsSince } from './elapsed';
+
+describe('elapsedSecondsSince', () => {
+  const anchor = Date.UTC(2026, 0, 1, 9, 0, 0);
+
+  it('is zero without an anchor', () => {
+    expect(elapsedSecondsSince(null, anchor + 60_000)).toBe(0);
+  });
+
+  it('is zero at the anchor', () => {
+    expect(elapsedSecondsSince(anchor, anchor)).toBe(0);
+  });
+
+  it('truncates sub-second remainders', () => {
+    expect(elapsedSecondsSince(anchor, anchor + 1_900)).toBe(1);
+  });
+
+  /** The regression: no matter how few repaints happened in between, the
+   * elapsed value comes from the clock gap, not from a tick count. */
+  it('reports the full gap across a long unobserved stretch', () => {
+    expect(elapsedSecondsSince(anchor, anchor + 45 * 60_000)).toBe(2700);
+  });
+
+  it('never goes negative when the clock moves backwards', () => {
+    expect(elapsedSecondsSince(anchor, anchor - 5_000)).toBe(0);
+  });
+});

--- a/src/lib/utils/elapsed.ts
+++ b/src/lib/utils/elapsed.ts
@@ -1,0 +1,14 @@
+/**
+ * Live elapsed time for an in-progress recording.
+ *
+ * Works off a wall-clock anchor rather than a tick count. A `setInterval`
+ * counter silently loses minutes because WebKit throttles timers while the
+ * window is backgrounded or occluded, which is exactly where Souffle sits
+ * for the whole of a meeting.
+ */
+
+/** Whole seconds between the anchor and `nowMs`. Never negative; 0 with no anchor. */
+export function elapsedSecondsSince(anchorMs: number | null, nowMs: number): number {
+  if (anchorMs === null) return 0;
+  return Math.max(0, Math.floor((nowMs - anchorMs) / 1000));
+}

--- a/src/lib/utils/format.test.ts
+++ b/src/lib/utils/format.test.ts
@@ -28,8 +28,33 @@ describe('formatDuration', () => {
     expect(formatDuration(0)).toBe('0:00');
   });
 
-  it('formats typical meeting duration', () => {
-    expect(formatDuration(3600)).toBe('60:00');
+  it('pads seconds under a minute', () => {
+    expect(formatDuration(5)).toBe('0:05');
+  });
+
+  it('formats minutes and seconds', () => {
+    expect(formatDuration(45 * 60 + 7)).toBe('45:07');
+  });
+
+  it('rolls over to hours instead of counting past 59 minutes', () => {
+    expect(formatDuration(3600)).toBe('1:00:00');
+    expect(formatDuration(90 * 60 + 3)).toBe('1:30:03');
+  });
+
+  it('pads minutes once hours are shown', () => {
+    expect(formatDuration(3600 + 5 * 60 + 9)).toBe('1:05:09');
+  });
+
+  it('handles multi-hour meetings', () => {
+    expect(formatDuration(4 * 3600 + 2 * 60 + 1)).toBe('4:02:01');
+  });
+
+  it('truncates fractional seconds', () => {
+    expect(formatDuration(61.9)).toBe('1:01');
+  });
+
+  it('never renders a negative span', () => {
+    expect(formatDuration(-5)).toBe('0:00');
   });
 });
 

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -1,4 +1,3 @@
-/** Format seconds as "M:SS" */
 /** "CommandOrControl+Shift+Space" → "⌘ ⇧ Space" for display. */
 export function formatShortcutLabel(shortcut: string): string {
   if (!shortcut) return "";
@@ -9,6 +8,9 @@ export function formatShortcutLabel(shortcut: string): string {
     .replace(/\+/g, " ");
 }
 
+/** Position inside a recording, as "M:SS". Stays minute-based past an hour
+ * ("61:01") because it renders in fixed-width columns next to the scrubber,
+ * where an "H:MM:SS" reading would overflow. Durations use `formatDuration`. */
 export function formatTimestamp(seconds: number): string {
   const mins = Math.floor(seconds / 60);
   const secs = Math.floor(seconds % 60);
@@ -20,11 +22,15 @@ export function formatDate(iso: string): string {
   return new Date(iso).toLocaleString();
 }
 
-/** Format duration in seconds as "M:SS" */
+/** A span of time, as "M:SS" below an hour and "H:MM:SS" from an hour on.
+ * Meetings routinely run past an hour, where a bare "90:00" is hard to read. */
 export function formatDuration(seconds: number): string {
-  const mins = Math.floor(seconds / 60);
-  const secs = Math.floor(seconds % 60);
-  return `${mins}:${secs.toString().padStart(2, "0")}`;
+  const total = Math.max(0, Math.floor(seconds));
+  const hours = Math.floor(total / 3600);
+  const mins = Math.floor((total % 3600) / 60);
+  const secs = `${total % 60}`.padStart(2, "0");
+  if (hours === 0) return `${mins}:${secs}`;
+  return `${hours}:${`${mins}`.padStart(2, "0")}:${secs}`;
 }
 
 /** Human-readable byte size, e.g. "482 KB" or "1.3 GB". */

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,4 +1,5 @@
 export { formatTimestamp, formatDate, formatDuration, formatShortcutLabel, formatBytes } from "./format";
+export { elapsedSecondsSince } from "./elapsed";
 export { keyEventToShortcut, shortcutMissingModifier } from "./shortcut";
 export { applyTheme } from "./theme";
 export { buildMeetingTranscriptBlocks, groupIntoParagraphs } from "./paragraphs";


### PR DESCRIPTION
> Stacked on #110. Review that one first; the base of this PR moves to `develop` once #110 merges.

Fixes the elapsed counter on the live session card reading far too low on a long meeting, around 20 minutes at 45 minutes real, while the transcript itself stays correctly timed (ticket SOU-022).

## Cause

`LiveSessionCard.svelte` counted `setInterval` ticks from zero (`let elapsedSeconds = $state(0)`, incremented in `onMount`). Two independent failure modes follow, and both are real:

1. **Timer throttling.** WebKit throttles `setInterval` while the window is backgrounded or occluded, which is exactly where Soufflé sits for the whole of a meeting: the user is in Teams or Zoom. Dropped ticks are never recovered. 20 minutes shown at 45 real is about 44% of the ticks, which fits sustained throttling and is very likely what the report describes.
2. **Remount.** Opening then closing Settings unmounts `HomeView`, so the component is recreated and the count restarts at 0:00.

A tick counter cannot fix either. The value has to come from a wall clock.

## Changes

- **Anchor on the app store** (`recordingStartedAtMs`), captured in the `machineState` setter when the machine enters a recording state and cleared next to `transcriptionHealth` and `systemAudioStatus`, which have the same lifetime. It sits on the store rather than in a controller because `machineState` is already the single source of truth for "recording, and in which mode", so one anchor serves both dictation and meeting with no branching in the card, and a module-level singleton survives the unmount.
- **The card derives its display** from `Date.now()` minus the anchor. The interval only assigns `nowMs`, so it drives repaints and nothing else.
- **Resume re-anchors**, so the counter restarts at zero for each recording session. That matches the data model (a meeting holds several `recording_sessions`) and the live transcript, which `resumeRecording` also resets.
- **`formatDuration` is now hour-aware** (`1:30:03`, not `90:03`). Meetings routinely run past an hour, and without this the live counter and the saved meeting header would have disagreed. `formatTimestamp`, which was a byte-identical duplicate, keeps `M:SS` and now carries a comment saying why: the audio scrubber renders it in a fixed-width `w-10` column where `H:MM:SS` would overflow. The scrubber was switched to it, which changes no output today and pins the intent.

## Tests

`npm test`: 332 passed. `npm run check`: 0 errors.

New: `elapsedSecondsSince` unit tests, including the regression case (a 45-minute clock gap yields 2700 regardless of how many repaints happened), hour-rollover cases on `formatDuration`, and two store tests covering anchor set, survival through `stopping`, clearing, and re-anchoring on resume.

The old `formatDuration(3600) === '60:00'` assertion was replaced, since that output is the thing being fixed.

## QA

1. Start a meeting, leave Soufflé in the background for a few minutes, come back: the counter must match real time.
2. Mid-recording, open Settings (⌘,) and come back: the counter must not restart.
3. Past an hour, it must read `1:00:05` rather than `60:05`, and the saved meeting header must agree after stopping.

## Known limitation, not introduced here

If the app is relaunched mid-recording, `recoverState()` pushes a recording state into the store and the anchor is taken at recovery time, so the counter under-reports for that session. The previous code showed 0:00 in the same case. Fixing it properly needs the backend to report the session start time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Live session timers now remain aligned with the actual recording start time, including after backgrounding the app or resuming a session.
  - Timers refresh immediately when returning to a visible window.
  - Audio playback timestamps now use clearer minute-based formatting.
  - Duration displays now correctly handle seconds, minutes, hours, fractional values, and negative inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->