### PR TITLE
Let you copy the last dictation from the menu bar

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -71,6 +71,32 @@ pub fn paste_text(text: &str, delay_ms: u64, method: PasteMethod) -> Result<(), 
     Ok(())
 }
 
+/// Write `text` to the clipboard without pasting: no synthetic Cmd+V, no AX.
+/// Backs the tray's "Copy Last Transcription" action, which exists partly to
+/// work around SOU-010 (a paste landing with the wrong clipboard contents):
+/// the user recovers by copying the same text a broken paste just wrote.
+/// Cancelling the pending restore first is what makes that recovery work:
+/// otherwise `restore_clipboard` would see its own text still on the
+/// pasteboard and dutifully overwrite this copy with the pre-paste clipboard.
+pub fn copy_text(text: &str) -> Result<(), String> {
+    // Hold RESTORE across cancel + write: otherwise a restore that already
+    // passed `take_if_current` can still `set_text` the pre-paste clipboard
+    // after this copy returns. Same mutex as `restore_clipboard`.
+    let mut burst = lock_restore();
+    burst.cancel_pending_restore();
+
+    let mut clipboard = Clipboard::new().map_err(|e| format!("Clipboard init: {e}"))?;
+    clipboard
+        .set_text(text)
+        .map_err(|e| format!("Clipboard set: {e}"))?;
+
+    if !wait_for_clipboard(&mut clipboard, text) {
+        return Err("Clipboard write did not take effect.".to_string());
+    }
+
+    Ok(())
+}
+
 fn is_blank(text: &str) -> bool {
     text.trim().is_empty()
 }
@@ -181,12 +207,26 @@ impl RestoreBurst {
         }
         Some(self.original.take())
     }
+
+    /// Disown any in-flight restore: bumping the generation makes its
+    /// `take_if_current` check fail regardless of what text is on the
+    /// clipboard when it wakes up, and clearing the snapshot leaves nothing
+    /// to write back even if it somehow ran anyway.
+    fn cancel_pending_restore(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+        self.original = None;
+    }
 }
 
 static RESTORE: Mutex<RestoreBurst> = Mutex::new(RestoreBurst::new());
 
 fn lock_restore() -> std::sync::MutexGuard<'static, RestoreBurst> {
     RESTORE.lock().unwrap_or_else(|p| p.into_inner())
+}
+
+#[cfg(test)]
+fn cancel_pending_restore() {
+    lock_restore().cancel_pending_restore();
 }
 
 /// The restore waits out `CLIPBOARD_RESTORE_DELAY`, and `paste_text` is a
