### PR TITLE
Ask the final summary pass to merge map chunks instead of concatenating them

### DIFF
--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -60,6 +60,12 @@ pub const OLLAMA_DEFAULT_URL: &str = "http://localhost:11434";
 /// only pass allowed to emit the user-facing markdown structure: it must run
 /// exactly once per summary, never per chunk or per intermediate reduce round,
 /// or its headings repeat once concatenated with sibling groups.
+///
+/// When the input is several map-stage fact lists (the common long-meeting
+/// path: one reduce call that still fits the token budget), this prompt must
+/// itself say to merge and dedupe. Intermediate rounds use
+/// [`OLLAMA_MERGE_PROMPT`]; a single final call never sees that prompt, and
+/// a small model will otherwise concatenate the parts and drop `## Topics`.
 /// Decisions/action items/open questions are extracted separately by
 /// OLLAMA_STRUCTURED_EXTRACT_PROMPT and rendered in their own UI section, so
 /// this prose pass stays a narrative recap and does not duplicate them.
@@ -73,12 +79,15 @@ Rules:
 - Do not greet, thank, apologize, or address the reader.
 - Do not add an introduction, conclusion, or commentary about the meeting quality.
 - Give equal weight to the beginning, middle, and end of the meeting; do not over-emphasize the final portion.
+- If the input is several fact lists from consecutive parts of ONE meeting, merge them into a single recap. Do not keep the parts as separate blocks and do not copy each list verbatim.
+- Merge duplicate or overlapping points into a single bullet instead of repeating them.
 - If the input is very short, output only the facts that are directly present.
 - If the input only contains greetings, attendance, or setup, say only that.
 - Keep the markdown section headings exactly as written below in English.
+- Never omit the Topics section.
 - Write the content of each bullet in the same language as the input.
 - If a section has no content, write a short \"none stated\" equivalent in the same language.
-- Use short, concrete bullets. No paragraphs.
+- Use short, concrete bullets. No paragraphs. At most 8 bullets per section.
 - Decisions, action items, and open questions are extracted separately elsewhere: do not add sections for them here.
 - Return exactly this structure and nothing before or after it:
 
@@ -176,12 +185,16 @@ Rules:
 - Do not greet, thank, apologize, or address the reader.
 - Do not add an introduction, conclusion, or commentary about the meeting quality.
 - Give equal weight to the beginning, middle, and end of the meeting; do not over-emphasize the final portion.
+- If the input is several fact lists from consecutive parts of ONE meeting, merge them into a single set of minutes. Do not keep the parts as separate blocks and do not copy each list verbatim.
+- Merge duplicate or overlapping points into a single bullet instead of repeating them.
 - Cover the meeting in chronological order with one bullet per distinct point discussed; be thorough rather than terse.
 - If the input is very short, output only the facts that are directly present.
 - If the input only contains greetings, attendance, or setup, say only that.
 - Keep the markdown section headings exactly as written below in English.
+- Never omit the Topics section.
 - Write the content of each bullet in the same language as the input.
 - If a section has no content, write a short \"none stated\" equivalent in the same language.
+- At most 16 bullets per section.
 - Decisions, action items, and open questions are extracted separately elsewhere: do not add sections for them here.
 - Return exactly this structure and nothing before or after it:
 
@@ -204,6 +217,8 @@ Rules:
 - Do not greet, thank, apologize, or address the reader.
 - Do not add an introduction, conclusion, or commentary about the meeting quality.
 - Give equal weight to the beginning, middle, and end of the meeting; do not over-emphasize the final portion.
+- If the input is several fact lists from consecutive parts of ONE meeting, merge them into a single overview. Do not keep the parts as separate blocks and do not copy each list verbatim.
+- Merge duplicate or overlapping points into a single bullet instead of repeating them.
 - Write at most 3 short bullets covering only the most important points.
 - If the input only contains greetings, attendance, or setup, say only that.
 - Keep the markdown section heading exactly as written below in English.

--- a/src-tauri/src/summary/mod.rs
+++ b/src-tauri/src/summary/mod.rs
@@ -211,6 +211,21 @@ fn sanitize_summary(text: &str) -> String {
     trimmed.to_string()
 }
 
