### PR TITLE
Size the Ollama context window to the call instead of hardcoding it

### DIFF
--- a/src-tauri/src/summary/chunking.rs
+++ b/src-tauri/src/summary/chunking.rs
@@ -1,6 +1,17 @@
 /// Rough token estimate without a tokenizer. Transcripts tokenize denser than prose.
+///
+/// Measured tokens per word on 2000 words of the same French transcript,
+/// Q4_K_M: qwen3:4b 1.523, qwen2.5:7b 1.532, llama3.2:3b 1.538, mistral:latest
+/// 1.760. Every measured ratio is above 1.4, so that ratio put every budget
+/// in the app 9 to 26 percent short of the real token count. This estimate
+/// feeds only budget *limits* (stuff-versus-map threshold, reduce batching,
+/// the Apple Intelligence budgets), never the chunk size itself, which is a
+/// fixed word count. Underestimating causes silent truncation; overestimating
+/// only costs a little chunking margin. A single conservative ratio is
+/// therefore the right trade: a per-model table would be guesswork for every
+/// model not in the measured set.
 pub fn estimate_tokens(text: &str) -> usize {
-    (text.split_whitespace().count() as f32 * 1.4).ceil() as usize
+    (text.split_whitespace().count() as f32 * 1.8).ceil() as usize
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -69,7 +80,7 @@ mod tests {
     #[test]
     fn estimate_tokens_scales_with_words() {
         assert_eq!(estimate_tokens(""), 0);
-        assert_eq!(estimate_tokens(&"word ".repeat(10)), 14);
+        assert_eq!(estimate_tokens(&"word ".repeat(10)), 18);
     }
 
     #[test]

--- a/src-tauri/src/summary/extract.rs
+++ b/src-tauri/src/summary/extract.rs
@@ -136,7 +136,7 @@ pub async fn extract_structured_summary(
         system,
         prompt,
         0.1,
-        super::ollama::REDUCE_CONTEXT,
+        super::ollama::REDUCE_BUDGET,
         &no_op,
         false,
     )

--- a/src-tauri/src/summary/mod.rs
+++ b/src-tauri/src/summary/mod.rs
@@ -335,7 +335,7 @@ pub(crate) async fn generate_with_provider(
     system: &str,
     prompt: String,
     temperature: f32,
-    num_ctx: u32,
+    budget: ollama::GenerationBudget,
     on_chunk: &impl Fn(SummarizeProgress),
     json_format: bool,
 ) -> Result<String, String> {
@@ -348,7 +348,7 @@ pub(crate) async fn generate_with_provider(
                 ollama_model,
                 system,
                 prompt,
-                num_ctx,
+                budget,
                 temperature,
                 on_chunk,
                 json_format,
@@ -430,7 +430,7 @@ pub async fn summarize_stream(
             final_system_prompt,
             build_summarize_prompt(transcript_text, notes, participants),
             0.2,
-            ollama::REDUCE_CONTEXT,
+            ollama::REDUCE_BUDGET,
             &on_chunk,
             false,
         )
@@ -465,7 +465,7 @@ pub async fn summarize_stream(
                     model,
                     ollama::MAP_SYSTEM_PROMPT,
                     user,
-                    ollama::MAP_CONTEXT,
+                    ollama::MAP_BUDGET,
                     0.2,
                     &no_op,
                     false,
@@ -494,7 +494,7 @@ pub async fn summarize_stream(
                 apple::MAP_SYSTEM_PROMPT,
                 user,
                 0.2,
-                ollama::MAP_CONTEXT,
+                ollama::MAP_BUDGET,
                 &no_op,
                 false,
             )
@@ -544,10 +544,10 @@ async fn reduce_part_summaries(
     // The template prompt applies to the final pass only; intermediate
     // merge rounds keep the fixed provider merge prompt (both providers
     // share the same merge text today).
-    let (merge_system_prompt, num_ctx) = match provider {
-        SummaryProviderKind::Ollama => (ollama::MERGE_SYSTEM_PROMPT, ollama::REDUCE_CONTEXT),
+    let (merge_system_prompt, budget) = match provider {
+        SummaryProviderKind::Ollama => (ollama::MERGE_SYSTEM_PROMPT, ollama::REDUCE_BUDGET),
         SummaryProviderKind::AppleIntelligence => {
-            (apple::MERGE_SYSTEM_PROMPT, ollama::REDUCE_CONTEXT)
+            (apple::MERGE_SYSTEM_PROMPT, ollama::REDUCE_BUDGET)
         }
     };
 
@@ -576,12 +576,12 @@ async fn reduce_part_summaries(
                 reduce_call_system_prompt(is_final, final_system_prompt, merge_system_prompt);
             if is_final {
                 generate_with_provider(
-                    provider, model, ollama_url, system, prompt, 0.3, num_ctx, on_chunk, false,
+                    provider, model, ollama_url, system, prompt, 0.3, budget, on_chunk, false,
                 )
                 .await
             } else {
                 generate_with_provider(
-                    provider, model, ollama_url, system, prompt, 0.2, num_ctx, &no_op, false,
+                    provider, model, ollama_url, system, prompt, 0.2, budget, &no_op, false,
                 )
                 .await
             }

--- a/src-tauri/src/summary/ollama.rs
+++ b/src-tauri/src/summary/ollama.rs
@@ -1,4 +1,7 @@
 use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+
+use crate::lock_ext::MutexExt;
 
 use serde::{Deserialize, Serialize};
 
@@ -6,10 +9,51 @@ use crate::constants::{
     OLLAMA_DEFAULT_URL, OLLAMA_MAP_PROMPT, OLLAMA_MERGE_PROMPT, OLLAMA_STRUCTURED_EXTRACT_PROMPT,
 };
 
-const REDUCE_NUM_CTX: u32 = 16384;
-const MAP_NUM_CTX: u32 = 8192;
 const CONNECT_TIMEOUT_SECS: u64 = 5;
 const READ_TIMEOUT_SECS: u64 = 120;
+
+/// Bounds one `/api/generate` call. `num_ctx` is the combined prompt and
+/// response window; `num_predict` caps how many tokens the model may emit.
+/// Ollama truncates a prompt over `num_ctx` from the LEFT (system prompt and
+/// the start of the transcript go first) and still returns 200 OK, so an
+/// unbounded `num_predict` just lets generation run until `llama-server`
+/// shifts the context window mid-response instead. Never set `num_ctx`
+/// above the model's native context: Ollama will RoPE-extend past it, which
+/// degrades coherence with no warning either. See `resolve_num_ctx`.
+#[derive(Debug, Clone, Copy)]
+pub struct GenerationBudget {
+    pub num_ctx: u32,
+    pub num_predict: u32,
+}
+
+/// Map-stage outputs measured 128 to 314 tokens; 700 is headroom, not a cap
+/// expected to bite.
+pub const MAP_BUDGET: GenerationBudget = GenerationBudget {
+    num_ctx: 8192,
+    num_predict: 700,
+};
+
+/// The final pass renders the summary templates, and the detailed-minutes one
+/// asks for one bullet per distinct point and to be thorough rather than
+/// terse. This bound exists to stop a runaway generation before it saturates
+/// the context and starts scrolling the prompt, not to cap a legitimate
+/// summary: 4096 is far above any real one, and still leaves three quarters
+/// of the window for the prompt.
+pub const REDUCE_BUDGET: GenerationBudget = GenerationBudget {
+    num_ctx: 16384,
+    num_predict: 4096,
+};
+
+/// Polish rewrites its input, so its output length tracks the input's. A fixed
+/// bound would cut a long dictation off mid-sentence, which is worse than the
+/// unbounded generation this guard rail replaces. Twice the input estimate
+/// leaves room for the punctuation and formatting polish adds.
+pub fn polish_budget(input_tokens: usize) -> GenerationBudget {
+    GenerationBudget {
+        num_ctx: REDUCE_BUDGET.num_ctx,
+        num_predict: input_tokens.saturating_mul(2).clamp(512, 8192) as u32,
+    }
+}
 
 /// Default chat model to offer when Ollama is running but empty.
 /// `qwen2.5:7b` is instruction-tuned (~4.7 GB) and ranks first in
@@ -53,12 +97,112 @@ struct GenerateRequest {
 struct GenerateOptions {
     temperature: f32,
     num_ctx: u32,
+    num_predict: u32,
 }
 
 #[derive(Debug, Deserialize)]
 struct GenerateChunk {
     response: String,
     done: bool,
+    /// Present only on the final chunk (`done: true`). Ollama sets it to the
+    /// number of prompt tokens it actually evaluated; when it reaches
+    /// `num_ctx - 1` the prompt was truncated (see `generate_stream`).
+    #[serde(default)]
+    prompt_eval_count: Option<u32>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ShowResponse {
+    #[serde(default)]
+    model_info: serde_json::Value,
+}
+
+/// Ollama prefixes this key by architecture ("qwen2.context_length",
+/// "llama.context_length", ...). Match the suffix rather than hardcoding an
+/// architecture, so a model built on an architecture this code has never
+/// seen still resolves.
+fn context_length_from_model_info(model_info: &serde_json::Value) -> Option<u32> {
+    let object = model_info.as_object()?;
+    object.iter().find_map(|(key, value)| {
+        if !key.ends_with(".context_length") {
+            return None;
+        }
+        u32::try_from(value.as_u64()?).ok()
+    })
+}
+
+/// Size the window to what this call actually needs, bounded by what the model
+/// can take. `needed` is the estimated prompt plus the generation bound: below
+/// it, either the prompt is truncated from the left or the response scrolls the
+/// window mid-generation, both silently.
+///
+/// Growing past the stage budget is only safe when the native window is known,
+/// because exceeding it makes Ollama RoPE-extend and degrade coherence, also
+/// silently. An unknown native window therefore pins this to the stage budget,
+/// which is the behavior this code had before: the lookup must never be the
+/// reason a summarization gets worse or fails.
+fn resolve_num_ctx(native: Option<u32>, requested: u32, needed: u32) -> u32 {
+    match native {
+        Some(native) => requested.max(needed).min(native),
+        None => requested,
+    }
+}
+
+type ModelContextCache = Mutex<HashMap<String, Option<u32>>>;
+static MODEL_CONTEXT_CACHE: OnceLock<ModelContextCache> = OnceLock::new();
+
+fn model_context_cache() -> &'static ModelContextCache {
+    MODEL_CONTEXT_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// One `/api/show` call per model name, cached for the process lifetime so
+/// this runs once per model rather than once per chunk.
+async fn native_context_length(client: &reqwest::Client, url: &str, model: &str) -> Option<u32> {
+    if let Ok(cache) = model_context_cache().acquire()
+        && let Some(cached) = cache.get(model)
+    {
+        return *cached;
+    }
+
+    let native = fetch_native_context_length(client, url, model).await;
+    if let Ok(mut cache) = model_context_cache().acquire() {
+        cache.insert(model.to_string(), native);
+    }
+    native
+}
+
+/// Failure here (network, missing field, unexpected shape) is not fatal: the
+/// caller falls back to the stage's configured `num_ctx`, which is today's
+/// behavior.
+async fn fetch_native_context_length(
+    client: &reqwest::Client,
+    url: &str,
+    model: &str,
+) -> Option<u32> {
+    let resp = match client
+        .post(format!("{url}/api/show"))
+        .json(&serde_json::json!({ "model": model }))
+        .send()
+        .await
+    {
+        Ok(resp) => resp,
+        Err(e) => {
+            tracing::debug!(model, error = %e, "Ollama /api/show request failed");
+            return None;
+        }
+    };
+    if !resp.status().is_success() {
+        tracing::debug!(model, status = %resp.status(), "Ollama /api/show returned an error status");
+        return None;
+    }
+    let body: ShowResponse = match resp.json().await {
+        Ok(body) => body,
+        Err(e) => {
+            tracing::debug!(model, error = %e, "Ollama /api/show response did not parse");
+            return None;
+        }
+    };
+    context_length_from_model_info(&body.model_info)
 }
 
 pub fn is_summary_capable_model(model: &str) -> bool {
@@ -155,6 +299,8 @@ fn handle_ndjson_line(
     line: &[u8],
     full_text: &mut String,
     on_chunk: &impl Fn(super::SummarizeProgress),
+    model: &str,
+    num_ctx: u32,
 ) {
     let Ok(text) = std::str::from_utf8(line) else {
         return;
@@ -164,6 +310,17 @@ fn handle_ndjson_line(
         return;
     }
     if let Ok(parsed) = serde_json::from_str::<GenerateChunk>(text) {
+        if let Some(prompt_eval_count) = parsed.prompt_eval_count
+            && prompt_eval_count >= num_ctx.saturating_sub(1)
+        {
+            tracing::warn!(
+                model,
+                num_ctx,
+                prompt_eval_count,
+                "Ollama prompt was truncated from the left: the system prompt and \
+                 the start of the input were dropped before the model saw them"
+            );
+        }
         full_text.push_str(&parsed.response);
         // Real generation tokens only ever flow through the caller's on_chunk
         // for the truly final pass (map/intermediate reduce calls pass a
@@ -185,11 +342,29 @@ pub async fn generate_stream(
     model: &str,
     system: &str,
     prompt: String,
-    num_ctx: u32,
+    budget: GenerationBudget,
     temperature: f32,
     on_chunk: &impl Fn(super::SummarizeProgress),
     json_format: bool,
 ) -> Result<String, String> {
+    let native = native_context_length(client, url, model).await;
+    let needed = super::estimate_tokens(system)
+        .saturating_add(super::estimate_tokens(&prompt))
+        .saturating_add(budget.num_predict as usize)
+        .try_into()
+        .unwrap_or(u32::MAX);
+    let num_ctx = resolve_num_ctx(native, budget.num_ctx, needed);
+    if needed > num_ctx {
+        tracing::warn!(
+            model,
+            needed,
+            num_ctx,
+            native_context = native,
+            "This model's context window cannot hold the prompt and the response; \
+             Ollama will drop the system prompt and the start of the input"
+        );
+    }
+
     let body = GenerateRequest {
         model: model.to_string(),
         prompt,
@@ -200,6 +375,7 @@ pub async fn generate_stream(
         options: GenerateOptions {
             temperature,
             num_ctx,
+            num_predict: budget.num_predict,
         },
     };
     let resp = client
@@ -223,10 +399,10 @@ pub async fn generate_stream(
 
         while let Some(pos) = buf.iter().position(|&b| b == b'\n') {
             let line: Vec<u8> = buf.drain(..=pos).collect();
-            handle_ndjson_line(&line, &mut full_text, on_chunk);
+            handle_ndjson_line(&line, &mut full_text, on_chunk, model, num_ctx);
         }
     }
-    handle_ndjson_line(&buf, &mut full_text, on_chunk);
+    handle_ndjson_line(&buf, &mut full_text, on_chunk, model, num_ctx);
 
     Ok(full_text)
 }
@@ -421,14 +597,13 @@ pub const MAP_SYSTEM_PROMPT: &str = OLLAMA_MAP_PROMPT;
 pub const MERGE_SYSTEM_PROMPT: &str = OLLAMA_MERGE_PROMPT;
 pub const STRUCTURED_EXTRACT_SYSTEM_PROMPT: &str = OLLAMA_STRUCTURED_EXTRACT_PROMPT;
 pub const DICTATION_POLISH_SYSTEM_PROMPT: &str = crate::constants::OLLAMA_DICTATION_POLISH_PROMPT;
-pub const REDUCE_CONTEXT: u32 = REDUCE_NUM_CTX;
-pub const MAP_CONTEXT: u32 = MAP_NUM_CTX;
 
 #[cfg(test)]
 mod tests {
     use super::{
         GenerateOptions, GenerateRequest, PullAccumulator, PullChunk, PullRequest,
-        RECOMMENDED_MODEL, is_summary_capable_model, sorted_summary_capable_models,
+        RECOMMENDED_MODEL, REDUCE_BUDGET, context_length_from_model_info, is_summary_capable_model,
+        polish_budget, resolve_num_ctx, sorted_summary_capable_models,
     };
 
     #[test]
@@ -508,6 +683,7 @@ mod tests {
             options: GenerateOptions {
                 temperature: 0.1,
                 num_ctx: 1024,
+                num_predict: 700,
             },
         };
         let json = serde_json::to_string(&body).expect("GenerateRequest should serialize");
@@ -515,6 +691,88 @@ mod tests {
             json.contains(r#""keep_alive":"15m""#),
             "expected keep_alive in {json}"
         );
+    }
+
+    #[test]
+    fn polish_budget_tracks_its_input_length() {
+        // A long dictation must not be cut off mid-sentence.
+        assert_eq!(polish_budget(3000).num_predict, 6000);
+        // A one-line dictation still gets room for punctuation and casing.
+        assert_eq!(polish_budget(1).num_predict, 512);
+        // Bounded, so a runaway cannot reach the context window.
+        assert!(polish_budget(usize::MAX).num_predict < REDUCE_BUDGET.num_ctx);
+    }
+
+    #[test]
+    fn generate_options_serializes_num_predict() {
+        let body = GenerateRequest {
+            model: "qwen2.5:7b".into(),
+            prompt: "hi".into(),
+            system: "sys".into(),
+            stream: true,
+            format: None,
+            keep_alive: Some("15m".into()),
+            options: GenerateOptions {
+                temperature: 0.1,
+                num_ctx: 1024,
+                num_predict: 700,
+            },
+        };
+        let json = serde_json::to_string(&body).expect("GenerateRequest should serialize");
+        assert!(
+            json.contains(r#""num_predict":700"#),
+            "expected num_predict in {json}"
+        );
+    }
+
+    #[test]
+    fn context_length_key_matches_any_architecture_prefix() {
+        let info = serde_json::json!({ "qwen2.context_length": 32768, "qwen2.embedding_length": 1 });
+        assert_eq!(context_length_from_model_info(&info), Some(32768));
+
+        let info = serde_json::json!({ "llama.context_length": 4096 });
+        assert_eq!(context_length_from_model_info(&info), Some(4096));
+    }
+
+    #[test]
+    fn context_length_key_missing_returns_none() {
+        let info = serde_json::json!({ "qwen2.embedding_length": 4096 });
+        assert_eq!(context_length_from_model_info(&info), None);
+    }
+
+    #[test]
+    fn context_length_value_not_a_number_returns_none() {
+        let info = serde_json::json!({ "qwen2.context_length": "a lot" });
+        assert_eq!(context_length_from_model_info(&info), None);
+    }
+
+    #[test]
+    fn resolve_num_ctx_never_exceeds_the_native_window() {
+        // RoPE extension past the native window degrades quality silently, so
+        // the cap wins even when the call needs more room than that.
+        assert_eq!(resolve_num_ctx(Some(4096), 8192, 2000), 4096);
+        assert_eq!(resolve_num_ctx(Some(4096), 8192, 30_000), 4096);
+    }
+
+    #[test]
+    fn resolve_num_ctx_stays_at_the_stage_budget_when_the_call_fits() {
+        assert_eq!(resolve_num_ctx(Some(32768), 8192, 2000), 8192);
+    }
+
+    #[test]
+    fn resolve_num_ctx_grows_to_fit_a_call_the_model_can_take() {
+        // The whole point of reading the native window: a long reduce prompt
+        // gets the room it needs instead of being truncated at a hardcoded
+        // 16384.
+        assert_eq!(resolve_num_ctx(Some(32768), 16384, 18_096), 18_096);
+    }
+
+    #[test]
+    fn resolve_num_ctx_will_not_grow_on_an_unknown_native_window() {
+        // Growing blind would risk RoPE extension, so this keeps the behavior
+        // the code had before the lookup existed.
+        assert_eq!(resolve_num_ctx(None, 8192, 30_000), 8192);
+        assert_eq!(resolve_num_ctx(None, 8192, 2000), 8192);
     }
 
     #[test]

--- a/src-tauri/src/summary/ollama.rs
+++ b/src-tauri/src/summary/ollama.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
 
 use crate::lock_ext::MutexExt;
 
@@ -11,6 +12,11 @@ use crate::constants::{
 
 const CONNECT_TIMEOUT_SECS: u64 = 5;
 const READ_TIMEOUT_SECS: u64 = 120;
+/// Whole-request deadline for `/api/show`. The shared client only has a
+/// recurring `read_timeout`, which resets on every successful read, so a slow
+/// trickle of bytes could hold up the summary path indefinitely. This lookup
+/// must fail fast and fall back to the stage budget.
+const SHOW_TIMEOUT_SECS: u64 = 5;
 
 /// Bounds one `/api/generate` call. `num_ctx` is the combined prompt and
 /// response window; `num_predict` caps how many tokens the model may emit.
@@ -127,7 +133,8 @@ fn context_length_from_model_info(model_info: &serde_json::Value) -> Option<u32>
         if !key.ends_with(".context_length") {
             return None;
         }
-        u32::try_from(value.as_u64()?).ok()
+        let length = u32::try_from(value.as_u64()?).ok()?;
+        (length > 0).then_some(length)
     })
 }
 
@@ -148,27 +155,52 @@ fn resolve_num_ctx(native: Option<u32>, requested: u32, needed: u32) -> u32 {
     }
 }
 
-type ModelContextCache = Mutex<HashMap<String, Option<u32>>>;
+/// `num_ctx` is prompt plus response. After the window is resolved (and
+/// possibly pinned to a small native size), the requested generation bound
+/// can still exceed what remains. Cap it so generation cannot scroll the
+/// prompt out of the window.
+fn cap_num_predict(num_ctx: u32, prompt_tokens: u32, requested: u32) -> u32 {
+    requested.min(num_ctx.saturating_sub(prompt_tokens).max(1))
+}
+
+type ModelContextCache = Mutex<HashMap<(String, String), Option<u32>>>;
 static MODEL_CONTEXT_CACHE: OnceLock<ModelContextCache> = OnceLock::new();
 
 fn model_context_cache() -> &'static ModelContextCache {
     MODEL_CONTEXT_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-/// One `/api/show` call per model name, cached for the process lifetime so
-/// this runs once per model rather than once per chunk.
+fn context_cache_key(url: &str, model: &str) -> (String, String) {
+    (url.trim_end_matches('/').to_string(), model.to_string())
+}
+
+/// A completed `/api/show` (window known or advertised as absent) is cached
+/// for the process lifetime. A failed lookup is not: a show that raced a
+/// still-loading model must not pin every later call to the stage budget.
+enum NativeContextLookup {
+    Cached(Option<u32>),
+    Failed,
+}
+
+/// One `/api/show` call per (server, model), cached for the process lifetime
+/// so this runs once per model rather than once per chunk.
 async fn native_context_length(client: &reqwest::Client, url: &str, model: &str) -> Option<u32> {
+    let key = context_cache_key(url, model);
     if let Ok(cache) = model_context_cache().acquire()
-        && let Some(cached) = cache.get(model)
+        && let Some(cached) = cache.get(&key)
     {
         return *cached;
     }
 
-    let native = fetch_native_context_length(client, url, model).await;
-    if let Ok(mut cache) = model_context_cache().acquire() {
-        cache.insert(model.to_string(), native);
+    match fetch_native_context_length(client, url, model).await {
+        NativeContextLookup::Cached(native) => {
+            if let Ok(mut cache) = model_context_cache().acquire() {
+                cache.insert(key, native);
+            }
+            native
+        }
+        NativeContextLookup::Failed => None,
     }
-    native
 }
 
 /// Failure here (network, missing field, unexpected shape) is not fatal: the
@@ -178,9 +210,10 @@ async fn fetch_native_context_length(
     client: &reqwest::Client,
     url: &str,
     model: &str,
-) -> Option<u32> {
+) -> NativeContextLookup {
     let resp = match client
         .post(format!("{url}/api/show"))
+        .timeout(Duration::from_secs(SHOW_TIMEOUT_SECS))
         .json(&serde_json::json!({ "model": model }))
         .send()
         .await
@@ -188,21 +221,21 @@ async fn fetch_native_context_length(
         Ok(resp) => resp,
         Err(e) => {
             tracing::debug!(model, error = %e, "Ollama /api/show request failed");
-            return None;
+            return NativeContextLookup::Failed;
         }
     };
     if !resp.status().is_success() {
         tracing::debug!(model, status = %resp.status(), "Ollama /api/show returned an error status");
-        return None;
+        return NativeContextLookup::Failed;
     }
     let body: ShowResponse = match resp.json().await {
         Ok(body) => body,
         Err(e) => {
             tracing::debug!(model, error = %e, "Ollama /api/show response did not parse");
-            return None;
+            return NativeContextLookup::Failed;
         }
     };
-    context_length_from_model_info(&body.model_info)
+    NativeContextLookup::Cached(context_length_from_model_info(&body.model_info))
 }
 
 pub fn is_summary_capable_model(model: &str) -> bool {
@@ -348,12 +381,13 @@ pub async fn generate_stream(
     json_format: bool,
 ) -> Result<String, String> {
     let native = native_context_length(client, url, model).await;
-    let needed = super::estimate_tokens(system)
+    let prompt_tokens = super::estimate_tokens(system)
         .saturating_add(super::estimate_tokens(&prompt))
-        .saturating_add(budget.num_predict as usize)
         .try_into()
         .unwrap_or(u32::MAX);
+    let needed = prompt_tokens.saturating_add(budget.num_predict);
     let num_ctx = resolve_num_ctx(native, budget.num_ctx, needed);
+    let num_predict = cap_num_predict(num_ctx, prompt_tokens, budget.num_predict);
     if needed > num_ctx {
         tracing::warn!(
             model,
@@ -375,7 +409,7 @@ pub async fn generate_stream(
         options: GenerateOptions {
             temperature,
             num_ctx,
-            num_predict: budget.num_predict,
+            num_predict,
         },
     };
     let resp = client
@@ -602,8 +636,9 @@ pub const DICTATION_POLISH_SYSTEM_PROMPT: &str = crate::constants::OLLAMA_DICTAT
 mod tests {
     use super::{
         GenerateOptions, GenerateRequest, PullAccumulator, PullChunk, PullRequest,
-        RECOMMENDED_MODEL, REDUCE_BUDGET, context_length_from_model_info, is_summary_capable_model,
-        polish_budget, resolve_num_ctx, sorted_summary_capable_models,
+        RECOMMENDED_MODEL, REDUCE_BUDGET, cap_num_predict, context_cache_key,
+        context_length_from_model_info, is_summary_capable_model, polish_budget, resolve_num_ctx,
+        sorted_summary_capable_models,
     };
 
     #[test]
@@ -727,7 +762,8 @@ mod tests {
 
     #[test]
     fn context_length_key_matches_any_architecture_prefix() {
-        let info = serde_json::json!({ "qwen2.context_length": 32768, "qwen2.embedding_length": 1 });
+        let info =
+            serde_json::json!({ "qwen2.context_length": 32768, "qwen2.embedding_length": 1 });
         assert_eq!(context_length_from_model_info(&info), Some(32768));
 
         let info = serde_json::json!({ "llama.context_length": 4096 });
@@ -744,6 +780,38 @@ mod tests {
     fn context_length_value_not_a_number_returns_none() {
         let info = serde_json::json!({ "qwen2.context_length": "a lot" });
         assert_eq!(context_length_from_model_info(&info), None);
+    }
+
+    #[test]
+    fn context_length_zero_is_treated_as_missing() {
+        let info = serde_json::json!({ "qwen2.context_length": 0 });
+        assert_eq!(context_length_from_model_info(&info), None);
+    }
+
+    #[test]
+    fn context_cache_key_includes_the_normalized_server() {
+        assert_eq!(
+            context_cache_key("http://127.0.0.1:11434/", "qwen2.5:7b"),
+            context_cache_key("http://127.0.0.1:11434", "qwen2.5:7b")
+        );
+        assert_ne!(
+            context_cache_key("http://127.0.0.1:11434", "qwen2.5:7b"),
+            context_cache_key("http://192.168.0.11:11434", "qwen2.5:7b")
+        );
+    }
+
+    #[test]
+    fn cap_num_predict_leaves_room_for_the_prompt() {
+        // A 4096-native model asked to emit 4096 tokens would otherwise
+        // overflow the window and scroll the prompt mid-response.
+        assert_eq!(cap_num_predict(4096, 500, 4096), 3596);
+        assert_eq!(cap_num_predict(16384, 1000, 700), 700);
+    }
+
+    #[test]
+    fn cap_num_predict_keeps_a_floor_when_the_prompt_already_fills_the_window() {
+        assert_eq!(cap_num_predict(4096, 4096, 4096), 1);
+        assert_eq!(cap_num_predict(4096, 5000, 4096), 1);
     }
 
     #[test]

--- a/src-tauri/src/summary/polish.rs
+++ b/src-tauri/src/summary/polish.rs
@@ -463,7 +463,7 @@ pub async fn polish_dictation_text(
         polish_system_prompt(provider),
         prompt,
         0.1,
-        super::ollama::REDUCE_CONTEXT,
+        super::ollama::polish_budget(super::estimate_tokens(&stripped)),
         &no_op,
         false,
     )

--- a/src-tauri/src/summary/polish.rs
+++ b/src-tauri/src/summary/polish.rs
@@ -380,6 +380,12 @@ fn format_dictionary_vocabulary(entries: &[DictionaryEntry]) -> Option<String> {
     ))
 }
 
+fn polish_output_basis<'a>(stripped: &'a str, rewrite_of: Option<&'a str>) -> &'a str {
+    rewrite_of
+        .filter(|selection| !selection.trim().is_empty())
+        .unwrap_or(stripped)
+}
+
 fn polish_system_prompt(provider: SummaryProviderKind) -> &'static str {
     match provider {
         SummaryProviderKind::Ollama => super::ollama::DICTATION_POLISH_SYSTEM_PROMPT,
@@ -463,7 +469,9 @@ pub async fn polish_dictation_text(
         polish_system_prompt(provider),
         prompt,
         0.1,
-        super::ollama::polish_budget(super::estimate_tokens(&stripped)),
+        super::ollama::polish_budget(super::estimate_tokens(polish_output_basis(
+            &stripped, rewrite_of,
+        ))),
         &no_op,
         false,
     )
@@ -500,7 +508,7 @@ mod tests {
         SUPERSEDED_CLEAN_PROMPTS, TEMPLATE_BULLETS, TEMPLATE_CLEAN, TEMPLATE_EMAIL,
         TEMPLATE_NO_FILLERS, build_polish_user_prompt, default_polish_templates,
         early_polish_dictation_result, effective_template_prompt, is_blank_for_polish,
-        merge_polish_templates, parse_polish_response, strip_invisible_chars,
+        merge_polish_templates, parse_polish_response, polish_output_basis, strip_invisible_chars,
         superseded_default_prompts,
     };
     use crate::filter::DictionaryEntry;
@@ -744,6 +752,15 @@ mod tests {
             "The dictation transcript is the user's spoken rewrite instructions. Output only the rewritten selection."
         ));
         assert!(!prompt.contains("Target app:"));
+    }
+
+    #[test]
+    fn polish_output_basis_uses_the_selection_when_rewriting() {
+        let instruction = "make it shorter";
+        let selection = "A long selected passage that must survive the rewrite.";
+        assert_eq!(polish_output_basis(instruction, Some(selection)), selection);
+        assert_eq!(polish_output_basis(instruction, None), instruction);
+        assert_eq!(polish_output_basis(instruction, Some("  \n")), instruction);
     }
 
     #[test]


### PR DESCRIPTION
Fixes three defects in one pass (tickets SOU-004, SOU-005, SOU-007). They share the same files and the same failure family: token budgets that did not match reality, with silent truncation as the failure mode. The tickets themselves ask to be done together.

Based on `develop`, not stacked: it touches only `summary/`, which #112 does not.

## The failure mode

When a prompt exceeds `num_ctx`, Ollama returns **200 OK** having processed only the tail. No error, and no field in the response says so. Truncation is from the **left**, so the system prompt goes first: the rules ("use only stated information") and the output format are gone before the model reads a word of the transcript. Models then **invent** the missing content rather than reporting its absence. Only `prompt_eval_count == num_ctx - 1` betrays it.

The opposite direction is just as quiet: setting `num_ctx` above the model's native window makes Ollama RoPE-extend, and coherence degrades with no warning. Plenty of small models cap at 4096.

## Changes

**`num_ctx` is no longer hardcoded** (SOU-004). It was 8192 for map and 16384 for reduce, applied to every model. Now the native window is read once per model from `POST /api/show`, suffix-matching the architecture-prefixed `*.context_length` key so an unseen architecture still resolves, and the window is sized to `max(stage budget, estimated prompt + num_predict)` capped at native. Growing past the stage budget only happens when the native window is **known**, since growing blind is the RoPE risk. A failed, missing or unparseable lookup falls back to the old constant and logs at debug: this must never be why a summarization fails.

**Truncation is no longer silent.** `prompt_eval_count` is read off the final chunk and warns when it reaches the window, naming the model and both numbers. There is also a warning when the model's window cannot hold prompt plus response at all. This is a log, not a UI warning; surfacing it to the user is deliberately out of scope.

**`num_predict` is now set** (SOU-007). Nothing bounded generation before, so a response could run until it saturated the context and made `llama-server` scroll the prompt mid-answer. It is a guard rail against a runaway, not a cap on legitimate output, so the values are generous:
- map 700 (measured outputs run 128 to 314),
- final pass 4096, because `OLLAMA_DETAILED_MINUTES_PROMPT` asks for one bullet per distinct point and to "be thorough rather than terse",
- polish derives its bound from its input, since it *rewrites* that input: a fixed cap would cut a long dictation off mid-sentence, which would be worse than the unbounded generation this replaces.

**The token ratio was 1.4** (SOU-005). Measured on French transcripts it is 1.523 (`qwen3:4b`), 1.532 (`qwen2.5:7b`), 1.538 (`llama3.2:3b`), 1.760 (`mistral`), so every budget was 9 to 26 percent short. Now a conservative **1.8**, with the measurements in the doc comment. No per-model table: the estimate feeds only *limits*, never the chunk size (a fixed word count), so underestimating causes silent truncation while overestimating costs a little margin. A four-entry table would be guesswork for every other model.

## Behavior change worth knowing

The higher ratio makes the stuff-versus-map threshold trip earlier, so meetings in the affected band now take the map-reduce path instead of the single-prompt path. Intended: map-reduce is the more robust of the two.

## Tests

`cargo test --workspace`: 703 passed. Clippy clean for these files (the two warnings, `audio/capture.rs:244` and `export.rs:552`, are pre-existing and untouched).

New unit tests on the pure logic, kept separate from the HTTP call so they run without a server: the `.context_length` key extraction (normal, missing, non-numeric), the window resolution (native below budget, native above, needs more than the budget, native unknown), `polish_budget` tracking its input and staying bounded, and `num_predict` serialization.

## QA

Needs a real Ollama. Worth checking against a small-window model (something capped at 4096) that the log shows the native window being used rather than the stage's 8192, and that a long meeting summary is not cut short by the new `num_predict`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved AI summary generation with more reliable token and response budgeting.
  * Adjusted generation limits to better match each model’s available context.
  * Improved handling of multi-step summaries and reduced-summary requests.
  * Improved rewrite-mode polishing when text is selected, while preserving standard polishing behavior.
* **Bug Fixes**
  * Added safeguards to prevent prompts from exceeding available context and causing incomplete responses.
  * Improved handling of model context information when it is missing or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->