### PR TITLE
Find the MCP sidecar wherever cargo actually wrote it

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -39,6 +39,8 @@ jobs:
           cache: npm
 
       - run: npm ci
+      # Cheap: cargo metadata honors CARGO_TARGET_DIR (no release build).
+      - run: ./scripts/build-mcp-sidecar.test.sh
       # Tauri's build script validates `externalBin` entries during `cargo test`,
       # so the MCP sidecar must exist before type export (same as release builds).
       - run: ./scripts/build-mcp-sidecar.sh

--- a/scripts/build-mcp-sidecar.sh
+++ b/scripts/build-mcp-sidecar.sh
@@ -7,8 +7,21 @@ set -euo pipefail
 # bundle). Not needed for `npm run dev` — the Settings UI handles a missing
 # sidecar gracefully — but must run before `tauri build` so release bundles
 # include it (wired into `beforeBuildCommand` in src-tauri/tauri.conf.json).
+#
+# Cargo artifacts are not always at src-tauri/target — CARGO_TARGET_DIR and
+# .cargo/config.toml `build.target-dir` relocate them. Ask cargo metadata.
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+cargo_target_dir() {
+  cargo metadata --format-version 1 --manifest-path src-tauri/Cargo.toml --no-deps \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])'
+}
+
+if [ "${1:-}" = "--print-target-dir" ]; then
+  cargo_target_dir
+  exit 0
+fi
 
 target_triple="$(rustc -vV | sed -n 's/^host: //p')"
 if [ -z "${target_triple}" ]; then
@@ -22,7 +35,15 @@ dest="${bin_dir}/souffle-mcp-${target_triple}"
 echo "Building souffle-mcp sidecar for ${target_triple}..."
 cargo build --manifest-path src-tauri/Cargo.toml -p souffle-mcp --release
 
+target_dir="$(cargo_target_dir)"
+src="${target_dir}/release/souffle-mcp"
+if [ ! -f "${src}" ]; then
+  echo "error: souffle-mcp not found at ${src}" >&2
+  echo "error: cargo's target directory may have been relocated via CARGO_TARGET_DIR or .cargo/config.toml build.target-dir" >&2
+  exit 1
+fi
+
 mkdir -p "${bin_dir}"
-cp "src-tauri/target/release/souffle-mcp" "${dest}"
+cp "${src}" "${dest}"
 
 echo "souffle-mcp sidecar ready at ${dest}"

--- a/scripts/build-mcp-sidecar.sh
+++ b/scripts/build-mcp-sidecar.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # sidecar gracefully — but must run before `tauri build` so release bundles
 # include it (wired into `beforeBuildCommand` in src-tauri/tauri.conf.json).
 #
-# Cargo artifacts are not always at src-tauri/target — CARGO_TARGET_DIR and
+# Cargo artifacts are not always at src-tauri/target. CARGO_TARGET_DIR and
 # .cargo/config.toml `build.target-dir` relocate them. Ask cargo metadata.
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."

--- a/scripts/build-mcp-sidecar.test.sh
+++ b/scripts/build-mcp-sidecar.test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cheap assertions for scripts/build-mcp-sidecar.sh: cargo metadata honors
+# CARGO_TARGET_DIR, and the script asks cargo rather than hardcoding
+# src-tauri/target. Does not build the sidecar.
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+script="./scripts/build-mcp-sidecar.sh"
+
+if grep -q 'src-tauri/target/release/souffle-mcp' "${script}"; then
+  echo "fail: ${script} still hardcodes src-tauri/target/release/souffle-mcp" >&2
+  exit 1
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
+
+abs="${tmpdir}/abs-target"
+got="$(CARGO_TARGET_DIR="${abs}" "${script}" --print-target-dir)"
+if [ "${got}" != "${abs}" ]; then
+  echo "fail: expected CARGO_TARGET_DIR ${abs}, got: ${got}" >&2
+  exit 1
+fi
+
+rel_dir="mcp-sidecar-rel-target-$$"
+cleanup_rel() {
+  rm -rf "${tmpdir}" "${rel_dir}"
+}
+trap cleanup_rel EXIT
+
+got_rel="$(CARGO_TARGET_DIR="${rel_dir}" "${script}" --print-target-dir)"
+expected_rel="$(pwd)/${rel_dir}"
+if [ "${got_rel}" != "${expected_rel}" ]; then
+  echo "fail: expected relative CARGO_TARGET_DIR to resolve to ${expected_rel}, got: ${got_rel}" >&2
+  exit 1
+fi
+
+echo "ok: MCP sidecar target dir resolves via cargo metadata"


### PR DESCRIPTION
## Summary
- `tauri build` failed when `CARGO_TARGET_DIR` relocated artifacts: cargo succeeded, then `cp` looked in `src-tauri/target/release/`
- Resolve the target dir via `cargo metadata` so shared caches, worktrees, and `.cargo/config.toml` all work
- Fail clearly if the binary isn’t at the resolved path

Fixes SOU-028.

## Test plan
- [ ] `./scripts/build-mcp-sidecar.test.sh`
- [ ] `CARGO_TARGET_DIR=/tmp/souffle-target ./scripts/build-mcp-sidecar.sh` then confirm copy from `/tmp/souffle-target/release/souffle-mcp`
- [ ] unset `CARGO_TARGET_DIR` and confirm default still lands in `src-tauri/binaries/souffle-mcp-$(rustc -vV | sed -n 's/^host: //p')`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Build & Release**
  - Improved sidecar build handling across custom and default build locations.
  - Added clearer validation and error reporting when the required sidecar binary cannot be found.
  - Updated the contracts workflow to validate the test sidecar build before production packaging and type checks.

- **Tests**
  - Added automated coverage for sidecar build paths, including absolute and relative custom target directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->