### PR TITLE
Fix SOU-076: Query segments_legacy for segment_count in v3 migration

### DIFF
--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -270,7 +270,7 @@ pub fn migrate_meetings_to_v3(conn: &mut Connection) -> Result<(), String> {
             let ended_at = row.ended_at.as_deref().map(parse_datetime).transpose()?;
             let segment_count: i64 = tx
                 .query_row(
-                    "SELECT COUNT(*) FROM segments WHERE meeting_id = ?1",
+                    "SELECT COUNT(*) FROM segments_legacy WHERE meeting_id = ?1",
                     params![row.id],
                     |segment_row| segment_row.get(0),
                 )

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -1117,6 +1117,7 @@ mod tests {
         let meeting = db.load_meeting("legacy-meeting").unwrap();
         assert_eq!(meeting.transcription_profile.engine_label, "Custom Engine");
         assert_eq!(meeting.recording_sessions.len(), 1);
+        assert_eq!(meeting.recording_sessions[0].end_segment_index, 1);
         assert!(!meeting.summary_is_stale);
         // v8 chain ran on the same open: pre-v8 rows read back cleanly.
         assert_eq!(meeting.calendar_event_id, None);


### PR DESCRIPTION
Fixes SOU-076. During v3 migration, the COUNT query for segment_count incorrectly targeted the empty segments table instead of segments_legacy, which broke seek functionality for historical data by setting end_segment_index to 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved legacy segment counts when migrating meetings and their recording sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->