### PR TITLE
Fix SOU-077: Sync transcript and dictation edits to FTS

### DIFF
--- a/src-tauri/src/db/dictation.rs
+++ b/src-tauri/src/db/dictation.rs
@@ -39,20 +39,29 @@ impl Database {
 
     /// Add a new dictation entry.
     pub fn add_dictation_entry(&self, id: &str, text: &str, timestamp: &str) -> Result<(), String> {
-        let conn = self.conn.acquire()?;
+        let mut conn = self.conn.acquire()?;
+        let tx = conn.transaction().map_err(|e| format!("Transaction: {e}"))?;
 
-        conn.execute(
-            "INSERT INTO dictation_entries (id, text, timestamp) VALUES (?1, ?2, ?3)",
+        tx.execute(
+            "INSERT INTO dictation_entries (id, text, timestamp) VALUES (?1, ?2, ?3)
+             ON CONFLICT(id) DO UPDATE SET text = excluded.text, timestamp = excluded.timestamp",
             params![id, text, timestamp],
         )
-        .map_err(|e| format!("Insert: {e}"))?;
+        .map_err(|e| format!("Insert/Update dictation: {e}"))?;
 
-        // Also index in FTS5
-        conn.execute(
+        tx.execute(
+            "DELETE FROM text_search WHERE source_type = 'dictation' AND source_id = ?1",
+            params![id],
+        )
+        .map_err(|e| format!("Delete FTS: {e}"))?;
+
+        tx.execute(
             "INSERT INTO text_search (content, source_type, source_id) VALUES (?1, ?2, ?3)",
             params![text, "dictation", id],
         )
         .map_err(|e| format!("FTS insert: {e}"))?;
+
+        tx.commit().map_err(|e| format!("Commit: {e}"))?;
 
         Ok(())
     }

--- a/src-tauri/src/db/meetings.rs
+++ b/src-tauri/src/db/meetings.rs
@@ -223,6 +223,42 @@ impl Database {
             )
             .map_err(|e| format!("Update segment text: {e}"))?;
         }
+
+        // Rebuild FTS only if there is no edited_transcript
+        let edited_transcript: Option<String> = tx
+            .query_row(
+                "SELECT edited_transcript FROM meetings WHERE id = ?1",
+                params![meeting_id],
+                |row| row.get(0),
+            )
+            .map_err(|e| format!("Query edited_transcript: {e}"))?;
+
+        if edited_transcript.as_ref().map(|t| t.is_empty()).unwrap_or(true) {
+            let mut stmt = tx
+                .prepare("SELECT text FROM segments WHERE meeting_id = ?1 ORDER BY sort_order")
+                .map_err(|e| format!("Prepare segments: {e}"))?;
+            let texts: Vec<String> = stmt
+                .query_map(params![meeting_id], |row| row.get(0))
+                .map_err(|e| format!("Query segments: {e}"))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| format!("Collect segments: {e}"))?;
+            let full_text = texts.join(" ");
+
+            tx.execute(
+                "DELETE FROM text_search WHERE source_type = 'meeting' AND source_id = ?1",
+                params![meeting_id],
+            )
+            .map_err(|e| format!("Delete FTS: {e}"))?;
+
+            if !full_text.is_empty() {
+                tx.execute(
+                    "INSERT INTO text_search (content, source_type, source_id) VALUES (?1, ?2, ?3)",
+                    params![full_text, "meeting", meeting_id],
+                )
+                .map_err(|e| format!("Insert FTS: {e}"))?;
+            }
+        }
+
         tx.commit().map_err(|e| format!("Commit: {e}"))?;
         Ok(())
     }
@@ -556,12 +592,46 @@ impl Database {
         id: &str,
         edited_transcript: Option<&str>,
     ) -> Result<(), String> {
-        let conn = self.conn.acquire()?;
-        conn.execute(
+        let mut conn = self.conn.acquire()?;
+        let tx = conn.transaction().map_err(|e| format!("Transaction: {e}"))?;
+
+        tx.execute(
             "UPDATE meetings SET edited_transcript = ?1 WHERE id = ?2",
             params![edited_transcript, id],
         )
         .map_err(|e| format!("Update edited transcript: {e}"))?;
+
+        // Rebuild FTS
+        let text_to_index = if let Some(edited) = edited_transcript.filter(|t| !t.is_empty()) {
+            edited.to_string()
+        } else {
+            let mut stmt = tx
+                .prepare("SELECT text FROM segments WHERE meeting_id = ?1 ORDER BY sort_order")
+                .map_err(|e| format!("Prepare segments: {e}"))?;
+            let texts: Vec<String> = stmt
+                .query_map(params![id], |row| row.get(0))
+                .map_err(|e| format!("Query segments: {e}"))?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|e| format!("Collect segments: {e}"))?;
+            texts.join(" ")
+        };
+
+        tx.execute(
+            "DELETE FROM text_search WHERE source_type = 'meeting' AND source_id = ?1",
+            params![id],
+        )
+        .map_err(|e| format!("Delete FTS: {e}"))?;
+
+        if !text_to_index.is_empty() {
+            tx.execute(
+                "INSERT INTO text_search (content, source_type, source_id) VALUES (?1, ?2, ?3)",
+                params![text_to_index, "meeting", id],
+            )
+            .map_err(|e| format!("Insert FTS: {e}"))?;
+        }
+
+        tx.commit().map_err(|e| format!("Commit: {e}"))?;
+
         Ok(())
     }
 

