### PR TITLE
Send labeled speaker turns to the summarizer, and pack whole turns

### DIFF
--- a/src-tauri/src/commands/meetings.rs
+++ b/src-tauri/src/commands/meetings.rs
@@ -490,14 +490,13 @@ pub async fn summarize_meeting(
     let transcript = state.db.load_meeting(&id)?;
     let settings = AppSettings::load(&state.db)?;
 
-    let text = match transcript.edited_transcript {
-        Some(ref edited) if !edited.is_empty() => edited.clone(),
-        _ => transcript
-            .segments
-            .iter()
-            .map(|s| s.text.as_str())
-            .collect::<Vec<_>>()
-            .join(" "),
+    let (text, turn_units) = match transcript.edited_transcript {
+        Some(ref edited) if !edited.is_empty() => (edited.clone(), None),
+        _ => {
+            let turns = crate::summary::turns_from_segments(&transcript.segments);
+            let text = turns.join("\n");
+            (text, Some(turns))
+        }
     };
 
     if text.is_empty() {
@@ -511,6 +510,7 @@ pub async fn summarize_meeting(
     let db = state.db.clone();
     let summary = crate::summary::summarize_stream(
         &text,
+        turn_units.as_deref(),
         transcript.notes.as_deref(),
         &transcript.participants,
         &model,

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -105,6 +105,7 @@ Rules:
 - Write dense, factual bullet points in the same language as the transcript.
 - One bullet per distinct fact: a topic discussed, a decision made, an action item assigned (name the owner if stated), or an open question or risk raised.
 - Do NOT use section headings or labels such as \"Decisions:\" or \"Topics:\". Output a single flat bullet list.
+- The excerpt may be labeled turns such as \"[0:12] Me:\". Extract facts only; do not reproduce the transcript, speaker labels, or timestamps.
 - No paragraphs, no commentary, no summary sentence.";
 
 /// System prompt for intermediate reduce rounds, used only when a meeting has
@@ -123,6 +124,7 @@ Rules:
 - Merge duplicate or overlapping points into a single bullet instead of repeating them.
 - Keep the parts in their given order; do not over-weight the last part.
 - Do NOT use section headings or labels such as \"Decisions:\" or \"Topics:\". Output a single flat bullet list.
+- Merge into one combined fact list. Do not keep per-part topic blocks or copy labeled transcript turns.
 - No paragraphs, no commentary, no summary sentence.";
 
 /// System prompt for dictation post-processing (polish) via Ollama.

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -21,7 +21,7 @@ const MIN_CUE_DURATION_SECONDS: f64 = 0.5;
 /// Paragraph pause threshold used for Markdown transcript rendering; mirrors
 /// the `pauseThreshold` the live transcript view passes to
 /// `groupIntoParagraphs` (src/lib/utils/paragraphs.ts).
-const PARAGRAPH_PAUSE_THRESHOLD_SECONDS: f64 = 1.5;
+pub(crate) const PARAGRAPH_PAUSE_THRESHOLD_SECONDS: f64 = 1.5;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, specta::Type)]
 #[serde(rename_all = "snake_case")]
@@ -424,13 +424,12 @@ fn finish_cue_block(out: String) -> String {
     format!("{}\n", out.trim_end())
 }
 
-/// Rust port of `groupIntoParagraphs` from `src/lib/utils/paragraphs.ts`,
-/// used only for the Markdown export's `## Transcript` section. Kept as a
-/// private submodule (not re-exported) since nothing outside export
-/// rendering needs paragraph grouping on the backend. See
+/// Rust port of `groupIntoParagraphs` from `src/lib/utils/paragraphs.ts`.
+/// Used for the Markdown export's `## Transcript` section and for the
+/// labeled turns sent to the summary LLM. See
 /// `src-tauri/tests/fixtures/paragraph_grouping.json` for the cross-language
 /// fixture that pins this port against the TS original.
-mod paragraphs {
+pub(crate) mod paragraphs {
     use crate::engine::{Speaker, TranscriptionSegment};
 
     /// Paragraph break after this many sentences, even with no pause.

--- a/src-tauri/src/summary/chunking.rs
+++ b/src-tauri/src/summary/chunking.rs
@@ -50,6 +50,51 @@ impl ChunkConfig {
     };
 }
 
+/// Pack whole turns into overlapping chunks. A turn is never split, even when
+/// it is longer than `chunk_words`. Overlap is whole trailing turns whose
+/// combined word count fits in `chunk_overlap_words`.
+pub fn chunk_turns(turns: &[String], config: ChunkConfig) -> Vec<String> {
+    if turns.is_empty() {
+        return Vec::new();
+    }
+    let words = |text: &str| text.split_whitespace().count();
+    let total: usize = turns.iter().map(|turn| words(turn)).sum();
+    if total <= config.chunk_words {
+        return vec![turns.join("\n")];
+    }
+
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    while start < turns.len() {
+        let mut end = start;
+        let mut count = 0;
+        while end < turns.len() {
+            let turn_words = words(&turns[end]);
+            if count > 0 && count + turn_words > config.chunk_words {
+                break;
+            }
+            count += turn_words;
+            end += 1;
+        }
+        chunks.push(turns[start..end].join("\n"));
+        if end >= turns.len() {
+            break;
+        }
+        let mut next = end;
+        let mut kept = 0;
+        while next > start + 1 {
+            let turn_words = words(&turns[next - 1]);
+            if kept + turn_words > config.chunk_overlap_words {
+                break;
+            }
+            kept += turn_words;
+            next -= 1;
+        }
+        start = next.max(start + 1);
+    }
+    chunks
+}
+
 /// Split a transcript into overlapping word chunks for the map stage.
 pub fn chunk_transcript(text: &str, config: ChunkConfig) -> Vec<String> {
     let words: Vec<&str> = text.split_whitespace().collect();
@@ -75,7 +120,7 @@ pub fn chunk_transcript(text: &str, config: ChunkConfig) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ChunkConfig, chunk_transcript, estimate_tokens};
+    use super::{ChunkConfig, chunk_transcript, chunk_turns, estimate_tokens};
 
     #[test]
     fn estimate_tokens_scales_with_words() {
@@ -112,5 +157,68 @@ mod tests {
         let ollama = chunk_transcript(&text, ChunkConfig::OLLAMA);
         let apple = chunk_transcript(&text, ChunkConfig::APPLE_INTELLIGENCE);
         assert!(apple.len() > ollama.len());
+    }
+
+    fn tight(chunk_words: usize, overlap: usize) -> ChunkConfig {
+        ChunkConfig {
+            stuff_token_limit: 6000,
+            reduce_token_limit: 12_000,
+            chunk_words,
+            chunk_overlap_words: overlap,
+            map_concurrency: 1,
+        }
+    }
+
+    #[test]
+    fn short_turns_fit_in_one_chunk() {
+        let turns = vec![
+            "[0:00] Me: hello there".into(),
+            "[0:05] Them: hi back".into(),
+        ];
+        let chunks = chunk_turns(&turns, tight(50, 4));
+        assert_eq!(chunks, vec!["[0:00] Me: hello there\n[0:05] Them: hi back"]);
+    }
+
+    #[test]
+    fn packing_never_splits_a_turn() {
+        let long = format!("[0:00] Me: unique-AAA {}", "pad ".repeat(30).trim());
+        let turns = vec![long.clone(), "[0:40] Them: unique-BBB".into()];
+        let chunks = chunk_turns(&turns, tight(10, 2));
+        let with_aaa: Vec<_> = chunks.iter().filter(|c| c.contains("unique-AAA")).collect();
+        assert_eq!(with_aaa.len(), 1);
+        assert_eq!(*with_aaa[0], long);
+        assert!(chunks.iter().any(|c| c.contains("unique-BBB")));
+        assert!(
+            !chunks
+                .iter()
+                .any(|c| c.contains("unique-AAA") && c.contains("unique-BBB"))
+        );
+    }
+
+    #[test]
+    fn a_turn_longer_than_the_budget_is_its_own_chunk() {
+        let long = format!("[0:00] Me: {}", "word ".repeat(20).trim());
+        let chunks = chunk_turns(&[long.clone(), "[1:00] Them: bye".into()], tight(8, 2));
+        assert_eq!(chunks[0], long);
+        assert_eq!(chunks[1], "[1:00] Them: bye");
+    }
+
+    #[test]
+    fn overlap_is_whole_trailing_turns() {
+        let turns = vec![
+            "[0:00] Me: one two three four".into(),
+            "[0:10] Them: five six seven eight".into(),
+            "[0:20] Me: nine ten eleven twelve".into(),
+        ];
+        // 6 words/turn; pack two per chunk; overlap one turn (6 <= 8).
+        let chunks = chunk_turns(&turns, tight(12, 8));
+        assert!(chunks.len() >= 2);
+        assert!(chunks[0].contains("[0:00] Me:"));
+        assert!(chunks[0].contains("[0:10] Them:"));
+        assert!(
+            chunks[1].contains("[0:10] Them:"),
+            "overlap should keep the trailing turn"
+        );
+        assert!(chunks[1].contains("[0:20] Me:"));
     }
 }

--- a/src-tauri/src/summary/mod.rs
+++ b/src-tauri/src/summary/mod.rs
@@ -8,6 +8,7 @@ mod polish;
 mod prompts;
 mod reduce;
 mod templates;
+mod turns;
 
 use serde::{Deserialize, Serialize};
 
@@ -15,7 +16,7 @@ use crate::apple_intelligence;
 use crate::constants::OLLAMA_DEFAULT_URL;
 use crate::transcript::{MeetingParticipant, StructuredSummary};
 
-pub use chunking::{ChunkConfig, chunk_transcript, estimate_tokens};
+pub use chunking::{ChunkConfig, chunk_transcript, chunk_turns, estimate_tokens};
 pub use extract::{extract_structured_summary, parse_structured_summary_response};
 pub use ollama::{OllamaPullProgress, RECOMMENDED_MODEL as RECOMMENDED_OLLAMA_MODEL, pull_model};
 pub use polish::{
@@ -32,6 +33,7 @@ pub use templates::{
     default_summary_templates, is_builtin_summary_template, merge_summary_templates,
     resolve_summary_template_prompt,
 };
+pub use turns::turns_from_segments;
 
 pub const APPLE_INTELLIGENCE_MODEL_ID: &str = "apple-intelligence";
 const APPLE_INTELLIGENCE_MODEL_LABEL: &str = "Apple Intelligence";
@@ -409,8 +411,14 @@ pub(crate) async fn generate_with_provider(
 /// `resolve_summary_template_prompt`). It replaces the final-pass system
 /// prompt only: the map and intermediate merge prompts stay fixed so the
 /// user-facing structure is rendered exactly once, by the terminal call.
+///
+/// `turn_units` is the speaker-labeled transcript when the meeting still has
+/// segments; packing those units never splits a turn. Edited prose has no
+/// turns and falls back to word chunks.
+#[allow(clippy::too_many_arguments)]
 pub async fn summarize_stream(
     transcript_text: &str,
+    turn_units: Option<&[String]>,
     notes: Option<&str>,
     participants: &[MeetingParticipant],
     model: &str,
@@ -441,7 +449,10 @@ pub async fn summarize_stream(
     }
 
     let no_op = |_: SummarizeProgress| {};
-    let chunks = chunk_transcript(transcript_text, config);
+    let chunks = match turn_units {
+        Some(turns) if !turns.is_empty() => chunk_turns(turns, config),
+        _ => chunk_transcript(transcript_text, config),
+    };
     let n = chunks.len();
     let mut part_summaries = Vec::with_capacity(n);
 
@@ -943,6 +954,10 @@ mod tests {
             !ollama::MAP_SYSTEM_PROMPT.contains("## "),
             "map stage must not request markdown headings: they repeat once chunks are merged"
         );
+        assert!(
+            ollama::MAP_SYSTEM_PROMPT.contains("[0:12] Me:"),
+            "labeled turns are input structure; map must still emit a flat fact list"
+        );
         assert_eq!(ollama::MAP_SYSTEM_PROMPT, apple::MAP_SYSTEM_PROMPT);
     }
 
@@ -951,6 +966,10 @@ mod tests {
         assert!(
             !ollama::MERGE_SYSTEM_PROMPT.contains("## "),
             "intermediate reduce rounds must not request markdown headings: they repeat by the final round"
+        );
+        assert!(
+            ollama::MERGE_SYSTEM_PROMPT.contains("per-part topic blocks"),
+            "merge must fuse into one list when the source transcript was labeled turns"
         );
         assert_eq!(ollama::MERGE_SYSTEM_PROMPT, apple::MERGE_SYSTEM_PROMPT);
     }

--- a/src-tauri/src/summary/turns.rs
+++ b/src-tauri/src/summary/turns.rs
@@ -1,0 +1,78 @@
+use crate::engine::{Speaker, TranscriptionSegment};
+use crate::export::{PARAGRAPH_PAUSE_THRESHOLD_SECONDS, paragraphs};
+
+/// Format one grouped paragraph as a labeled turn for the summary LLM.
+fn format_turn(paragraph: &paragraphs::Paragraph) -> String {
+    match paragraph.speaker {
+        Some(Speaker::Me) => format!("[{}] Me: {}", paragraph.timestamp, paragraph.text),
+        Some(Speaker::Them) => format!("[{}] Them: {}", paragraph.timestamp, paragraph.text),
+        None => format!("[{}] {}", paragraph.timestamp, paragraph.text),
+    }
+}
+
+/// Speaker-labeled turns with timestamps, using the same grouping as the
+/// transcript UI / Markdown export (`paragraphs.ts`).
+pub fn turns_from_segments(segments: &[TranscriptionSegment]) -> Vec<String> {
+    paragraphs::group_into_paragraphs(segments, PARAGRAPH_PAUSE_THRESHOLD_SECONDS)
+        .into_iter()
+        .filter(|paragraph| !paragraph.text.trim().is_empty())
+        .map(|paragraph| format_turn(&paragraph))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::turns_from_segments;
+    use crate::engine::Speaker;
+    use crate::test_helpers::fixtures::sample_segment;
+
+    fn tagged(
+        text: &str,
+        start: f64,
+        end: f64,
+        speaker: Speaker,
+    ) -> crate::engine::TranscriptionSegment {
+        let mut seg = sample_segment(text, start, end);
+        seg.speaker = Some(speaker);
+        seg
+    }
+
+    #[test]
+    fn diarized_turns_carry_timestamp_and_speaker() {
+        let turns = turns_from_segments(&[
+            tagged("hello there", 12.0, 14.0, Speaker::Me),
+            tagged("hi back", 15.0, 16.0, Speaker::Them),
+        ]);
+        assert_eq!(
+            turns,
+            vec![
+                "[0:12] Me: hello there".to_string(),
+                "[0:15] Them: hi back".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn undiarized_turns_keep_timestamp_without_a_speaker() {
+        let turns = turns_from_segments(&[sample_segment("just talking", 5.0, 7.0)]);
+        assert_eq!(turns, vec!["[0:05] just talking".to_string()]);
+    }
+
+    #[test]
+    fn consecutive_same_speaker_stays_one_turn() {
+        let turns = turns_from_segments(&[
+            tagged("hello", 0.0, 1.0, Speaker::Me),
+            tagged("there", 1.1, 2.0, Speaker::Me),
+        ]);
+        assert_eq!(turns, vec!["[0:00] Me: hello there".to_string()]);
+    }
+
+    #[test]
+    fn empty_segments_are_dropped() {
+        let turns = turns_from_segments(&[
+            tagged("   ", 0.0, 1.0, Speaker::Me),
+            tagged("kept", 2.0, 3.0, Speaker::Them),
+        ]);
+        assert_eq!(turns, vec!["[0:02] Them: kept".to_string()]);
+    }
+}

--- a/src-tauri/src/summary/turns.rs
+++ b/src-tauri/src/summary/turns.rs
@@ -13,9 +13,13 @@ fn format_turn(paragraph: &paragraphs::Paragraph) -> String {
 /// Speaker-labeled turns with timestamps, using the same grouping as the
 /// transcript UI / Markdown export (`paragraphs.ts`).
 pub fn turns_from_segments(segments: &[TranscriptionSegment]) -> Vec<String> {
-    paragraphs::group_into_paragraphs(segments, PARAGRAPH_PAUSE_THRESHOLD_SECONDS)
+    let nonempty: Vec<TranscriptionSegment> = segments
+        .iter()
+        .filter(|segment| !segment.text.trim().is_empty())
+        .cloned()
+        .collect();
+    paragraphs::group_into_paragraphs(&nonempty, PARAGRAPH_PAUSE_THRESHOLD_SECONDS)
         .into_iter()
-        .filter(|paragraph| !paragraph.text.trim().is_empty())
         .map(|paragraph| format_turn(&paragraph))
         .collect()
 }
@@ -74,5 +78,20 @@ mod tests {
             tagged("kept", 2.0, 3.0, Speaker::Them),
         ]);
         assert_eq!(turns, vec!["[0:02] Them: kept".to_string()]);
+    }
+
+    #[test]
+    fn whitespace_prefix_does_not_steal_the_timestamp() {
+        let same_speaker = turns_from_segments(&[
+            tagged(" ", 0.0, 1.0, Speaker::Me),
+            tagged("kept", 2.0, 3.0, Speaker::Me),
+        ]);
+        assert_eq!(same_speaker, vec!["[0:02] Me: kept".to_string()]);
+
+        let undiarized = turns_from_segments(&[
+            sample_segment(" ", 0.0, 1.0),
+            sample_segment("kept", 2.0, 3.0),
+        ]);
+        assert_eq!(undiarized, vec!["[0:02] kept".to_string()]);
     }
 }


### PR DESCRIPTION
## Summary
- The meeting transcript sent to the LLM is now labeled turns (`[0:12] Me: …`), using the same grouping as the transcript UI, instead of a speaker-less `join(" ")` blob.
- Map-reduce packs **whole turns**. A turn is never split, even when it is longer than the word budget. Overlap is whole trailing turns that fit in the existing overlap window.
- Map and merge prompts still forbid headings / per-part Topics blocks, so a structured input does not reproduce the C1 form break. Map-reduce stays; no single-pass path.

## Why
The prompt asks the model to attribute action items, but it was given no speakers. Word chunking also cut mid-turn. The C1 bench “better coverage” was confounded by empty map chunks (SOU-006, already on develop); this change is the structure, not a claim that C1 coverage was proven.

## Test plan
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib -- summary::turns summary::chunking summary::tests::map_prompt summary::tests::merge_prompt`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --lib -- summary:: export::`
- [ ] QA with `qwen2.5:7b` on a long diarized meeting: action items should be able to name Me/Them (and calendar participants), the summary should be one fused `## Topics` (not one block per chunk), and the end of the meeting should still be present (SOU-006 net).
- [ ] Edited-transcript path still summarizes as prose (word chunks), not turns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Meeting summaries better preserve complete speaker turns and surrounding context.
  - Long transcripts are divided at natural turn boundaries, reducing fragmented summaries.
  - Speaker-labeled and unlabeled transcripts are handled more consistently.
  - Summaries focus on consolidated facts without repeating speaker labels, timestamps, or separate topic sections.
  - Transcript grouping remains aligned with paragraph breaks used elsewhere in the app.
  - Empty transcript segments are filtered more reliably during summary generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->