### PR TITLE
Keep the recording overlay sized after a display change, and let you move or hide it

### DIFF
--- a/src-tauri/src/commands/pill.rs
+++ b/src-tauri/src/commands/pill.rs
@@ -35,12 +35,11 @@ pub fn pill_release(app: AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-/// Resize the pill window to `width` x `height` (logical pixels), keeping
-/// its top edge pinned below the menu bar and staying horizontally
-/// centered. The frontend calls this as the live transcript grows/shrinks
-/// (e.g. switching between the compact and expanded live-text layouts): a
-/// single native frame change avoids the top-edge drift that a separate
-/// resize-then-recenter pair produces.
+/// Resize the pill window to `width` x `height` (logical pixels). A
+/// dragged position is kept (and clamped on-screen); otherwise the pill
+/// stays top-centered. The frontend calls this as the live transcript
+/// grows/shrinks. A single native frame change avoids the top-edge drift
+/// that a separate resize-then-recenter pair produces.
 #[tauri::command]
 #[specta::specta]
 pub fn pill_resize(app: AppHandle, width: f64, height: f64) -> Result<(), String> {

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -40,8 +40,11 @@ pub fn save_settings(
             priority: settings.input_priority.clone(),
             allow_bluetooth_mic: settings.allow_bluetooth_mic,
         });
-    // A locale change must relabel the tray menu immediately.
+    crate::pill::set_hidden(settings.pill_hidden);
+    // A locale change must relabel the tray menu immediately. Hide/show of
+    // the recording overlay is applied on the same pass.
     if let Ok(machine) = state.current_machine_state() {
+        crate::pill::sync(&app, &machine);
         crate::tray::sync(&app, &machine);
     }
     Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -272,12 +272,7 @@ pub fn run() {
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             tray::show_main_window(app);
         }))
