### PR TITLE
Fix SOU-081: Inject meeting language in structured extraction

### DIFF
--- a/src-tauri/src/commands/meetings.rs
+++ b/src-tauri/src/commands/meetings.rs
@@ -615,6 +615,7 @@ pub async fn summarize_meeting(
         &transcript.participants,
         &model,
         Some(&settings.ollama_url),
+        output_language,
     )
     .await;
 

--- a/src-tauri/src/summary/extract.rs
+++ b/src-tauri/src/summary/extract.rs
@@ -120,20 +120,22 @@ pub async fn extract_structured_summary(
     participants: &[MeetingParticipant],
     model: &str,
     ollama_base_url: Option<&str>,
+    output_language: super::SummaryLanguage,
 ) -> Result<StructuredSummary, String> {
     let provider = resolve_provider(model)?;
     let ollama_url = ollama_base_url.unwrap_or(crate::constants::OLLAMA_DEFAULT_URL);
-    let system = match provider {
+    let system_base = match provider {
         SummaryProviderKind::Ollama => super::ollama::STRUCTURED_EXTRACT_SYSTEM_PROMPT,
         SummaryProviderKind::AppleIntelligence => super::apple::STRUCTURED_EXTRACT_SYSTEM_PROMPT,
     };
+    let system = super::with_language_instruction(system_base, output_language);
     let prompt = build_structured_extract_prompt(prose_summary, notes, participants);
     let no_op = |_: SummarizeProgress| {};
     let raw = generate_with_provider(
         provider,
         model,
         ollama_url,
-        system,
+        &system,
         prompt,
         0.1,
         super::ollama::REDUCE_BUDGET,


### PR DESCRIPTION
Fixes SOU-081. The structured summary extraction step (Action items, decisions) previously ignored the meeting's language setting. This PR passes the output_language parameter and injects it into the system prompt, ensuring the LLM replies in the correct language.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Structured meeting summaries now follow the selected output language more consistently.
  * Language preferences are applied during summary generation across supported providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->