@@ -209,7 +249,16 @@ fn spawn_restore(previous: Option<String>, ours: String) {
 /// exercised in CI).
 fn restore_clipboard(generation: u64, ours: &str) -> bool {
     thread::sleep(CLIPBOARD_RESTORE_DELAY);
-    let Some(Some(previous)) = lock_restore().take_if_current(generation) else {
+    restore_clipboard_now(generation, ours)
+}
+
+/// Post-sleep half of the restore. Kept separate so tests can exercise the
+/// lock window without waiting out `CLIPBOARD_RESTORE_DELAY`.
+fn restore_clipboard_now(generation: u64, ours: &str) -> bool {
+    // Stay locked through the pasteboard write so `copy_text` cannot land a
+    // verified copy that we then overwrite with `previous`.
+    let mut burst = lock_restore();
+    let Some(Some(previous)) = burst.take_if_current(generation) else {
         return false;
     };
     let Ok(mut clipboard) = Clipboard::new() else {
@@ -339,5 +388,97 @@ mod tests {
         let (generation, has_snapshot) = burst.begin(None);
         assert!(!has_snapshot);
         assert_eq!(burst.take_if_current(generation), Some(None));
+    }
+
+    #[test]
+    fn cancel_pending_restore_blocks_a_scheduled_restore() {
+        // The SOU-010 recovery scenario: a paste is pending a restore, and
+        // the user copies before it fires. RestoreBurst has no notion of
+        // "text" (that check lives in restore_clipboard against the live
+        // pasteboard), so cancellation must be unconditional: it does not
+        // matter here whether the copy used the identical string the paste
+        // wrote.
+        let mut burst = RestoreBurst::new();
+        let (generation, has_snapshot) = burst.begin(Some("old clipboard".into()));
+        assert!(has_snapshot);
+
+        burst.cancel_pending_restore();
+
+        assert!(
+            burst.take_if_current(generation).is_none(),
+            "a copy must cancel the paste's pending restore, even with identical text"
+        );
+    }
+
+    #[test]
+    fn cancel_pending_restore_without_a_pending_paste_is_a_no_op() {
+        let mut burst = RestoreBurst::new();
+        burst.cancel_pending_restore();
+        // The old generation (0) is stale either way.
+        assert!(burst.take_if_current(0).is_none());
+        // The new generation (1) matches, but there was never a snapshot to
+        // restore, so restore_clipboard still has nothing to write back.
+        assert_eq!(burst.take_if_current(1), Some(None));
+    }
+
+    #[test]
+    fn a_new_paste_after_a_cancelled_restore_still_gets_its_own_snapshot() {
+        let mut burst = RestoreBurst::new();
+        let (first, _) = burst.begin(Some("notes".into()));
+        burst.cancel_pending_restore();
+        assert!(burst.take_if_current(first).is_none());
+
+        let (second, has_snapshot) = burst.begin(Some("clipboard after copy".into()));
+        assert!(has_snapshot);
+        assert_eq!(
+            burst.take_if_current(second),
+            Some(Some("clipboard after copy".into()))
+        );
+    }
+
+    #[test]
+    fn cancel_waits_out_a_restore_that_already_took_its_snapshot() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::{Arc, Barrier};
+        use std::time::Duration;
+
+        // The race CodeRabbit flagged: restore has already passed
+        // take_if_current (and still holds RESTORE through the write).
+        // cancel_pending_restore must not run until that lock is released,
+        // or copy_text can land and then be overwritten by previous.
+        let generation = {
+            let mut burst = lock_restore();
+            burst.begin(Some("old clipboard".into())).0
+        };
+
+        let barrier = Arc::new(Barrier::new(2));
+        let cancel_returned = Arc::new(AtomicBool::new(false));
+        let cancel_handle = {
+            let barrier = Arc::clone(&barrier);
+            let cancel_returned = Arc::clone(&cancel_returned);
+            thread::spawn(move || {
+                barrier.wait();
+                cancel_pending_restore();
+                cancel_returned.store(true, Ordering::SeqCst);
+            })
+        };
+
+        {
+            let mut burst = lock_restore();
+            assert_eq!(
+                burst.take_if_current(generation),
+                Some(Some("old clipboard".into()))
+            );
+            barrier.wait();
+            thread::sleep(Duration::from_millis(50));
+            assert!(
+                !cancel_returned.load(Ordering::SeqCst),
+                "cancel must block until the in-flight restore releases RESTORE"
+            );
+        }
+
+        cancel_handle.join().expect("cancel thread");
+        assert!(cancel_returned.load(Ordering::SeqCst));
+        *lock_restore() = RestoreBurst::new();
     }
 }

--- a/src-tauri/src/commands/dictation.rs
+++ b/src-tauri/src/commands/dictation.rs
@@ -22,21 +22,29 @@ pub fn list_dictation_entries(
 pub fn add_dictation_entry(state: State<'_, AppState>, text: String) -> Result<(), String> {
     let id = uuid::Uuid::new_v4().to_string();
     let timestamp = chrono::Utc::now().to_rfc3339();
-    state.db.add_dictation_entry(&id, &text, &timestamp)
+    state.db.add_dictation_entry(&id, &text, &timestamp)?;
+    // The Idle transition also syncs the tray, but it fires before this write
+    // (the frontend saves history only after stop resolves).
+    sync_tray(&state);
+    Ok(())
 }
 
 /// Delete a single dictation entry
 #[tauri::command]
 #[specta::specta]
 pub fn delete_dictation_entry(state: State<'_, AppState>, id: String) -> Result<(), String> {
-    state.db.delete_dictation_entry(&id)
+    state.db.delete_dictation_entry(&id)?;
+    sync_tray(&state);
+    Ok(())
 }
 
 /// Clear all dictation history
 #[tauri::command]
 #[specta::specta]
 pub fn clear_dictation_history(state: State<'_, AppState>) -> Result<(), String> {
-    state.db.clear_dictation_entries()
+    state.db.clear_dictation_entries()?;
+    sync_tray(&state);
+    Ok(())
 }
 
 /// Optional LLM polish pass for dictation text before paste/history.
@@ -64,4 +72,13 @@ pub async fn polish_dictation(
         rewrite_of.as_deref(),
     )
     .await)
+}
+
+/// Best-effort tray refresh so "Copy Last Transcription" tracks history.
+/// No-op without a handle (tests, early startup) — same tolerance as
+/// `apply_transition`.
+fn sync_tray(state: &AppState) {
+    if let (Ok(app), Ok(machine)) = (state.app_handle(), state.current_machine_state()) {
+        crate::tray::sync(&app, &machine);
+    }
 }

--- a/src-tauri/src/db/dictation.rs
+++ b/src-tauri/src/db/dictation.rs
@@ -6,7 +6,7 @@ use crate::lock_ext::MutexExt;
 use super::Database;
 
 /// A dictation history entry
-#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
 pub struct DictationEntry {
     pub id: String,
     pub text: String,

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -2,10 +2,12 @@ use tauri::image::Image;
 use tauri::menu::{Menu, MenuItem};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
 use tauri::{AppHandle, Manager, Wry};
+use tauri_plugin_notification::NotificationExt;
 use tauri_specta::Event;
 use tracing::{info, warn};
 
 use crate::app_events::{AppView, MeetingStopRequested, Navigate, ShortcutToggle};
+use crate::db::dictation::DictationEntry;
 use crate::state::AppState;
 use crate::state_machine::AppStateMachine;
 
@@ -15,6 +17,7 @@ const TRAY_ID: &str = "tray";
 struct TrayHandles {
     dictation: MenuItem<Wry>,
     meeting: MenuItem<Wry>,
+    copy_last_transcription: MenuItem<Wry>,
 }
 
 /// Monochrome template icon (black + alpha — macOS recolors it).
@@ -36,6 +39,17 @@ fn is_french(app: &AppHandle) -> bool {
         .unwrap_or(false)
 }
 
+/// Whether "Copy Last Transcription" has anything to act on. Re-checked in
+/// `sync` too, since a dictation completing does not by itself flip this
+/// (see the doc comment on `sync`).
+fn has_dictation_history(app: &AppHandle) -> bool {
+    app.state::<AppState>()
+        .db
+        .count_dictation_entries()
+        .map(|count| count > 0)
+        .unwrap_or(false)
+}
+
 fn label(key: &str, fr: bool) -> &'static str {
     match (key, fr) {
         ("start_dictation", false) => "Start Dictation",
@@ -46,6 +60,8 @@ fn label(key: &str, fr: bool) -> &'static str {
         ("start_meeting", true) => "Démarrer un meeting",
         ("stop_meeting", false) => "Stop Meeting Recording",
         ("stop_meeting", true) => "Arrêter le meeting",
+        ("copy_last_transcription", false) => "Copy Last Transcription",
+        ("copy_last_transcription", true) => "Copier la dernière transcription",
         ("settings", false) => "Settings",
         ("settings", true) => "Réglages",
         ("show", false) => "Show Window",
@@ -54,6 +70,123 @@ fn label(key: &str, fr: bool) -> &'static str {
         ("quit", true) => "Quitter",
         _ => "",
     }
+}
+
+/// Outcome of a "Copy Last Transcription" attempt, driving both the
+/// notification and (for failures) the log line. `Ok` carries nothing: the
+/// success notification text does not vary.
+#[derive(Debug, PartialEq)]
+enum CopyOutcome {
+    NoHistory,
+    DbError,
+    NotVerified,
+}
+
+/// Pure decision: which entry (if any) a copy attempt acts on. Split out from
+/// `copy_last_transcription_to_clipboard` so the "no history" / "db error" /
+/// "found an entry" branching is testable without a live AppHandle.
+fn select_dictation_to_copy(
+    entries: Result<Vec<DictationEntry>, String>,
+) -> Result<DictationEntry, CopyOutcome> {
+    match entries {
+        Err(_) => Err(CopyOutcome::DbError),
+        Ok(mut entries) => {
+            if entries.is_empty() {
+                Err(CopyOutcome::NoHistory)
+            } else {
+                Ok(entries.remove(0))
+            }
+        }
+    }
+}
+
+fn copy_notification_text(
+    result: &Result<(), CopyOutcome>,
+    fr: bool,
+) -> (&'static str, &'static str) {
+    match result {
+        Ok(()) => (
+            if fr {
+                "Copié dans le presse-papiers"
+            } else {
+                "Copied to clipboard"
+            },
+            if fr {
+                "Votre dernière dictée a été copiée dans le presse-papiers."
+            } else {
+                "Your last dictation was copied to the clipboard."
+            },
+        ),
+        Err(CopyOutcome::NoHistory) => (
+            if fr {
+                "Rien à copier"
+            } else {
+                "Nothing to copy"
+            },
+            if fr {
+                "Aucune dictée n'a encore été enregistrée."
+            } else {
+                "No dictation has been recorded yet."
+            },
+        ),
+        Err(CopyOutcome::DbError) => (
+            if fr {
+                "Échec de la copie"
+            } else {
+                "Copy failed"
+            },
+            if fr {
+                "Impossible de lire l'historique des dictées."
+            } else {
+                "Could not read your dictation history."
+            },
+        ),
+        Err(CopyOutcome::NotVerified) => (
+            if fr {
+                "Échec de la copie"
+            } else {
+                "Copy failed"
+            },
+            if fr {
+                "Le presse-papiers n'a pas été mis à jour. Réessayez."
+            } else {
+                "The clipboard did not update. Please try again."
+            },
+        ),
+    }
+}
+
+fn notify_copy_result(app: &AppHandle, fr: bool, result: &Result<(), CopyOutcome>) {
+    let (title, body) = copy_notification_text(result, fr);
+    if let Err(e) = app.notification().builder().title(title).body(body).show() {
+        warn!("Copy last transcription notification failed: {e}");
+    }
+}
+
+/// Copy the newest dictation to the clipboard (tray "Copy Last
+/// Transcription"). Dictations only, meeting transcripts are out of scope,
+/// per the ticket. Always notifies: a tray action with no visible result is
+/// confusing, and staying silent on failure defeats the point of a feature
+/// whose whole purpose is to recover from a bad paste (SOU-010) without
+/// opening the app.
+fn copy_last_transcription_to_clipboard(app: &AppHandle) {
+    let fr = is_french(app);
+    let entries = app.state::<AppState>().db.list_dictation_entries(1);
+    if let Err(e) = &entries {
+        warn!("Copy last transcription: dictation history read failed: {e}");
+    }
+
+    let result = select_dictation_to_copy(entries).and_then(|entry| {
+        crate::clipboard::copy_text(&entry.text).map_err(|e| {
+            warn!("Copy last transcription: clipboard write failed: {e}");
+            CopyOutcome::NotVerified
+        })
+    });
+
+    if result.is_ok() {
+        info!("Copied last dictation to clipboard via tray");
+    }
+    notify_copy_result(app, fr, &result);
 }
 
 /// Bring the main window to the front. The recording pill is a visible
@@ -120,6 +253,13 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         true,
         None::<&str>,
     )?;