-        .manage(AppState::new(
-            cmd_tx,
-            engine_actor,
-            database,
-            audio_rms,
-        ))
+        .manage(AppState::new(cmd_tx, engine_actor, database, audio_rms))
         .invoke_handler(specta.invoke_handler())
         .setup(move |app| {
             specta.mount_events(app);
@@ -316,6 +311,7 @@ pub fn run() {
                     if let Err(e) = logging::set_level(app_settings.log_level) {
                         tracing::warn!("Failed to apply log level: {e}");
                     }
+                    crate::pill::restore_from_db(&state.db, app_settings.pill_hidden);
                     state
                         .engine_actor
                         .set_unload_timeout(app_settings.model_unload_timeout_minutes);
@@ -397,10 +393,20 @@ pub fn run() {
                 device_watch::destroy_orphaned_souffle_taps();
             }
 
-            if let Some(pill) = app.get_webview_window("pill")
-                && let Err(e) = crate::pill::position_top_center(&pill)
-            {
-                tracing::warn!("Pill overlay configure failed: {e}");
+            if let Some(pill) = app.get_webview_window("pill") {
+                if let Err(e) = crate::pill::apply_current_frame(&pill) {
+                    tracing::warn!("Pill overlay configure failed: {e}");
+                }
+                let pill_events = pill.clone();
+                pill.on_window_event(move |event| match event {
+                    tauri::WindowEvent::Moved(_) => crate::pill::note_user_moved(&pill_events),
+                    tauri::WindowEvent::ScaleFactorChanged { .. } => {
+                        if let Err(e) = crate::pill::apply_current_frame(&pill_events) {
+                            tracing::warn!("Pill overlay rescale failed: {e}");
+                        }
+                    }
+                    _ => {}
+                });
             }
 
             // Close hides; it must not destroy. The pill + tray keep the

--- a/src-tauri/src/pill.rs
+++ b/src-tauri/src/pill.rs
@@ -13,10 +13,31 @@ use tauri_specta::Event;
 use tracing::warn;
 
 use crate::app_events::{PillHoldChanged, PillHoldKind};
+use crate::db::Database;
+use crate::settings::PILL_POSITION_KEY;
+use crate::state::AppState;
 use crate::state_machine::AppStateMachine;
 
 /// Vertical offset below the menu bar.
 const TOP_MARGIN: f64 = 40.0;
+
+/// Compact dictation size — must match the "pill" window in tauri.conf.json
+/// and `PILL_WIDTH`/`BASE_HEIGHT` in `PillApp.svelte`. Never derived from
+/// `outer_size()`: after a scale/resolution change that physical size is
+/// stale, and converting it with the new scale factor is what shrinks the
+/// HUD into a tiny scrolling box (SOU-011).
+const COMPACT_WIDTH: f64 = 280.0;
+const COMPACT_HEIGHT: f64 = 64.0;
+
+/// Last logical size the frontend asked for (`pill_resize`), or compact.
+static LAST_SIZE: Mutex<(f64, f64)> = Mutex::new((COMPACT_WIDTH, COMPACT_HEIGHT));
+/// User-dragged AppKit origin (bottom-left, global points). `None` = default
+/// top-center on the active screen.
+static CUSTOM_ORIGIN: Mutex<Option<(f64, f64)>> = Mutex::new(None);
+/// Last origin we applied ourselves, so a follow-up `Moved` echo is ignored.
+static LAST_APPLIED_ORIGIN: Mutex<(f64, f64)> = Mutex::new((0.0, 0.0));
+static APPLYING_FRAME: AtomicBool = AtomicBool::new(false);
+static PILL_HIDDEN: AtomicBool = AtomicBool::new(false);
 
 /// Minimum spacing between `DictationLiveText` emissions. Well under the
 /// 5-10Hz cap so it reads as "live" without flooding the pill's IPC channel.
@@ -72,10 +93,19 @@ pub fn clear_hold(app: &AppHandle) {
     }
 }
 
-/// Whether the pill should be visible given the current recording state and
-/// hold. Pure so it's testable without a live window/AppHandle.
-fn should_show_pill(recording: bool, held: bool) -> bool {
-    recording || held
+/// Whether the pill should be visible given the current recording state,
+/// hold, and the user's hide preference. Pure so it's testable without a
+/// live window/AppHandle.
+fn should_show_pill(recording: bool, held: bool, hidden: bool) -> bool {
+    !hidden && (recording || held)
+}
+
+pub fn set_hidden(hidden: bool) {
+    PILL_HIDDEN.store(hidden, Ordering::SeqCst);
+}
+
+fn is_hidden() -> bool {
+    PILL_HIDDEN.load(Ordering::SeqCst)
 }
 
 /// Drop a leftover hold only when a *new* recording starts. Polish holds
@@ -109,9 +139,10 @@ pub fn sync(app: &AppHandle, machine: &AppStateMachine) {
         clear_hold(app);
     }
 
-    let result = if should_show_pill(recording, is_held()) {
-        position_top_center(&pill).and_then(|()| order_overlay(&pill, true))
+    let result = if should_show_pill(recording, is_held(), is_hidden()) {
+        apply_current_frame(&pill).and_then(|()| order_overlay(&pill, true))
     } else {
+        persist_position(app);
         order_overlay(&pill, false)
     };
     if let Err(e) = result {
@@ -144,15 +175,11 @@ pub fn live_text_tail(text: &str, max_chars: usize) -> String {
     text.chars().skip(total - max_chars).collect()
 }
 
-/// Recenters the pill horizontally below the menu bar on the active screen.
-/// `pub(crate)` so `sync` can call it when showing the pill in its compact state.
-pub(crate) fn position_top_center(pill: &tauri::WebviewWindow) -> tauri::Result<()> {
-    let scale = pill
-        .primary_monitor()?
-        .map(|m| m.scale_factor())
-        .unwrap_or(1.0);
-    let size = pill.outer_size()?.to_logical::<f64>(scale);
-    set_frame_top_center(pill, size.width, size.height)
+/// Places the pill using the last requested logical size (compact until the
+/// frontend has resized), on the active screen, clamped on-screen.
+pub(crate) fn apply_current_frame(pill: &tauri::WebviewWindow) -> tauri::Result<()> {
+    let (width, height) = last_size();
+    set_frame(pill, width, height)
 }
 
 /// Lower/upper bounds on the pill's size, defensively clamped in
@@ -182,9 +209,12 @@ fn frame_origin(
     (x, y)
 }
 
-/// Resizes and repositions the pill in a single native `setFrame:` call, so
-/// the top edge stays pinned at `TOP_MARGIN` and the window stays centered
-/// as its height grows with the live transcript.
+/// Resizes and repositions the pill in a single native `setFrame:` call.
+///
+/// Default placement pins the top edge at `TOP_MARGIN` and centers
+/// horizontally. A user-dragged origin is kept (top edge + x), then clamped
+/// to the active screen so a saved position cannot land off-screen after a
+/// resolution change.
 ///
 /// This bypasses tao's `set_inner_size` (AppKit's `setContentSize:` anchors
 /// the window's BOTTOM-left corner, so growing the height pushes the top
@@ -204,8 +234,97 @@ pub(crate) fn set_frame_top_center(
     width: f64,
     height: f64,
 ) -> tauri::Result<()> {
+    set_frame(pill, width, height)
+}
+
+fn last_size() -> (f64, f64) {
+    LAST_SIZE
+        .lock()
+        .map(|guard| *guard)
+        .unwrap_or((COMPACT_WIDTH, COMPACT_HEIGHT))
+}
+
+fn store_last_size(width: f64, height: f64) {
+    if let Ok(mut guard) = LAST_SIZE.lock() {
+        *guard = (width, height);
+    }
+}
+
+fn custom_origin() -> Option<(f64, f64)> {
+    CUSTOM_ORIGIN.lock().ok().and_then(|guard| *guard)
+}
+
+fn store_custom_origin(origin: Option<(f64, f64)>) {
+    if let Ok(mut guard) = CUSTOM_ORIGIN.lock() {
+        *guard = origin;
+    }
+}
+
+/// Keep a rectangle of `width`×`height` fully inside `screen` when possible.
+pub(crate) fn clamp_origin(
+    screen_x: f64,
+    screen_y: f64,
+    screen_width: f64,
+    screen_height: f64,
+    width: f64,
+    height: f64,
+    x: f64,
+    y: f64,
+) -> (f64, f64) {
+    let max_x = screen_x + screen_width - width;
+    let max_y = screen_y + screen_height - height;
+    let x = if max_x < screen_x {
+        screen_x
+    } else {
+        x.clamp(screen_x, max_x)
+    };
+    let y = if max_y < screen_y {
+        screen_y
+    } else {
+        y.clamp(screen_y, max_y)
+    };
+    (x, y)
+}
+
+fn origin_for_frame(
+    screen_x: f64,
+    screen_y: f64,
+    screen_width: f64,
+    screen_height: f64,
+    width: f64,
+    height: f64,
+    previous_height: f64,
+) -> (f64, f64) {
+    if let Some((x, y)) = custom_origin() {
+        let top = y + previous_height;
+        clamp_origin(
+            screen_x,
+            screen_y,
+            screen_width,
+            screen_height,
+            width,
+            height,
+            x,
+            top - height,
+        )
+    } else {
+        frame_origin(
+            screen_x,
+            screen_y,
+            screen_width,
+            screen_height,
+            width,
+            height,
+            TOP_MARGIN,
+        )
+    }
+}
+
+fn set_frame(pill: &tauri::WebviewWindow, width: f64, height: f64) -> tauri::Result<()> {
     let width = width.clamp(MIN_WIDTH, MAX_WIDTH);
     let height = height.clamp(MIN_HEIGHT, MAX_HEIGHT);
+    let previous_height = last_size().1;
+    store_last_size(width, height);
 
     let window = pill.clone();
     pill.run_on_main_thread(move || {
@@ -220,21 +339,83 @@ pub(crate) fn set_frame_top_center(
         let ns_window: &objc2_app_kit::NSWindow = unsafe { &*ns_window_ptr.cast() };
         let overlay = configure_overlay_window(ns_window);
         let (screen_x, screen_y, screen_width, screen_height) = active_screen_frame();
-        let (x, y) = frame_origin(
+        let (x, y) = origin_for_frame(
             screen_x,
             screen_y,
             screen_width,
             screen_height,
             width,
             height,
-            TOP_MARGIN,
+            previous_height,
         );
         let frame = objc2_foundation::NSRect {
             origin: objc2_foundation::NSPoint { x, y },
             size: objc2_foundation::NSSize { width, height },
         };
+        APPLYING_FRAME.store(true, Ordering::SeqCst);
         overlay.setFrame_display(frame, true);
+        if let Ok(mut guard) = LAST_APPLIED_ORIGIN.lock() {
+            *guard = (x, y);
+        }
+        APPLYING_FRAME.store(false, Ordering::SeqCst);
     })
+}
+
+/// Record a user drag. Ignores the `Moved` echo from our own `setFrame`.
+pub(crate) fn note_user_moved(pill: &tauri::WebviewWindow) {
+    if APPLYING_FRAME.load(Ordering::SeqCst) {
+        return;
+    }
+    let window = pill.clone();
+    let _ = pill.run_on_main_thread(move || {
+        if APPLYING_FRAME.load(Ordering::SeqCst) {
+            return;
+        }
+        let Ok(ns_window_ptr) = window.ns_window() else {
+            return;
+        };
+        // SAFETY: same contract as `set_frame` — pill NSWindow*, main thread.
+        let ns_window: &objc2_app_kit::NSWindow = unsafe { &*ns_window_ptr.cast() };
+        let origin = ns_window.frame().origin;
+        let last = LAST_APPLIED_ORIGIN
+            .lock()
+            .map(|guard| *guard)
+            .unwrap_or((origin.x, origin.y));
+        if (origin.x - last.0).abs() < 2.0 && (origin.y - last.1).abs() < 2.0 {
+            return;
+        }
+        store_custom_origin(Some((origin.x, origin.y)));
+    });
+}
+
+pub(crate) fn restore_from_db(db: &Database, hidden: bool) {
+    set_hidden(hidden);
+    match db.get_setting(PILL_POSITION_KEY) {
+        Ok(Some(raw)) => {
+            if let Ok((x, y)) = serde_json::from_str::<(f64, f64)>(&raw) {
+                store_custom_origin(Some((x, y)));
+            }
+        }
+        Ok(None) => {}
+        Err(e) => warn!("Failed to load pill position: {e}"),
+    }
+}
+
+fn persist_position(app: &tauri::AppHandle) {
+    let Some(origin) = custom_origin() else {
+        return;
+    };
+    let Some(state) = app.try_state::<AppState>() else {
+        return;
+    };
+    match serde_json::to_string(&origin) {
+        Ok(raw) => {
+            if let Err(e) = state.db.set_setting(PILL_POSITION_KEY, &raw) {
+                warn!("Failed to persist pill position: {e}");
+            }
+        }
+        Err(e) => warn!("Failed to serialize pill position: {e}"),
+    }
 }
 
 /// Show or hide the overlay without activating the app. Tauri's `show` /
@@ -353,10 +534,14 @@ mod tests {
 
     #[test]
     fn should_show_pill_when_recording_or_held() {
-        assert!(should_show_pill(true, false));
-        assert!(should_show_pill(false, true));
-        assert!(should_show_pill(true, true));
-        assert!(!should_show_pill(false, false));
+        assert!(should_show_pill(true, false, false));
+        assert!(should_show_pill(false, true, false));
+        assert!(should_show_pill(true, true, false));
+        assert!(!should_show_pill(false, false, false));
+        assert!(
+            !should_show_pill(true, true, true),
+            "the hide option wins even while recording or held"
+        );
     }
 
     #[test]
@@ -475,6 +660,45 @@ mod tests {
         let (x, y) = frame_origin(1920.0, 0.0, 1512.0, 982.0, 400.0, 100.0, 40.0);
         assert_eq!(x, 1920.0 + (1512.0 - 400.0) / 2.0);
         assert_eq!(y + 100.0 + 40.0, 982.0);
+    }
+
+    #[test]
+    fn clamp_origin_pulls_a_saved_position_back_on_screen() {
+        // Saved on a 1920×1080 display, then the display shrinks to 1280×800.
+        let (x, y) = clamp_origin(0.0, 0.0, 1280.0, 800.0, 280.0, 64.0, 1700.0, 900.0);
+        assert_eq!(x, 1280.0 - 280.0);
+        assert_eq!(y, 800.0 - 64.0);
+    }
+
+    #[test]
+    fn clamp_origin_leaves_an_on_screen_position_alone() {
+        let (x, y) = clamp_origin(0.0, 0.0, 1920.0, 1080.0, 280.0, 64.0, 100.0, 200.0);
+        assert_eq!((x, y), (100.0, 200.0));
+    }
+
+    #[test]
+    fn clamp_origin_pins_when_the_window_is_larger_than_the_screen() {
+        let (x, y) = clamp_origin(0.0, 0.0, 200.0, 50.0, 280.0, 64.0, 10.0, 10.0);
+        assert_eq!((x, y), (0.0, 0.0));
+    }
+
+    #[test]
+    fn compact_logical_size_is_the_configured_pill_window() {
+        assert_eq!((COMPACT_WIDTH, COMPACT_HEIGHT), (280.0, 64.0));
+    }
+
+    #[test]
+    fn restore_from_db_loads_a_saved_origin_and_hide_flag() {
+        store_custom_origin(None);
+        set_hidden(false);
+        let (db, _dir) = crate::test_helpers::fixtures::test_db();
+        db.set_setting(crate::settings::PILL_POSITION_KEY, "[100.5,200.25]")
+            .unwrap();
+        restore_from_db(&db, true);
+        assert!(is_hidden());
+        assert_eq!(custom_origin(), Some((100.5, 200.25)));
+        set_hidden(false);
+        store_custom_origin(None);
     }
 
     /// Exercises the full hold lifecycle against the shared module-level

--- a/src-tauri/src/pill.rs
+++ b/src-tauri/src/pill.rs
@@ -338,7 +338,8 @@ fn set_frame(pill: &tauri::WebviewWindow, width: f64, height: f64) -> tauri::Res
         // this `run_on_main_thread` closure.
         let ns_window: &objc2_app_kit::NSWindow = unsafe { &*ns_window_ptr.cast() };
         let overlay = configure_overlay_window(ns_window);
-        let (screen_x, screen_y, screen_width, screen_height) = active_screen_frame();
+        let (screen_x, screen_y, screen_width, screen_height) =
+            placement_screen_frame(custom_origin());
         let (x, y) = origin_for_frame(
             screen_x,
             screen_y,
@@ -502,10 +503,57 @@ fn configure_overlay_window(ns_window: &objc2_app_kit::NSWindow) -> &objc2_app_k
     ns_window
 }
 
+fn ns_rect_to_frame(frame: objc2_foundation::NSRect) -> (f64, f64, f64, f64) {
+    (
+        frame.origin.x,
+        frame.origin.y,
+        frame.size.width,
+        frame.size.height,
+    )
+}
+
+/// Display whose frame contains `(x, y)` in AppKit global points.
+pub(crate) fn screen_containing_point(
+    screens: &[(f64, f64, f64, f64)],
+    x: f64,
+    y: f64,
+) -> Option<(f64, f64, f64, f64)> {
+    screens
+        .iter()
+        .copied()
+        .find(|&(sx, sy, sw, sh)| x >= sx && x < sx + sw && y >= sy && y < sy + sh)
+}
+
+/// Screen to place/clamp against: the display that holds a dragged origin,
+/// otherwise the focused screen. An origin that sits on no display (unplugged
+/// monitor, shrink) falls back to the focused screen so `clamp_origin` can
+/// pull the HUD back on-screen.
+fn placement_screen_frame(origin: Option<(f64, f64)>) -> (f64, f64, f64, f64) {
+    if let Some((x, y)) = origin {
+        if let Some(frame) = screen_containing_point(&all_screen_frames(), x, y) {
+            return frame;
+        }
+    }
+    active_screen_frame()
+}
+
+fn all_screen_frames() -> Vec<(f64, f64, f64, f64)> {
+    use objc2::MainThreadMarker;
+    use objc2_app_kit::NSScreen;
+
+    let Some(mtm) = MainThreadMarker::new() else {
+        return Vec::new();
+    };
+    NSScreen::screens(mtm)
+        .iter()
+        .map(|screen| ns_rect_to_frame(screen.frame()))
+        .collect()
+}
+
 /// Screen that currently has keyboard focus (`NSScreen.main`), falling back
-/// to the first screen. Fullscreen apps put the key window on that Space's
-/// display, so this is where the HUD belongs — not always the primary
-/// monitor.
+/// to the first screen. Default (undragged) placement follows this so the
+/// HUD sits on the Space the user is dictating into — not always the
+/// primary monitor.
 fn active_screen_frame() -> (f64, f64, f64, f64) {
     use objc2::MainThreadMarker;
     use objc2_app_kit::NSScreen;
@@ -515,15 +563,7 @@ fn active_screen_frame() -> (f64, f64, f64, f64) {
     };
     let screen = NSScreen::mainScreen(mtm).or_else(|| NSScreen::screens(mtm).firstObject());
     match screen {
-        Some(screen) => {
-            let frame = screen.frame();
-            (
-                frame.origin.x,
-                frame.origin.y,
-                frame.size.width,
-                frame.size.height,
-            )
-        }
+        Some(screen) => ns_rect_to_frame(screen.frame()),
         None => (0.0, 0.0, 0.0, 0.0),
     }
 }
@@ -685,6 +725,20 @@ mod tests {
     #[test]
     fn compact_logical_size_is_the_configured_pill_window() {
         assert_eq!((COMPACT_WIDTH, COMPACT_HEIGHT), (280.0, 64.0));
+    }
+
+    #[test]
+    fn screen_containing_point_keeps_a_dragged_origin_on_the_secondary() {
+        let screens = [(0.0, 0.0, 1920.0, 1080.0), (1920.0, 0.0, 1512.0, 982.0)];
+        assert_eq!(
+            screen_containing_point(&screens, 2200.0, 100.0),
+            Some(screens[1])
+        );
+        assert_eq!(
+            screen_containing_point(&screens, 100.0, 100.0),
+            Some(screens[0])
+        );
+        assert_eq!(screen_containing_point(&screens, 4000.0, 100.0), None);
     }
 
     #[test]

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -34,12 +34,16 @@ const CALENDAR_SELECTED_IDS_KEY: &str = "calendar_selected_ids";
 const CALENDAR_REMINDER_MINUTES_KEY: &str = "calendar_reminder_minutes";
 const CALENDAR_AUTOSTART_ENABLED_KEY: &str = "calendar_autostart_enabled";
 const FEEDBACK_SOUNDS_ENABLED_KEY: &str = "feedback_sounds_enabled";
+const PILL_HIDDEN_KEY: &str = "pill_hidden";
 const FEEDBACK_SOUNDS_VOLUME_KEY: &str = "feedback_sounds_volume";
 const MODEL_UNLOAD_TIMEOUT_MINUTES_KEY: &str = "model_unload_timeout_minutes";
 const AUTO_UPDATE_CHECK_ENABLED_KEY: &str = "auto_update_check_enabled";
 /// Unix seconds of the last completed check. Not part of `AppSettings`: it is
 /// bookkeeping, not a preference, and nothing in the UI shows it.
 pub const LAST_UPDATE_CHECK_AT_KEY: &str = "last_update_check_at";
+/// Last user-dragged pill origin (JSON `[x, y]` in AppKit points). Not a
+/// preference: the overlay re-clamps it when the screen changes.
+pub const PILL_POSITION_KEY: &str = "pill_position";
 const MEETING_AUTOSTOP_ENABLED_KEY: &str = "meeting_autostop_enabled";
 const MEETING_AUTOSTOP_MINUTES_KEY: &str = "meeting_autostop_minutes";
 const MEETING_MAX_DURATION_MINUTES_KEY: &str = "meeting_max_duration_minutes";
@@ -179,6 +183,8 @@ pub struct AppSettings {
     pub auto_update_check_enabled: bool,
     /// Audible start/stop cues for dictation sessions.
     pub feedback_sounds_enabled: bool,
+    /// When true, the floating recording HUD is not shown.
+    pub pill_hidden: bool,
     /// Feedback sound volume (0-100).
     pub feedback_sounds_volume: u32,
     /// Unload the transcription model after this many idle minutes to
@@ -257,6 +263,7 @@ impl Default for AppSettings {
             calendar_autostart_enabled: true,
             auto_update_check_enabled: true,
             feedback_sounds_enabled: true,
+            pill_hidden: false,
             feedback_sounds_volume: 70,
             model_unload_timeout_minutes: 60,
             meeting_autostop_enabled: true,
@@ -398,6 +405,9 @@ impl AppSettings {
             read_json_setting::<bool>(db, FEEDBACK_SOUNDS_ENABLED_KEY)?
         {
             settings.feedback_sounds_enabled = feedback_sounds_enabled;
+        }
+        if let Some(pill_hidden) = read_json_setting::<bool>(db, PILL_HIDDEN_KEY)? {
+            settings.pill_hidden = pill_hidden;
         }
         if let Some(feedback_sounds_volume) =
             read_json_setting::<u32>(db, FEEDBACK_SOUNDS_VOLUME_KEY)?
@@ -804,6 +814,7 @@ impl AppSettings {
             FEEDBACK_SOUNDS_ENABLED_KEY,
             &normalized.feedback_sounds_enabled,
         )?;
+        write_json_setting(db, PILL_HIDDEN_KEY, &normalized.pill_hidden)?;
         write_json_setting(
             db,
             FEEDBACK_SOUNDS_VOLUME_KEY,
@@ -1054,6 +1065,7 @@ mod tests {
             calendar_reminder_minutes: 5,
             calendar_autostart_enabled: true,
             feedback_sounds_enabled: false,
+            pill_hidden: true,
             feedback_sounds_volume: 40,
             model_unload_timeout_minutes: 15,
             meeting_autostop_enabled: false,

--- a/src/lib/components/SettingsView.svelte
+++ b/src/lib/components/SettingsView.svelte
@@ -223,6 +223,8 @@
         onStartRecording={controller.startRecording}
         onClearShortcut={controller.clearShortcut}
         formatShortcut={controller.formatShortcut}
+        pillHidden={controller.app.settings.pill_hidden}
+        onPillHiddenChange={controller.onPillHiddenChange}
       />
 
       <FeedbackSoundsSettingsSection

--- a/src/lib/features/settings/components/InterfaceSettingsSection.svelte
+++ b/src/lib/features/settings/components/InterfaceSettingsSection.svelte
@@ -32,6 +32,8 @@
     onStartRecording,
     onClearShortcut,
     formatShortcut,
+    pillHidden,
+    onPillHiddenChange,
   }: {
     theme: Theme;
     locale: string;
@@ -51,6 +53,8 @@
     onStartRecording: (field: "toggle" | "ptt" | "rewrite") => void;
     onClearShortcut: (field: "toggle" | "ptt" | "rewrite") => void | Promise<void>;
     formatShortcut: (shortcut: string) => string;
+    pillHidden: boolean;
+    onPillHiddenChange: (event: Event) => void;
   } = $props();
 </script>
 
@@ -201,6 +205,21 @@
           <button onclick={() => onClearShortcut("rewrite")} class="btn btn-ghost text-sm">{$t("settings_interface.clear")}</button>
         {/if}
       </div>
+    {/snippet}
+  </SettingsField>
+
+  <SettingsField
+    label={$t("settings_interface.pill_hidden")}
+    description={$t("settings_interface.pill_hidden_desc")}
+  >
+    {#snippet control()}
+      <input
+        type="checkbox"
+        checked={pillHidden}
+        onchange={onPillHiddenChange}
+        class="switch"
+        aria-label={$t("settings_interface.pill_hidden")}
+      />
     {/snippet}
   </SettingsField>
 

--- a/src/lib/features/settings/controller.svelte.test.ts
+++ b/src/lib/features/settings/controller.svelte.test.ts
@@ -74,6 +74,7 @@ const defaultSettings: AppSettings = {
   calendar_reminder_minutes: 2,
   calendar_autostart_enabled: true,
   feedback_sounds_enabled: true,
+  pill_hidden: false,
   feedback_sounds_volume: 70,
   model_unload_timeout_minutes: 0,
   meeting_autostop_enabled: true,

--- a/src/lib/features/settings/controller.svelte.ts
+++ b/src/lib/features/settings/controller.svelte.ts
@@ -718,6 +718,13 @@ export function createSettingsController() {
     });
   }
 
+  function onPillHiddenChange(event: Event) {
+    const checked = (event.target as HTMLInputElement).checked;
+    void persistSettings((settings) => {
+      settings.pill_hidden = checked;
+    });
+  }
+
   function onFeedbackSoundsVolumeChange(event: Event) {
     const value = parseInt((event.target as HTMLInputElement).value, 10);
     if (!Number.isFinite(value)) return;
@@ -848,6 +855,7 @@ export function createSettingsController() {
     onCalendarAutostartEnabledChange,
     onFeedbackSoundsEnabledChange,
     onFeedbackSoundsVolumeChange,
+    onPillHiddenChange,
     mount,
     refreshRuntimeStatus,
     refreshDevices,

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -124,6 +124,8 @@
     "clear": "Clear",
     "push_to_talk": "Push-to-talk",
     "push_to_talk_desc": "Hold to record, release to stop.",
+    "pill_hidden": "Hide recording overlay",
+    "pill_hidden_desc": "Don't show the floating HUD while dictating or in a meeting. Drag it when visible to move it; the position is remembered and stays on-screen if the display changes.",
     "language": "Language",
     "language_desc": "Choose the interface language."
   },

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -124,6 +124,8 @@
     "clear": "Effacer",
     "push_to_talk": "Appuyer pour parler",
     "push_to_talk_desc": "Maintenez pour enregistrer, relâchez pour arrêter.",
+    "pill_hidden": "Masquer l'overlay d'enregistrement",
+    "pill_hidden_desc": "Ne pas afficher le HUD flottant pendant une dictée ou une réunion. Déplacez-le par glisser-déposer ; la position est mémorisée et reste à l'écran si la résolution change.",
     "language": "Langue",
     "language_desc": "Choisissez la langue de l'interface."
   },

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -90,6 +90,7 @@ let settings = $state<AppSettings>({
   calendar_reminder_minutes: 2,
   calendar_autostart_enabled: true,
   feedback_sounds_enabled: true,
+  pill_hidden: false,
   feedback_sounds_volume: 70,
   model_unload_timeout_minutes: 60,
   meeting_autostop_enabled: true,

--- a/src/lib/test-helpers/fixtures.ts
+++ b/src/lib/test-helpers/fixtures.ts
@@ -205,6 +205,7 @@ export const mockSettings: AppSettings = {
   calendar_reminder_minutes: 2,
   calendar_autostart_enabled: true,
   feedback_sounds_enabled: true,
+  pill_hidden: false,
   feedback_sounds_volume: 70,
   model_unload_timeout_minutes: 60,
   meeting_autostop_enabled: true,

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -555,12 +555,11 @@ async pillRelease() : Promise<Result<null, string>> {
 }
 },
 /**
- * Resize the pill window to `width` x `height` (logical pixels), keeping
- * its top edge pinned below the menu bar and staying horizontally
- * centered. The frontend calls this as the live transcript grows/shrinks
- * (e.g. switching between the compact and expanded live-text layouts): a
- * single native frame change avoids the top-edge drift that a separate
- * resize-then-recenter pair produces.
+ * Resize the pill window to `width` x `height` (logical pixels). A
+ * dragged position is kept (and clamped on-screen); otherwise the pill
+ * stays top-centered. The frontend calls this as the live transcript
+ * grows/shrinks. A single native frame change avoids the top-edge drift
+ * that a separate resize-then-recenter pair produces.
  */
 async pillResize(width: number, height: number) : Promise<Result<null, string>> {
     try {
@@ -1044,6 +1043,10 @@ auto_update_check_enabled: boolean;
  * Audible start/stop cues for dictation sessions.
  */
 feedback_sounds_enabled: boolean; 
+/**
+ * When true, the floating recording HUD is not shown.
+ */
+pill_hidden: boolean; 
 /**
  * Feedback sound volume (0-100).
  */


### PR DESCRIPTION
## Summary
- The dictation HUD no longer shrinks into a tiny scrolling box after a resolution or scale change. Size is the last logical size the frontend asked for (compact 280×64 until then), reapplied on every show and on `ScaleFactorChanged` — not a stale physical `outer_size` converted through the new scale.
- You can drag the overlay; the position is saved and clamped back on-screen if the display shrinks. Settings → Interface has a checkbox to hide it while dictating or in a meeting.

## Why
SOU-011: reboot fixed it because size was derived once from `outer_size()`; after a scale-up that leftover physical size ÷ new scale is ~140×32. SOU-012: same window code; a persisted origin must be re-validated against the current screen so the HUD cannot land off-screen.

## Test plan
- [ ] Start dictation on the current display: overlay is the normal compact pill, no scrollbars.
- [ ] Change display resolution or scaling while the app is running, then dictate again: overlay stays 280×64 (or the expanded live-text size), not a tiny box. Reboot should not be required.
- [ ] Drag the overlay elsewhere, stop dictation, quit and relaunch, dictate again: it comes back where you left it.
- [ ] Drag it near a corner, then switch to a smaller resolution: it stays fully on-screen.
- [ ] Settings → Interface → hide overlay: HUD does not appear during dictation or a meeting; uncheck and it comes back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a setting to hide or show the recording overlay.
  - The overlay now remembers its dragged position between sessions and across displays.
  - Overlay placement stays on-screen and adapts to display scaling.
  - Resizing supports growing and shrinking live transcripts while preserving positioning.
  - Added localized English and French descriptions for the new setting.

- **Bug Fixes**
  - Restored overlay visibility and position consistently when the app starts or settings are refreshed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->