### PR TITLE
Fix SOU-072: Add timeouts to EngineActor recv() calls

### DIFF
--- a/src-tauri/src/pipeline/actor.rs
+++ b/src-tauri/src/pipeline/actor.rs
@@ -199,12 +199,15 @@ impl EngineActorHandle {
                 model_dir,
                 reply,
             },
-            None,
+            Some(Duration::from_secs(300)), // 5 minute timeout for model loading
         )
     }
 
     pub fn unload_model(&self) -> Result<(), String> {
-        self.request(|reply| EngineCommand::UnloadModel { reply }, None)
+        self.request(
+            |reply| EngineCommand::UnloadModel { reply },
+            Some(Duration::from_secs(60)), // 1 minute timeout for unloading
+        )
     }
 
     /// Reconfigure the idle-unload timeout; `0` disables it. Fire-and-forget:
@@ -238,7 +241,7 @@ impl EngineActorHandle {
                 on_segment,
                 reply,
             },
-            None,
+            Some(Duration::from_secs(60)), // 1 minute timeout for setup
         )
     }
 
@@ -253,7 +256,7 @@ impl EngineActorHandle {
     pub fn debug_transcribe(&self, samples: Vec<f32>) -> Result<Vec<TranscriptionSegment>, String> {
         self.request(
             |reply| EngineCommand::DebugTranscribe { samples, reply },
-            None,
+            Some(Duration::from_secs(60)), // 1 minute timeout for debug transcribe
         )
     }
 
@@ -262,7 +265,7 @@ impl EngineActorHandle {
     pub fn add_session_correction(&self, correction: SessionCorrection) -> Result<(), String> {
         self.request(
             |reply| EngineCommand::AddSessionCorrection { correction, reply },
-            None,
+            Some(Duration::from_secs(5)), // 5 second timeout for light dict operations
         )
     }
 


### PR DESCRIPTION
Fixes SOU-072. Adds timeouts to synchronous channel recv() calls in EngineActorHandle (e.g., load_model) to prevent indefinite blocking in the 'Loading' state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added time limits to model loading, session setup, unloading, debug transcription, and session correction operations.
  - Prevents these operations from waiting indefinitely when a response is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->