### PR TITLE
Show the last recognized word immediately, then replace it when it finalizes

### DIFF
--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -368,7 +368,7 @@ struct DictationLiveTextState {
 }
 
 /// Confirmed text plus the current pending word, for the pill preview only.
-/// Does not mutate `accumulated` — paste still uses confirmed finals.
+/// Does not mutate `accumulated`, so paste still uses confirmed finals.
 fn dictation_live_preview(accumulated: &str, tentative: &str) -> String {
     if tentative.is_empty() {
         accumulated.to_string()

--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -67,6 +67,12 @@ fn build_meeting_on_segment(
     Box::new(move |seg| {
         let _ = channel.send(seg.clone());
 
+        // Tentatives are live-UI only. Persisting them would write a row
+        // that the later final then duplicates.
+        if !seg.is_final {
+            return;
+        }
+
         let batch = {
             let Ok(mut guard) = accumulator.lock() else {
                 return;
@@ -361,6 +367,20 @@ struct DictationLiveTextState {
     last_emit: Option<std::time::Instant>,
 }
 
+/// Confirmed text plus the current pending word, for the pill preview only.
+/// Does not mutate `accumulated` — paste still uses confirmed finals.
+fn dictation_live_preview(accumulated: &str, tentative: &str) -> String {
+    if tentative.is_empty() {
+        accumulated.to_string()
+    } else if accumulated.is_empty() {
+        tentative.to_string()
+    } else if accumulated.ends_with(' ') || tentative.starts_with(' ') {
+        format!("{accumulated}{tentative}")
+    } else {
+        format!("{accumulated} {tentative}")
+    }
+}
+
 /// The per-segment callback for dictation: forward every segment to the main
 /// window's channel as before, and additionally accumulate final segments'
 /// text to emit a throttled `DictationLiveText` sample to the (separate)
@@ -376,21 +396,33 @@ fn build_dictation_on_segment(
         let text = seg.text.clone();
         let _ = channel.send(seg);
 
-        if !is_final {
-            return;
-        }
         let Ok(mut state) = live_text.lock() else {
             return;
         };
-        if !state.accumulated.is_empty() && !state.accumulated.ends_with(' ') && !text.starts_with(' ') {
+        if !is_final {
+            let preview = dictation_live_preview(&state.accumulated, &text);
+            let tail = crate::pill::live_text_tail(&preview, crate::pill::LIVE_TEXT_MAX_CHARS);
+            drop(state);
+            let _ = crate::app_events::DictationLiveText { text: tail }.emit(&app);
+            return;
+        }
+        if !state.accumulated.is_empty()
+            && !state.accumulated.ends_with(' ')
+            && !text.starts_with(' ')
+        {
             state.accumulated.push(' ');
         }
         state.accumulated.push_str(&text);
 
         let now = std::time::Instant::now();
-        if crate::pill::should_emit_live_text(state.last_emit, now, crate::pill::LIVE_TEXT_MIN_INTERVAL) {
+        if crate::pill::should_emit_live_text(
+            state.last_emit,
+            now,
+            crate::pill::LIVE_TEXT_MIN_INTERVAL,
+        ) {
             state.last_emit = Some(now);
-            let tail = crate::pill::live_text_tail(&state.accumulated, crate::pill::LIVE_TEXT_MAX_CHARS);
+            let tail =
+                crate::pill::live_text_tail(&state.accumulated, crate::pill::LIVE_TEXT_MAX_CHARS);
             drop(state);
             let _ = crate::app_events::DictationLiveText { text: tail }.emit(&app);
         }
@@ -822,13 +854,25 @@ pub fn take_sleep_paused_meeting(state: State<'_, AppState>) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{MEETING_FLUSH_THRESHOLD, build_meeting_on_segment};
+    use super::{MEETING_FLUSH_THRESHOLD, build_meeting_on_segment, dictation_live_preview};
     use crate::engine::{TranscriptionSegment, default_transcription_profile};
     use crate::state::MeetingAccumulator;
     use crate::test_helpers::fixtures::test_db;
     use chrono::Utc;
     use std::sync::{Arc, Mutex};
     use tauri::ipc::Channel;
+
+    fn test_segment(text: &str, is_final: bool) -> TranscriptionSegment {
+        TranscriptionSegment {
+            text: text.to_string(),
+            start_time: 0.0,
+            end_time: 0.0,
+            is_final,
+            language: None,
+            confidence: None,
+            speaker: None,
+        }
+    }
 
     #[test]
     fn build_meeting_on_segment_rolls_back_persisted_count_on_flush_failure() {
@@ -879,5 +923,53 @@ mod tests {
             meeting.persisted_new_count, 0,
             "flush failed (FK violation) so the batch must be retried, not lost"
         );
+    }
+
+    #[test]
+    fn build_meeting_on_segment_skips_non_finals_for_persistence() {
+        let (db, _dir) = test_db();
+        let db = Arc::new(db);
+
+        let accumulator = Arc::new(Mutex::new(Some(MeetingAccumulator {
+            id: "live-only".to_string(),
+            title: "Live".to_string(),
+            existing_segments: Vec::new(),
+            new_segments: Vec::new(),
+            recording_sessions: Vec::new(),
+            session_started_at: Utc::now(),
+            transcription_profile: default_transcription_profile(),
+            summary: None,
+            summary_is_stale: false,
+            summary_model: None,
+            summary_generated_at: None,
+            structured_summary: None,
+            notes: None,
+            calendar_event_id: None,
+            participants: Vec::new(),
+            persisted_new_count: 0,
+        })));
+
+        let channel: Channel<TranscriptionSegment> = Channel::new(|_| Ok(()));
+        let on_segment = build_meeting_on_segment(channel, Arc::clone(&accumulator), db);
+
+        on_segment(test_segment("pending", false));
+        on_segment(test_segment("hello", true));
+        on_segment(test_segment("world", false));
+
+        let guard = accumulator.lock().unwrap();
+        let meeting = guard.as_ref().unwrap();
+        assert_eq!(meeting.new_segments.len(), 1);
+        assert_eq!(meeting.new_segments[0].text, "hello");
+        assert!(meeting.new_segments[0].is_final);
+        assert_eq!(meeting.persisted_new_count, 0);
+    }
+
+    #[test]
+    fn dictation_live_preview_joins_confirmed_and_tentative() {
+        assert_eq!(dictation_live_preview("", "hello"), "hello");
+        assert_eq!(dictation_live_preview("hello", ""), "hello");
+        assert_eq!(dictation_live_preview("hello", "world"), "hello world");
+        assert_eq!(dictation_live_preview("hello ", "world"), "hello world");
+        assert_eq!(dictation_live_preview("hello", " world"), "hello world");
     }
 }

--- a/src-tauri/src/engine/kyutai.rs
+++ b/src-tauri/src/engine/kyutai.rs
@@ -468,7 +468,7 @@ impl KyutaiEngine {
     }
 
     /// Live preview of a word still waiting for EndWord. Does not consume
-    /// the pending slot — the later final still comes from `emit_pending`.
+    /// the pending slot; the later final still comes from `emit_pending`.
     fn pending_to_tentative_segment(pending: &PendingWord) -> TranscriptionSegment {
         TranscriptionSegment {
             text: pending.text.clone(),
@@ -492,15 +492,38 @@ impl KyutaiEngine {
         }
     }
 
-    fn drain_orphans(model: &mut LoadedModel, segments: &mut Vec<TranscriptionSegment>) {
-        for pending in model.orphaned_words.drain(..) {
+    fn drain_orphans(
+        orphaned_words: &mut Vec<PendingWord>,
+        segments: &mut Vec<TranscriptionSegment>,
+    ) {
+        for pending in orphaned_words.drain(..) {
             let end = pending.start_time;
             segments.push(Self::pending_to_segment(pending, end));
         }
     }
 
+    /// Everything a new word owes the UI, in the order the consumers expect:
+    /// words orphaned by a lane reset, then the previous word closed at this
+    /// word's start, then this word as a preview. A final must never land
+    /// after the preview it would otherwise erase.
+    fn open_word(
+        pending_words: &mut Vec<Option<PendingWord>>,
+        orphaned_words: &mut Vec<PendingWord>,
+        batch_idx: usize,
+        pending: PendingWord,
+        segments: &mut Vec<TranscriptionSegment>,
+    ) {
+        Self::drain_orphans(orphaned_words, segments);
+        Self::emit_pending(pending_words, batch_idx, pending.start_time, segments);
+        if batch_idx >= pending_words.len() {
+            pending_words.resize_with(batch_idx + 1, || None);
+        }
+        segments.push(Self::pending_to_tentative_segment(&pending));
+        pending_words[batch_idx] = Some(pending);
+    }
+
     fn drain_all_pending(model: &mut LoadedModel, segments: &mut Vec<TranscriptionSegment>) {
-        Self::drain_orphans(model, segments);
+        Self::drain_orphans(&mut model.orphaned_words, segments);
         for batch_idx in 0..model.pending_words.len() {
             if let Some(pending) = model.pending_words[batch_idx].take() {
                 let end = pending.start_time;
@@ -776,7 +799,7 @@ impl KyutaiEngine {
         debug_enabled: bool,
         segments: &mut Vec<TranscriptionSegment>,
     ) {
-        Self::drain_orphans(model, segments);
+        Self::drain_orphans(&mut model.orphaned_words, segments);
         let frame_num = FRAME_COUNT.load(Ordering::Relaxed).saturating_sub(1);
         let diarized = model.state.batch_size() == 2;
 
@@ -846,22 +869,18 @@ impl KyutaiEngine {
                     } else {
                         None
                     };
-                    // Previous word on this lane never got EndWord: close it
-                    // at this word's start so we don't drop it.
-                    Self::emit_pending(&mut model.pending_words, *batch_idx, start_time, segments);
-                    if *batch_idx >= model.pending_words.len() {
-                        model.pending_words.resize_with(*batch_idx + 1, || None);
-                    }
-                    let pending = PendingWord {
-                        text,
-                        start_time,
-                        language,
-                        speaker,
-                    };
-                    // Show the last word immediately; it stays pending until
-                    // EndWord / the next Word / drain finalizes it.
-                    segments.push(Self::pending_to_tentative_segment(&pending));
-                    model.pending_words[*batch_idx] = Some(pending);
+                    Self::open_word(
+                        &mut model.pending_words,
+                        &mut model.orphaned_words,
+                        *batch_idx,
+                        PendingWord {
+                            text,
+                            start_time,
+                            language,
+                            speaker,
+                        },
+                        segments,
+                    );
                 }
                 moshi::asr::AsrMsg::EndWord {
                     stop_time,
@@ -876,7 +895,7 @@ impl KyutaiEngine {
                 }
             }
         }
-        Self::drain_orphans(model, segments);
+        Self::drain_orphans(&mut model.orphaned_words, segments);
     }
 
     fn context_window_stats(&self) -> Option<super::ContextWindowStats> {
@@ -1540,5 +1559,85 @@ mod tests {
         assert_eq!(finalized.text, "hello");
         assert_eq!(finalized.end_time, 1.6);
         assert!(finalized.is_final);
+    }
+
+    fn word(text: &str, start_time: f64) -> PendingWord {
+        PendingWord {
+            text: text.into(),
+            start_time,
+            language: None,
+            speaker: None,
+        }
+    }
+
+    #[test]
+    fn open_word_emits_the_orphan_final_before_the_new_preview() {
+        // A language-mismatch reset moved "bonjour" to the orphan list before
+        // "monde" arrived. The consumers drop a preview as soon as a final
+        // lands, so the orphan has to come first.
+        let mut pending_words = vec![None];
+        let mut orphaned_words = vec![word("bonjour", 1.0)];
+        let mut segments = Vec::new();
+
+        KyutaiEngine::open_word(
+            &mut pending_words,
+            &mut orphaned_words,
+            0,
+            word("monde", 1.4),
+            &mut segments,
+        );
+
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].text, "bonjour");
+        assert!(segments[0].is_final);
+        assert_eq!(segments[1].text, "monde");
+        assert!(!segments[1].is_final);
+        assert!(orphaned_words.is_empty());
+        assert_eq!(
+            pending_words[0].as_ref().map(|p| p.text.as_str()),
+            Some("monde")
+        );
+    }
+
+    #[test]
+    fn open_word_closes_the_previous_word_before_previewing_the_new_one() {
+        let mut pending_words = vec![Some(word("hello", 1.0))];
+        let mut orphaned_words = Vec::new();
+        let mut segments = Vec::new();
+
+        KyutaiEngine::open_word(
+            &mut pending_words,
+            &mut orphaned_words,
+            0,
+            word("world", 1.5),
+            &mut segments,
+        );
+
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].text, "hello");
+        assert!(segments[0].is_final);
+        assert_eq!(segments[0].end_time, 1.5);
+        assert_eq!(segments[1].text, "world");
+        assert!(!segments[1].is_final);
+    }
+
+    #[test]
+    fn open_word_grows_the_lane_list_for_a_new_batch_index() {
+        let mut pending_words = Vec::new();
+        let mut orphaned_words = Vec::new();
+        let mut segments = Vec::new();
+
+        KyutaiEngine::open_word(
+            &mut pending_words,
+            &mut orphaned_words,
+            1,
+            word("them", 2.0),
+            &mut segments,
+        );
+
+        assert_eq!(pending_words.len(), 2);
+        assert!(pending_words[0].is_none());
+        assert_eq!(segments.len(), 1);
+        assert!(!segments[0].is_final);
     }
 }

--- a/src-tauri/src/engine/kyutai.rs
+++ b/src-tauri/src/engine/kyutai.rs
@@ -467,6 +467,20 @@ impl KyutaiEngine {
         }
     }
 
+    /// Live preview of a word still waiting for EndWord. Does not consume
+    /// the pending slot — the later final still comes from `emit_pending`.
+    fn pending_to_tentative_segment(pending: &PendingWord) -> TranscriptionSegment {
+        TranscriptionSegment {
+            text: pending.text.clone(),
+            start_time: pending.start_time,
+            end_time: pending.start_time,
+            is_final: false,
+            language: pending.language.clone(),
+            confidence: None,
+            speaker: pending.speaker,
+        }
+    }
+
     fn emit_pending(
         pending_words: &mut [Option<PendingWord>],
         batch_idx: usize,
@@ -838,12 +852,16 @@ impl KyutaiEngine {
                     if *batch_idx >= model.pending_words.len() {
                         model.pending_words.resize_with(*batch_idx + 1, || None);
                     }
-                    model.pending_words[*batch_idx] = Some(PendingWord {
+                    let pending = PendingWord {
                         text,
                         start_time,
                         language,
                         speaker,
-                    });
+                    };
+                    // Show the last word immediately; it stays pending until
+                    // EndWord / the next Word / drain finalizes it.
+                    segments.push(Self::pending_to_tentative_segment(&pending));
+                    model.pending_words[*batch_idx] = Some(pending);
                 }
                 moshi::asr::AsrMsg::EndWord {
                     stop_time,
@@ -1500,5 +1518,27 @@ mod tests {
         };
         let seg = KyutaiEngine::pending_to_segment(pending, 1.5);
         assert_eq!(seg.end_time, 2.0);
+    }
+
+    #[test]
+    fn pending_word_tentative_is_not_final_and_does_not_consume() {
+        let pending = PendingWord {
+            text: "hello".into(),
+            start_time: 1.2,
+            language: Some("en".into()),
+            speaker: Some(Speaker::Me),
+        };
+        let tentative = KyutaiEngine::pending_to_tentative_segment(&pending);
+        assert_eq!(tentative.text, "hello");
+        assert_eq!(tentative.start_time, 1.2);
+        assert_eq!(tentative.end_time, 1.2);
+        assert_eq!(tentative.language.as_deref(), Some("en"));
+        assert_eq!(tentative.speaker, Some(Speaker::Me));
+        assert!(!tentative.is_final);
+
+        let finalized = KyutaiEngine::pending_to_segment(pending, 1.6);
+        assert_eq!(finalized.text, "hello");
+        assert_eq!(finalized.end_time, 1.6);
+        assert!(finalized.is_final);
     }
 }

--- a/src/lib/features/home/LiveSessionCard.svelte
+++ b/src/lib/features/home/LiveSessionCard.svelte
@@ -9,7 +9,7 @@
   import type { LiveParagraph } from "../meeting/live-transcript.svelte";
   import type { createMeetingController } from "../meeting/controller.svelte";
   import type { createTranscriptionController } from "../transcription/controller.svelte";
-  import { elapsedSecondsSince, formatDuration, resolveSpeakerLabel } from "../../utils";
+  import { elapsedSecondsSince, formatDuration, resolveSpeakerLabel, segmentGap } from "../../utils";
 
   let {
     mode,
@@ -48,6 +48,7 @@
   const liveTentative = $derived(
     mode === "meeting" ? meeting.liveTranscript.tentative : transcription.tentative,
   );
+
 
   const hasLiveContent = $derived(
     mode === "dictation"
@@ -197,7 +198,7 @@
   {#if mode === "dictation"}
     <div class="flex min-h-[340px] flex-col rounded-[18px] bg-surface-1 p-[30px] px-8 outline-1 outline-ghost-border">
       <p class="m-0 text-[19px] font-normal leading-[1.85] text-text-secondary">
-        {liveText}{#if liveTentative}<span class="opacity-50">{liveText ? " " : ""}{liveTentative}</span>{/if}<span
+        {liveText}{#if liveTentative}<span class="opacity-50">{segmentGap(liveText, liveTentative)}{liveTentative}</span>{/if}<span
           class="ml-0.5 inline-block h-5 w-0.5 bg-accent align-[-3px]"
           style="animation: blink 1s step-end infinite;"
         ></span>
@@ -298,7 +299,7 @@
                     class="m-0 inline text-[15px] leading-[1.75] text-text-secondary"
                   />
                   {#if i === liveParagraphs.length - 1 && liveTentative}
-                    <span class="opacity-50">{paragraph.text ? " " : ""}{liveTentative}</span>
+                    <span class="opacity-50">{segmentGap(paragraph.text, liveTentative)}{liveTentative}</span>
                   {/if}
                 </p>
               {/if}

--- a/src/lib/features/home/LiveSessionCard.svelte
+++ b/src/lib/features/home/LiveSessionCard.svelte
@@ -45,10 +45,14 @@
         .slice(-LIVE_PARAGRAPH_WINDOW)
       : [],
   );
-  const liveTentative = $derived(mode === "meeting" ? meeting.liveTranscript.tentative : "");
+  const liveTentative = $derived(
+    mode === "meeting" ? meeting.liveTranscript.tentative : transcription.tentative,
+  );
 
   const hasLiveContent = $derived(
-    mode === "dictation" ? Boolean(liveText) : liveParagraphs.length > 0 || Boolean(liveTentative),
+    mode === "dictation"
+      ? Boolean(liveText) || Boolean(liveTentative)
+      : liveParagraphs.length > 0 || Boolean(liveTentative),
   );
 
   const elapsed = $derived(
@@ -193,7 +197,7 @@
   {#if mode === "dictation"}
     <div class="flex min-h-[340px] flex-col rounded-[18px] bg-surface-1 p-[30px] px-8 outline-1 outline-ghost-border">
       <p class="m-0 text-[19px] font-normal leading-[1.85] text-text-secondary">
-        {liveText}<span
+        {liveText}{#if liveTentative}<span class="opacity-50">{liveText ? " " : ""}{liveTentative}</span>{/if}<span
           class="ml-0.5 inline-block h-5 w-0.5 bg-accent align-[-3px]"
           style="animation: blink 1s step-end infinite;"
         ></span>

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -576,4 +576,114 @@ describe("transcription controller", () => {
     }
   });
 
+  function captureTranscriptionChannel() {
+    let transcriptionChannel: { onmessage: ((msg: unknown) => void) | null } | null = null;
+    mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "start_transcription") {
+        transcriptionChannel = args?.channel as { onmessage: ((msg: unknown) => void) | null };
+        return Promise.resolve(null);
+      }
+      return defaultInvoke(cmd, args);
+    });
+    return {
+      emit(segment: { text: string; is_final: boolean }) {
+        transcriptionChannel?.onmessage?.(segment);
+      },
+    };
+  }
+
+  it("non-final sets tentative without changing transcript", async () => {
+    const channel = captureTranscriptionChannel();
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+    await ctrl.toggleRecording();
+
+    channel.emit({ text: "hello", is_final: false });
+
+    expect(ctrl.tentative).toBe("hello");
+    expect(ctrl.transcript).toBe("");
+  });
+
+  it("final after tentative clears tentative and appends to transcript", async () => {
+    const channel = captureTranscriptionChannel();
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+    await ctrl.toggleRecording();
+
+    channel.emit({ text: "hello", is_final: true });
+    channel.emit({ text: "world", is_final: false });
+    expect(ctrl.transcript).toBe("hello");
+    expect(ctrl.tentative).toBe("world");
+
+    channel.emit({ text: "world", is_final: true });
+    expect(ctrl.tentative).toBe("");
+    expect(ctrl.transcript).toBe("hello world");
+  });
+
+  it("paste and polish use transcript only, not the live tentative", async () => {
+    const channel = captureTranscriptionChannel();
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+    ctrl.app.settings = { ...ctrl.app.settings, dictation_polish_enabled: true, auto_paste: true };
+
+    await ctrl.toggleRecording(true);
+    simulateRecordingStarted(ctrl.app);
+    channel.emit({ text: "hello", is_final: true });
+    channel.emit({ text: "pending", is_final: false });
+    expect(ctrl.tentative).toBe("pending");
+
+    await ctrl.toggleRecording(true);
+
+    expect(mockInvoke).toHaveBeenCalledWith("polish_dictation", expect.objectContaining({
+      text: "hello",
+    }));
+    expect(mockInvoke).toHaveBeenCalledWith("add_dictation_entry", { text: "hello" });
+    expect(mockInvoke).toHaveBeenCalledWith("paste_text", expect.objectContaining({
+      text: "hello",
+    }));
+    expect(mockInvoke).not.toHaveBeenCalledWith("polish_dictation", expect.objectContaining({
+      text: expect.stringContaining("pending"),
+    }));
+  });
+
+  it("abort clears tentative and saves transcript only", async () => {
+    const channel = captureTranscriptionChannel();
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+    ctrl.app.settings = { ...ctrl.app.settings, dictation_polish_enabled: false };
+
+    await ctrl.toggleRecording();
+    simulateRecordingStarted(ctrl.app);
+    channel.emit({ text: "hello", is_final: true });
+    channel.emit({ text: "pending", is_final: false });
+    expect(ctrl.tentative).toBe("pending");
+
+    ctrl.handleRecordingAborted();
+
+    expect(ctrl.tentative).toBe("");
+    await vi.waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("add_dictation_entry", { text: "hello" });
+    });
+    expect(mockInvoke).not.toHaveBeenCalledWith("add_dictation_entry", {
+      text: expect.stringContaining("pending"),
+    });
+  });
+
+  it("starting a session resets leftover tentative", async () => {
+    const channel = captureTranscriptionChannel();
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+
+    await ctrl.toggleRecording();
+    simulateRecordingStarted(ctrl.app);
+    channel.emit({ text: "stale", is_final: false });
+    expect(ctrl.tentative).toBe("stale");
+
+    await ctrl.toggleRecording();
+    ctrl.app.machineState = { state: "idle" };
+    await ctrl.toggleRecording();
+    expect(ctrl.tentative).toBe("");
+    expect(ctrl.transcript).toBe("");
+  });
+
 });

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -134,6 +134,7 @@ function createTranscriptionControllerInstance() {
   let isStartingRecording = $state(false);
   let isStopping = $state(false);
   let transcript = $state("");
+  let tentative = $state("");
   let statusMessage = $state("");
   let catalog = $state<TranscriptionCatalog | null>(null);
 
@@ -355,6 +356,7 @@ function createTranscriptionControllerInstance() {
     cancelLearnFromEditPoll();
     if (!fromShortcut) sessionMode = "insert";
     transcript = "";
+    tentative = "";
     statusMessage = "";
     isStartingRecording = true;
     sessionGeneration += 1;
@@ -364,14 +366,17 @@ function createTranscriptionControllerInstance() {
       await captureStartContext();
       await startStreamingTranscription((segment: TranscriptionSegment) => {
         if (generation !== sessionGeneration) return; // stale session
-        if (segment.is_final) {
-          if (transcript) {
-            if (!transcript.endsWith(" ") && !segment.text.startsWith(" ")) {
-              transcript += " ";
-            }
-          }
-          transcript += segment.text;
+        if (!segment.is_final) {
+          tentative = segment.text;
+          return;
         }
+        tentative = "";
+        if (transcript) {
+          if (!transcript.endsWith(" ") && !segment.text.startsWith(" ")) {
+            transcript += " ";
+          }
+        }
+        transcript += segment.text;
       });
     } catch (e) {
       statusMessage = errorMessage(e);
@@ -388,6 +393,7 @@ function createTranscriptionControllerInstance() {
     sessionGeneration += 1; // cut off in-flight segments from the dead session
     isStartingRecording = false;
     isStopping = false;
+    tentative = "";
     cancelLearnFromEditPoll();
     if (transcript.trim()) {
       void finalizeDictationText(transcript, sessionFocusedApp, sessionRewriteOf).then(({ text, warning }) => {
@@ -410,6 +416,7 @@ function createTranscriptionControllerInstance() {
     get isStartingRecording() { return isStartingRecording; },
     get isStopping() { return isStopping; },
     get transcript() { return transcript; },
+    get tentative() { return tentative; },
     get statusMessage() { return statusMessage; },
     get catalog() { return catalog; },
     get runtimePhase() { return app.transcriptionRuntimePhase; },

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -13,7 +13,7 @@ import { frontmostAppName, readFocusedText, readSelectedText } from "../../api/f
 import { events } from "../../api/generated";
 import { createTimelineController } from "../timeline/controller.svelte";
 import type { TranscriptionCatalog, TranscriptionSegment } from "../../types";
-import { errorMessage } from "../../utils";
+import { errorMessage, segmentGap } from "../../utils";
 import { formatSelectedTranscriptionLabel } from "./catalog";
 import { ensureModelLoaded, refreshTranscriptionRuntimeStatus } from "./runtime";
 
@@ -371,12 +371,7 @@ function createTranscriptionControllerInstance() {
           return;
         }
         tentative = "";
-        if (transcript) {
-          if (!transcript.endsWith(" ") && !segment.text.startsWith(" ")) {
-            transcript += " ";
-          }
-        }
-        transcript += segment.text;
+        transcript += segmentGap(transcript, segment.text) + segment.text;
       });
     } catch (e) {
       statusMessage = errorMessage(e);

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -7,6 +7,7 @@ export type { Paragraph, TranscriptBlock } from "./paragraphs";
 export { isClickableTranscriptWord, tokenizeTranscriptWords } from "./transcript-words";
 export type { TranscriptWordToken } from "./transcript-words";
 export { errorMessage } from "./errors";
+export { segmentGap } from "./segment-join";
 export { renderReleaseNotesMarkdown } from "./markdown";
 export { createDebouncedSearch, filterResultsByType, findSnippet, matchedIdsForType } from "./search.svelte";
 export type { DebouncedSearch } from "./search.svelte";

--- a/src/lib/utils/segment-join.test.ts
+++ b/src/lib/utils/segment-join.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+
+import { segmentGap } from "./segment-join";
+
+describe("segmentGap", () => {
+  it("adds a space when neither side has one", () => {
+    expect(segmentGap("hello", "world")).toBe(" ");
+  });
+
+  it("adds nothing when the text already ends with a space", () => {
+    expect(segmentGap("hello ", "world")).toBe("");
+  });
+
+  it("adds nothing when the segment already starts with a space", () => {
+    expect(segmentGap("hello", " world")).toBe("");
+  });
+
+  it("adds nothing when both sides have a space", () => {
+    expect(segmentGap("hello ", " world")).toBe("");
+  });
+
+  it("adds nothing at the start of a transcript", () => {
+    expect(segmentGap("", "hello")).toBe("");
+  });
+
+  it("adds nothing for an empty segment", () => {
+    expect(segmentGap("hello", "")).toBe("");
+  });
+});

--- a/src/lib/utils/segment-join.ts
+++ b/src/lib/utils/segment-join.ts
@@ -1,0 +1,12 @@
+/**
+ * The separator to insert between already-transcribed text and the next
+ * segment. Engines emit their own leading spaces inconsistently, so a
+ * segment is joined with a single space only when neither side supplies one.
+ *
+ * The live preview and the finalized transcript both use this, so the word
+ * shown in grey sits exactly where it lands once it is confirmed.
+ */
+export function segmentGap(before: string, next: string): string {
+  if (!before || !next) return "";
+  return before.endsWith(" ") || next.startsWith(" ") ? "" : " ";
+}


### PR DESCRIPTION
## Summary
- Kyutai now emits the pending last word as `is_final: false` without taking it out of `pending_words`; the existing EndWord / next-Word path still emits the final
- Meeting persistence skips non-finals so SQLite never stores a tentative that the later final would duplicate; the live channel still forwards them
- Dictation gets its own `tentative` state (transcript stays append-only for paste/polish/history); LiveSessionCard and the pill show the pending word faded

Fixes SOU-003 (reopened after #117). Punctuation-too-fast is still out of scope.

## Test plan
- [ ] Dictation: last word of a phrase appears immediately (faded) between sentences; next phrase / stop replaces it with the final
- [ ] Stop + auto-paste / polish: only confirmed `transcript` is pasted (flush should finalize the pending word before stop returns)
- [ ] Abort mid-phrase: tentative is cleared and not saved/pasted
- [ ] Meeting: last word shows faded; reopen/replay has no duplicate tentative rows
- [ ] Diarized meeting: both Me and Them lanes show tentatives
- [ ] Pill live text shows the pending word without it leaking into paste

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Live transcription now displays tentative text as words are recognized, before they are finalized.
  - Meeting and dictation sessions provide real-time preview text.
  - Dictation previews appear visually distinct from confirmed text.

- **Bug Fixes**
  - Only finalized transcription is used for transcript history, saving, polishing, and paste actions.
  - Tentative text is cleared when recording ends, is aborted, or a new session begins.
  - Confirmed transcription remains available even when a session is aborted.
  - Improved spacing between transcription segments to prevent duplicate or missing spaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->