+    let copy_last_transcription = MenuItem::with_id(
+        app,
+        "copy_last_transcription",
+        label("copy_last_transcription", fr),
+        has_dictation_history(app),
+        None::<&str>,
+    )?;
     let separator = MenuItem::with_id(app, "sep", "─────────", false, None::<&str>)?;
     let settings = MenuItem::with_id(app, "settings", label("settings", fr), true, None::<&str>)?;
     let show = MenuItem::with_id(app, "show", label("show", fr), true, None::<&str>)?;
@@ -130,6 +270,7 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
         &[
             &toggle_dictation,
             &toggle_meeting,
+            &copy_last_transcription,
             &separator,
             &settings,
             &show,
@@ -140,6 +281,7 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
     app.manage(TrayHandles {
         dictation: toggle_dictation,
         meeting: toggle_meeting,
+        copy_last_transcription,
     });
 
     TrayIconBuilder::with_id(TRAY_ID)
@@ -167,6 +309,9 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
                     show_main_window(app);
                     let _ = Navigate(AppView::Home).emit(app);
                 }
+            }
+            "copy_last_transcription" => {
+                copy_last_transcription_to_clipboard(app);
             }
             "settings" => {
                 show_main_window(app);
@@ -199,8 +344,13 @@ pub fn setup_tray(app: &AppHandle) -> Result<(), Box<dyn std::error::Error>> {
 
 /// Reflect the machine state in the menu bar: recording shows the red-dot
 /// icon and Stop labels. Also called after settings save so a locale change
-/// relabels the menu. Never re-acquires the machine lock (the caller may
-/// hold it) — the state is passed in.
+/// relabels the menu, and after `add_dictation_entry` so "Copy Last
+/// Transcription" enables itself as soon as the entry is actually in the
+/// database. The state-machine transition back to Idle fires before that
+/// write happens (the frontend saves history only after the stop command
+/// resolves), so relying on it alone would leave the item disabled until
+/// some unrelated later sync. Never re-acquires the machine lock (the caller
+/// may hold it) — the state is passed in.
 pub fn sync(app: &AppHandle, machine: &AppStateMachine) {
     let Some(tray) = app.tray_by_id(TRAY_ID) else {
         return;
@@ -238,12 +388,21 @@ pub fn sync(app: &AppHandle, machine: &AppStateMachine) {
             },
             fr,
         ));
+        let _ = handles
+            .copy_last_transcription
+            .set_text(label("copy_last_transcription", fr));
+        let _ = handles
+            .copy_last_transcription
+            .set_enabled(has_dictation_history(app));
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::should_restore_main_on_reopen;
+    use super::{
+        CopyOutcome, DictationEntry, copy_notification_text, label, select_dictation_to_copy,
+        should_restore_main_on_reopen,
+    };
 
     #[test]
     fn dock_reopen_restores_main_even_when_the_pill_counts_as_visible() {
@@ -252,5 +411,105 @@ mod tests {
             "the overlay panel is a visible NSWindow; gating on has_visible_windows leaves the main UI stuck behind"
         );
         assert!(should_restore_main_on_reopen(false));
+    }
+
+    fn entry(text: &str) -> DictationEntry {
+        DictationEntry {
+            id: "d1".to_string(),
+            text: text.to_string(),
+            timestamp: "2024-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn no_dictation_history_selects_the_no_history_outcome() {
+        assert_eq!(
+            select_dictation_to_copy(Ok(vec![])),
+            Err(CopyOutcome::NoHistory)
+        );
+    }
+
+    #[test]
+    fn a_database_error_selects_the_db_error_outcome() {
+        assert_eq!(
+            select_dictation_to_copy(Err("disk full".to_string())),
+            Err(CopyOutcome::DbError)
+        );
+    }
+
+    #[test]
+    fn the_newest_entry_is_selected_when_present() {
+        let selected = select_dictation_to_copy(Ok(vec![entry("hello"), entry("older")]))
+            .expect("an entry was found");
+        assert_eq!(selected.text, "hello");
+    }
+
+    #[test]
+    fn copy_menu_label_matches_locale() {
+        assert_eq!(
+            label("copy_last_transcription", false),
+            "Copy Last Transcription"
+        );
+        assert_eq!(
+            label("copy_last_transcription", true),
+            "Copier la dernière transcription"
+        );
+    }
+
+    #[test]
+    fn copy_notification_text_covers_every_outcome_in_both_locales() {
+        let cases: [(Result<(), CopyOutcome>, bool, &str, &str); 8] = [
+            (
+                Ok(()),
+                false,
+                "Copied to clipboard",
+                "Your last dictation was copied to the clipboard.",
+            ),
+            (
+                Ok(()),
+                true,
+                "Copié dans le presse-papiers",
+                "Votre dernière dictée a été copiée dans le presse-papiers.",
+            ),
+            (
+                Err(CopyOutcome::NoHistory),
+                false,
+                "Nothing to copy",
+                "No dictation has been recorded yet.",
+            ),
+            (
+                Err(CopyOutcome::NoHistory),
+                true,
+                "Rien à copier",
+                "Aucune dictée n'a encore été enregistrée.",
+            ),
+            (
+                Err(CopyOutcome::DbError),
+                false,
+                "Copy failed",
+                "Could not read your dictation history.",
+            ),
+            (
+                Err(CopyOutcome::DbError),
+                true,
+                "Échec de la copie",
+                "Impossible de lire l'historique des dictées.",
+            ),
+            (
+                Err(CopyOutcome::NotVerified),
+                false,
+                "Copy failed",
+                "The clipboard did not update. Please try again.",
+            ),
+            (
+                Err(CopyOutcome::NotVerified),
+                true,
+                "Échec de la copie",
+                "Le presse-papiers n'a pas été mis à jour. Réessayez.",
+            ),
+        ];
+        for (result, fr, title, body) in cases {
+            assert_eq!(copy_notification_text(&result, fr), (title, body));
+        }
     }
 }


### PR DESCRIPTION
Closes SOU-016.

When a paste lands with the wrong clipboard contents, recovering the transcription meant opening the app. The menu-bar icon now has **Copy Last Transcription** / **Copier la dernière transcription**: one click copies the newest dictation, and a notification confirms it.

## Why this also covers SOU-010

A dictation paste restores the previous clipboard after 400ms. Copying the same text before that restore would look like it worked, then get overwritten. The copy cancels the in-flight restore first, so the recovery actually sticks.

`copy_text` and `restore_clipboard` also share the restore mutex through the pasteboard write. Cancelling only invalidates restores that have not yet passed `take_if_current`; without the lock, a restore that already took its snapshot could still overwrite a copy of the same text after `copy_text` returned.

Dictations only — meeting transcripts are out of scope.

## Enable / disable

The item starts disabled with an empty history. `add_dictation_entry` re-syncs the tray because the Idle transition fires before the frontend writes history. Delete and clear do the same, so clearing history actually greys the item out.

## Testing

Clipboard unit tests cover cancel-before-restore, a new paste after cancel, and cancel blocking until an in-flight restore releases the mutex. Tray click and the 400ms-after-paste recovery are not exercisable in CI.

## Test plan

- [ ] With at least one dictation in history, copy from the tray without opening the app, then paste elsewhere
- [ ] Empty history: item is disabled
- [ ] After a dictation finishes, the item enables without waiting for some other tray sync
- [ ] After clearing history in Settings, the item disables
- [ ] Dictate, then copy from the tray within ~400ms of the paste: clipboard stays the transcription, not the pre-paste contents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tray-menu option to copy the newest dictation transcription to the clipboard.
  * The option is available when dictation history contains entries.
  * Added localized success and failure notifications for copy actions.

* **Bug Fixes**
  * The tray now refreshes after dictation history is added, deleted, or cleared.
  * Clipboard copying verifies that the requested transcription was copied successfully and prevents pending restores from overwriting it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->