### PR TITLE
Fix SOU-042: Save live meeting notes and title immediately to DB

### DIFF
--- a/src-tauri/src/commands/meetings.rs
+++ b/src-tauri/src/commands/meetings.rs
@@ -116,9 +116,8 @@ pub fn get_meeting_audio(
         .collect())
 }
 
-/// Save the user's live meeting notes. Targets the in-memory accumulator
-/// while that meeting is still recording (it only reaches the DB at stop),
-/// the DB otherwise.
+/// Save the user's live meeting notes. Updates the in-memory accumulator
+/// and immediately persists to the DB (for crash recovery).
 #[tauri::command]
 #[specta::specta]
 pub fn save_meeting_notes(
@@ -136,16 +135,15 @@ pub fn save_meeting_notes(
         if let Some(ref mut meeting) = *acc
             && meeting.id == id
         {
-            meeting.notes = notes;
-            return Ok(());
+            meeting.notes = notes.clone();
         }
     }
 
     state.db.save_meeting_notes(&id, notes.as_deref())
 }
 
-/// Rename a meeting. Targets the in-memory accumulator while that meeting
-/// is still recording (it only reaches the DB at stop), the DB otherwise.
+/// Rename a meeting. Updates the in-memory accumulator and immediately
+/// persists to the DB (for crash recovery).
 #[tauri::command]
 #[specta::specta]
 pub fn rename_meeting(state: State<'_, AppState>, id: String, title: String) -> Result<(), String> {
@@ -160,8 +158,7 @@ pub fn rename_meeting(state: State<'_, AppState>, id: String, title: String) -> 
         if let Some(ref mut meeting) = *acc
             && meeting.id == id
         {
-            meeting.title = title;
-            return Ok(());
+            meeting.title = title.clone();
         }
     }
 

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -327,8 +327,8 @@ async getMeetingAudio(meetingId: string) : Promise<Result<MeetingAudioSession[],
 }
 },
 /**
- * Rename a meeting. Targets the in-memory accumulator while that meeting
- * is still recording (it only reaches the DB at stop), the DB otherwise.
+ * Rename a meeting. Updates the in-memory accumulator and immediately
+ * persists to the DB (for crash recovery).
  */
 async renameMeeting(id: string, title: string) : Promise<Result<null, string>> {
     try {
@@ -339,9 +339,8 @@ async renameMeeting(id: string, title: string) : Promise<Result<null, string>> {
 }
 },
 /**
- * Save the user's live meeting notes. Targets the in-memory accumulator
- * while that meeting is still recording (it only reaches the DB at stop),
- * the DB otherwise.
+ * Save the user's live meeting notes. Updates the in-memory accumulator
+ * and immediately persists to the DB (for crash recovery).
  */
 async saveMeetingNotes(id: string, notes: string | null) : Promise<Result<null, string>> {
     try {


### PR DESCRIPTION
Fixes SOU-042. Previously, live meeting notes and titles were only kept in the in-memory accumulator and not written to the database until the meeting stopped. Now, they fall through and are written to the database immediately to prevent data loss on crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Changes to meeting titles and notes now save immediately, including for the currently active meeting.
  - Meeting updates are persisted promptly to help prevent data loss if the app closes unexpectedly.

- **Documentation**
  - Updated command documentation to reflect immediate persistence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->