--- a/src-tauri/src/db/meetings.rs
+++ b/src-tauri/src/db/meetings.rs
@@ -10,6 +10,44 @@ use crate::transcript::{
 
 use super::Database;
 
+fn meeting_fts_text(edited_transcript: Option<&str>, segment_text: String) -> String {
+    edited_transcript
+        .filter(|t| !t.is_empty())
+        .map(str::to_owned)
+        .unwrap_or(segment_text)
+}
+
+fn reindex_meeting_fts(
+    tx: &rusqlite::Transaction<'_>,
+    id: &str,
+    text: &str,
+) -> Result<(), String> {
+    tx.execute(
+        "DELETE FROM text_search WHERE source_type = 'meeting' AND source_id = ?1",
+        params![id],
+    )
+    .map_err(|e| format!("Delete FTS: {e}"))?;
+    if !text.is_empty() {
+        tx.execute(
+            "INSERT INTO text_search (content, source_type, source_id) VALUES (?1, ?2, ?3)",
+            params![text, "meeting", id],
+        )
+        .map_err(|e| format!("Insert FTS: {e}"))?;
+    }
+    Ok(())
+}
+
+fn joined_segment_text(tx: &rusqlite::Transaction<'_>, meeting_id: &str) -> Result<String, String> {
+    let mut stmt = tx
+        .prepare("SELECT text FROM segments WHERE meeting_id = ?1 ORDER BY sort_order")
+        .map_err(|e| format!("Prepare segments: {e}"))?;
+    stmt.query_map(params![meeting_id], |row| row.get::<_, String>(0))
+        .map_err(|e| format!("Query segments: {e}"))?
+        .collect::<Result<Vec<_>, _>>()
+        .map(|texts| texts.join(" "))
+        .map_err(|e| format!("Collect segments: {e}"))
+}
+
 impl Database {
     /// Save a meeting with all its segments in a single transaction.
     /// Also indexes the full text for FTS5 search.
@@ -86,26 +124,16 @@ impl Database {
             .map_err(|e| format!("Insert segment: {e}"))?;
         }
 
-        tx.execute(
-            "DELETE FROM text_search WHERE source_type = 'meeting' AND source_id = ?1",
-            params![meeting.id],
-        )
-        .map_err(|e| format!("Delete FTS: {e}"))?;
-
-        let full_text = meeting
-            .segments
-            .iter()
-            .map(|segment| segment.text.as_str())
-            .collect::<Vec<_>>()
-            .join(" ");
-
-        if !full_text.is_empty() {
-            tx.execute(
-                "INSERT INTO text_search (content, source_type, source_id) VALUES (?1, ?2, ?3)",
-                params![full_text, "meeting", meeting.id],
-            )
-            .map_err(|e| format!("Insert FTS: {e}"))?;
-        }
+        let full_text = meeting_fts_text(
+            meeting.edited_transcript.as_deref(),
+            meeting
+                .segments
+                .iter()
+                .map(|segment| segment.text.as_str())
+                .collect::<Vec<_>>()
+                .join(" "),
+        );
+        reindex_meeting_fts(&tx, &meeting.id, &full_text)?;
 
         tx.commit().map_err(|e| format!("Commit: {e}"))?;
         Ok(())
@@ -234,29 +262,8 @@ impl Database {
             .map_err(|e| format!("Query edited_transcript: {e}"))?;
 
         if edited_transcript.as_ref().map(|t| t.is_empty()).unwrap_or(true) {
-            let mut stmt = tx
-                .prepare("SELECT text FROM segments WHERE meeting_id = ?1 ORDER BY sort_order")
-                .map_err(|e| format!("Prepare segments: {e}"))?;
-            let texts: Vec<String> = stmt
-                .query_map(params![meeting_id], |row| row.get(0))
-                .map_err(|e| format!("Query segments: {e}"))?
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|e| format!("Collect segments: {e}"))?;
-            let full_text = texts.join(" ");
-
-            tx.execute(
-                "DELETE FROM text_search WHERE source_type = 'meeting' AND source_id = ?1",
-                params![meeting_id],
-            )
-            .map_err(|e| format!("Delete FTS: {e}"))?;
-
-            if !full_text.is_empty() {
-                tx.execute(
-                    "INSERT INTO text_search (content, source_type, source_id) VALUES (?1, ?2, ?3)",
-                    params![full_text, "meeting", meeting_id],
-                )
-                .map_err(|e| format!("Insert FTS: {e}"))?;
-            }
+            let full_text = joined_segment_text(&tx, meeting_id)?;
+            reindex_meeting_fts(&tx, meeting_id, &full_text)?;
         }
 
         tx.commit().map_err(|e| format!("Commit: {e}"))?;
@@ -601,34 +608,8 @@ impl Database {
         )
         .map_err(|e| format!("Update edited transcript: {e}"))?;
 
-        // Rebuild FTS
-        let text_to_index = if let Some(edited) = edited_transcript.filter(|t| !t.is_empty()) {
-            edited.to_string()
-        } else {
-            let mut stmt = tx
-                .prepare("SELECT text FROM segments WHERE meeting_id = ?1 ORDER BY sort_order")
-                .map_err(|e| format!("Prepare segments: {e}"))?;
-            let texts: Vec<String> = stmt
-                .query_map(params![id], |row| row.get(0))
-                .map_err(|e| format!("Query segments: {e}"))?
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|e| format!("Collect segments: {e}"))?;
-            texts.join(" ")
-        };
-
-        tx.execute(
-            "DELETE FROM text_search WHERE source_type = 'meeting' AND source_id = ?1",
-            params![id],
-        )
-        .map_err(|e| format!("Delete FTS: {e}"))?;
-
-        if !text_to_index.is_empty() {
-            tx.execute(
-                "INSERT INTO text_search (content, source_type, source_id) VALUES (?1, ?2, ?3)",
-                params![text_to_index, "meeting", id],
-            )
-            .map_err(|e| format!("Insert FTS: {e}"))?;
-        }
+        let text_to_index = meeting_fts_text(edited_transcript, joined_segment_text(&tx, id)?);
+        reindex_meeting_fts(&tx, id, &text_to_index)?;
 
         tx.commit().map_err(|e| format!("Commit: {e}"))?;
 

--- a/src-tauri/src/db/search.rs
+++ b/src-tauri/src/db/search.rs
@@ -111,4 +111,31 @@ mod tests {
         let results = db.search_text("Hello", 3).unwrap();
         assert_eq!(results.len(), 3);
     }
+
+    #[test]
+    fn search_prefers_edited_transcript_over_segments() {
+        let (db, _dir) = test_db();
+        db.save_meeting(&sample_meeting("m1")).unwrap();
+        db.save_edited_transcript("m1", Some("Kubernetes cluster")).unwrap();
+
+        assert_eq!(db.search_text("Kubernetes", 20).unwrap().len(), 1);
+        assert!(
+            db.search_text("Hello", 20).unwrap().is_empty(),
+            "ASR text must leave FTS after an edit"
+        );
+
+        let mut again = sample_meeting("m1");
+        again.edited_transcript = Some("Kubernetes cluster".into());
+        db.save_meeting(&again).unwrap();
+        assert_eq!(
+            db.search_text("Kubernetes", 20).unwrap().len(),
+            1,
+            "save_meeting must keep the edited transcript in FTS"
+        );
+        assert!(db.search_text("Hello", 20).unwrap().is_empty());
+
+        db.save_edited_transcript("m1", None).unwrap();
+        assert_eq!(db.search_text("Hello", 20).unwrap().len(), 1);
+        assert!(db.search_text("Kubernetes", 20).unwrap().is_empty());
+    }
 }


### PR DESCRIPTION
Fixes SOU-077. Previously, edits made to dictations or meeting transcripts were not synchronized to the text_search FTS table, meaning search results (and MCP) would still surface the unedited text. This PR ensures that FTS is atomically updated alongside the edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when updating dictation entries by keeping saved content and search results synchronized.
  - Meeting search content now stays current after transcript or segment edits.
  - Edited transcripts are indexed correctly, with fallback to the original transcript when edits are cleared.
  - Database updates and related search-index changes now complete together, preventing partial updates.
  - Improved search accuracy when replacing edited meeting transcripts and restoring the original content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->