### PR TITLE
Write meeting summaries in the language the meeting was actually in

### DIFF
--- a/src-tauri/src/commands/meetings.rs
+++ b/src-tauri/src/commands/meetings.rs
@@ -505,6 +505,11 @@ pub async fn summarize_meeting(
 
     let final_system_prompt =
         crate::summary::resolve_summary_template_prompt(&settings, template_id.as_deref());
+    let output_language = crate::summary::resolve_summary_language(
+        settings.meeting_transcription_language,
+        &transcript.segments,
+        &settings.locale,
+    );
 
     let channel_clone = channel.clone();
     let db = state.db.clone();
@@ -516,6 +521,7 @@ pub async fn summarize_meeting(
         &model,
         Some(&settings.ollama_url),
         &final_system_prompt,
+        output_language,
         move |progress| {
             let _ = channel_clone.send(progress);
         },

--- a/src-tauri/src/summary/language.rs
+++ b/src-tauri/src/summary/language.rs
@@ -1,0 +1,218 @@
+use crate::engine::TranscriptionSegment;
+use crate::lid::LanguageCode;
+use crate::settings::MeetingTranscriptionLanguage;
+
+/// Language the summary must be written in. Same two codes the meeting
+/// language setting and segment `language` fields already use.
+pub use crate::lid::LanguageCode as SummaryLanguage;
+
+/// English display name used in the system-prompt instruction. The rest of
+/// the prompt stays English: a 7B follows the instruction language, so the
+/// language *name* has to be explicit.
+fn language_english_name(language: SummaryLanguage) -> &'static str {
+    match language {
+        LanguageCode::En => "English",
+        LanguageCode::Fr => "French",
+    }
+}
+
+/// Parse a BCP-47-ish tag (`fr`, `fr-FR`, `en_US`). Null, empty, `unknown`,
+/// and anything else we do not summarize in are ignored.
+fn language_from_tag(raw: &str) -> Option<SummaryLanguage> {
+    let primary = raw
+        .trim()
+        .split(['-', '_'])
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    match primary.as_str() {
+        "en" => Some(LanguageCode::En),
+        "fr" => Some(LanguageCode::Fr),
+        _ => None,
+    }
+}
+
+/// Majority vote over segment `language` values. Ties and "no identified
+/// languages" return `None` so the caller can fall through to locale / English.
+pub fn majority_language_from_segments(
+    segments: &[TranscriptionSegment],
+) -> Option<SummaryLanguage> {
+    let mut en = 0u32;
+    let mut fr = 0u32;
+    for segment in segments {
+        match segment.language.as_deref().and_then(language_from_tag) {
+            Some(LanguageCode::En) => en += 1,
+            Some(LanguageCode::Fr) => fr += 1,
+            None => {}
+        }
+    }
+    match (en, fr) {
+        (0, 0) => None,
+        (e, f) if f > e => Some(LanguageCode::Fr),
+        (e, f) if e > f => Some(LanguageCode::En),
+        _ => None,
+    }
+}
+
+/// Resolve the language a meeting summary should be written in.
+///
+/// Explicit `MeetingTranscriptionLanguage` (En / Fr) wins: the user already
+/// told the engine that prior via `set_meeting_language_prior`. Auto votes
+/// on identified segments, then the UI locale, then English.
+pub fn resolve_summary_language(
+    setting: MeetingTranscriptionLanguage,
+    segments: &[TranscriptionSegment],
+    ui_locale: &str,
+) -> SummaryLanguage {
+    LanguageCode::from_setting(setting)
+        .or_else(|| majority_language_from_segments(segments))
+        .or_else(|| language_from_tag(ui_locale))
+        .unwrap_or(LanguageCode::En)
+}
+
+/// Append an explicit output-language rule. "Same language as the
+/// transcript" is not enough: a 7B follows the English system prompt.
+pub fn with_language_instruction(system_prompt: &str, language: SummaryLanguage) -> String {
+    format!(
+        "{}\n\nWrite every bullet in {}.",
+        system_prompt.trim_end(),
+        language_english_name(language)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        majority_language_from_segments, resolve_summary_language, with_language_instruction,
+    };
+    use crate::constants::{OLLAMA_MAP_PROMPT, OLLAMA_MERGE_PROMPT, OLLAMA_SUMMARIZE_PROMPT};
+    use crate::engine::TranscriptionSegment;
+    use crate::lid::LanguageCode;
+    use crate::settings::MeetingTranscriptionLanguage;
+
+    fn seg(language: Option<&str>) -> TranscriptionSegment {
+        TranscriptionSegment {
+            text: "x".into(),
+            start_time: 0.0,
+            end_time: 1.0,
+            is_final: true,
+            language: language.map(str::to_string),
+            confidence: None,
+            speaker: None,
+        }
+    }
+
+    #[test]
+    fn majority_mixed_french_wins() {
+        let segments: Vec<_> = std::iter::repeat_with(|| seg(Some("fr")))
+            .take(20)
+            .chain(std::iter::repeat_with(|| seg(Some("en"))).take(2))
+            .collect();
+        assert_eq!(
+            majority_language_from_segments(&segments),
+            Some(LanguageCode::Fr)
+        );
+    }
+
+    #[test]
+    fn majority_mixed_english_wins() {
+        let segments = [seg(Some("en")), seg(Some("en")), seg(Some("fr"))];
+        assert_eq!(
+            majority_language_from_segments(&segments),
+            Some(LanguageCode::En)
+        );
+    }
+
+    #[test]
+    fn majority_tie_is_undecided() {
+        let segments = [seg(Some("fr")), seg(Some("en"))];
+        assert_eq!(majority_language_from_segments(&segments), None);
+    }
+
+    #[test]
+    fn majority_all_null_is_undecided() {
+        let segments = [seg(None), seg(None), seg(Some("")), seg(Some("unknown"))];
+        assert_eq!(majority_language_from_segments(&segments), None);
+    }
+
+    #[test]
+    fn majority_ignores_null_unknown_and_normalizes_tags() {
+        let segments = [
+            seg(None),
+            seg(Some("unknown")),
+            seg(Some("und")),
+            seg(Some("fr-FR")),
+            seg(Some("FR")),
+            seg(Some("en_US")),
+        ];
+        assert_eq!(
+            majority_language_from_segments(&segments),
+            Some(LanguageCode::Fr)
+        );
+    }
+
+    #[test]
+    fn explicit_setting_beats_segment_majority() {
+        let french_meeting = [seg(Some("fr")), seg(Some("fr")), seg(Some("en"))];
+        assert_eq!(
+            resolve_summary_language(MeetingTranscriptionLanguage::En, &french_meeting, "fr"),
+            LanguageCode::En
+        );
+        assert_eq!(
+            resolve_summary_language(
+                MeetingTranscriptionLanguage::Fr,
+                &[seg(Some("en")), seg(Some("en"))],
+                "en"
+            ),
+            LanguageCode::Fr
+        );
+    }
+
+    #[test]
+    fn auto_uses_majority_then_locale_then_english() {
+        let french = [seg(Some("fr")), seg(Some("fr")), seg(Some("en"))];
+        assert_eq!(
+            resolve_summary_language(MeetingTranscriptionLanguage::Auto, &french, "en"),
+            LanguageCode::Fr
+        );
+
+        let unidentified = [seg(None), seg(Some("unknown"))];
+        assert_eq!(
+            resolve_summary_language(MeetingTranscriptionLanguage::Auto, &unidentified, "fr-CA"),
+            LanguageCode::Fr
+        );
+        assert_eq!(
+            resolve_summary_language(MeetingTranscriptionLanguage::Auto, &unidentified, ""),
+            LanguageCode::En
+        );
+
+        let tied = [seg(Some("fr")), seg(Some("en"))];
+        assert_eq!(
+            resolve_summary_language(MeetingTranscriptionLanguage::Auto, &tied, "fr"),
+            LanguageCode::Fr
+        );
+        assert_eq!(
+            resolve_summary_language(MeetingTranscriptionLanguage::Auto, &tied, "en"),
+            LanguageCode::En
+        );
+    }
+
+    #[test]
+    fn map_and_final_prompts_contain_the_chosen_language() {
+        let language = resolve_summary_language(
+            MeetingTranscriptionLanguage::Auto,
+            &[seg(Some("fr")), seg(Some("fr")), seg(Some("en"))],
+            "en",
+        );
+        assert_eq!(language, LanguageCode::Fr);
+
+        let map = with_language_instruction(OLLAMA_MAP_PROMPT, language);
+        let merge = with_language_instruction(OLLAMA_MERGE_PROMPT, language);
+        let final_pass = with_language_instruction(OLLAMA_SUMMARIZE_PROMPT, language);
+        assert!(map.contains("Write every bullet in French."));
+        assert!(merge.contains("Write every bullet in French."));
+        assert!(final_pass.contains("Write every bullet in French."));
+        assert!(map.contains("same language as the transcript"));
+        assert!(final_pass.contains("same language as the input"));
+    }
+}

--- a/src-tauri/src/summary/language.rs
+++ b/src-tauri/src/summary/language.rs
@@ -73,12 +73,14 @@ pub fn resolve_summary_language(
 /// Append an explicit output-language rule. "Same language as the
 /// transcript" is not enough: a 7B follows the English system prompt.
 ///
-/// Covers headings too, not just bullets: nothing downstream matches a
-/// heading by its literal text, and an English heading over French bullets
-/// reads as a bug.
+/// Covers every line of content, not only bullets: the "none stated"
+/// placeholders and the minutes prose drift back to English otherwise. The
+/// markdown headings stay English on purpose, matching the rule the system
+/// prompts already carry.
 pub fn with_language_instruction(system_prompt: &str, language: SummaryLanguage) -> String {
     format!(
-        "{}\n\nWrite all output, including headings and bullets, in {}.",
+        "{}\n\nWrite all summary content in {}. Keep the markdown section \
+         headings in English, exactly as specified above.",
         system_prompt.trim_end(),
         language_english_name(language)
     )
@@ -213,10 +215,17 @@ mod tests {
         let map = with_language_instruction(OLLAMA_MAP_PROMPT, language);
         let merge = with_language_instruction(OLLAMA_MERGE_PROMPT, language);
         let final_pass = with_language_instruction(OLLAMA_SUMMARIZE_PROMPT, language);
-        let rule = "Write all output, including headings and bullets, in French.";
+        let rule = "Write all summary content in French.";
         assert!(map.contains(rule));
         assert!(merge.contains(rule));
         assert!(final_pass.contains(rule));
+        // Must not contradict the headings rule the prompts already carry.
+        assert!(final_pass.contains("Keep the markdown section headings in English"));
+        assert!(
+            final_pass.contains(
+                "Keep the markdown section headings exactly as written below in English."
+            )
+        );
         assert!(map.contains("same language as the transcript"));
         assert!(final_pass.contains("same language as the input"));
     }

--- a/src-tauri/src/summary/language.rs
+++ b/src-tauri/src/summary/language.rs
@@ -72,9 +72,13 @@ pub fn resolve_summary_language(
 
 /// Append an explicit output-language rule. "Same language as the
 /// transcript" is not enough: a 7B follows the English system prompt.
+///
+/// Covers headings too, not just bullets: nothing downstream matches a
+/// heading by its literal text, and an English heading over French bullets
+/// reads as a bug.
 pub fn with_language_instruction(system_prompt: &str, language: SummaryLanguage) -> String {
     format!(
-        "{}\n\nWrite every bullet in {}.",
+        "{}\n\nWrite all output, including headings and bullets, in {}.",
         system_prompt.trim_end(),
         language_english_name(language)
     )
@@ -209,9 +213,10 @@ mod tests {
         let map = with_language_instruction(OLLAMA_MAP_PROMPT, language);
         let merge = with_language_instruction(OLLAMA_MERGE_PROMPT, language);
         let final_pass = with_language_instruction(OLLAMA_SUMMARIZE_PROMPT, language);
-        assert!(map.contains("Write every bullet in French."));
-        assert!(merge.contains("Write every bullet in French."));
-        assert!(final_pass.contains("Write every bullet in French."));
+        let rule = "Write all output, including headings and bullets, in French.";
+        assert!(map.contains(rule));
+        assert!(merge.contains(rule));
+        assert!(final_pass.contains(rule));
         assert!(map.contains("same language as the transcript"));
         assert!(final_pass.contains("same language as the input"));
     }

--- a/src-tauri/src/summary/mod.rs
+++ b/src-tauri/src/summary/mod.rs
@@ -2,6 +2,7 @@ mod apple;
 mod chunking;
 mod extract;
 mod formatters;
+mod language;
 mod map;
 mod ollama;
 mod polish;
@@ -18,6 +19,10 @@ use crate::transcript::{MeetingParticipant, StructuredSummary};
 
 pub use chunking::{ChunkConfig, chunk_transcript, chunk_turns, estimate_tokens};
 pub use extract::{extract_structured_summary, parse_structured_summary_response};
+pub use language::{
+    SummaryLanguage, majority_language_from_segments, resolve_summary_language,
+    with_language_instruction,
+};
 pub use ollama::{OllamaPullProgress, RECOMMENDED_MODEL as RECOMMENDED_OLLAMA_MODEL, pull_model};
 pub use polish::{
     DictationPolishResult, TEMPLATE_BULLETS, TEMPLATE_CLEAN, TEMPLATE_EMAIL, TEMPLATE_NO_FILLERS,
@@ -415,6 +420,10 @@ pub(crate) async fn generate_with_provider(
 /// `turn_units` is the speaker-labeled transcript when the meeting still has
 /// segments; packing those units never splits a turn. Edited prose has no
 /// turns and falls back to word chunks.
+///
+/// `output_language` is injected into the map, merge, and final system
+/// prompts. A 7B follows the English instruction language unless told
+/// explicitly which language to write in.
 #[allow(clippy::too_many_arguments)]
 pub async fn summarize_stream(
     transcript_text: &str,
@@ -424,11 +433,23 @@ pub async fn summarize_stream(
     model: &str,
     ollama_base_url: Option<&str>,
     final_system_prompt: &str,
+    output_language: SummaryLanguage,
     on_chunk: impl Fn(SummarizeProgress),
 ) -> Result<String, String> {
     let provider = resolve_provider(model)?;
     let config = chunk_config(provider);
     let ollama_url = ollama_base_url.unwrap_or(OLLAMA_DEFAULT_URL);
+    let final_system_prompt = with_language_instruction(final_system_prompt, output_language);
+    // Both providers share the same map/merge text today; pick the provider
+    // constant so Apple stays on the same language-injection path if they diverge.
+    let (map_base, merge_base) = match provider {
+        SummaryProviderKind::Ollama => (ollama::MAP_SYSTEM_PROMPT, ollama::MERGE_SYSTEM_PROMPT),
+        SummaryProviderKind::AppleIntelligence => {
+            (apple::MAP_SYSTEM_PROMPT, apple::MERGE_SYSTEM_PROMPT)
+        }
+    };
+    let map_system_prompt = with_language_instruction(map_base, output_language);
+    let merge_system_prompt = with_language_instruction(merge_base, output_language);
 
     if estimate_tokens(transcript_text) <= config.stuff_token_limit {
         // Single-call path: the whole transcript fits, so this one call IS
@@ -437,7 +458,7 @@ pub async fn summarize_stream(
             provider,
             model,
             ollama_url,
-            final_system_prompt,
+            &final_system_prompt,
             build_summarize_prompt(transcript_text, notes, participants),
             0.2,
             ollama::REDUCE_BUDGET,
@@ -469,17 +490,19 @@ pub async fn summarize_stream(
                 let client = client.clone();
                 let ollama_url = ollama_url.to_string();
                 let model = model.to_string();
+                let map_system_prompt = map_system_prompt.clone();
                 async move {
                     map::map_one_chunk(i + 1, n, &chunk, |user, temperature| {
                         let client = client.clone();
                         let ollama_url = ollama_url.clone();
                         let model = model.clone();
+                        let map_system_prompt = map_system_prompt.clone();
                         async move {
                             ollama::generate_stream(
                                 &client,
                                 &ollama_url,
                                 &model,
-                                ollama::MAP_SYSTEM_PROMPT,
+                                &map_system_prompt,
                                 user,
                                 ollama::MAP_BUDGET,
                                 temperature,
@@ -506,23 +529,27 @@ pub async fn summarize_stream(
                 Some(i as u32 + 1),
                 Some(n as u32),
             ));
-            let part = map::map_one_chunk(i + 1, n, &chunk, |user, temperature| async move {
-                generate_with_provider(
-                    provider,
-                    model,
-                    ollama_url,
-                    apple::MAP_SYSTEM_PROMPT,
-                    user,
-                    temperature,
-                    ollama::MAP_BUDGET,
-                    &no_op,
-                    false,
-                )
-                .await
-                .map(|text| map::MapOutput {
-                    text,
-                    eval_count: None,
-                })
+            let map_system_prompt = map_system_prompt.clone();
+            let part = map::map_one_chunk(i + 1, n, &chunk, |user, temperature| {
+                let map_system_prompt = map_system_prompt.clone();
+                async move {
+                    generate_with_provider(
+                        provider,
+                        model,
+                        ollama_url,
+                        &map_system_prompt,
+                        user,
+                        temperature,
+                        ollama::MAP_BUDGET,
+                        &no_op,
+                        false,
+                    )
+                    .await
+                    .map(|text| map::MapOutput {
+                        text,
+                        eval_count: None,
+                    })
+                }
             })
             .await?;
             part_summaries.push(part);
@@ -537,7 +564,8 @@ pub async fn summarize_stream(
         notes,
         participants,
         config,
-        final_system_prompt,
+        &final_system_prompt,
+        &merge_system_prompt,
         &on_chunk,
     )
     .await?;
@@ -565,17 +593,13 @@ async fn reduce_part_summaries(
     participants: &[MeetingParticipant],
     config: ChunkConfig,
     final_system_prompt: &str,
+    merge_system_prompt: &str,
     on_chunk: &impl Fn(SummarizeProgress),
 ) -> Result<String, String> {
     // The template prompt applies to the final pass only; intermediate
-    // merge rounds keep the fixed provider merge prompt (both providers
-    // share the same merge text today).
-    let (merge_system_prompt, budget) = match provider {
-        SummaryProviderKind::Ollama => (ollama::MERGE_SYSTEM_PROMPT, ollama::REDUCE_BUDGET),
-        SummaryProviderKind::AppleIntelligence => {
-            (apple::MERGE_SYSTEM_PROMPT, ollama::REDUCE_BUDGET)
-        }
-    };
+    // merge rounds keep the (language-annotated) merge prompt. Both
+    // providers share the same merge text today.
+    let budget = ollama::REDUCE_BUDGET;
 
     on_chunk(SummarizeProgress::stage_marker(
         SummarizeStage::Combine,


### PR DESCRIPTION
## Summary
- Stop 7B map/reduce from following the English system prompt on a French meeting
- Inject an explicit output language from the existing meeting-language setting, or a segment majority vote when that’s Auto (then UI locale, then English)
- Same instruction on map, merge, and the final pass, including Apple Intelligence

Fixes SOU-027.

## Test plan
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml --lib summary::`
- [ ] Auto + mostly-`fr` segments → French bullets at map and final
- [ ] Setting Fr + English-majority segments → still French
- [ ] Auto + no language tags + locale `fr` → French; empty locale → English
- [ ] Re-summarize a long French meeting (the 72 min one) and check the recap is French

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Meeting summaries now select English or French based on meeting settings, transcript language, and app locale.
  * Summary content follows the selected language, while Markdown headings remain in English.
* **Bug Fixes**
  * Improved language consistency across streamed, multi-part, and merged summaries.
* **Tests**
  * Added coverage for language detection, precedence rules, fallbacks, ties, and prompt generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->