### PR TITLE
Keep the transcript timeline when stall recovery rebuilds the engine

### DIFF
--- a/src-tauri/src/engine/kyutai.rs
+++ b/src-tauri/src/engine/kyutai.rs
@@ -434,6 +434,27 @@ impl KyutaiEngine {
         *frames = 0;
     }
 
+    /// Compute the epoch origins and monotonic floors to carry into a
+    /// rebuilt model, by applying `credit_lane_epoch`'s arithmetic to every
+    /// lane. Used by a stall-recovery rebuild, which must not rewind the
+    /// transcript the way a session-boundary `reset_state` deliberately
+    /// does. `last_emitted_start` already reflects each lane's true
+    /// wall-clock position and is returned unchanged.
+    fn carry_timeline_across_rebuild(
+        epoch_origin_seconds: &[f64],
+        time_offset_seconds: &[f64],
+        frames_since_lane_reset: &[usize],
+        last_emitted_start: &[f64],
+    ) -> (Vec<f64>, Vec<f64>) {
+        let mut origin = epoch_origin_seconds.to_vec();
+        let mut offset = time_offset_seconds.to_vec();
+        let mut frames = frames_since_lane_reset.to_vec();
+        for lane in 0..origin.len() {
+            Self::credit_lane_epoch(&mut origin, &mut offset, &mut frames, lane);
+        }
+        (origin, last_emitted_start.to_vec())
+    }
+
     fn pending_to_segment(pending: PendingWord, end_time: f64) -> TranscriptionSegment {
         TranscriptionSegment {
             text: pending.text,
@@ -862,12 +883,38 @@ impl KyutaiEngine {
     /// Full rebuild of Mimi + LM + State from disk because moshi's
     /// State::reset() does NOT reset model_step_idx, causing RoPE
     /// positional encoding to start at the wrong offset with empty KV caches.
-    /// Teardown and rebuild use separate autorelease pools so stale Metal
-    /// objects are drained before a fresh device/model is created.
     ///
     /// Mid-session freezes should use soft `refresh_loaded` instead; this
     /// full rebuild remains for session boundaries and diarize mode changes.
+    /// A genuinely new session should start its timeline at zero, so this
+    /// does not carry the old model's timeline over.
     pub fn reset_state(&mut self) -> Result<(), EngineError> {
+        self.rebuild_model(false)?;
+        info!("ASR state rebuilt for new session");
+        Ok(())
+    }
+
+    /// Same full rebuild as `reset_state`, but for stall recovery: the
+    /// session is still ongoing, so every lane's elapsed audio is credited
+    /// into the rebuilt model's epoch origin first, and the monotonic floors
+    /// carry over too. Without this, a stall-recovery rebuild would silently
+    /// rewind every subsequent timestamp to 0 (see SOU-002), and the
+    /// `monotonic_time` safety net can't catch it because it is the floor
+    /// that gets zeroed.
+    pub fn reset_state_preserving_timeline(&mut self) -> Result<(), EngineError> {
+        self.rebuild_model(true)?;
+        info!("ASR state rebuilt mid-session, timeline preserved");
+        Ok(())
+    }
+
+    /// Shared teardown-and-rebuild for `reset_state` and
+    /// `reset_state_preserving_timeline`. Teardown and rebuild use separate
+    /// autorelease pools so stale Metal objects are drained before a fresh
+    /// device/model is created. Everything but the timeline (KV state,
+    /// `frames_since_refresh`, `refresh_count`, `vad_pause_streak`,
+    /// `language_tracker`, `pending_words`, `prefix_pending`) is always
+    /// reinitialised: the point of the reset is to discard the wedged state.
+    fn rebuild_model(&mut self, preserve_timeline: bool) -> Result<(), EngineError> {
         FRAME_COUNT.store(0, Ordering::Relaxed);
         if let Ok(mut dbg) = DEBUG_SAMPLES.lock() {
             *dbg = None;
@@ -882,6 +929,24 @@ impl KyutaiEngine {
         let batch_size = self.batch_size();
         let meeting_language_prior = self.meeting_language_prior;
         let old = self.model.take().ok_or(EngineError::NotInitialized)?;
+
+        // Read the timeline off the old model before its fields are moved
+        // into the drop/rebuild closures below.
+        let carried_timeline = preserve_timeline.then(|| {
+            Self::carry_timeline_across_rebuild(
+                &old.epoch_origin_seconds,
+                &old.time_offset_seconds,
+                &old.frames_since_lane_reset,
+                &old.last_emitted_start,
+            )
+        });
+        // A word mid-utterance when the rebuild happens has no EndWord yet
+        // and is silently dropped by the `..` below: there is no return path
+        // here for a trailing segment without a larger change to this
+        // reset's return type, so this is only a log breadcrumb, not a fix.
+        let dropped_pending = old.pending_words.iter().filter(|w| w.is_some()).count();
+        let dropped_orphaned = old.orphaned_words.len();
+
         let LoadedModel {
             state: old_state,
             text_tokenizer,
@@ -896,7 +961,7 @@ impl KyutaiEngine {
             drop(old_device);
         });
 
-        let rebuilt = with_autorelease_pool(move || -> Result<LoadedModel, EngineError> {
+        let mut rebuilt = with_autorelease_pool(move || -> Result<LoadedModel, EngineError> {
             let device = Self::select_device()?;
             Self::build_loaded_model(
                 device,
@@ -908,8 +973,34 @@ impl KyutaiEngine {
             )
         })?;
 
+        if let Some((epoch_origin_seconds, last_emitted_start)) = carried_timeline {
+            // The rebuilt model's vectors are sized from `batch_size`, so a
+            // carried vector should be the same length; fall back to the
+            // fresh (zeroed) timeline rather than indexing blindly if not.
+            if epoch_origin_seconds.len() == rebuilt.epoch_origin_seconds.len()
+                && last_emitted_start.len() == rebuilt.last_emitted_start.len()
+            {
+                rebuilt.epoch_origin_seconds = epoch_origin_seconds;
+                rebuilt.last_emitted_start = last_emitted_start;
+            } else {
+                warn!(
+                    old_lanes = epoch_origin_seconds.len(),
+                    new_lanes = rebuilt.epoch_origin_seconds.len(),
+                    "Stall recovery rebuild changed lane count; timeline not carried over"
+                );
+            }
+        }
+
+        if preserve_timeline && (dropped_pending > 0 || dropped_orphaned > 0) {
+            warn!(
+                dropped_pending,
+                dropped_orphaned,
+                "Stall recovery rebuild dropped in-flight word(s) with no EndWord: \
+                 the transcript is missing whatever was being said right before the freeze"
+            );
+        }
+
         self.model = Some(rebuilt);
-        info!("ASR state rebuilt for new session");
         Ok(())
     }
 }
@@ -1107,6 +1198,10 @@ impl TranscriptionEngine for KyutaiEngine {
 
     fn reset_state(&mut self) -> Result<(), EngineError> {
         KyutaiEngine::reset_state(self)
+    }
+
+    fn reset_state_preserving_timeline(&mut self) -> Result<(), EngineError> {
+        KyutaiEngine::reset_state_preserving_timeline(self)
     }
 
     fn supports_diarization(&self) -> bool {
@@ -1314,6 +1409,69 @@ mod tests {
         assert_eq!(origin[1], 58.0);
         assert_eq!(offset[1], 1.04);
         assert_eq!(frames[1], 300);
+    }
+
+    #[test]
+    fn carry_timeline_across_rebuild_credits_a_lane_mid_epoch() {
+        // 10s of real audio decoded (125 frames at 12.5 fps), no prefix left
+        // to subtract: the full 10s must be credited into the origin.
+        let origin = [10.0f64];
+        let offset = [0.0f64];
+        let frames = [125usize];
+        let last_emitted = [9.5f64];
+
+        let (carried_origin, carried_last_emitted) =
+            KyutaiEngine::carry_timeline_across_rebuild(&origin, &offset, &frames, &last_emitted);
+
+        assert_eq!(carried_origin, vec![20.0]);
+        // Monotonic floors are copied through untouched: they already reflect
+        // each lane's true wall-clock position.
+        assert_eq!(carried_last_emitted, vec![9.5]);
+    }
+
+    #[test]
+    fn carry_timeline_across_rebuild_leaves_an_already_credited_lane_unchanged() {
+        // Freshly refreshed lane: no frames decoded since its last credit.
+        let origin = [42.0f64];
+        let offset = [0.0f64];
+        let frames = [0usize];
+        let last_emitted = [42.0f64];
+
+        let (carried_origin, _) =
+            KyutaiEngine::carry_timeline_across_rebuild(&origin, &offset, &frames, &last_emitted);
+
+        assert_eq!(carried_origin, vec![42.0]);
+    }
+
+    #[test]
+    fn carry_timeline_across_rebuild_does_not_double_count_the_prefix() {
+        // Epoch opened with a 13-frame (1.04s) silence prefix and only that
+        // prefix has been fed so far: the prefix must not itself be credited
+        // as real audio.
+        let origin = [5.0f64];
+        let offset = [1.04f64];
+        let frames = [13usize];
+        let last_emitted = [5.0f64];
+
+        let (carried_origin, _) =
+            KyutaiEngine::carry_timeline_across_rebuild(&origin, &offset, &frames, &last_emitted);
+
+        assert_eq!(carried_origin, vec![5.0]);
+    }
+
+    #[test]
+    fn carry_timeline_across_rebuild_clamps_a_negative_credit_at_zero() {
+        // Fewer frames decoded than the prefix accounts for (shouldn't
+        // happen, but `credit_lane_epoch` clamps rather than going negative).
+        let origin = [7.0f64];
+        let offset = [1.04f64];
+        let frames = [5usize];
+        let last_emitted = [7.0f64];
+
+        let (carried_origin, _) =
+            KyutaiEngine::carry_timeline_across_rebuild(&origin, &offset, &frames, &last_emitted);
+
+        assert_eq!(carried_origin, vec![7.0]);
     }
 
     #[test]

--- a/src-tauri/src/engine/mock.rs
+++ b/src-tauri/src/engine/mock.rs
@@ -23,6 +23,13 @@ pub struct MockEngine {
     /// Shared with tests via `reset_state_count_handle()`, for asserting the
     /// actor's pre-warm / skip-reset-when-fresh behavior.
     reset_state_count: Arc<AtomicUsize>,
+    /// Shared with tests via `reset_state_preserving_count_handle()`. Kept
+    /// separate from `reset_state_count` so a test can tell the two
+    /// `TranscriptionEngine` reset methods apart: the trait default routes
+    /// `reset_state_preserving_timeline()` back into `reset_state()`, so a
+    /// single shared counter would climb identically no matter which one the
+    /// caller actually invoked.
+    reset_state_preserving_count: Arc<AtomicUsize>,
     /// Value returned by `emission_delay_seconds()`; configurable via
     /// `with_emission_delay_seconds` for drain-window tests.
     emission_delay_seconds: f64,
@@ -48,6 +55,7 @@ impl MockEngine {
             flush_responses: VecDeque::new(),
             unload_count: Arc::new(AtomicUsize::new(0)),
             reset_state_count: Arc::new(AtomicUsize::new(0)),
+            reset_state_preserving_count: Arc::new(AtomicUsize::new(0)),
             emission_delay_seconds: 0.0,
             tail_drained_schedule: VecDeque::new(),
             tail_drained_value: false,
@@ -64,6 +72,12 @@ impl MockEngine {
     /// into the actor's factory closure.
     pub fn reset_state_count_handle(&self) -> Arc<AtomicUsize> {
         Arc::clone(&self.reset_state_count)
+    }
+
+    /// Clone of the reset_state_preserving_timeline call counter; call
+    /// before the mock is moved into the actor's factory closure.
+    pub fn reset_state_preserving_count_handle(&self) -> Arc<AtomicUsize> {
+        Arc::clone(&self.reset_state_preserving_count)
     }
 
     /// Configure the value returned by `emission_delay_seconds()`.
@@ -142,6 +156,12 @@ impl TranscriptionEngine for MockEngine {
 
     fn reset_state(&mut self) -> Result<(), EngineError> {
         self.reset_state_count.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    fn reset_state_preserving_timeline(&mut self) -> Result<(), EngineError> {
+        self.reset_state_preserving_count
+            .fetch_add(1, Ordering::SeqCst);
         Ok(())
     }
 

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -209,6 +209,16 @@ pub trait TranscriptionEngine {
     ) -> Result<Vec<TranscriptionSegment>, EngineError>;
     fn flush(&mut self) -> Result<Vec<TranscriptionSegment>, EngineError>;
     fn reset_state(&mut self) -> Result<(), EngineError>;
+    /// Reset the engine's internal state mid-session without rewinding the
+    /// transcript: the timeline carries over so words after the reset keep
+    /// timestamps continuous with the ones before it. Each engine implements
+    /// this against whatever it tracks as session-elapsed time (Kyutai's
+    /// per-lane epoch origin, Whisper/Parakeet's `consumed_samples`); the
+    /// default here is only a fallback for an engine that overrides neither,
+    /// and simply rewinds like a session-start `reset_state`.
+    fn reset_state_preserving_timeline(&mut self) -> Result<(), EngineError> {
+        self.reset_state()
+    }
     /// Audio format requirements for this engine's inference pipeline.
     /// Used by the audio capture thread (target sample rate) and the
     /// inference pipeline (chunk size) to adapt to each engine.

--- a/src-tauri/src/engine/parakeet.rs
+++ b/src-tauri/src/engine/parakeet.rs
@@ -43,6 +43,18 @@ impl ParakeetEngine {
         }
     }
 
+    /// Shared implementation for `reset_state` and
+    /// `reset_state_preserving_timeline`: both must drop the buffered audio
+    /// a wedged engine choked on. Only a plain reset also drops
+    /// `consumed_samples`, since a stall-recovery reset happens mid-session
+    /// and must keep the window-timestamp offset continuous.
+    fn reset_buffer(&mut self, preserve_timeline: bool) {
+        self.audio_buffer.clear();
+        if !preserve_timeline {
+            self.consumed_samples = 0;
+        }
+    }
+
     /// Session-time offset (seconds) for the next inference window,
     /// then advance by the window length.
     fn take_window_offset(&mut self, window_len: usize) -> f64 {
@@ -172,8 +184,12 @@ impl TranscriptionEngine for ParakeetEngine {
 
     fn reset_state(&mut self) -> Result<(), EngineError> {
         // TDT inference is stateless per window; only our buffer carries over.
-        self.audio_buffer.clear();
-        self.consumed_samples = 0;
+        self.reset_buffer(false);
+        Ok(())
+    }
+
+    fn reset_state_preserving_timeline(&mut self) -> Result<(), EngineError> {
+        self.reset_buffer(true);
         Ok(())
     }
 

--- a/src-tauri/src/engine/whisper.rs
+++ b/src-tauri/src/engine/whisper.rs
@@ -156,6 +156,20 @@ impl WhisperEngine {
         offset
     }
 
+    /// Shared implementation for `reset_state` and
+    /// `reset_state_preserving_timeline`: both must drop the buffered audio
+    /// a wedged engine choked on. Only a plain reset also drops
+    /// `consumed_samples` and `detected_language`, since a stall-recovery
+    /// reset happens mid-session against the same speaker and must keep the
+    /// window-timestamp offset and cached language continuous.
+    fn reset_buffer(&mut self, preserve_timeline: bool) {
+        self.audio_buffer.clear();
+        if !preserve_timeline {
+            self.detected_language = None;
+            self.consumed_samples = 0;
+        }
+    }
+
     /// Run inference on a chunk of audio. Returns detected language code
     /// alongside the transcription segments.
     fn run_inference(
@@ -381,10 +395,12 @@ impl TranscriptionEngine for WhisperEngine {
     }
 
     fn reset_state(&mut self) -> Result<(), EngineError> {
-        self.audio_buffer.clear();
-        // Clear cached language so next session auto-detects fresh
-        self.detected_language = None;
-        self.consumed_samples = 0;
+        self.reset_buffer(false);
+        Ok(())
+    }
+
+    fn reset_state_preserving_timeline(&mut self) -> Result<(), EngineError> {
+        self.reset_buffer(true);
         Ok(())
     }
 

--- a/src-tauri/src/pipeline/actor.rs
+++ b/src-tauri/src/pipeline/actor.rs
@@ -1219,22 +1219,7 @@ fn run_session_loop(
                 let _ = snapshot.emit(app);
             }
             match action {
-                Some(StallAction::Reset) => {
-                    warn!(
-                        "Session {session_id} stalled for 30s with no frames processed; \
-                         attempting in-place engine reset"
-                    );
-                    // Match the panic protection already used for engine
-                    // calls in this loop (mode.step / catch_engine below): a
-                    // broken engine must not take the actor thread down
-                    // while we try to recover it.
-                    match catch_engine(|| engine.reset_state()) {
-                        Ok(()) => info!("Session {session_id}: stall recovery reset succeeded"),
-                        Err(e) => {
-                            warn!("Session {session_id}: stall recovery reset failed: {e}")
-                        }
-                    }
-                }
+                Some(StallAction::Reset) => attempt_stall_recovery_reset(engine, session_id),
                 Some(StallAction::Abort) => {
                     let message = "The transcription engine stopped responding; \
                                     the recording so far was saved."
@@ -1563,6 +1548,28 @@ fn finish_session(
     }
 }
 
+/// Attempt an in-place engine reset as part of stall recovery. The session
+/// is still live when this fires, so it must go through
+/// `reset_state_preserving_timeline` and not the plain `reset_state` used at
+/// session boundaries: the latter would silently rewind every timestamp
+/// after the reset to 0 (SOU-002). Broken out of `run_session_loop` so this
+/// one branch can be unit tested directly against a mock engine, without
+/// driving the real `SessionHealth`/`StallRecovery` timing (30+ real
+/// seconds) through the full session loop.
+fn attempt_stall_recovery_reset(engine: &mut dyn TranscriptionEngine, session_id: u64) {
+    warn!(
+        "Session {session_id} stalled for 30s with no frames processed; \
+         attempting in-place engine reset"
+    );
+    // Match the panic protection already used for engine calls in this loop
+    // (mode.step / catch_engine below): a broken engine must not take the
+    // actor thread down while we try to recover it.
+    match catch_engine(|| engine.reset_state_preserving_timeline()) {
+        Ok(()) => info!("Session {session_id}: stall recovery reset succeeded"),
+        Err(e) => warn!("Session {session_id}: stall recovery reset failed: {e}"),
+    }
+}
+
 /// Run a fallible engine call, converting a panic into an `Err` so a bug in the
 /// engine/Metal/candle path degrades to a logged error instead of unwinding out
 /// of the actor thread (or, under abort, taking down the whole process).
@@ -1650,7 +1657,7 @@ mod tests {
 
     use super::{
         EngineActorHandle, SessionConfig, SessionMode, SessionSummary, SingleMode, TextFilterChain,
-        finish_session,
+        attempt_stall_recovery_reset, finish_session,
     };
 
     /// Helper: create a disabled filter config for tests (no VAD, no text filters).
@@ -2722,6 +2729,36 @@ mod tests {
         assert!(
             wait_for(|| reset_count.load(Ordering::SeqCst) >= 4, Duration::from_secs(2)),
             "post-session pre-warm resets back to single-stream"
+        );
+    }
+
+    // Driving the stall-recovery ladder end to end through `run_session_loop`
+    // would need `SessionHealth` to observe ~35s of continuous real elapsed
+    // time (5s STALL_THRESHOLD + 30s RESET_AFTER), since it reads
+    // `Instant::now()` internally with no seam for a fake clock. That is
+    // impractical for a unit test, so this instead calls the extracted
+    // `attempt_stall_recovery_reset` directly: it is exactly the code
+    // `run_session_loop` runs once `StallRecovery` (already unit tested
+    // against synthetic `Instant`s in `pipeline::health`) decides to reset,
+    // so this covers the actual wiring bug this ticket is about: that stall
+    // recovery calls the timeline-preserving reset, not the plain one.
+    #[test]
+    fn stall_recovery_reset_calls_the_timeline_preserving_variant() {
+        let mut mock = MockEngine::new();
+        let reset_count = mock.reset_state_count_handle();
+        let preserving_count = mock.reset_state_preserving_count_handle();
+
+        attempt_stall_recovery_reset(&mut mock, 1);
+
+        assert_eq!(
+            preserving_count.load(Ordering::SeqCst),
+            1,
+            "stall recovery must call reset_state_preserving_timeline"
+        );
+        assert_eq!(
+            reset_count.load(Ordering::SeqCst),
+            0,
+            "stall recovery must not call the plain reset_state, which rewinds the timeline"
         );
     }
 }


### PR DESCRIPTION
Closes SOU-002.

**Latent defect: real in the code, never observed.** Zero `stall recovery reset` lines in the logs from 2026-08-18 to 2026-09-04. P3, and the fix is scoped accordingly.

## The bug

After 30 seconds with no frames processed, the stall ladder resets the engine in place to try to revive it. It called the same `reset_state` used at session boundaries, which wipes whatever the engine tracks as elapsed session time. Every word after it would be timestamped from zero, rewinding the transcript by the entire session so far.

The `monotonic_time` floor added for SOU-001 cannot catch this: `last_emitted_start` is zeroed by the same rebuild, so the floor vanishes exactly when it is needed and the rewind is silent.

## The fix

Stall recovery now calls a timeline-preserving reset. Of the three approaches the ticket listed, this one reuses the epoch machinery SOU-001 already built rather than adding a parallel one, and does not change what a recording session means.

- **Kyutai**: `carry_timeline_across_rebuild` applies `credit_lane_epoch`'s arithmetic to every lane before teardown, and the resulting `epoch_origin_seconds` and `last_emitted_start` are written into the rebuilt model. It calls `credit_lane_epoch` rather than reimplementing it, so the two cannot drift. `reset_state` and the preserving variant are now thin wrappers over one shared `rebuild_model`.
- **Whisper and Parakeet**: keep `consumed_samples`, the accumulated offset added to every windowed segment through `take_window_offset`. Whisper also keeps `detected_language`: mid-session it is the same speaker, so re-detecting from scratch is a regression, not a reset.
- Session start, pre-warm, and debug transcribe keep the plain `reset_state`. A new session should start at zero.

## Caught in review

The first pass fixed **Kyutai only**. But `consumed_samples` in Whisper and Parakeet plays exactly the same role, both zero it in `reset_state`, and the stall ladder is engine-agnostic with all three backends user-selectable. Two of three backends would still have had the defect while the ticket was marked closed. The trait doc was wrong too: it said "engines with no such notion", when they have the notion and are simply simpler about it.

Review also caught that the one line wiring the fix in had **no differentiating coverage**: `MockEngine`'s counter incremented identically either way, because the trait default forwards to `reset_state`. The test would have passed if someone reverted that line. There is now a separate counter and a test that fails if the plain reset comes back.

## Known limitation, logged not fixed

The rebuild still discards `pending_words` and `orphaned_words`, so a word that started right before the freeze and never got its `EndWord` is dropped from the transcript. `refresh_lane` handles this by moving in-flight words to `orphaned_words`, but doing the same here would mean changing the reset's return type to carry trailing segments, which is more than this P3 warrants. It now logs the dropped counts instead of vanishing silently.

## Testing

The crediting arithmetic is unit tested directly over slices: mid-epoch credit, already-credited lane, prefix not double counted, negative credit clamped.

There is **no** end-to-end test constructing a real `LoadedModel` and diffing timelines across the two reset flavours, because that needs Kyutai model files that are not in the repo or CI. And the stall ladder's 30-second timing is not driven end to end, since `SessionHealth` reads `Instant::now()` internally with no clock seam. That timing is already unit tested against synthetic `Instant`s in `pipeline::health`; the wiring is tested here by calling the extracted `attempt_stall_recovery_reset` against a mock.

Stall recovery now logs a message distinct from `ASR state rebuilt for new session`, so the grep that proved this path had never fired stays usable.