### PR TITLE
Keep audio and vision Ollama models out of Auto summary (SOU-080)

### DIFF
--- a/src-tauri/src/summary/ollama.rs
+++ b/src-tauri/src/summary/ollama.rs
@@ -274,7 +274,9 @@ pub fn is_summary_capable_model(model: &str) -> bool {
         return false;
     }
 
-    let blocked_tokens = ["stt", "asr", "e5", "bge", "gte", "code"];
+    let blocked_tokens = [
+        "stt", "asr", "e5", "bge", "gte", "code", "audio", "omni", "vl", "vision", "tts", "xtts",
+    ];
     let tokens = lower.split(|c: char| !c.is_alphanumeric());
     !tokens
         .into_iter()
@@ -682,6 +684,19 @@ mod tests {
     }
 
     #[test]
+    fn rejects_audio_omni_and_vision_models_for_summary() {
+        assert!(!is_summary_capable_model("qwen2-audio"));
+        assert!(!is_summary_capable_model("qwen2.5-omni"));
+        assert!(!is_summary_capable_model("qwen2.5-vl:7b"));
+        assert!(!is_summary_capable_model("llama3.2-vision"));
+        assert!(is_summary_capable_model("qwen2.5:7b"));
+        assert_eq!(
+            sorted_summary_capable_models(&["qwen2-audio".into(), "qwen2.5:7b".into()]),
+            vec!["qwen2.5:7b".to_string()]
+        );
+    }
+
+    #[test]
     fn rejects_short_keyword_models_as_whole_tokens() {
         assert!(!is_summary_capable_model("intfloat/e5-large"));
         assert!(!is_summary_capable_model("kyutai-stt:1b"));
@@ -691,6 +706,7 @@ mod tests {
     fn accepts_models_where_short_keyword_is_only_a_substring() {
         assert!(is_summary_capable_model("faste5ish:latest"));
         assert!(is_summary_capable_model("vgte-model:latest"));
+        assert!(is_summary_capable_model("audiolm:latest"));
     }
 
     /// A code model can follow the polish prompt just enough to look like it

--- a/src-tauri/src/summary/ollama.rs
+++ b/src-tauri/src/summary/ollama.rs
@@ -264,11 +264,14 @@ pub fn is_summary_capable_model(model: &str) -> bool {
     // worse than offering nothing, because the feature then looks broken
     // instead of unconfigured.
     let speech_or_embedding = ["whisper", "speech", "wav2vec", "embed", "minilm"];
+    // llava covers bakllava and the llava-llama3 / llava-phi3 variants.
+    let vision_models = ["llava", "moondream"];
     // "coder" alone covers starcoder, sqlcoder, deepseek-coder and qwen-coder.
     let code_models = ["coder", "codellama", "codegemma", "codestral", "code-"];
     if speech_or_embedding
         .iter()
         .chain(code_models.iter())
+        .chain(vision_models.iter())
         .any(|keyword| lower.contains(keyword))
     {
         return false;
@@ -277,10 +280,19 @@ pub fn is_summary_capable_model(model: &str) -> bool {
     let blocked_tokens = [
         "stt", "asr", "e5", "bge", "gte", "code", "audio", "omni", "vl", "vision", "tts", "xtts",
     ];
+    // Ollama also glues the modality onto the version number (`qwen2.5vl`),
+    // which never yields a standalone token. Only reject the glued form when a
+    // digit precedes it, so `audiolm` and friends stay accepted.
+    let glued_modalities = ["vl", "vision", "audio", "omni", "tts"];
     let tokens = lower.split(|c: char| !c.is_alphanumeric());
-    !tokens
-        .into_iter()
-        .any(|token| blocked_tokens.contains(&token))
+    !tokens.into_iter().any(|token| {
+        blocked_tokens.contains(&token)
+            || glued_modalities.iter().any(|modality| {
+                token
+                    .strip_suffix(modality)
+                    .is_some_and(|head| head.ends_with(|c: char| c.is_ascii_digit()))
+            })
+    })
 }
 
 fn summary_model_priority(model: &str) -> usize {
@@ -689,6 +701,11 @@ mod tests {
         assert!(!is_summary_capable_model("qwen2.5-omni"));
         assert!(!is_summary_capable_model("qwen2.5-vl:7b"));
         assert!(!is_summary_capable_model("llama3.2-vision"));
+        assert!(!is_summary_capable_model("qwen2.5vl:7b"));
+        assert!(!is_summary_capable_model("qwen3vl:8b"));
+        assert!(!is_summary_capable_model("llava:13b"));
+        assert!(!is_summary_capable_model("bakllava"));
+        assert!(!is_summary_capable_model("moondream"));
         assert!(is_summary_capable_model("qwen2.5:7b"));
         assert_eq!(
             sorted_summary_capable_models(&["qwen2-audio".into(), "qwen2.5:7b".into()]),
@@ -707,6 +724,7 @@ mod tests {
         assert!(is_summary_capable_model("faste5ish:latest"));
         assert!(is_summary_capable_model("vgte-model:latest"));
         assert!(is_summary_capable_model("audiolm:latest"));
+        assert!(is_summary_capable_model("supervision-writer:latest"));
     }
 
     /// A code model can follow the polish prompt just enough to look like it


### PR DESCRIPTION
Fixes SOU-080.

## Problème

Le filtre `is_summary_capable_model` écarte whisper / embed / coder, mais laisse `qwen2-audio`, `qwen2.5-omni`, `qwen2.5-vl`. Ils portent `qwen` → priorité 0, *devant* `qwen2.5:7b`. Sous Auto sans Apple, ou Ollama sans modèle stocké, `choose_summary_model` prend le premier : résumé parti sur un modèle parole / omni / vision.

Distinct de SOU-029 (#124) : le picker est visible, c'est le **défaut** qui est faux.

## Correctif

Tokens bloqués ajoutés : `audio`, `omni`, `vl`, `vision`, `tts`, `xtts` (entiers, pas sous-chaînes — `audiolm` reste accepté).

Le picker peut toujours afficher ce qui passe le filtre ; `validate_model` refuse un nom filtré si on le force.

## Tests

- `qwen2-audio` / `qwen2.5-omni` / `qwen2.5-vl:7b` refusés ; `qwen2.5:7b` accepté.
- `sorted_summary_capable_models(["qwen2-audio", "qwen2.5:7b"])` → `qwen2.5:7b`.

`cargo test --workspace` passe.

## QA sur machine

1. Ollama avec `qwen2.5:7b` seul : Auto inchangé.
2. Ajouter `qwen2-audio` (ou omni) : plus dans le picker ; Auto prend `qwen2.5:7b`.
3. `whisper` / `nomic-embed-text` : toujours exclus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic summary model selection by excluding incompatible vision models, including Llava, Moondream, and numeric model versions with vision suffixes such as “qwen2.5vl.”
  - Preserved support for valid text-generation models and names that only contain related terms, such as “audiolm.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->