+/// True when the sanitized final-pass text has no `## Topics` heading.
+///
+/// A 7B on a single final reduce (many map chunks, still under the token
+/// budget) will concatenate the fact lists and drop this section. We detect
+/// that here so tests — and a future one-shot retry — can see it. Retry is
+/// not wired: the live preview concatenates streamed tokens, so a second
+/// `generate` would append a second draft on screen, and a model that
+/// concatenated once often does it again.
+#[cfg(test)]
+fn summary_missing_topics(text: &str) -> bool {
+    !sanitize_summary(text)
+        .lines()
+        .any(|line| line.trim().eq_ignore_ascii_case("## Topics"))
+}
+
 fn apple_model_descriptor() -> SummaryModelDescriptor {
     SummaryModelDescriptor {
         id: APPLE_INTELLIGENCE_MODEL_ID.to_string(),
@@ -714,7 +729,7 @@ mod tests {
         APPLE_INTELLIGENCE_MODEL_ID, ChunkConfig, ModelChoiceError, SummaryModelDescriptor,
         SummaryProviderChoice, SummaryProviderKind, apple, check_providers, choose_summary_model,
         ollama, reduce_call_system_prompt, resolve_provider, run_reduce_tree, sanitize_summary,
-        structured_extract_for_persist,
+        structured_extract_for_persist, summary_missing_topics,
     };
     use crate::transcript::StructuredSummary;
 
@@ -765,6 +780,35 @@ mod tests {
         let input = "Here is a summary of the meeting.\n## Summary\nKey points are listed below.";
         let result = sanitize_summary(input);
         assert_eq!(result, "## Summary\nKey points are listed below.");
+    }
+
+    #[test]
+    fn summary_missing_topics_detects_concatenated_map_chunks() {
+        let concatenated =
+            "## Summary\n- fact from part 1\n\n- fact from part 2\n\n- fact from part 3";
+        assert!(
+            summary_missing_topics(concatenated),
+            "a reduce that only emitted ## Summary must be flagged"
+        );
+        assert!(summary_missing_topics(""));
+        assert!(summary_missing_topics(
+            "Just a blob of bullets\n- one\n- two"
+        ));
+    }
+
+    #[test]
+    fn summary_missing_topics_accepts_required_structure() {
+        assert!(!summary_missing_topics(
+            "## Summary\n- recap\n\n## Topics\n- agenda\n"
+        ));
+        assert!(
+            !summary_missing_topics("Thanks.\n\n## Summary\n- recap\n\n## Topics\n- agenda\n"),
+            "preamble stripped by sanitize must not hide ## Topics"
+        );
+        assert!(
+            !summary_missing_topics("## Meeting Minutes\n- point\n\n## Topics\n- none stated\n"),
+            "detailed minutes still require ## Topics"
+        );
     }
 
     fn model(id: &str, provider: SummaryProviderKind) -> SummaryModelDescriptor {
@@ -991,6 +1035,58 @@ mod tests {
             super::default_summary_templates()[0].prompt,
             prompt,
             "the Default template must ship the standard final-pass prompt"
+        );
+    }
+
+    /// The common long-meeting path is a single final reduce (map chunks still
+    /// fit `reduce_token_limit`), so merge/dedup cannot live only on
+    /// `OLLAMA_MERGE_PROMPT`. Every final-pass template must say so, or a 7B
+    /// concatenates the parts and — on the default/detailed templates — drops
+    /// `## Topics`.
+    #[test]
+    fn final_pass_prompts_merge_map_chunks_and_cap_output() {
+        let default = crate::constants::OLLAMA_SUMMARIZE_PROMPT;
+        let detailed = crate::constants::OLLAMA_DETAILED_MINUTES_PROMPT;
+        let brief = crate::constants::OLLAMA_BRIEF_OVERVIEW_PROMPT;
+
+        for prompt in [default, detailed, brief] {
+            assert!(
+                prompt.contains("consecutive parts of ONE meeting"),
+                "final pass must treat map chunks as parts of one meeting"
+            );
+            assert!(
+                prompt.contains("Do not keep the parts as separate blocks"),
+                "final pass must forbid per-part blocks"
+            );
+            assert!(
+                prompt.contains("Merge duplicate or overlapping points"),
+                "final pass must carry the merge-prompt dedup rule"
+            );
+        }
+
+        assert!(
+            default.contains("Never omit the Topics section"),
+            "default recap must require ## Topics"
+        );
+        assert!(
+            default.contains("At most 8 bullets per section"),
+            "default recap must cap length so concatenating 12 map lists is not the cheap path"
+        );
+        assert!(
+            detailed.contains("Never omit the Topics section"),
+            "detailed minutes must require ## Topics"
+        );
+        assert!(
+            detailed.contains("At most 16 bullets per section"),
+            "detailed minutes still need a ceiling"
+        );
+        assert!(
+            !brief.contains("## Topics"),
+            "brief overview keeps a single ## Summary section"
+        );
+        assert!(
+            brief.contains("at most 3 short bullets"),
+            "brief overview already caps output"
         );
     }
 

--- a/src-tauri/src/summary/mod.rs
+++ b/src-tauri/src/summary/mod.rs
@@ -211,19 +211,28 @@ fn sanitize_summary(text: &str) -> String {
     trimmed.to_string()
 }
 
-/// True when the sanitized final-pass text has no `## Topics` heading.
+/// Log when the final pass dropped a section its own prompt asked for.
 ///
-/// A 7B on a single final reduce (many map chunks, still under the token
-/// budget) will concatenate the fact lists and drop this section. We detect
-/// that here so tests — and a future one-shot retry — can see it. Retry is
-/// not wired: the live preview concatenates streamed tokens, so a second
+/// A small model given many map-stage fact lists concatenates them and stops
+/// after `## Summary`. No retry: the live preview streams tokens, so a second
 /// `generate` would append a second draft on screen, and a model that
-/// concatenated once often does it again.
-#[cfg(test)]
-fn summary_missing_topics(text: &str) -> bool {
-    !sanitize_summary(text)
-        .lines()
-        .any(|line| line.trim().eq_ignore_ascii_case("## Topics"))
+/// concatenated once usually does it again. The warning is how we find out it
+/// happened. Only checked for prompts that actually request the section, so a
+/// brief-overview template stays quiet.
+fn final_summary_is_truncated(summary: &str, final_system_prompt: &str) -> bool {
+    final_system_prompt.contains("## Topics")
+        && !summary
+            .lines()
+            .any(|line| line.trim().eq_ignore_ascii_case("## Topics"))
+}
+
+fn warn_if_final_summary_is_truncated(summary: &str, final_system_prompt: &str) {
+    if final_summary_is_truncated(summary, final_system_prompt) {
+        tracing::warn!(
+            "Final summary is missing the Topics section its prompt required; \
+             the model likely concatenated the map chunks"
+        );
+    }
 }
 
 fn apple_model_descriptor() -> SummaryModelDescriptor {
@@ -460,7 +469,9 @@ pub async fn summarize_stream(
             false,
         )
         .await?;
-        return Ok(sanitize_summary(&full));
+        let summary = sanitize_summary(&full);
+        warn_if_final_summary_is_truncated(&summary, final_system_prompt);
+        return Ok(summary);
     }
 
     let no_op = |_: SummarizeProgress| {};
@@ -556,7 +567,9 @@ pub async fn summarize_stream(
         &on_chunk,
     )
     .await?;
-    Ok(sanitize_summary(&full))
+    let summary = sanitize_summary(&full);
+    warn_if_final_summary_is_truncated(&summary, final_system_prompt);
+    Ok(summary)
 }
 
 /// Combine map-stage part summaries into the final prose summary.
@@ -728,8 +741,8 @@ mod tests {
     use super::{
         APPLE_INTELLIGENCE_MODEL_ID, ChunkConfig, ModelChoiceError, SummaryModelDescriptor,
         SummaryProviderChoice, SummaryProviderKind, apple, check_providers, choose_summary_model,
-        ollama, reduce_call_system_prompt, resolve_provider, run_reduce_tree, sanitize_summary,
-        structured_extract_for_persist, summary_missing_topics,
+        final_summary_is_truncated, ollama, reduce_call_system_prompt, resolve_provider,
+        run_reduce_tree, sanitize_summary, structured_extract_for_persist,
     };
     use crate::transcript::StructuredSummary;
 
@@ -783,32 +796,29 @@ mod tests {
     }
 
     #[test]
-    fn summary_missing_topics_detects_concatenated_map_chunks() {
+    fn truncated_summary_warns_only_when_the_prompt_asked_for_topics() {
+        let prompt = crate::constants::OLLAMA_SUMMARIZE_PROMPT;
+        let brief = crate::constants::OLLAMA_BRIEF_OVERVIEW_PROMPT;
+        assert!(prompt.contains("## Topics"));
+        assert!(!brief.contains("## Topics"));
+
         let concatenated =
             "## Summary\n- fact from part 1\n\n- fact from part 2\n\n- fact from part 3";
-        assert!(
-            summary_missing_topics(concatenated),
-            "a reduce that only emitted ## Summary must be flagged"
-        );
-        assert!(summary_missing_topics(""));
-        assert!(summary_missing_topics(
-            "Just a blob of bullets\n- one\n- two"
-        ));
-    }
+        assert!(final_summary_is_truncated(concatenated, prompt));
+        assert!(final_summary_is_truncated("", prompt));
 
-    #[test]
-    fn summary_missing_topics_accepts_required_structure() {
-        assert!(!summary_missing_topics(
-            "## Summary\n- recap\n\n## Topics\n- agenda\n"
+        // A brief overview has no Topics section by design.
+        assert!(!final_summary_is_truncated(concatenated, brief));
+
+        // The required structure is quiet.
+        assert!(!final_summary_is_truncated(
+            "## Summary\n- recap\n\n## Topics\n- agenda\n",
+            prompt
         ));
-        assert!(
-            !summary_missing_topics("Thanks.\n\n## Summary\n- recap\n\n## Topics\n- agenda\n"),
-            "preamble stripped by sanitize must not hide ## Topics"
-        );
-        assert!(
-            !summary_missing_topics("## Meeting Minutes\n- point\n\n## Topics\n- none stated\n"),
-            "detailed minutes still require ## Topics"
-        );
+        assert!(!final_summary_is_truncated(
+            "## Meeting Minutes\n- point\n\n## Topics\n- none stated\n",
+            crate::constants::OLLAMA_DETAILED_MINUTES_PROMPT
+        ));
     }
 
     fn model(id: &str, provider: SummaryProviderKind) -> SummaryModelDescriptor {
@@ -1041,7 +1051,7 @@ mod tests {
     /// The common long-meeting path is a single final reduce (map chunks still
     /// fit `reduce_token_limit`), so merge/dedup cannot live only on
     /// `OLLAMA_MERGE_PROMPT`. Every final-pass template must say so, or a 7B
-    /// concatenates the parts and — on the default/detailed templates — drops
+    /// concatenates the parts and, on the default/detailed templates, drops
     /// `## Topics`.
     #[test]
     fn final_pass_prompts_merge_map_chunks_and_cap_output() {


### PR DESCRIPTION
## Summary
- Long meetings that fit one reduce call were concatenating N map fact-lists because merge/dedup lived only on `OLLAMA_MERGE_PROMPT`
- Default, detailed, and brief final prompts now say merge/dedupe and not to keep per-part blocks; default/detailed require Topics and cap bullets (8 / 16)
- Topics-missing detector is unit-tested; no retry (streaming preview would append a second draft, and a 7B that concatenated once often does it again)

Fixes SOU-026.

Note: overlaps `src-tauri/src/summary/mod.rs` with #125 (language injection). Rebase whichever lands second.

## Test plan
- [ ] 72-min / ~12-chunk meeting on qwen2.5:7b: one `## Summary` + one `## Topics`, not 12 blank-line blocks
- [ ] Bullet count well under 125; duplicates across chunks collapsed
- [ ] Short meeting (single-shot, no map-reduce) still has Summary + Topics
- [ ] Detailed minutes: Topics present, not a dump of map lists
- [ ] Brief overview: still just `## Summary`, ≤3 bullets, merged if map-reduce ran
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml --lib -- summary`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Summary generation now merges consecutive fact lists and removes overlapping or duplicate points.
  - Standard summaries are limited to 8 bullets per section.
  - Detailed minutes are limited to 16 bullets per section.
  - Structured summaries continue to preserve the required **Topics** section.
  - A warning is now shown when a required **Topics** section is missing from the final summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->