### PR TITLE
Fix transcript and media issues

### DIFF
--- a/src-tauri/src/commands/meetings.rs
+++ b/src-tauri/src/commands/meetings.rs
@@ -558,6 +558,7 @@ pub async fn summarize_meeting(
     channel: Channel<crate::summary::SummarizeProgress>,
 ) -> Result<(), String> {
     let transcript = state.db.load_meeting(&id)?;
+    let generated_from_edited = transcript.edited_transcript.clone();
     let settings = AppSettings::load(&state.db)?;
 
     let (text, turn_units) = match transcript.edited_transcript {
@@ -622,7 +623,13 @@ pub async fn summarize_meeting(
         tracing::warn!("Structured summary extract failed, saving prose only: {warning}");
     }
 
-    db.update_meeting_summary(&id, &summary, structured.as_ref(), &model)?;
+    db.update_meeting_summary(
+        &id,
+        &summary,
+        structured.as_ref(),
+        &model,
+        generated_from_edited.as_deref(),
+    )?;
 
     Ok(())
 }

--- a/src-tauri/src/commands/meetings.rs
+++ b/src-tauri/src/commands/meetings.rs
@@ -559,6 +559,7 @@ pub async fn summarize_meeting(
 ) -> Result<(), String> {
     let transcript = state.db.load_meeting(&id)?;
     let generated_from_edited = transcript.edited_transcript.clone();
+    let generated_from_notes = transcript.notes.clone();
     let settings = AppSettings::load(&state.db)?;
 
     let (text, turn_units) = match transcript.edited_transcript {
@@ -629,6 +630,7 @@ pub async fn summarize_meeting(
         structured.as_ref(),
         &model,
         generated_from_edited.as_deref(),
+        generated_from_notes.as_deref(),
     )?;
 
     Ok(())

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -22,7 +22,13 @@ pub fn save_settings(
     state: State<'_, AppState>,
     settings: AppSettings,
 ) -> Result<(), String> {
-    let settings = settings.sanitize_for_save()?;
+    let mut settings = settings.sanitize_for_save()?;
+    let stored = AppSettings::load(&state.db)?;
+    let recording = state
+        .current_machine_state()
+        .map(|machine| machine.is_recording())
+        .unwrap_or(false);
+    let pinned = settings.pin_transcription_while_recording(&stored, recording);
     settings.save(&state.db)?;
     crate::debug::set_transcription_debug(settings.debug_transcription);
     crate::logging::set_level(settings.log_level)?;
@@ -46,6 +52,9 @@ pub fn save_settings(
     if let Ok(machine) = state.current_machine_state() {
         crate::pill::sync(&app, &machine);
         crate::tray::sync(&app, &machine);
+    }
+    if pinned {
+        return Err("Cannot change the transcription model while recording".into());
     }
     Ok(())
 }

--- a/src-tauri/src/db/meetings.rs
+++ b/src-tauri/src/db/meetings.rs
@@ -492,7 +492,10 @@ impl Database {
     pub fn save_meeting_notes(&self, id: &str, notes: Option<&str>) -> Result<(), String> {
         let conn = self.conn.acquire()?;
         conn.execute(
-            "UPDATE meetings SET notes = ?1 WHERE id = ?2",
+            "UPDATE meetings
+             SET notes = ?1,
+                 summary_is_stale = CASE WHEN summary IS NOT NULL THEN 1 ELSE summary_is_stale END
+             WHERE id = ?2",
             params![notes, id],
         )
         .map_err(|e| format!("Update meeting notes: {e}"))?;
@@ -554,27 +557,35 @@ impl Database {
         Ok(())
     }
 
-    /// Update meeting summary fields, structured summary, and clear the stale flag.
+    /// Update meeting summary fields and structured summary.
+    ///
+    /// `generated_from_edited` is the `edited_transcript` snapshot taken when
+    /// summarization started. If the transcript was edited during generation,
+    /// the new summary is still stored but `summary_is_stale` stays set so an
+    /// older summary cannot be marked fresh.
     pub fn update_meeting_summary(
         &self,
         id: &str,
         summary: &str,
         structured_summary: Option<&StructuredSummary>,
         model: &str,
+        generated_from_edited: Option<&str>,
     ) -> Result<(), String> {
         let conn = self.conn.acquire()?;
         let now = Utc::now().to_rfc3339();
 
         conn.execute(
             "UPDATE meetings
-             SET summary = ?1, summary_is_stale = 0, summary_model = ?2, summary_generated_at = ?3,
-                 structured_summary = ?4
-             WHERE id = ?5",
+             SET summary = ?1, summary_model = ?2, summary_generated_at = ?3,
+                 structured_summary = ?4,
+                 summary_is_stale = CASE WHEN edited_transcript IS NOT DISTINCT FROM ?5 THEN 0 ELSE 1 END
+             WHERE id = ?6",
             params![
                 summary,
                 model,
                 now,
                 serialize_structured_summary(structured_summary)?,
+                generated_from_edited,
                 id
             ],
         )
@@ -603,7 +614,10 @@ impl Database {
         let tx = conn.transaction().map_err(|e| format!("Transaction: {e}"))?;
 
         tx.execute(
-            "UPDATE meetings SET edited_transcript = ?1, summary_is_stale = CASE WHEN summary IS NOT NULL THEN 1 ELSE summary_is_stale END WHERE id = ?2",
+            "UPDATE meetings
+             SET edited_transcript = ?1,
+                 summary_is_stale = CASE WHEN summary IS NOT NULL THEN 1 ELSE summary_is_stale END
+             WHERE id = ?2",
             params![edited_transcript, id],
         )
         .map_err(|e| format!("Update edited transcript: {e}"))?;
@@ -899,6 +913,7 @@ mod tests {
                 open_questions: vec![],
             }),
             "qwen2.5",
+            None,
         )
         .unwrap();
 
@@ -924,9 +939,10 @@ mod tests {
                 open_questions: vec![],
             }),
             "qwen2.5",
+            None,
         )
         .unwrap();
-        db.update_meeting_summary("m1", "Prose only after extract fail", None, "qwen2.5")
+        db.update_meeting_summary("m1", "Prose only after extract fail", None, "qwen2.5", None)
             .unwrap();
 
         let loaded = db.load_meeting("m1").unwrap();
@@ -1186,6 +1202,103 @@ mod tests {
         let edited = db.load_edited_transcript("m1").unwrap();
         assert!(edited.is_none());
     }
+
+    #[test]
+    fn save_edited_transcript_marks_summary_stale_when_summary_exists() {
+        let (db, _dir) = test_db();
+        let mut meeting = sample_meeting("m1");
+        meeting.summary = Some("budget recap".to_string());
+        db.save_meeting(&meeting).unwrap();
+        assert!(!db.load_meeting("m1").unwrap().summary_is_stale);
+
+        db.save_edited_transcript("m1", Some("forecast recap"))
+            .unwrap();
+        let loaded = db.load_meeting("m1").unwrap();
+        assert_eq!(loaded.edited_transcript.as_deref(), Some("forecast recap"));
+        assert!(loaded.summary_is_stale);
+    }
+
+    #[test]
+    fn save_edited_transcript_does_not_mark_stale_without_summary() {
+        let (db, _dir) = test_db();
+        db.save_meeting(&sample_meeting("m1")).unwrap();
+
+        db.save_edited_transcript("m1", Some("corrigé")).unwrap();
+        let loaded = db.load_meeting("m1").unwrap();
+        assert_eq!(loaded.edited_transcript.as_deref(), Some("corrigé"));
+        assert!(!loaded.summary_is_stale);
+    }
+
+    #[test]
+    fn save_meeting_notes_marks_summary_stale_when_summary_exists() {
+        let (db, _dir) = test_db();
+        let mut meeting = sample_meeting("m1");
+        meeting.summary = Some("budget recap".to_string());
+        db.save_meeting(&meeting).unwrap();
+        assert!(!db.load_meeting("m1").unwrap().summary_is_stale);
+
+        db.save_meeting_notes("m1", Some("décision : on ship vendredi"))
+            .unwrap();
+        let loaded = db.load_meeting("m1").unwrap();
+        assert_eq!(loaded.notes.as_deref(), Some("décision : on ship vendredi"));
+        assert!(loaded.summary_is_stale);
+    }
+
+    #[test]
+    fn save_meeting_notes_does_not_mark_stale_without_summary() {
+        let (db, _dir) = test_db();
+        db.save_meeting(&sample_meeting("m1")).unwrap();
+
+        db.save_meeting_notes("m1", Some("remember this")).unwrap();
+        assert!(!db.load_meeting("m1").unwrap().summary_is_stale);
+    }
+
+    #[test]
+    fn update_summary_clears_stale_when_transcript_matches_generation_snapshot() {
+        let (db, _dir) = test_db();
+        let mut meeting = sample_meeting("m1");
+        meeting.summary = Some("old".to_string());
+        db.save_meeting(&meeting).unwrap();
+        db.save_edited_transcript("m1", Some("corrigé")).unwrap();
+        assert!(db.load_meeting("m1").unwrap().summary_is_stale);
+
+        db.update_meeting_summary("m1", "fresh from corrigé", None, "qwen2.5", Some("corrigé"))
+            .unwrap();
+        let loaded = db.load_meeting("m1").unwrap();
+        assert_eq!(loaded.summary.as_deref(), Some("fresh from corrigé"));
+        assert!(!loaded.summary_is_stale);
+    }
+
+    #[test]
+    fn update_summary_keeps_stale_when_transcript_changed_during_generation() {
+        let (db, _dir) = test_db();
+        let mut meeting = sample_meeting("m1");
+        meeting.summary = Some("old".to_string());
+        db.save_meeting(&meeting).unwrap();
+
+        // Generation started from the unedited segments.
+        let snapshot = meeting.edited_transcript.clone();
+        db.save_edited_transcript("m1", Some("corrigé")).unwrap();
+        db.update_meeting_summary(
+            "m1",
+            "summary of the old transcript",
+            None,
+            "qwen2.5",
+            snapshot.as_deref(),
+        )
+        .unwrap();
+
+        let loaded = db.load_meeting("m1").unwrap();
+        assert_eq!(
+            loaded.summary.as_deref(),
+            Some("summary of the old transcript")
+        );
+        assert!(
+            loaded.summary_is_stale,
+            "an older summary must not be marked fresh after an edit during generation"
+        );
+    }
+
     #[test]
     fn recover_unfinished_preserves_shell_when_audio_check_fails() {
         let (db, _dir) = test_db();

--- a/src-tauri/src/db/meetings.rs
+++ b/src-tauri/src/db/meetings.rs
@@ -494,7 +494,10 @@ impl Database {
         conn.execute(
             "UPDATE meetings
              SET notes = ?1,
-                 summary_is_stale = CASE WHEN summary IS NOT NULL THEN 1 ELSE summary_is_stale END
+                 summary_is_stale = CASE
+                   WHEN summary IS NOT NULL AND notes IS DISTINCT FROM ?1 THEN 1
+                   ELSE summary_is_stale
+                 END
              WHERE id = ?2",
             params![notes, id],
         )
@@ -622,7 +625,10 @@ impl Database {
         tx.execute(
             "UPDATE meetings
              SET edited_transcript = ?1,
-                 summary_is_stale = CASE WHEN summary IS NOT NULL THEN 1 ELSE summary_is_stale END
+                 summary_is_stale = CASE
+                   WHEN summary IS NOT NULL AND edited_transcript IS DISTINCT FROM ?1 THEN 1
+                   ELSE summary_is_stale
+                 END
              WHERE id = ?2",
             params![edited_transcript, id],
         )
@@ -1266,6 +1272,39 @@ mod tests {
 
         db.save_meeting_notes("m1", Some("remember this")).unwrap();
         assert!(!db.load_meeting("m1").unwrap().summary_is_stale);
+    }
+
+    #[test]
+    fn save_same_edited_transcript_does_not_mark_stale() {
+        let (db, _dir) = test_db();
+        let mut meeting = sample_meeting("m1");
+        meeting.summary = Some("budget recap".to_string());
+        meeting.edited_transcript = Some("forecast recap".to_string());
+        db.save_meeting(&meeting).unwrap();
+        assert!(!db.load_meeting("m1").unwrap().summary_is_stale);
+
+        db.save_edited_transcript("m1", Some("forecast recap"))
+            .unwrap();
+        assert!(
+            !db.load_meeting("m1").unwrap().summary_is_stale,
+            "re-saving the same transcript must not invalidate a fresh summary"
+        );
+    }
+
+    #[test]
+    fn save_same_meeting_notes_does_not_mark_stale() {
+        let (db, _dir) = test_db();
+        let mut meeting = sample_meeting("m1");
+        meeting.summary = Some("budget recap".to_string());
+        meeting.notes = Some("remember this".to_string());
+        db.save_meeting(&meeting).unwrap();
+        assert!(!db.load_meeting("m1").unwrap().summary_is_stale);
+
+        db.save_meeting_notes("m1", Some("remember this")).unwrap();
+        assert!(
+            !db.load_meeting("m1").unwrap().summary_is_stale,
+            "re-saving the same notes must not invalidate a fresh summary"
+        );
     }
 
     #[test]

--- a/src-tauri/src/db/meetings.rs
+++ b/src-tauri/src/db/meetings.rs
@@ -603,7 +603,7 @@ impl Database {
         let tx = conn.transaction().map_err(|e| format!("Transaction: {e}"))?;
 
         tx.execute(
-            "UPDATE meetings SET edited_transcript = ?1 WHERE id = ?2",
+            "UPDATE meetings SET edited_transcript = ?1, summary_is_stale = CASE WHEN summary IS NOT NULL THEN 1 ELSE summary_is_stale END WHERE id = ?2",
             params![edited_transcript, id],
         )
         .map_err(|e| format!("Update edited transcript: {e}"))?;

--- a/src-tauri/src/db/meetings.rs
+++ b/src-tauri/src/db/meetings.rs
@@ -559,9 +559,9 @@ impl Database {
 
     /// Update meeting summary fields and structured summary.
     ///
-    /// `generated_from_edited` is the `edited_transcript` snapshot taken when
-    /// summarization started. If the transcript was edited during generation,
-    /// the new summary is still stored but `summary_is_stale` stays set so an
+    /// `generated_from_edited` / `generated_from_notes` are snapshots taken
+    /// when summarization started. If either changed during generation, the
+    /// new summary is still stored but `summary_is_stale` stays set so an
     /// older summary cannot be marked fresh.
     pub fn update_meeting_summary(
         &self,
@@ -570,6 +570,7 @@ impl Database {
         structured_summary: Option<&StructuredSummary>,
         model: &str,
         generated_from_edited: Option<&str>,
+        generated_from_notes: Option<&str>,
     ) -> Result<(), String> {
         let conn = self.conn.acquire()?;
         let now = Utc::now().to_rfc3339();
@@ -578,14 +579,19 @@ impl Database {
             "UPDATE meetings
              SET summary = ?1, summary_model = ?2, summary_generated_at = ?3,
                  structured_summary = ?4,
-                 summary_is_stale = CASE WHEN edited_transcript IS NOT DISTINCT FROM ?5 THEN 0 ELSE 1 END
-             WHERE id = ?6",
+                 summary_is_stale = CASE
+                   WHEN edited_transcript IS NOT DISTINCT FROM ?5
+                    AND notes IS NOT DISTINCT FROM ?6 THEN 0
+                   ELSE 1
+                 END
+             WHERE id = ?7",
             params![
                 summary,
                 model,
                 now,
                 serialize_structured_summary(structured_summary)?,
                 generated_from_edited,
+                generated_from_notes,
                 id
             ],
         )
@@ -914,6 +920,7 @@ mod tests {
             }),
             "qwen2.5",
             None,
+            None,
         )
         .unwrap();
 
@@ -940,10 +947,18 @@ mod tests {
             }),
             "qwen2.5",
             None,
+            None,
         )
         .unwrap();
-        db.update_meeting_summary("m1", "Prose only after extract fail", None, "qwen2.5", None)
-            .unwrap();
+        db.update_meeting_summary(
+            "m1",
+            "Prose only after extract fail",
+            None,
+            "qwen2.5",
+            None,
+            None,
+        )
+        .unwrap();
 
         let loaded = db.load_meeting("m1").unwrap();
         assert_eq!(loaded.summary.as_deref(), Some("Prose only after extract fail"));
@@ -1262,8 +1277,15 @@ mod tests {
         db.save_edited_transcript("m1", Some("corrigé")).unwrap();
         assert!(db.load_meeting("m1").unwrap().summary_is_stale);
 
-        db.update_meeting_summary("m1", "fresh from corrigé", None, "qwen2.5", Some("corrigé"))
-            .unwrap();
+        db.update_meeting_summary(
+            "m1",
+            "fresh from corrigé",
+            None,
+            "qwen2.5",
+            Some("corrigé"),
+            None,
+        )
+        .unwrap();
         let loaded = db.load_meeting("m1").unwrap();
         assert_eq!(loaded.summary.as_deref(), Some("fresh from corrigé"));
         assert!(!loaded.summary_is_stale);
@@ -1285,6 +1307,7 @@ mod tests {
             None,
             "qwen2.5",
             snapshot.as_deref(),
+            None,
         )
         .unwrap();
 
@@ -1296,6 +1319,34 @@ mod tests {
         assert!(
             loaded.summary_is_stale,
             "an older summary must not be marked fresh after an edit during generation"
+        );
+    }
+
+    #[test]
+    fn update_summary_keeps_stale_when_notes_changed_during_generation() {
+        let (db, _dir) = test_db();
+        let mut meeting = sample_meeting("m1");
+        meeting.summary = Some("old".to_string());
+        db.save_meeting(&meeting).unwrap();
+
+        let notes_snapshot = meeting.notes.clone();
+        db.save_meeting_notes("m1", Some("décision : on ship vendredi"))
+            .unwrap();
+        db.update_meeting_summary(
+            "m1",
+            "summary of the old notes",
+            None,
+            "qwen2.5",
+            None,
+            notes_snapshot.as_deref(),
+        )
+        .unwrap();
+
+        let loaded = db.load_meeting("m1").unwrap();
+        assert_eq!(loaded.summary.as_deref(), Some("summary of the old notes"));
+        assert!(
+            loaded.summary_is_stale,
+            "an older summary must not be marked fresh after a notes edit during generation"
         );
     }
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -555,6 +555,25 @@ impl AppSettings {
         Ok(normalized)
     }
 
+    /// Keep the stored transcription triple when a recording is in progress.
+    /// Other settings in `self` are left untouched. Returns true when the
+    /// incoming triple was pinned back.
+    pub fn pin_transcription_while_recording(&mut self, stored: &Self, is_recording: bool) -> bool {
+        if !is_recording {
+            return false;
+        }
+        let unchanged = self.transcription_engine_id == stored.transcription_engine_id
+            && self.transcription_model_id == stored.transcription_model_id
+            && self.transcription_backend_id == stored.transcription_backend_id;
+        if unchanged {
+            return false;
+        }
+        self.transcription_engine_id = stored.transcription_engine_id.clone();
+        self.transcription_model_id = stored.transcription_model_id.clone();
+        self.transcription_backend_id = stored.transcription_backend_id.clone();
+        true
+    }
+
     fn sanitized(&self) -> Self {
         let mut normalized = self.clone();
         normalized.locale = normalized.locale.trim().to_string();
@@ -1090,6 +1109,36 @@ mod tests {
         assert_eq!(loaded, expected);
         #[cfg(target_os = "macos")]
         assert!(!loaded.input_priority.known.is_empty());
+    }
+
+    #[test]
+    fn pin_transcription_while_recording_keeps_stored_triple() {
+        let stored = AppSettings {
+            transcription_engine_id: "kyutai".into(),
+            transcription_model_id: "stt-1b-en_fr".into(),
+            transcription_backend_id: "candle".into(),
+            ..AppSettings::default()
+        };
+
+        let mut incoming = stored.clone();
+        incoming.theme = Theme::Light;
+        incoming.transcription_model_id = "stt-2.6b-en".into();
+        assert!(incoming.pin_transcription_while_recording(&stored, true));
+        assert_eq!(incoming.transcription_model_id, "stt-1b-en_fr");
+        assert_eq!(incoming.transcription_engine_id, "kyutai");
+        assert_eq!(incoming.transcription_backend_id, "candle");
+        assert_eq!(incoming.theme, Theme::Light);
+
+        let mut idle_switch = stored.clone();
+        idle_switch.transcription_model_id = "stt-2.6b-en".into();
+        assert!(!idle_switch.pin_transcription_while_recording(&stored, false));
+        assert_eq!(idle_switch.transcription_model_id, "stt-2.6b-en");
+
+        let mut same_triple = stored.clone();
+        same_triple.theme = Theme::Light;
+        assert!(!same_triple.pin_transcription_while_recording(&stored, true));
+        assert_eq!(same_triple.theme, Theme::Light);
+        assert_eq!(same_triple.transcription_model_id, "stt-1b-en_fr");
     }
 
     #[test]

--- a/src/lib/components/SettingsView.svelte
+++ b/src/lib/components/SettingsView.svelte
@@ -144,6 +144,7 @@
         downloadTotalBytes={controller.downloadTotalBytes}
         downloadFile={controller.downloadFile}
         unloadTimeoutMinutes={controller.app.settings.model_unload_timeout_minutes}
+        recording={controller.app.isRecording}
         onSelectModel={controller.selectModelOption}
         onUnloadTimeoutChange={controller.onModelUnloadTimeoutChange}
       />

--- a/src/lib/components/ui/StatusChip.svelte
+++ b/src/lib/components/ui/StatusChip.svelte
@@ -23,9 +23,8 @@
 
   const status = $derived.by((): { key: string; tone: "ready" | "busy" | "attention" } => {
     if (operationState === "downloading") return { key: "status_chip.downloading", tone: "busy" };
-    if (operationState === "loading" || phase === "load_required") {
-      return { key: "status_chip.loading", tone: "busy" };
-    }
+    if (operationState === "loading") return { key: "status_chip.loading", tone: "busy" };
+    if (phase === "load_required") return { key: "status_chip.load_required", tone: "attention" };
     if (phase === "ready") return { key: "status_chip.ready", tone: "ready" };
     return { key: "status_chip.model_required", tone: "attention" };
   });

--- a/src/lib/components/ui/StatusChip.test.ts
+++ b/src/lib/components/ui/StatusChip.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/svelte";
+import StatusChip from "./StatusChip.svelte";
+
+describe("StatusChip", () => {
+  it("treats load_required as an action, not an in-flight load", () => {
+    render(StatusChip, {
+      props: { phase: "load_required", operationState: "idle" },
+    });
+
+    expect(screen.getByRole("status").textContent).toContain("Model not loaded");
+    expect(screen.getByRole("status").textContent).not.toContain("Loading model");
+  });
+
+  it("keeps the busy loading label for an in-flight load", () => {
+    render(StatusChip, {
+      props: { phase: "load_required", operationState: "loading" },
+    });
+
+    expect(screen.getByRole("status").textContent).toContain("Loading model");
+  });
+});

--- a/src/lib/features/home/LiveSessionCard.svelte
+++ b/src/lib/features/home/LiveSessionCard.svelte
@@ -10,6 +10,12 @@
   import type { createMeetingController } from "../meeting/controller.svelte";
   import type { createTranscriptionController } from "../transcription/controller.svelte";
   import { elapsedSecondsSince, formatDuration, resolveSpeakerLabel, segmentGap } from "../../utils";
+  import {
+    leadingRemovedCount,
+    measureLeadingHeight,
+    scrollTopAfterLeadingUnmount,
+    windowedParagraphs,
+  } from "./live-paragraph-window";
 
   let {
     mode,
@@ -38,7 +44,7 @@
 
   const liveParagraphs = $derived(
     mode === "meeting"
-      ? [...meeting.liveTranscript.committed, ...meeting.liveTranscript.tail]
+      ? windowedParagraphs(meeting.liveTranscript.committed, meeting.liveTranscript.tail)
       : [],
   );
   const liveTentative = $derived(
@@ -120,6 +126,8 @@
 
   let isNearBottom = true;
   let scrollRafId: number | null = null;
+  let pendingRemovedHeight = 0;
+  let previousWindowIds: number[] = [];
 
   function handleScroll() {
     const el = transcriptEl;
@@ -135,10 +143,28 @@
     });
   }
 
+  $effect.pre(() => {
+    const nextIds = liveParagraphs.map((paragraph) => paragraph.id);
+    const el = transcriptEl;
+    if (el && !isNearBottom) {
+      const removed = leadingRemovedCount(previousWindowIds, nextIds);
+      if (removed > 0) {
+        const gap = Number.parseFloat(getComputedStyle(el).rowGap || el.style.gap || "0") || 0;
+        pendingRemovedHeight = measureLeadingHeight(el, removed, gap);
+      }
+    }
+    previousWindowIds = nextIds;
+  });
+
   $effect(() => {
     void liveText;
     void liveParagraphs;
     void liveTentative;
+    const el = transcriptEl;
+    if (el && pendingRemovedHeight > 0) {
+      el.scrollTop = scrollTopAfterLeadingUnmount(el.scrollTop, pendingRemovedHeight);
+      pendingRemovedHeight = 0;
+    }
     scheduleAutoscroll();
   });
 

--- a/src/lib/features/home/LiveSessionCard.svelte
+++ b/src/lib/features/home/LiveSessionCard.svelte
@@ -21,9 +21,6 @@
     meeting: ReturnType<typeof createMeetingController>;
   } = $props();
 
-  /** Only the most recent paragraphs stay in the DOM; older ones are still in
-   * `meeting.liveTranscript.committed` but are never rendered live. */
-  const LIVE_PARAGRAPH_WINDOW = 30;
   /** Auto-scroll only kicks in when already within this many px of the bottom. */
   const NEAR_BOTTOM_PX = 40;
 
@@ -41,8 +38,7 @@
 
   const liveParagraphs = $derived(
     mode === "meeting"
-      ? [...meeting.liveTranscript.committed.slice(-LIVE_PARAGRAPH_WINDOW), ...meeting.liveTranscript.tail]
-        .slice(-LIVE_PARAGRAPH_WINDOW)
+      ? [...meeting.liveTranscript.committed, ...meeting.liveTranscript.tail]
       : [],
   );
   const liveTentative = $derived(

--- a/src/lib/features/home/live-paragraph-window.test.ts
+++ b/src/lib/features/home/live-paragraph-window.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  LIVE_PARAGRAPH_WINDOW,
+  leadingRemovedCount,
+  measureLeadingHeight,
+  scrollTopAfterLeadingUnmount,
+  windowedParagraphs,
+} from "./live-paragraph-window";
+
+function ids(count: number, start = 0): number[] {
+  return Array.from({ length: count }, (_, i) => start + i);
+}
+
+describe("windowedParagraphs", () => {
+  it("keeps the last 30 committed paragraphs plus tail, capped at 30", () => {
+    const committed = ids(40).map((id) => ({ id }));
+    const tail = [{ id: 40 }];
+    const windowed = windowedParagraphs(committed, tail);
+    expect(windowed).toHaveLength(LIVE_PARAGRAPH_WINDOW);
+    expect(windowed[0].id).toBe(11);
+    expect(windowed.at(-1)?.id).toBe(40);
+  });
+
+  it("does not mount the full transcript under the cap", () => {
+    const committed = ids(80).map((id) => ({ id }));
+    expect(windowedParagraphs(committed, []).map((item) => item.id)).toEqual(ids(30, 50));
+  });
+});
+
+describe("live window scroll compensation", () => {
+  const paraHeight = 50;
+  const gap = 16;
+  const stride = paraHeight + gap;
+
+  function idAtScrollTop(paragraphIds: number[], scrollTop: number): number {
+    const index = Math.min(paragraphIds.length - 1, Math.floor(scrollTop / stride));
+    return paragraphIds[index];
+  }
+
+  it("keeps the paragraph under the viewport top when the 31st commit unmounts the oldest", () => {
+    const previous = windowedParagraphs(ids(30), []);
+    const next = windowedParagraphs(ids(31), []);
+    expect(next).toHaveLength(30);
+    expect(leadingRemovedCount(previous, next)).toBe(1);
+
+    const scrollTop = 8 * stride + 10;
+    const beforeId = idAtScrollTop(previous, scrollTop);
+    const compensated = scrollTopAfterLeadingUnmount(scrollTop, stride);
+    expect(idAtScrollTop(next, compensated)).toBe(beforeId);
+  });
+
+  it("leaves a bottom-stuck viewport to autoscroll (compensation is a no-op at 0 unmounts)", () => {
+    const previous = windowedParagraphs(ids(10), []);
+    const next = windowedParagraphs(ids(11), []);
+    expect(leadingRemovedCount(previous, next)).toBe(0);
+    expect(scrollTopAfterLeadingUnmount(400, 0)).toBe(400);
+  });
+
+  it("clamps compensated scrollTop at 0", () => {
+    expect(scrollTopAfterLeadingUnmount(10, 40)).toBe(0);
+  });
+
+  it("measures the height of leading children including gap", () => {
+    const children = [
+      { offsetHeight: 50 },
+      { offsetHeight: 60 },
+      { offsetHeight: 70 },
+    ];
+    const container = { children } as unknown as HTMLElement;
+    expect(measureLeadingHeight(container, 2, 16)).toBe(50 + 16 + 60 + 16);
+  });
+});

--- a/src/lib/features/home/live-paragraph-window.test.ts
+++ b/src/lib/features/home/live-paragraph-window.test.ts
@@ -49,6 +49,13 @@ describe("live window scroll compensation", () => {
     expect(idAtScrollTop(next, compensated)).toBe(beforeId);
   });
 
+  it("treats a fully replaced 30-item window as 30 leading unmounts", () => {
+    const previous = windowedParagraphs(ids(30), []);
+    const next = windowedParagraphs(ids(30, 100), []);
+    expect(next[0]).not.toBe(previous[0]);
+    expect(leadingRemovedCount(previous, next)).toBe(LIVE_PARAGRAPH_WINDOW);
+  });
+
   it("leaves a bottom-stuck viewport to autoscroll (compensation is a no-op at 0 unmounts)", () => {
     const previous = windowedParagraphs(ids(10), []);
     const next = windowedParagraphs(ids(11), []);

--- a/src/lib/features/home/live-paragraph-window.ts
+++ b/src/lib/features/home/live-paragraph-window.ts
@@ -14,7 +14,7 @@ export function windowedParagraphs<T>(
 export function leadingRemovedCount<T>(previous: readonly T[], next: readonly T[]): number {
   if (previous.length === 0 || next.length === 0) return 0;
   const index = previous.indexOf(next[0]);
-  return index > 0 ? index : 0;
+  return index === -1 ? previous.length : index;
 }
 
 export function measureLeadingHeight(

--- a/src/lib/features/home/live-paragraph-window.ts
+++ b/src/lib/features/home/live-paragraph-window.ts
@@ -1,0 +1,35 @@
+/** Only the most recent paragraphs stay in the DOM; older ones remain in
+ * `committed` but are not rendered live. */
+export const LIVE_PARAGRAPH_WINDOW = 30;
+
+export function windowedParagraphs<T>(
+  committed: readonly T[],
+  tail: readonly T[],
+  limit = LIVE_PARAGRAPH_WINDOW,
+): T[] {
+  return [...committed.slice(-limit), ...tail].slice(-limit);
+}
+
+/** How many leading items will unmount when the window slides forward. */
+export function leadingRemovedCount<T>(previous: readonly T[], next: readonly T[]): number {
+  if (previous.length === 0 || next.length === 0) return 0;
+  const index = previous.indexOf(next[0]);
+  return index > 0 ? index : 0;
+}
+
+export function measureLeadingHeight(
+  container: Pick<HTMLElement, "children">,
+  count: number,
+  gap: number,
+): number {
+  let height = 0;
+  const n = Math.min(count, container.children.length);
+  for (let i = 0; i < n; i++) {
+    height += (container.children[i] as HTMLElement).offsetHeight + gap;
+  }
+  return height;
+}
+
+export function scrollTopAfterLeadingUnmount(scrollTop: number, removedHeight: number): number {
+  return Math.max(0, scrollTop - removedHeight);
+}

--- a/src/lib/features/meeting/audio-seek.test.ts
+++ b/src/lib/features/meeting/audio-seek.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { HAVE_METADATA, applyPendingSeek, seekNeedsMetadata } from "./audio-seek";
 
-function media(readyState: number, currentTime = 0) {
+function media(readyState: number, currentTime = 0, src = "/rec/0.ogg") {
   return {
     readyState,
     currentTime,
+    src,
     play: vi.fn(() => undefined),
   };
 }
@@ -26,15 +27,15 @@ describe("seekNeedsMetadata", () => {
 describe("applyPendingSeek", () => {
   it("does not set currentTime before metadata", () => {
     const el = media(0);
-    const leftover = applyPendingSeek(el, { seekSeconds: 12.5 });
+    const leftover = applyPendingSeek(el, { seekSeconds: 12.5, src: "/rec/0.ogg" });
     expect(el.currentTime).toBe(0);
     expect(el.play).not.toHaveBeenCalled();
-    expect(leftover).toEqual({ seekSeconds: 12.5 });
+    expect(leftover).toEqual({ seekSeconds: 12.5, src: "/rec/0.ogg" });
   });
 
   it("applies the pending offset once metadata is available", () => {
     const el = media(HAVE_METADATA);
-    const leftover = applyPendingSeek(el, { seekSeconds: 12.5 });
+    const leftover = applyPendingSeek(el, { seekSeconds: 12.5, src: "/rec/0.ogg" });
     expect(el.currentTime).toBe(12.5);
     expect(el.play).toHaveBeenCalledOnce();
     expect(leftover).toBeNull();
@@ -42,10 +43,18 @@ describe("applyPendingSeek", () => {
 
   it("a later pending seek replaces the earlier one", () => {
     const el = media(0);
-    applyPendingSeek(el, { seekSeconds: 4 });
+    applyPendingSeek(el, { seekSeconds: 4, src: "/rec/0.ogg" });
     el.readyState = HAVE_METADATA;
-    const leftover = applyPendingSeek(el, { seekSeconds: 18 });
+    const leftover = applyPendingSeek(el, { seekSeconds: 18, src: "/rec/0.ogg" });
     expect(el.currentTime).toBe(18);
     expect(leftover).toBeNull();
+  });
+
+  it("does not apply a later file's offset to a stale metadata event", () => {
+    const el = media(HAVE_METADATA, 0, "/rec/b.ogg");
+    const leftover = applyPendingSeek(el, { seekSeconds: 20, src: "/rec/c.ogg" });
+    expect(el.currentTime).toBe(0);
+    expect(el.play).not.toHaveBeenCalled();
+    expect(leftover).toEqual({ seekSeconds: 20, src: "/rec/c.ogg" });
   });
 });

--- a/src/lib/features/meeting/audio-seek.test.ts
+++ b/src/lib/features/meeting/audio-seek.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { HAVE_METADATA, applyPendingSeek, seekNeedsMetadata } from "./audio-seek";
+
+function media(readyState: number, currentTime = 0) {
+  return {
+    readyState,
+    currentTime,
+    play: vi.fn(() => undefined),
+  };
+}
+
+describe("seekNeedsMetadata", () => {
+  it("waits when the same file has no metadata yet", () => {
+    expect(seekNeedsMetadata(0, false)).toBe(true);
+  });
+
+  it("applies immediately when the same file already has metadata", () => {
+    expect(seekNeedsMetadata(HAVE_METADATA, false)).toBe(false);
+  });
+
+  it("waits on a session swap even if the current element already has metadata", () => {
+    expect(seekNeedsMetadata(HAVE_METADATA, true)).toBe(true);
+  });
+});
+
+describe("applyPendingSeek", () => {
+  it("does not set currentTime before metadata", () => {
+    const el = media(0);
+    const leftover = applyPendingSeek(el, { seekSeconds: 12.5 });
+    expect(el.currentTime).toBe(0);
+    expect(el.play).not.toHaveBeenCalled();
+    expect(leftover).toEqual({ seekSeconds: 12.5 });
+  });
+
+  it("applies the pending offset once metadata is available", () => {
+    const el = media(HAVE_METADATA);
+    const leftover = applyPendingSeek(el, { seekSeconds: 12.5 });
+    expect(el.currentTime).toBe(12.5);
+    expect(el.play).toHaveBeenCalledOnce();
+    expect(leftover).toBeNull();
+  });
+
+  it("a later pending seek replaces the earlier one", () => {
+    const el = media(0);
+    applyPendingSeek(el, { seekSeconds: 4 });
+    el.readyState = HAVE_METADATA;
+    const leftover = applyPendingSeek(el, { seekSeconds: 18 });
+    expect(el.currentTime).toBe(18);
+    expect(leftover).toBeNull();
+  });
+});

--- a/src/lib/features/meeting/audio-seek.test.ts
+++ b/src/lib/features/meeting/audio-seek.test.ts
@@ -57,4 +57,18 @@ describe("applyPendingSeek", () => {
     expect(el.play).not.toHaveBeenCalled();
     expect(leftover).toEqual({ seekSeconds: 20, src: "/rec/c.ogg" });
   });
+
+  it("prefers currentSrc over src during a source transition", () => {
+    const el = {
+      readyState: HAVE_METADATA,
+      currentTime: 0,
+      src: "/rec/c.ogg",
+      currentSrc: "/rec/b.ogg",
+      play: vi.fn(() => undefined),
+    };
+    const leftover = applyPendingSeek(el, { seekSeconds: 20, src: "/rec/c.ogg" });
+    expect(el.currentTime).toBe(0);
+    expect(el.play).not.toHaveBeenCalled();
+    expect(leftover).toEqual({ seekSeconds: 20, src: "/rec/c.ogg" });
+  });
 });

--- a/src/lib/features/meeting/audio-seek.ts
+++ b/src/lib/features/meeting/audio-seek.ts
@@ -17,7 +17,9 @@ export type SeekableMedia = {
 };
 
 function mediaSrc(el: SeekableMedia): string {
-  return el.src || el.currentSrc || "";
+  // currentSrc is the resource actually loaded. During a src swap, `src` can
+  // already point at the next file while currentSrc is still the previous one.
+  return el.currentSrc || el.src || "";
 }
 
 /** Wait for loadedmetadata when the file is swapping or metadata is not here yet. */

--- a/src/lib/features/meeting/audio-seek.ts
+++ b/src/lib/features/meeting/audio-seek.ts
@@ -3,26 +3,38 @@ export const HAVE_METADATA = 1;
 
 export type PendingSeek = {
   seekSeconds: number;
+  /** Media src this seek was armed for. A stale loadedmetadata from another
+   * file must not apply this offset. */
+  src: string;
 };
 
 export type SeekableMedia = {
   readyState: number;
   currentTime: number;
+  src?: string;
+  currentSrc?: string;
   play: () => Promise<void> | void;
 };
+
+function mediaSrc(el: SeekableMedia): string {
+  return el.src || el.currentSrc || "";
+}
 
 /** Wait for loadedmetadata when the file is swapping or metadata is not here yet. */
 export function seekNeedsMetadata(readyState: number, sessionChanged: boolean): boolean {
   return sessionChanged || readyState < HAVE_METADATA;
 }
 
-/** Apply a pending seek if metadata is available. Returns remaining pending seek. */
+/** Apply a pending seek if metadata is available on the file it was armed for.
+ * Returns remaining pending seek. */
 export function applyPendingSeek(
   el: SeekableMedia | undefined | null,
   pending: PendingSeek | null,
 ): PendingSeek | null {
   if (!el || !pending) return pending;
   if (el.readyState < HAVE_METADATA) return pending;
+  const actual = mediaSrc(el);
+  if (actual && actual !== pending.src) return pending;
   el.currentTime = pending.seekSeconds;
   void el.play();
   return null;

--- a/src/lib/features/meeting/audio-seek.ts
+++ b/src/lib/features/meeting/audio-seek.ts
@@ -1,0 +1,29 @@
+/** HTMLMediaElement.HAVE_METADATA — `currentTime` can be set. */
+export const HAVE_METADATA = 1;
+
+export type PendingSeek = {
+  seekSeconds: number;
+};
+
+export type SeekableMedia = {
+  readyState: number;
+  currentTime: number;
+  play: () => Promise<void> | void;
+};
+
+/** Wait for loadedmetadata when the file is swapping or metadata is not here yet. */
+export function seekNeedsMetadata(readyState: number, sessionChanged: boolean): boolean {
+  return sessionChanged || readyState < HAVE_METADATA;
+}
+
+/** Apply a pending seek if metadata is available. Returns remaining pending seek. */
+export function applyPendingSeek(
+  el: SeekableMedia | undefined | null,
+  pending: PendingSeek | null,
+): PendingSeek | null {
+  if (!el || !pending) return pending;
+  if (el.readyState < HAVE_METADATA) return pending;
+  el.currentTime = pending.seekSeconds;
+  void el.play();
+  return null;
+}

--- a/src/lib/features/meeting/components/MeetingAudioPlayerSection.svelte
+++ b/src/lib/features/meeting/components/MeetingAudioPlayerSection.svelte
@@ -24,6 +24,7 @@
   // Guards re-applying the same click twice (e.g. an unrelated prop update
   // re-running the effect) without needing seekRequestId in a closure ref.
   let lastAppliedSeekId = -1;
+  let seekAbortController = new AbortController();
 
   // Show something to play as soon as sessions arrive, before any paragraph
   // has been clicked.
@@ -38,16 +39,27 @@
     if (!seekTarget || !audioEl || seekRequestId === lastAppliedSeekId) return;
     lastAppliedSeekId = seekRequestId;
 
+    seekAbortController.abort();
+    seekAbortController = new AbortController();
+
     const command = buildPlayCommand(seekTarget, currentPath);
     const el = audioEl;
     const applySeek = () => {
-      el.currentTime = command.seekSeconds;
-      void el.play();
+      // In case the audio element is not yet ready even if session didn't change (edge case)
+      if (el.readyState >= 1) {
+        el.currentTime = command.seekSeconds;
+        void el.play();
+      } else {
+        el.addEventListener("loadedmetadata", () => {
+          el.currentTime = command.seekSeconds;
+          void el.play();
+        }, { once: true, signal: seekAbortController.signal });
+      }
     };
 
     if (command.sessionChanged) {
       currentPath = command.path;
-      el.addEventListener("loadedmetadata", applySeek, { once: true });
+      el.addEventListener("loadedmetadata", applySeek, { once: true, signal: seekAbortController.signal });
     } else {
       applySeek();
     }

--- a/src/lib/features/meeting/components/MeetingAudioPlayerSection.svelte
+++ b/src/lib/features/meeting/components/MeetingAudioPlayerSection.svelte
@@ -54,7 +54,7 @@
     lastAppliedSeekId = seekRequestId;
 
     const command = buildPlayCommand(seekTarget, currentPath);
-    pendingSeek = { seekSeconds: command.seekSeconds };
+    pendingSeek = { seekSeconds: command.seekSeconds, src: convertFileSrc(command.path) };
 
     if (command.sessionChanged) {
       currentPath = command.path;

--- a/src/lib/features/meeting/components/MeetingAudioPlayerSection.svelte
+++ b/src/lib/features/meeting/components/MeetingAudioPlayerSection.svelte
@@ -3,6 +3,7 @@
   import { Pause, Play } from "@lucide/svelte";
   import { t } from "svelte-i18n";
   import { defaultAudioTarget, buildPlayCommand, type AudioSeekTarget } from "../audio-map";
+  import { applyPendingSeek, seekNeedsMetadata, type PendingSeek } from "../audio-seek";
   import type { MeetingAudioSession } from "../../../types";
   import { formatTimestamp } from "../../../utils";
 
@@ -24,7 +25,20 @@
   // Guards re-applying the same click twice (e.g. an unrelated prop update
   // re-running the effect) without needing seekRequestId in a closure ref.
   let lastAppliedSeekId = -1;
+  let pendingSeek: PendingSeek | null = null;
   let seekAbortController = new AbortController();
+
+  function armMetadataListener(el: HTMLAudioElement) {
+    seekAbortController.abort();
+    seekAbortController = new AbortController();
+    el.addEventListener(
+      "loadedmetadata",
+      () => {
+        pendingSeek = applyPendingSeek(el, pendingSeek);
+      },
+      { once: true, signal: seekAbortController.signal },
+    );
+  }
 
   // Show something to play as soon as sessions arrive, before any paragraph
   // has been clicked.
@@ -39,30 +53,21 @@
     if (!seekTarget || !audioEl || seekRequestId === lastAppliedSeekId) return;
     lastAppliedSeekId = seekRequestId;
 
-    seekAbortController.abort();
-    seekAbortController = new AbortController();
-
     const command = buildPlayCommand(seekTarget, currentPath);
-    const el = audioEl;
-    const applySeek = () => {
-      // In case the audio element is not yet ready even if session didn't change (edge case)
-      if (el.readyState >= 1) {
-        el.currentTime = command.seekSeconds;
-        void el.play();
-      } else {
-        el.addEventListener("loadedmetadata", () => {
-          el.currentTime = command.seekSeconds;
-          void el.play();
-        }, { once: true, signal: seekAbortController.signal });
-      }
-    };
+    pendingSeek = { seekSeconds: command.seekSeconds };
 
     if (command.sessionChanged) {
       currentPath = command.path;
-      el.addEventListener("loadedmetadata", applySeek, { once: true, signal: seekAbortController.signal });
-    } else {
-      applySeek();
     }
+
+    if (seekNeedsMetadata(audioEl.readyState, command.sessionChanged)) {
+      armMetadataListener(audioEl);
+      return;
+    }
+
+    seekAbortController.abort();
+    seekAbortController = new AbortController();
+    pendingSeek = applyPendingSeek(audioEl, pendingSeek);
   });
 
   function togglePlay() {
@@ -87,7 +92,11 @@
       onplay={() => { playing = true; }}
       onpause={() => { playing = false; }}
       ontimeupdate={() => { if (audioEl) currentTime = audioEl.currentTime; }}
-      onloadedmetadata={() => { if (audioEl) duration = audioEl.duration; }}
+      onloadedmetadata={() => {
+        if (!audioEl) return;
+        duration = audioEl.duration;
+        pendingSeek = applyPendingSeek(audioEl, pendingSeek);
+      }}
     ></audio>
     <button
       class="btn btn-icon shrink-0"

--- a/src/lib/features/settings/components/ModelSettingsSection.svelte
+++ b/src/lib/features/settings/components/ModelSettingsSection.svelte
@@ -25,6 +25,7 @@
     downloadTotalBytes,
     downloadFile,
     unloadTimeoutMinutes,
+    recording,
     onSelectModel,
     onUnloadTimeoutChange,
   }: {
@@ -37,13 +38,14 @@
     downloadTotalBytes: number | null;
     downloadFile: string;
     unloadTimeoutMinutes: number;
+    recording: boolean;
     onSelectModel: (key: string) => void | Promise<void>;
     onUnloadTimeoutChange: (event: Event) => void;
   } = $props();
 
   const options = $derived(listAvailableModelOptions(catalog));
   const selectedKey = $derived(`${selectedEngineId}:${selectedModelId}`);
-  const busy = $derived(operationState !== "idle");
+  const busy = $derived(operationState !== "idle" || recording);
 </script>
 
 <section class="settings-group">
@@ -66,6 +68,7 @@
       <select
         value={selectedKey}
         disabled={busy}
+        title={recording ? $t("settings_model.recording_locked") : undefined}
         onchange={async (event) => {
           const target = event.currentTarget as HTMLSelectElement;
           try {

--- a/src/lib/features/settings/components/ModelSettingsSection.svelte
+++ b/src/lib/features/settings/components/ModelSettingsSection.svelte
@@ -66,7 +66,14 @@
       <select
         value={selectedKey}
         disabled={busy}
-        onchange={(event) => void onSelectModel((event.currentTarget as HTMLSelectElement).value)}
+        onchange={async (event) => {
+          const target = event.currentTarget as HTMLSelectElement;
+          try {
+            await onSelectModel(target.value);
+          } finally {
+            target.value = selectedKey;
+          }
+        }}
         class="field-select"
         aria-label={$t("settings_model.title")}
       >

--- a/src/lib/features/settings/components/ModelSettingsSection.test.ts
+++ b/src/lib/features/settings/components/ModelSettingsSection.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/svelte";
+import type { TranscriptionCatalog } from "../../../types";
+import ModelSettingsSection from "./ModelSettingsSection.svelte";
+
+const catalog: TranscriptionCatalog = {
+  engines: [
+    {
+      id: "kyutai",
+      label: "Kyutai",
+      description: "Kyutai STT",
+      models: [
+        {
+          id: "stt-1b-en_fr",
+          label: "STT 1B",
+          description: "1B",
+          download_size_bytes: 1,
+          recommended_memory_bytes: 1,
+          supported_languages: ["en"],
+          capabilities: {
+            supports_streaming: true,
+            supports_batch_transcription: false,
+            supports_language_auto_detect: true,
+            supports_word_timestamps: true,
+            supports_partial_results: true,
+          },
+          audio_input: { sample_rate_hz: 24000, channels: 1, chunk_size_samples: 1920 },
+          available_in_app: true,
+          availability_note: null,
+          backends: [
+            {
+              id: "candle",
+              label: "Candle",
+              description: "Candle",
+              recommended: true,
+              available_in_app: true,
+              availability_note: null,
+              artifacts: [],
+            },
+          ],
+          recommended_backend_id: "candle",
+        },
+      ],
+    },
+  ],
+  selected_engine_id: "kyutai",
+  selected_model_id: "stt-1b-en_fr",
+  selected_backend_id: "candle",
+};
+
+function renderSection(recording: boolean) {
+  render(ModelSettingsSection, {
+    props: {
+      catalog,
+      selectedEngineId: "kyutai",
+      selectedModelId: "stt-1b-en_fr",
+      runtimePhase: "ready",
+      operationState: "idle",
+      downloadedBytes: 0,
+      downloadTotalBytes: null,
+      downloadFile: "",
+      unloadTimeoutMinutes: 0,
+      recording,
+      onSelectModel: vi.fn(),
+      onUnloadTimeoutChange: vi.fn(),
+    },
+  });
+}
+
+describe("ModelSettingsSection recording guard", () => {
+  afterEach(cleanup);
+
+  it("disables the model picker while recording", () => {
+    renderSection(true);
+    const picker = screen.getByLabelText("Transcription model") as HTMLSelectElement;
+    expect(picker.disabled).toBe(true);
+    expect(picker.title).toBe("Can't change the transcription model while recording.");
+  });
+
+  it("leaves the picker enabled when idle", () => {
+    renderSection(false);
+    const picker = screen.getByLabelText("Transcription model") as HTMLSelectElement;
+    expect(picker.disabled).toBe(false);
+  });
+});

--- a/src/lib/features/settings/controller.svelte.test.ts
+++ b/src/lib/features/settings/controller.svelte.test.ts
@@ -462,6 +462,86 @@ describe("settings controller", () => {
     expect(mockInvoke).not.toHaveBeenCalledWith("download_model", expect.anything());
   });
 
+  it("selectModelOption does not persist while a meeting is recording", async () => {
+    const ctrl = createSettingsController();
+    await ctrl.mount();
+
+    ctrl.app.machineState = {
+      state: "recording_meeting",
+      data: {
+        profile: {
+          engine_id: "kyutai",
+          engine_label: "Kyutai",
+          model_id: "stt-1b-en_fr",
+          model_label: "STT 1B",
+          backend_id: "candle",
+          backend_label: "Candle",
+        },
+        session_id: 1,
+        meeting_id: "m1",
+      },
+    };
+
+    mockInvoke.mockClear();
+    await ctrl.selectModelOption("kyutai:stt-2.6b-en");
+
+    expect(mockInvoke).not.toHaveBeenCalledWith("save_settings", expect.anything());
+    expect(mockInvoke).not.toHaveBeenCalledWith("load_model", expect.anything());
+    expect(ctrl.app.settings.transcription_engine_id).toBe("kyutai");
+    expect(ctrl.app.settings.transcription_model_id).toBe("stt-1b-en_fr");
+    expect(ctrl.app.settings.transcription_backend_id).toBe("candle");
+    expect(ctrl.statusMessage).toBe("Can't change the transcription model while recording.");
+  });
+
+  it("selectModelOption does not persist while dictation is recording", async () => {
+    const ctrl = createSettingsController();
+    await ctrl.mount();
+
+    ctrl.app.machineState = {
+      state: "recording_dictation",
+      data: {
+        profile: {
+          engine_id: "kyutai",
+          engine_label: "Kyutai",
+          model_id: "stt-1b-en_fr",
+          model_label: "STT 1B",
+          backend_id: "candle",
+          backend_label: "Candle",
+        },
+        session_id: 1,
+      },
+    };
+
+    mockInvoke.mockClear();
+    await ctrl.selectModelOption("kyutai:stt-2.6b-en");
+
+    expect(mockInvoke).not.toHaveBeenCalledWith("save_settings", expect.anything());
+    expect(ctrl.app.settings.transcription_model_id).toBe("stt-1b-en_fr");
+  });
+
+  it("restores the previous model triple when save_settings refuses the switch", async () => {
+    mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "save_settings") {
+        const settings = args?.settings as AppSettings;
+        if (settings.transcription_model_id !== "stt-1b-en_fr") {
+          return Promise.reject("Cannot change the transcription model while recording");
+        }
+        return Promise.resolve(null);
+      }
+      return defaultInvoke(cmd, args);
+    });
+
+    const ctrl = createSettingsController();
+    await ctrl.mount();
+
+    await ctrl.selectModelOption("kyutai:stt-2.6b-en");
+
+    expect(ctrl.app.settings.transcription_engine_id).toBe("kyutai");
+    expect(ctrl.app.settings.transcription_model_id).toBe("stt-1b-en_fr");
+    expect(ctrl.app.settings.transcription_backend_id).toBe("candle");
+    expect(mockInvoke).not.toHaveBeenCalledWith("load_model", expect.anything());
+  });
+
   it("shortcut recording flow", async () => {
     const ctrl = createSettingsController();
     await ctrl.mount();

--- a/src/lib/features/settings/controller.svelte.ts
+++ b/src/lib/features/settings/controller.svelte.ts
@@ -25,6 +25,8 @@ import { listCalendars } from "../../api/calendar";
 import { requestPermission } from "../../api/permissions";
 import { setLocale } from "../../i18n";
 import { getAppState } from "../../stores/app.svelte";
+import { get } from "svelte/store";
+import { t } from "svelte-i18n";
 import type {
   AppSettings,
   AudioInputDevice,
@@ -163,7 +165,7 @@ export function createSettingsController() {
     }
   }
 
-  async function persistSettings(updater: (settings: AppSettings) => void) {
+  async function persistSettings(updater: (settings: AppSettings) => void): Promise<boolean> {
     const previousSettings = app.settings;
     const nextSettings: AppSettings = {
       ...previousSettings,
@@ -175,18 +177,27 @@ export function createSettingsController() {
       || nextSettings.transcription_model_id !== previousSettings.transcription_model_id
       || nextSettings.transcription_backend_id !== previousSettings.transcription_backend_id;
 
+    if (selectionChanged && app.isRecording) {
+      statusMessage = get(t)("settings_model.recording_locked");
+      return false;
+    }
+
     try {
       await saveSettings(nextSettings);
-      app.settings = nextSettings;
-      app.selectedDevice = nextSettings.audio_device ?? "";
-      if (selectionChanged) {
-        resetTranscriptionRuntimeState(app);
-        await loadCatalog();
-        await refreshRuntimeStatus();
-      }
     } catch (e) {
+      app.settings = previousSettings;
       statusMessage = errorMessage(e);
+      return false;
     }
+
+    app.settings = nextSettings;
+    app.selectedDevice = nextSettings.audio_device ?? "";
+    if (selectionChanged) {
+      resetTranscriptionRuntimeState(app);
+      await loadCatalog();
+      await refreshRuntimeStatus();
+    }
+    return true;
   }
 
   async function refreshDevices() {
@@ -435,11 +446,17 @@ export function createSettingsController() {
     const option = listAvailableModelOptions(catalog).find((candidate) => candidate.key === key);
     if (!option) return;
 
-    await persistSettings((settings) => {
+    if (app.isRecording) {
+      statusMessage = get(t)("settings_model.recording_locked");
+      return;
+    }
+
+    const persisted = await persistSettings((settings) => {
       settings.transcription_engine_id = option.engineId;
       settings.transcription_model_id = option.modelId;
       settings.transcription_backend_id = option.backendId;
     });
+    if (!persisted) return;
 
     // Branch on the phase the backend just reported for the newly selected
     // model, never on stored state a StateChanged event may have overwritten

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -414,6 +414,7 @@
   "status_chip": {
     "ready": "Ready",
     "loading": "Loading model…",
+    "load_required": "Model not loaded",
     "downloading": "Downloading",
     "model_required": "Model required"
   },
@@ -427,6 +428,7 @@
   "settings_model": {
     "title": "Transcription model",
     "description": "Pick a model — it downloads and loads automatically. Everything runs on this Mac.",
+    "recording_locked": "Can't change the transcription model while recording.",
     "downloading": "Downloading…",
     "unload_timeout_label": "Unload model when idle",
     "unload_timeout_desc": "Frees memory after a period of no transcription activity. Reloads automatically the next time you start recording.",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -414,6 +414,7 @@
   "status_chip": {
     "ready": "Prêt",
     "loading": "Chargement du modèle…",
+    "load_required": "Modèle à charger",
     "downloading": "Téléchargement",
     "model_required": "Modèle requis"
   },
@@ -427,6 +428,7 @@
   "settings_model": {
     "title": "Modèle de transcription",
     "description": "Choisissez un modèle — il se télécharge et se charge automatiquement. Tout tourne sur ce Mac.",
+    "recording_locked": "Impossible de changer de modèle pendant un enregistrement.",
     "downloading": "Téléchargement…",
     "unload_timeout_label": "Décharger le modèle en cas d'inactivité",
     "unload_timeout_desc": "Libère de la mémoire après une période sans transcription. Se recharge automatiquement au prochain enregistrement.",


### PR DESCRIPTION
Fixes SOU-079, SOU-086, SOU-087, SOU-088.

- **SOU-079:** `summary_is_stale` on transcript *and* notes edits. Summarize snapshots both; if either changes during generation the new summary is stored but stays stale.
- **SOU-086:** Keep the 30-paragraph live window (do not mount the full hour). Compensate `scrollTop` when the oldest node unmounts.
- **SOU-087:** One pending seek, one live `loadedmetadata` listener. Wait for metadata even on the same file. Abort the previous listener on a new click.
- **SOU-088:** Disable the model picker while recording. Refuse persist before `load_model`. Backend pins the stored triple during recording. `load_required` is no longer painted as an in-flight load.

Machine QA still needed on a live meeting (stale badge, live scroll, cold seek, refused model switch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Meeting summaries remain marked outdated when transcripts or notes change during generation.
  - Live meeting scrolling stays anchored as older paragraphs leave the active view.
  - Audio seeking handles delayed metadata, repeated seeks, and changing audio files more reliably.
  - Transcription model changes are prevented during recording, with settings restored if saving fails.
  - Status indicators distinguish loading from attention-required states.

- **Localization**
  - Added English and French messages for model loading and recording-related restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->