### PR TITLE
Fix SOU-045: Queue PTT release during recording startup

### DIFF
--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -900,6 +900,40 @@ describe("transcription controller", () => {
     expect(pasteCalls[0][1]).toEqual(expect.objectContaining({ text: "hello" }));
   });
 
+  it("queued PTT stop does not stop a later dictation after abort (SOU-045)", async () => {
+    let releaseStart: (() => void) | undefined;
+    mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "start_transcription") {
+        return new Promise<void>((r) => { releaseStart = r; });
+      }
+      return defaultInvoke(cmd, args);
+    });
+
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+
+    const firstStart = ctrl.toggleRecording(true);
+    await vi.waitFor(() => {
+      expect(releaseStart).toBeTypeOf("function");
+    });
+
+    eventListeners["shortcut-ptt-stop"]?.({ payload: null });
+    releaseStart!();
+    await firstStart;
+    simulateRecordingStarted(ctrl.app);
+
+    ctrl.handleRecordingAborted();
+    ctrl.app.machineState = { state: "idle" };
+
+    mockInvoke.mockImplementation(defaultInvoke);
+    await ctrl.toggleRecording(true);
+    simulateRecordingStarted(ctrl.app);
+
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(mockInvoke).not.toHaveBeenCalledWith("stop_transcription");
+  });
+
   it("toggleRecording directly is a no-op while a meeting is recording", async () => {
     const ctrl = createTranscriptionController();
     await ctrl.mount();

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -927,6 +927,8 @@ describe("transcription controller", () => {
 
     mockInvoke.mockImplementation(defaultInvoke);
     await ctrl.toggleRecording(true);
+    const startCalls = mockInvoke.mock.calls.filter((call) => call[0] === "start_transcription");
+    expect(startCalls).toHaveLength(2);
     simulateRecordingStarted(ctrl.app);
 
     await new Promise((r) => setTimeout(r, 60));

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -148,6 +148,7 @@ function createTranscriptionControllerInstance() {
   let focusedApp: string | null = null;
   let rewriteOf: string | null = null;
   let learnFromEditTimer: ReturnType<typeof setTimeout> | null = null;
+  let pttStopQueued = false;
 
   let activeProfileLabel = $derived.by(() => {
     if (!catalog) return "Transcription model";
@@ -257,7 +258,11 @@ function createTranscriptionControllerInstance() {
         }
       }),
       events.shortcutPttStop.listen(() => {
-        if (isDictating && !isStopping) void toggleRecording(true);
+        if (isStartingRecording) {
+          pttStopQueued = true;
+        } else if (isDictating && !isStopping) {
+          void toggleRecording(true);
+        }
       }),
     ]);
 
@@ -424,6 +429,14 @@ function createTranscriptionControllerInstance() {
       clearSessionContext();
     } finally {
       isStartingRecording = false;
+      if (pttStopQueued) {
+        pttStopQueued = false;
+        // PTT stop was queued while starting. Wait briefly for machineState
+        // to sync (Tauri event to be processed by Svelte stores), then stop.
+        setTimeout(() => {
+          if (isDictating && !isStopping) void toggleRecording(true);
+        }, 50);
+      }
     }
   }
 
@@ -434,6 +447,7 @@ function createTranscriptionControllerInstance() {
     sessionGeneration += 1; // cut off in-flight segments from the dead session
     isStartingRecording = false;
     isStopping = false;
+    pttStopQueued = false;
     tentative = "";
     cancelLearnFromEditPoll();
     if (transcript.trim()) {

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -433,7 +433,9 @@ function createTranscriptionControllerInstance() {
         pttStopQueued = false;
         // PTT stop was queued while starting. Wait briefly for machineState
         // to sync (Tauri event to be processed by Svelte stores), then stop.
+        const queuedGeneration = generation;
         setTimeout(() => {
+          if (queuedGeneration !== sessionGeneration) return;
           if (isDictating && !isStopping) void toggleRecording(true);
         }, 50);
       }


### PR DESCRIPTION
Fixes SOU-045. When PTT is pressed and released very quickly, the release event was ignored because the recording was still initializing. This PR queues the stop event and executes it once the startup sequence completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved push-to-talk behavior when stopping dictation during startup.
  - Prevented delayed stop actions from an aborted startup from affecting a subsequent dictation session.
  - Ensured stop requests are ignored when they belong to an earlier dictation session.
  - Improved reliability when replacing an in-progress dictation session by ensuring the new session starts transcription correctly.
- **Tests**
  - Added regression coverage for push-to-talk behavior after an aborted startup and for replacement dictation sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->