### PR TITLE
Fix SOU-047: Verify target app in learn-from-edit

### DIFF
--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -742,6 +742,49 @@ describe("transcription controller", () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     try {
       let transcriptionChannel: { onmessage: ((msg: unknown) => void) | null } | null = null;
+      let frontmost: string | null = "Notes";
+      mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+        if (cmd === "start_transcription") {
+          transcriptionChannel = args?.channel as { onmessage: ((msg: unknown) => void) | null };
+          return Promise.resolve(null);
+        }
+        if (cmd === "frontmost_app_name") return Promise.resolve(frontmost);
+        if (cmd === "read_focused_text") return Promise.resolve("hello Kubernetes");
+        if (cmd === "learn_from_edit") return Promise.resolve(1);
+        return defaultInvoke(cmd, args);
+      });
+
+      const ctrl = createTranscriptionController();
+      await ctrl.mount();
+      ctrl.app.settings = {
+        ...ctrl.app.settings,
+        auto_paste: true,
+        dictation_polish_enabled: false,
+        dictation_learn_from_edit: true,
+      };
+
+      await ctrl.toggleRecording(true);
+      simulateRecordingStarted(ctrl.app);
+      (transcriptionChannel as { onmessage: ((msg: unknown) => void) | null } | null)?.onmessage?.({
+        text: "hello world",
+        is_final: true,
+        start_ms: 0,
+        end_ms: 1000,
+      });
+      await ctrl.toggleRecording(true);
+      frontmost = null;
+
+      await vi.advanceTimersByTimeAsync(4000);
+      expect(mockInvoke).not.toHaveBeenCalledWith("learn_from_edit", expect.anything());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("learn_from_edit skips when the paste target was never captured (SOU-047)", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      let transcriptionChannel: { onmessage: ((msg: unknown) => void) | null } | null = null;
       mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
         if (cmd === "start_transcription") {
           transcriptionChannel = args?.channel as { onmessage: ((msg: unknown) => void) | null };

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -656,6 +656,7 @@ describe("transcription controller", () => {
           transcriptionChannel = args?.channel as { onmessage: ((msg: unknown) => void) | null };
           return Promise.resolve(null);
         }
+        if (cmd === "frontmost_app_name") return Promise.resolve("Notes");
         if (cmd === "read_focused_text") return Promise.resolve("hello Kubernetes");
         if (cmd === "learn_from_edit") return Promise.resolve(1);
         return defaultInvoke(cmd, args);
@@ -689,6 +690,90 @@ describe("transcription controller", () => {
         original: "hello world",
         corrected: "hello Kubernetes",
       });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("learn_from_edit skips when the focused app changed (SOU-047)", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      let transcriptionChannel: { onmessage: ((msg: unknown) => void) | null } | null = null;
+      let frontmost = "Notes";
+      mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+        if (cmd === "start_transcription") {
+          transcriptionChannel = args?.channel as { onmessage: ((msg: unknown) => void) | null };
+          return Promise.resolve(null);
+        }
+        if (cmd === "frontmost_app_name") return Promise.resolve(frontmost);
+        if (cmd === "read_focused_text") return Promise.resolve("hello Kubernetes");
+        if (cmd === "learn_from_edit") return Promise.resolve(1);
+        return defaultInvoke(cmd, args);
+      });
+
+      const ctrl = createTranscriptionController();
+      await ctrl.mount();
+      ctrl.app.settings = {
+        ...ctrl.app.settings,
+        auto_paste: true,
+        dictation_polish_enabled: false,
+        dictation_learn_from_edit: true,
+      };
+
+      await ctrl.toggleRecording(true);
+      simulateRecordingStarted(ctrl.app);
+      (transcriptionChannel as { onmessage: ((msg: unknown) => void) | null } | null)?.onmessage?.({
+        text: "hello world",
+        is_final: true,
+        start_ms: 0,
+        end_ms: 1000,
+      });
+      await ctrl.toggleRecording(true);
+      frontmost = "Safari";
+
+      await vi.advanceTimersByTimeAsync(4000);
+      expect(mockInvoke).not.toHaveBeenCalledWith("learn_from_edit", expect.anything());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("learn_from_edit skips when the focused app cannot be identified (SOU-047)", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      let transcriptionChannel: { onmessage: ((msg: unknown) => void) | null } | null = null;
+      mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+        if (cmd === "start_transcription") {
+          transcriptionChannel = args?.channel as { onmessage: ((msg: unknown) => void) | null };
+          return Promise.resolve(null);
+        }
+        if (cmd === "frontmost_app_name") return Promise.resolve(null);
+        if (cmd === "read_focused_text") return Promise.resolve("hello Kubernetes");
+        if (cmd === "learn_from_edit") return Promise.resolve(1);
+        return defaultInvoke(cmd, args);
+      });
+
+      const ctrl = createTranscriptionController();
+      await ctrl.mount();
+      ctrl.app.settings = {
+        ...ctrl.app.settings,
+        auto_paste: true,
+        dictation_polish_enabled: false,
+        dictation_learn_from_edit: true,
+      };
+
+      await ctrl.toggleRecording(true);
+      simulateRecordingStarted(ctrl.app);
+      (transcriptionChannel as { onmessage: ((msg: unknown) => void) | null } | null)?.onmessage?.({
+        text: "hello world",
+        is_final: true,
+        start_ms: 0,
+        end_ms: 1000,
+      });
+      await ctrl.toggleRecording(true);
+
+      await vi.advanceTimersByTimeAsync(4000);
+      expect(mockInvoke).not.toHaveBeenCalledWith("learn_from_edit", expect.anything());
     } finally {
       vi.useRealTimers();
     }

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -211,10 +211,9 @@ function createTranscriptionControllerInstance() {
       learnFromEditTimer = null;
       try {
         if (!app.settings.dictation_learn_from_edit) return;
-        if (targetApp) {
-          const currentApp = await frontmostAppName().catch(() => null);
-          if (currentApp && currentApp !== targetApp) return;
-        }
+        if (!targetApp) return;
+        const currentApp = await frontmostAppName().catch(() => null);
+        if (currentApp !== targetApp) return;
         const focused = (await readFocusedText())?.trim() ?? null;
         if (!focused || focused === pasted) return;
         // Whole-field AX reads include pre-existing content around the paste.

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -203,7 +203,7 @@ function createTranscriptionControllerInstance() {
     }
   }
 
-  function scheduleLearnFromEdit(pasted: string) {
+  function scheduleLearnFromEdit(pasted: string, targetApp: string | null) {
     cancelLearnFromEditPoll();
     if (!app.settings.dictation_learn_from_edit || !pasted) return;
 
@@ -211,6 +211,10 @@ function createTranscriptionControllerInstance() {
       learnFromEditTimer = null;
       try {
         if (!app.settings.dictation_learn_from_edit) return;
+        if (targetApp) {
+          const currentApp = await frontmostAppName().catch(() => null);
+          if (currentApp && currentApp !== targetApp) return;
+        }
         const focused = (await readFocusedText())?.trim() ?? null;
         if (!focused || focused === pasted) return;
         // Whole-field AX reads include pre-existing content around the paste.
@@ -345,7 +349,7 @@ function createTranscriptionControllerInstance() {
                 app.settings.paste_delay_ms,
                 app.settings.paste_method,
               );
-              scheduleLearnFromEdit(finalized.text);
+              scheduleLearnFromEdit(finalized.text, sessionFocusedApp);
             } catch (e) {
               const message = errorMessage(e);
               statusMessage = accessibilityPasteFailureMessage(message);


### PR DESCRIPTION
Fixes SOU-047. The learn-from-edit feature now tracks the app that was focused during the paste and bails out if the user has switched apps before the polling timer fires, preventing dictionary pollution from unrelated inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription learning behavior when pasting into an application.
  * Learning is now skipped if the active application changes during the paste process, preventing edits from being attributed to the wrong app.
  * Learning is also skipped when the paste target or current active application cannot be identified, improving reliability and preventing unintended associations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->