### PR TITLE
Name an untagged build "local build" instead of a stale version

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6395,7 +6395,7 @@ dependencies = [
 
 [[package]]
 name = "souffle"
-version = "0.4.0"
+version = "0.0.0"
 dependencies = [
  "accessibility-sys",
  "arboard",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -3,7 +3,11 @@ members = [".", "souffle-mcp", "tts-fixtures"]
 
 [package]
 name = "souffle"
-version = "0.4.0"
+# Placeholder. The release workflow rewrites this line from the release tag, so
+# a version still reading 0.0.0 at compile time means the binary was built from
+# a checkout rather than cut from a tag. `update_check::current_version` turns
+# that into "local build".
+version = "0.0.0"
 description = "Local speech-to-text desktop application"
 authors = ["Damien Goehrig"]
 license = "GPL-3.0-or-later"

--- a/src-tauri/src/archive.rs
+++ b/src-tauri/src/archive.rs
@@ -86,7 +86,7 @@ pub fn run_archive_export(
         .map_err(|e| format!("Write dictations.json: {e}"))?;
 
     let manifest = ArchiveManifest {
-        app_version: env!("CARGO_PKG_VERSION").to_string(),
+        app_version: crate::update_check::current_version(),
         schema_version: crate::db::schema::SCHEMA_VERSION,
         meeting_count: meetings.len() as u32,
         dictation_count: dictation_entries.len() as u32,
@@ -223,7 +223,7 @@ mod tests {
         let manifest_json = fs::read_to_string(outcome.archive_dir.join("manifest.json")).unwrap();
         let manifest: ArchiveManifest = serde_json::from_str(&manifest_json).unwrap();
         assert_eq!(manifest.meeting_count, 2);
-        assert_eq!(manifest.app_version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(manifest.app_version, crate::update_check::current_version());
     }
 
     #[test]

--- a/src-tauri/src/diagnostics.rs
+++ b/src-tauri/src/diagnostics.rs
@@ -89,7 +89,7 @@ pub fn collect_bundle(state: &AppState, settings: &crate::settings::AppSettings)
         .unwrap_or_else(|e| format!("error: {e}"));
 
     DiagnosticsBundle {
-        app_version: env!("CARGO_PKG_VERSION").to_string(),
+        app_version: crate::update_check::current_version(),
         data_dir: data_dir.display().to_string(),
         log_dir: log_dir().display().to_string(),
         log_file: log_path.map(|p| p.display().to_string()),

--- a/src-tauri/src/update_check.rs
+++ b/src-tauri/src/update_check.rs
@@ -20,7 +20,22 @@ struct GitHubRelease {
     body: Option<String>,
 }
 
+/// Cargo version of a checkout the release workflow has not stamped.
+const UNRELEASED: &str = "0.0.0";
+
+/// Shown wherever a release would show its number, so a binary built from a
+/// checkout never passes itself off as a shipped version.
+pub const LOCAL_BUILD: &str = "local build";
+
+/// True when this binary was built from a checkout rather than cut from a tag.
+pub fn is_local_build() -> bool {
+    env!("CARGO_PKG_VERSION") == UNRELEASED
+}
+
 pub fn current_version() -> String {
+    if is_local_build() {
+        return LOCAL_BUILD.to_string();
+    }
     env!("CARGO_PKG_VERSION").to_string()
 }
 
@@ -31,7 +46,7 @@ pub fn check_for_updates() -> UpdateCheckResult {
     match fetch_latest_release() {
         Ok(release) => {
             let latest = normalize_version_tag(&release.tag_name);
-            let update_available = version_gt(&latest, &current);
+            let update_available = should_offer_update(&latest, &current, is_local_build());
             UpdateCheckResult {
                 current_version: current,
                 latest_version: Some(latest),
@@ -99,6 +114,13 @@ fn normalize_version_tag(tag: &str) -> String {
     tag.trim().trim_start_matches('v').to_string()
 }
 
+/// Whether to announce `latest` to someone running `current`. A local build is
+/// normally ahead of the newest tag and its version does not compare, so it is
+/// never offered an "update" to code older than what was just built.
+fn should_offer_update(latest: &str, current: &str, local_build: bool) -> bool {
+    !local_build && version_gt(latest, current)
+}
+
 /// Compare dotted numeric version strings (`0.1.0` style).
 pub fn version_gt(left: &str, right: &str) -> bool {
     parse_version_parts(left) > parse_version_parts(right)
@@ -114,6 +136,24 @@ fn parse_version_parts(version: &str) -> Vec<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Guards the contract with the release workflow: it rewrites the Cargo
+    /// version from the tag, so anything it has not touched is a local build.
+    #[test]
+    fn an_unstamped_checkout_reports_a_local_build() {
+        assert!(is_local_build());
+        assert_eq!(current_version(), LOCAL_BUILD);
+    }
+
+    /// A tag parses as numerically greater than the placeholder, so without
+    /// the guard every local build would nag daily to install older code.
+    #[test]
+    fn a_local_build_is_never_offered_an_update() {
+        assert!(version_gt("0.10.0", UNRELEASED));
+        assert!(!should_offer_update("0.10.0", LOCAL_BUILD, true));
+        assert!(should_offer_update("0.10.0", "0.9.0", false));
+        assert!(!should_offer_update("0.10.0", "0.10.0", false));
+    }
 
     #[test]
     fn version_gt_orders_semver_parts() {

--- a/src/lib/bootstrap.test.ts
+++ b/src/lib/bootstrap.test.ts
@@ -25,7 +25,7 @@ vi.mock("./utils/theme", () => ({
   applyTheme: vi.fn(),
 }));
 
-import { bootstrapAppState } from "./bootstrap";
+import { LOCAL_BUILD, bootstrapAppState } from "./bootstrap";
 import { getAppState } from "./stores/app.svelte";
 import { mockSettings } from "./test-helpers/fixtures";
 import { SETUP_STORAGE_KEY } from "./features/onboarding/setup";
@@ -80,5 +80,20 @@ describe("bootstrapAppState what's new", () => {
 
     const result = await bootstrapAppState(app);
     expect(result.whatsNew).toBeNull();
+  });
+
+  it("shows no changelog for a local build, and leaves last_seen_version alone", async () => {
+    localStorage.setItem(SETUP_STORAGE_KEY, "1");
+    getSettings.mockResolvedValue({ ...mockSettings, last_seen_version: "0.10.0" });
+    getAppVersion.mockResolvedValue(LOCAL_BUILD);
+
+    const result = await bootstrapAppState(app);
+
+    expect(result.whatsNew).toBeNull();
+    // Stamping "local build" here would swallow the next real release's
+    // changelog, since that release would then differ from what was stored.
+    expect(saveSettings).not.toHaveBeenCalledWith(
+      expect.objectContaining({ last_seen_version: LOCAL_BUILD }),
+    );
   });
 });

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -11,6 +11,10 @@ export type BootstrapResult = {
   whatsNew: { version: string; releaseNotes: string } | null;
 };
 
+/** Mirrors `update_check::LOCAL_BUILD`: what get_app_version returns from a
+ * checkout the release workflow never stamped. */
+export const LOCAL_BUILD = "local build";
+
 export async function bootstrapAppState(
   app: ReturnType<typeof getAppState>,
 ): Promise<BootstrapResult> {
@@ -43,6 +47,14 @@ export async function bootstrapAppState(
   const currentVersion = await getAppVersion();
   const previousVersion = app.settings.last_seen_version.trim();
   const setupDone = readSetupFlags().setupDone;
+
+  // A build made from a checkout has no release notes to show, and its version
+  // string is not a number, so "Updated to vlocal build." would be the whole
+  // dialog. Leave last_seen_version alone too: the next real release should
+  // still announce itself.
+  if (currentVersion === LOCAL_BUILD) {
+    return { whatsNew: null };
+  }
 
   // First launch and unfinished setup: stamp the version silently so the
   // changelog never stacks on the wizard, and so finishing setup doesn't


### PR DESCRIPTION
## Problème

`src-tauri/Cargo.toml` porte `version = "0.4.0"` alors que le dernier tag est `v0.10.0`. Le workflow de release réécrit cette ligne depuis le tag (`release.yml:139-147`), donc la valeur commitée n'est jamais vue que par une build faite depuis un checkout.

Conséquences pour une build locale :

- À propos, bundle de diagnostic et manifeste d'archive annoncent `0.4.0`, une version publiée il y a des mois.
- `check_for_updates` compare `0.10.0 > 0.4.0` et propose donc quotidiennement de « mettre à jour » vers du code **plus ancien** que celui qui vient d'être compilé.

## Correctif

- Placeholder explicite `0.0.0` dans Cargo.toml, avec le commentaire qui dit pourquoi. Le `sed` de la release ne matche toujours qu'une seule ligne (`^version = `).
- `update_check::current_version()` rend `"local build"` pour ce placeholder ; `is_local_build()` expose le test.
- `should_offer_update(latest, current, local_build)` extrait la décision pour que les deux branches soient testables (dans une build de test, `is_local_build()` est toujours vrai).
- Diagnostics et manifeste d'archive passent par `current_version()`, donc un rapport de bug dit « local build » au lieu de mentir.
- `bootstrap.ts` ne montre pas de changelog pour une build locale, et **n'écrit pas** `last_seen_version`, sinon la prochaine vraie release n'annoncerait plus rien.

Aucun impact sur les releases : le tag reste la source de vérité et écrase le placeholder.

## Tests

`cargo test --workspace` (832), `npm test` (412), `npm run check`. Nouveaux cas : le checkout non tamponné se déclare local, et une build locale ne se voit jamais proposer de mise à jour.

## Note

Mergée directement dans `develop` sans attendre la CI, à la demande, pour débloquer une build de test locale.
