### PR TITLE
Repair the summary build after two merges collided

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -45,3 +45,9 @@ jobs:
       # so the MCP sidecar must exist before type export (same as release builds).
       - run: ./scripts/build-mcp-sidecar.sh
       - run: npm run check:generated-types
+      # Two PRs can each be green and still break develop together: one turned
+      # a &str into a String while the other added a caller. Only the merged
+      # tree catches that, so run the suites here as well as locally.
+      - run: cargo test --manifest-path src-tauri/Cargo.toml --workspace
+      - run: npm test
+      - run: npm run check

--- a/src-tauri/src/summary/mod.rs
+++ b/src-tauri/src/summary/mod.rs
@@ -491,7 +491,7 @@ pub async fn summarize_stream(
         )
         .await?;
         let summary = sanitize_summary(&full);
-        warn_if_final_summary_is_truncated(&summary, final_system_prompt);
+        warn_if_final_summary_is_truncated(&summary, &final_system_prompt);
         return Ok(summary);
     }
 
@@ -596,7 +596,7 @@ pub async fn summarize_stream(
     )
     .await?;
     let summary = sanitize_summary(&full);
-    warn_if_final_summary_is_truncated(&summary, final_system_prompt);
+    warn_if_final_summary_is_truncated(&summary, &final_system_prompt);
     Ok(summary)
 }
 


### PR DESCRIPTION
`#125` made the final system prompt an owned `String` so it could carry the output-language rule. `#126` added two callers that still take a `&str`. Each branch was green on its own; the merged tree does not compile.

## Fixed

- The two `warn_if_final_summary_is_truncated` call sites now borrow the prompt.

## Improved

- CI runs `cargo test --workspace`, `npm test` and `npm run check`. Until now the only thing compiling the backend was the generated-type export, and the frontend suite never ran in CI at all, which is why this got through.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded the generated-contracts validation workflow to also run Rust workspace tests, JavaScript tests, and project checks.
  - Improved coverage of automated validation for generated contract changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->