### PR TITLE
Fix SOU-078: Prevent deletion of live meeting from timeline

### DIFF
--- a/src/lib/features/timeline/components/TimelineItem.svelte
+++ b/src/lib/features/timeline/components/TimelineItem.svelte
@@ -9,11 +9,13 @@
   let {
     item,
     expanded,
+    isLive = false,
     onOpen,
     onRemove,
   }: {
     item: TimelineItem;
     expanded: boolean;
+    isLive?: boolean;
     onOpen: () => void;
     onRemove: () => void;
   } = $props();
@@ -68,22 +70,24 @@
       {#if item.kind === "dictation"}
         <CopyButton text={item.title} />
       {/if}
-      {#if confirmingDelete}
-        <button
-          onclick={() => { confirmingDelete = false; onRemove(); }}
-          class="rounded-md px-1.5 py-0.5 text-xs text-danger-soft hover:bg-danger/15"
-        >
-          {$t("timeline.confirm_delete")}
-        </button>
-      {:else}
-        <button
-          onclick={() => (confirmingDelete = true)}
-          onblur={() => (confirmingDelete = false)}
-          class="cursor-pointer rounded-md p-1 text-text-muted hover:bg-surface-3 hover:text-danger-soft"
-          aria-label={$t("timeline.delete")}
-        >
-          <Trash2 size={14} aria-hidden="true" />
-        </button>
+      {#if !isLive}
+        {#if confirmingDelete}
+          <button
+            onclick={() => { confirmingDelete = false; onRemove(); }}
+            class="rounded-md px-1.5 py-0.5 text-xs text-danger-soft hover:bg-danger/15"
+          >
+            {$t("timeline.confirm_delete")}
+          </button>
+        {:else}
+          <button
+            onclick={() => (confirmingDelete = true)}
+            onblur={() => (confirmingDelete = false)}
+            class="cursor-pointer rounded-md p-1 text-text-muted hover:bg-surface-3 hover:text-danger-soft"
+            aria-label={$t("timeline.delete")}
+          >
+            <Trash2 size={14} aria-hidden="true" />
+          </button>
+        {/if}
       {/if}
     </span>
   </div>

--- a/src/lib/features/timeline/components/TimelineSection.svelte
+++ b/src/lib/features/timeline/components/TimelineSection.svelte
@@ -162,6 +162,7 @@
             <TimelineItem
               {item}
               expanded={item.kind === "dictation" && controller.expandedDictationId === item.id}
+              isLive={item.kind === "meeting" && controller.app.machineState.state === "recording_meeting" && controller.app.machineState.data.meeting_id === item.id}
               onOpen={() => controller.openItem(item)}
               onRemove={() => void controller.removeItem(item)}
             />

--- a/src/lib/features/timeline/components/TimelineSection.svelte
+++ b/src/lib/features/timeline/components/TimelineSection.svelte
@@ -162,7 +162,7 @@
             <TimelineItem
               {item}
               expanded={item.kind === "dictation" && controller.expandedDictationId === item.id}
-              isLive={item.kind === "meeting" && controller.app.machineState.state === "recording_meeting" && controller.app.machineState.data.meeting_id === item.id}
+              isLive={item.kind === "meeting" && controller.isLiveMeeting(item.id)}
               onOpen={() => controller.openItem(item)}
               onRemove={() => void controller.removeItem(item)}
             />

--- a/src/lib/features/timeline/controller.svelte.ts
+++ b/src/lib/features/timeline/controller.svelte.ts
@@ -141,6 +141,13 @@ function createTimelineControllerInstance() {
 
   async function removeItem(item: TimelineItem) {
     try {
+      if (
+        item.kind === "meeting" &&
+        app.machineState.state === "recording_meeting" &&
+        app.machineState.data.meeting_id === item.id
+      ) {
+        throw new Error("Cannot delete a meeting while it is recording.");
+      }
       if (item.kind === "dictation") {
         await deleteDictationEntry(item.id);
         if (expandedDictationId === item.id) expandedDictationId = null;

--- a/src/lib/features/timeline/controller.svelte.ts
+++ b/src/lib/features/timeline/controller.svelte.ts
@@ -4,7 +4,7 @@ import {
   listDictationEntries,
 } from "../../api/transcription";
 import { getAppState } from "../../stores/app.svelte";
-import type { DictationEntry, MeetingListItem } from "../../types";
+import type { AppStateMachine, DictationEntry, MeetingListItem } from "../../types";
 import {
   createDebouncedSearch,
   errorMessage,
@@ -27,6 +27,15 @@ export interface TimelineGroup {
   /** YYYY-MM-DD key in local time. */
   day: string;
   items: TimelineItem[];
+}
+
+/** Meeting ID that is recording or still draining on stop, else null. */
+export function liveMeetingId(state: AppStateMachine): string | null {
+  if (state.state === "recording_meeting") return state.data.meeting_id;
+  if (state.state === "stopping" && typeof state.data.was_recording === "object") {
+    return state.data.was_recording.meeting.meeting_id;
+  }
+  return null;
 }
 
 function dayKey(iso: string): string {
@@ -139,13 +148,13 @@ function createTimelineControllerInstance() {
     expandedDictationId = expandedDictationId === id ? null : id;
   }
 
+  function isLiveMeeting(id: string): boolean {
+    return liveMeetingId(app.machineState) === id;
+  }
+
   async function removeItem(item: TimelineItem) {
     try {
-      if (
-        item.kind === "meeting" &&
-        app.machineState.state === "recording_meeting" &&
-        app.machineState.data.meeting_id === item.id
-      ) {
+      if (item.kind === "meeting" && isLiveMeeting(item.id)) {
         throw new Error("Cannot delete a meeting while it is recording.");
       }
       if (item.kind === "dictation") {
@@ -181,6 +190,7 @@ function createTimelineControllerInstance() {
     get searchResults() { return search.results; },
     get isSearching() { return search.isSearching; },
     get expandedDictationId() { return expandedDictationId; },
+    isLiveMeeting,
     refresh,
     openItem,
     removeItem,

--- a/src/lib/features/timeline/controller.test.ts
+++ b/src/lib/features/timeline/controller.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from "vitest";
-import type { DictationEntry, MeetingListItem } from "../../types";
-import { groupByDay, toTimelineItems } from "./controller.svelte";
+import type { AppStateMachine, DictationEntry, MeetingListItem, TranscriptionProfile } from "../../types";
+import { groupByDay, liveMeetingId, toTimelineItems } from "./controller.svelte";
+
+const profile: TranscriptionProfile = {
+  engine_id: "kyutai",
+  engine_label: "Kyutai",
+  model_id: "stt-1b-en_fr",
+  model_label: "STT 1B",
+  backend_id: "candle",
+  backend_label: "Candle",
+};
 
 function dictation(id: string, timestamp: string): DictationEntry {
   return { id, text: `text ${id}`, timestamp };
@@ -49,5 +58,31 @@ describe("timeline items", () => {
     expect(groups[0].day).toBe("2026-06-12");
     expect(groups[0].items.map((item) => item.id)).toEqual(["d1", "m1"]);
     expect(groups[1].day).toBe("2026-06-11");
+  });
+});
+
+describe("liveMeetingId", () => {
+  it("matches the recording meeting", () => {
+    const state: AppStateMachine = {
+      state: "recording_meeting",
+      data: { profile, session_id: 1, meeting_id: "m1" },
+    };
+    expect(liveMeetingId(state)).toBe("m1");
+  });
+
+  it("matches the meeting still draining on stop", () => {
+    const state: AppStateMachine = {
+      state: "stopping",
+      data: { profile, was_recording: { meeting: { meeting_id: "m1" } } },
+    };
+    expect(liveMeetingId(state)).toBe("m1");
+  });
+
+  it("ignores dictation stop and idle", () => {
+    expect(liveMeetingId({
+      state: "stopping",
+      data: { profile, was_recording: "dictation" },
+    })).toBeNull();
+    expect(liveMeetingId({ state: "idle" })).toBeNull();
   });
 });


### PR DESCRIPTION
Fixes SOU-078. Hides the delete button in the timeline for the currently recording meeting and adds a safety check in the controller to prevent zombie states or data corruption when stopping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented deletion controls from appearing for meetings currently being recorded or stopped.
  * Added protection against deleting active meetings in either live state.
  * Preserved the existing confirmation flow and deletion behavior for other timeline items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->