### PR TITLE
Fix batch UI/Accessibility issues

### DIFF
--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -327,6 +327,11 @@ mod tests {
     #[test]
     fn copy_instead_of_paste_still_reports_accessibility_when_copy_fails() {
         let err = copy_instead_of_paste("hello", |_| Err("no pasteboard".into())).unwrap_err();
+        assert_ne!(
+            err.as_str(),
+            ACCESSIBILITY_STALE_ERROR,
+            "copy failure must not be the exact copied-for-⌘V signal"
+        );
         assert!(err.starts_with(ACCESSIBILITY_STALE_ERROR), "{err}");
         assert!(err.contains("no pasteboard"), "{err}");
     }

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -11,7 +11,7 @@ use crate::settings::PasteMethod;
 /// Shown when Accessibility is missing at paste time. Distinct from Enigo's
 /// own init error so the UI can recognize it and offer the repair action
 /// instead of just relaying a raw OS error string.
-pub const ACCESSIBILITY_STALE_ERROR: &str = "Accessibility permission missing. If Souffle is already listed and checked in System Settings > Privacy & Security > Accessibility, this is usually a stale entry left by an app update: remove Souffle with the minus button and re-add it, or use Repair permission in Souffle's Settings > Advanced > Permissions.";
+pub const ACCESSIBILITY_STALE_ERROR: &str = "Accessibility permission missing.";
 
 /// The synthetic ⌘V is asynchronous: the target app reads the pasteboard from
 /// its own run loop, and a busy app, an Electron one, or one that was just
@@ -36,7 +36,11 @@ pub fn paste_text(text: &str, delay_ms: u64, method: PasteMethod) -> Result<(), 
     }
 
     if !permissions::accessibility_granted() {
-        return Err(ACCESSIBILITY_STALE_ERROR.to_string());
+        // SOU-033: leave the transcription on the pasteboard so the user can
+        // ⌘V. Do not snapshot/restore — restoring would wipe the only copy
+        // they have. Full NSPasteboard (image/file) snapshot is still text-only;
+        // see RestoreBurst.
+        return copy_instead_of_paste(text, copy_text);
     }
 
     // Never let a background paste pop the OS permission pane on its own;
@@ -178,9 +182,26 @@ fn send_paste_keys(enigo: &mut Enigo) -> Result<(), String> {
 /// burst. Only the newest generation restores it; older restores no-op so a
 /// second paste within `CLIPBOARD_RESTORE_DELAY` cannot write the first
 /// transcription back as if it were the user's original contents.
+///
+/// Text-only (arboard). A full `NSPasteboardItem` snapshot — images, files,
+/// custom types — is the remaining SOU-033 piece; it needs a main-thread
+/// pasteboard copy and a different restore payload than `Option<String>`.
 struct RestoreBurst {
     generation: u64,
     original: Option<String>,
+}
+
+/// Accessibility is missing: write `text` for a manual ⌘V and return the
+/// distinctive error the UI matches on. The copy error is appended so a
+/// dead pasteboard is still visible, but the accessibility cause stays first.
+fn copy_instead_of_paste(
+    text: &str,
+    copy: impl FnOnce(&str) -> Result<(), String>,
+) -> Result<(), String> {
+    match copy(text) {
+        Ok(()) => Err(ACCESSIBILITY_STALE_ERROR.to_string()),
+        Err(copy_err) => Err(format!("{ACCESSIBILITY_STALE_ERROR} ({copy_err})")),
+    }
 }
 
 impl RestoreBurst {
@@ -284,9 +305,30 @@ mod tests {
     }
 
     #[test]
-    fn accessibility_stale_error_points_to_repair() {
-        assert!(ACCESSIBILITY_STALE_ERROR.contains("Accessibility"));
-        assert!(ACCESSIBILITY_STALE_ERROR.contains("Repair permission"));
+    fn accessibility_stale_error_is_a_stable_prefix() {
+        assert!(ACCESSIBILITY_STALE_ERROR.contains("Accessibility permission missing"));
+        assert!(
+            !ACCESSIBILITY_STALE_ERROR.contains("Settings >"),
+            "itineraries belong in the UI button, not this error string"
+        );
+    }
+
+    #[test]
+    fn copy_instead_of_paste_leaves_the_transcription_and_errors() {
+        let mut copied = None;
+        let result = copy_instead_of_paste("hello", |text| {
+            copied = Some(text.to_string());
+            Ok(())
+        });
+        assert_eq!(result.unwrap_err(), ACCESSIBILITY_STALE_ERROR);
+        assert_eq!(copied.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn copy_instead_of_paste_still_reports_accessibility_when_copy_fails() {
+        let err = copy_instead_of_paste("hello", |_| Err("no pasteboard".into())).unwrap_err();
+        assert!(err.starts_with(ACCESSIBILITY_STALE_ERROR), "{err}");
+        assert!(err.contains("no pasteboard"), "{err}");
     }
 
     #[test]
@@ -446,11 +488,6 @@ mod tests {
         // take_if_current (and still holds RESTORE through the write).
         // cancel_pending_restore must not run until that lock is released,
         // or copy_text can land and then be overwritten by previous.
-        let generation = {
-            let mut burst = lock_restore();
-            burst.begin(Some("old clipboard".into())).0
-        };
-
         let barrier = Arc::new(Barrier::new(2));
         let cancel_returned = Arc::new(AtomicBool::new(false));
         let cancel_handle = {
@@ -465,6 +502,10 @@ mod tests {
 
         {
             let mut burst = lock_restore();
+            // Reset + begin under the same lock as take_if_current so a
+            // parallel spawn_restore cannot bump the generation in between.
+            *burst = RestoreBurst::new();
+            let generation = burst.begin(Some("old clipboard".into())).0;
             assert_eq!(
                 burst.take_if_current(generation),
                 Some(Some("old clipboard".into()))

--- a/src-tauri/src/commands/model.rs
+++ b/src-tauri/src/commands/model.rs
@@ -279,8 +279,13 @@ pub fn delete_model(
 ) -> Result<(), String> {
     let profile = resolve_transcription_selection(&selection)?;
 
-    // Cannot delete the actively loaded model
     let machine = state.current_machine_state()?;
+    if matches!(
+        machine,
+        AppStateMachine::Downloading { .. } | AppStateMachine::Loading { .. }
+    ) {
+        return Err("Cannot delete a model while it is downloading or loading.".into());
+    }
     if machine.is_model_ready() && machine.active_profile() == Some(&profile) {
         return Err("Cannot delete the currently loaded model. Unload it first or switch to a different model.".into());
     }

--- a/src-tauri/src/commands/model.rs
+++ b/src-tauri/src/commands/model.rs
@@ -11,7 +11,7 @@ use crate::engine::{
 use crate::models;
 use crate::settings::AppSettings;
 use crate::state::AppState;
-use crate::state_machine::{AppStateMachine, StateAction};
+use crate::state_machine::{AppStateMachine, ErrorRecovery, StateAction};
 
 /// Drop the loaded engine so the machine can leave Ready. On actor error,
 /// Fail out of Unloading — never leave that corridor without UnloadComplete.
@@ -281,7 +281,10 @@ pub fn delete_model(
 
     let machine = state.current_machine_state()?;
     if model_delete_blocked_by_transition(&machine) {
-        return Err("Cannot delete a model while it is downloading, loading, or unloading.".into());
+        return Err(
+            "Cannot delete a model while it is downloading, loading, unloading, or recovering from a failed unload."
+                .into(),
+        );
     }
     if machine.is_model_ready() && machine.active_profile() == Some(&profile) {
         return Err("Cannot delete the currently loaded model. Unload it first or switch to a different model.".into());
@@ -299,14 +302,19 @@ pub fn delete_model(
     Ok(())
 }
 
-/// Downloading/loading/unloading all hold model files; Unloading is not
-/// `is_model_ready`, so it must be listed here or delete can race teardown.
+/// Downloading/loading/unloading all hold model files; Unloading and
+/// RetryFromReady are not `is_model_ready`, so they must be listed here or
+/// delete can race teardown (or delete files still held after a failed unload).
 fn model_delete_blocked_by_transition(machine: &AppStateMachine) -> bool {
     matches!(
         machine,
         AppStateMachine::Downloading { .. }
             | AppStateMachine::Loading { .. }
             | AppStateMachine::Unloading { .. }
+            | AppStateMachine::Error {
+                recovery: ErrorRecovery::RetryFromReady { .. },
+                ..
+            }
     )
 }
 
@@ -387,5 +395,21 @@ mod tests {
         assert!(!model_delete_blocked_by_transition(
             &AppStateMachine::Ready { profile: profile() }
         ));
+    }
+
+    #[test]
+    fn delete_is_blocked_while_retry_from_ready() {
+        let failed = AppStateMachine::Error {
+            message: "Recording session active".into(),
+            recovery: ErrorRecovery::RetryFromReady {
+                profile: profile(),
+            },
+        };
+        assert!(model_delete_blocked_by_transition(&failed));
+        assert!(!failed.is_model_ready());
+        assert!(!model_delete_blocked_by_transition(&AppStateMachine::Error {
+            message: "download failed".into(),
+            recovery: ErrorRecovery::RetryFromIdle,
+        }));
     }
 }

--- a/src-tauri/src/commands/model.rs
+++ b/src-tauri/src/commands/model.rs
@@ -1,12 +1,12 @@
+use tauri::ipc::Channel;
 use tauri::Manager;
 use tauri::State;
-use tauri::ipc::Channel;
 use tracing::info;
 
 use crate::engine::{
+    resolve_transcription_profile, resolve_transcription_selection, transcription_engine_catalog,
     TranscriptionCatalog, TranscriptionProfile, TranscriptionProfileSelection,
-    TranscriptionRuntimeStatus, resolve_transcription_profile, resolve_transcription_selection,
-    transcription_engine_catalog,
+    TranscriptionRuntimeStatus,
 };
 use crate::models;
 use crate::settings::AppSettings;
@@ -280,11 +280,8 @@ pub fn delete_model(
     let profile = resolve_transcription_selection(&selection)?;
 
     let machine = state.current_machine_state()?;
-    if matches!(
-        machine,
-        AppStateMachine::Downloading { .. } | AppStateMachine::Loading { .. }
-    ) {
-        return Err("Cannot delete a model while it is downloading or loading.".into());
+    if model_delete_blocked_by_transition(&machine) {
+        return Err("Cannot delete a model while it is downloading, loading, or unloading.".into());
     }
     if machine.is_model_ready() && machine.active_profile() == Some(&profile) {
         return Err("Cannot delete the currently loaded model. Unload it first or switch to a different model.".into());
@@ -300,6 +297,17 @@ pub fn delete_model(
     );
 
     Ok(())
+}
+
+/// Downloading/loading/unloading all hold model files; Unloading is not
+/// `is_model_ready`, so it must be listed here or delete can race teardown.
+fn model_delete_blocked_by_transition(machine: &AppStateMachine) -> bool {
+    matches!(
+        machine,
+        AppStateMachine::Downloading { .. }
+            | AppStateMachine::Loading { .. }
+            | AppStateMachine::Unloading { .. }
+    )
 }
 
 /// Debug: feed the debug WAV through the engine to test model in isolation.
@@ -346,5 +354,38 @@ pub fn test_transcribe_wav(state: State<'_, AppState>) -> Result<String, String>
         Ok("No words detected (model produced 0 segments)".into())
     } else {
         Ok(text)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profile() -> TranscriptionProfile {
+        TranscriptionProfile::default()
+    }
+
+    #[test]
+    fn delete_is_blocked_while_unloading() {
+        let unloading = AppStateMachine::Unloading {
+            profile: profile(),
+            next_profile: None,
+        };
+        assert!(model_delete_blocked_by_transition(&unloading));
+        assert!(!unloading.is_model_ready());
+    }
+
+    #[test]
+    fn delete_is_blocked_while_downloading_or_loading() {
+        assert!(model_delete_blocked_by_transition(
+            &AppStateMachine::Downloading { profile: profile() }
+        ));
+        assert!(model_delete_blocked_by_transition(
+            &AppStateMachine::Loading { profile: profile() }
+        ));
+        assert!(!model_delete_blocked_by_transition(&AppStateMachine::Idle));
+        assert!(!model_delete_blocked_by_transition(
+            &AppStateMachine::Ready { profile: profile() }
+        ));
     }
 }

--- a/src-tauri/src/commands/permissions.rs
+++ b/src-tauri/src/commands/permissions.rs
@@ -1,4 +1,6 @@
-use crate::permissions::{self, PermState, PermissionKind, PermissionStatus};
+use crate::permissions::{
+    self, PermState, PermissionKind, PermissionStatus, RepairAccessibilityResult,
+};
 
 /// Cheap, non-prompting snapshot for the onboarding's initial render.
 #[tauri::command]
@@ -24,8 +26,8 @@ pub async fn request_permission(kind: PermissionKind) -> Result<PermState, Strin
 /// the command thread since it shells out and may block on the prompt.
 #[tauri::command]
 #[specta::specta]
-pub async fn repair_accessibility_permission() -> Result<PermState, String> {
+pub async fn repair_accessibility_permission() -> Result<RepairAccessibilityResult, String> {
     tauri::async_runtime::spawn_blocking(permissions::repair_accessibility)
         .await
-        .map_err(|e| format!("Accessibility repair failed: {e}"))
+        .map_err(|e| format!("Accessibility repair failed: {e}"))?
 }

--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -147,7 +147,8 @@ async fn launch_meeting(
     // The on-disk file index a recorder should write to, if recording is on.
     let recording_target = RecordingTarget {
         meeting_id: accumulator.id.clone(),
-        session_index: crate::audio::recorder::next_session_index(&accumulator.id).map_err(|e| format!("Determine session index: {e}"))?,
+        session_index: crate::audio::recorder::next_session_index(&accumulator.id)
+            .map_err(|e| format!("Determine session index: {e}"))?,
     };
 
     // Persist the header before any segments so a crash leaves a recoverable
@@ -277,16 +278,17 @@ fn start_pipeline_blocking(
     // short and user-driven, so "meeting is over" doesn't apply. This is a
     // session-start snapshot; a setting changed mid-meeting only takes effect
     // on the next meeting.
-    let idle_config = (mode == PipelineMode::Meeting && settings.meeting_autostop_enabled).then(
-        || crate::pipeline::MeetingIdleConfig {
-            silence_threshold: Some(Duration::from_secs(u64::from(
-                settings.meeting_autostop_minutes * 60,
-            ))),
-            max_duration: Some(Duration::from_secs(u64::from(
-                settings.meeting_max_duration_minutes * 60,
-            ))),
-        },
-    );
+    let idle_config =
+        (mode == PipelineMode::Meeting && settings.meeting_autostop_enabled).then(|| {
+            crate::pipeline::MeetingIdleConfig {
+                silence_threshold: Some(Duration::from_secs(u64::from(
+                    settings.meeting_autostop_minutes * 60,
+                ))),
+                max_duration: Some(Duration::from_secs(u64::from(
+                    settings.meeting_max_duration_minutes * 60,
+                ))),
+            }
+        });
 
     let config = SessionConfig {
         pipeline_config: settings.pipeline_config(),
@@ -307,9 +309,9 @@ fn start_pipeline_blocking(
     let record_path = if mode == PipelineMode::Meeting
         && settings.meeting_audio_retention != crate::settings::MeetingAudioRetention::Off
     {
-        recording_target
-            .as_ref()
-            .map(|target| crate::audio::recorder::session_path(&target.meeting_id, target.session_index))
+        recording_target.as_ref().map(|target| {
+            crate::audio::recorder::session_path(&target.meeting_id, target.session_index)
+        })
     } else {
         None
     };
@@ -545,16 +547,15 @@ pub async fn stop_transcription(state: State<'_, AppState>) -> Result<(), String
     // Clear the pill's live-text preview now that the session is over — the
     // dictation on_segment closure (and its accumulated text) is dropped
     // with the session, so nothing else will do this.
-    if is_dictation
-        && let Ok(app) = state.app_handle()
-    {
+    if is_dictation && let Ok(app) = state.app_handle() {
         crate::pill::push_live_text("");
-        let _ = crate::app_events::DictationLiveText { text: String::new() }.emit(&app);
+        let _ = crate::app_events::DictationLiveText {
+            text: String::new(),
+        }
+        .emit(&app);
     }
 
-    if is_dictation
-        && let Ok(settings) = AppSettings::load(&state.db)
-    {
+    if is_dictation && let Ok(settings) = AppSettings::load(&state.db) {
         crate::audio::feedback::play_dictation_feedback(
             &settings,
             crate::audio::feedback::DictationFeedbackKind::Stop,
@@ -786,7 +787,10 @@ pub async fn stop_meeting_recording(state: State<'_, AppState>) -> Result<String
             warn!("Pipeline stop failed (meeting saved anyway): {err}");
         }
 
-        let _ = MeetingFinalized { id: id_for_task.clone() }.emit(&app);
+        let _ = MeetingFinalized {
+            id: id_for_task.clone(),
+        }
+        .emit(&app);
     });
 
     Ok(meeting_id)
@@ -806,23 +810,27 @@ pub fn paste_text(
 /// Pure decision: notification text for a failed paste, split out from
 /// `notify_paste_failed` so it's testable without a live AppHandle (mirrors
 /// `copy_notification_text` in `tray.rs`).
-fn paste_failure_notification_text(french: bool, error: &str, saved_to_history: bool) -> (&'static str, &'static str) {
+fn paste_failure_notification_text(
+    french: bool,
+    error: &str,
+    saved_to_history: bool,
+) -> (&'static str, &'static str) {
     let accessibility_missing = error.contains("Accessibility permission missing");
     match (french, accessibility_missing, saved_to_history) {
         (false, true, true) => (
-            "Paste failed",
+            "Copied — press ⌘V",
             "Accessibility permission is needed to paste automatically. Your dictation was saved to history.",
         ),
         (false, true, false) => (
-            "Paste failed",
+            "Copied — press ⌘V",
             "Accessibility permission is needed to paste automatically.",
         ),
         (true, true, true) => (
-            "Collage échoué",
+            "Copié — presse ⌘V",
             "L'autorisation Accessibilité est nécessaire pour coller automatiquement. Votre dictée a été enregistrée dans l'historique.",
         ),
         (true, true, false) => (
-            "Collage échoué",
+            "Copié — presse ⌘V",
             "L'autorisation Accessibilité est nécessaire pour coller automatiquement.",
         ),
         (false, false, true) => (
@@ -853,7 +861,11 @@ fn paste_failure_notification_text(french: bool, error: &str, saved_to_history: 
 /// notification plugin.
 #[tauri::command]
 #[specta::specta]
-pub fn notify_paste_failed(app: AppHandle, error: String, saved_to_history: bool) -> Result<(), String> {
+pub fn notify_paste_failed(
+    app: AppHandle,
+    error: String,
+    saved_to_history: bool,
+) -> Result<(), String> {
     let state = app.state::<AppState>();
     let french = AppSettings::load(&state.db)
         .map(|settings| settings.locale.starts_with("fr"))
@@ -1078,7 +1090,7 @@ mod tests {
             crate::clipboard::ACCESSIBILITY_STALE_ERROR,
             true,
         );
-        assert_eq!(title, "Paste failed");
+        assert_eq!(title, "Copied — press ⌘V");
         assert!(body.contains("Accessibility permission"));
         assert!(body.contains("saved to history"));
 
@@ -1087,19 +1099,21 @@ mod tests {
             crate::clipboard::ACCESSIBILITY_STALE_ERROR,
             false,
         );
-        assert_eq!(title_not_saved, "Paste failed");
+        assert_eq!(title_not_saved, "Copied — press ⌘V");
         assert!(body_not_saved.contains("Accessibility permission"));
         assert!(!body_not_saved.contains("saved to history"));
     }
 
     #[test]
     fn paste_failure_notification_falls_back_to_a_generic_message() {
-        let (title, body) = paste_failure_notification_text(false, "Enigo init: some OS error", true);
+        let (title, body) =
+            paste_failure_notification_text(false, "Enigo init: some OS error", true);
         assert_eq!(title, "Paste failed");
         assert!(!body.contains("Accessibility permission"));
         assert!(body.contains("saved to history"));
 
-        let (title_not_saved, body_not_saved) = paste_failure_notification_text(false, "Enigo init: some OS error", false);
+        let (title_not_saved, body_not_saved) =
+            paste_failure_notification_text(false, "Enigo init: some OS error", false);
         assert_eq!(title_not_saved, "Paste failed");
         assert!(!body_not_saved.contains("Accessibility permission"));
         assert!(!body_not_saved.contains("saved to history"));
@@ -1112,7 +1126,7 @@ mod tests {
             crate::clipboard::ACCESSIBILITY_STALE_ERROR,
             true,
         );
-        assert_eq!(title, "Collage échoué");
+        assert_eq!(title, "Copié — presse ⌘V");
         assert!(body.contains("Accessibilité"));
         assert!(body.contains("l'historique"));
 
@@ -1121,7 +1135,7 @@ mod tests {
             crate::clipboard::ACCESSIBILITY_STALE_ERROR,
             false,
         );
-        assert_eq!(title_not_saved, "Collage échoué");
+        assert_eq!(title_not_saved, "Copié — presse ⌘V");
         assert!(body_not_saved.contains("Accessibilité"));
         assert!(!body_not_saved.contains("l'historique"));
     }

--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -807,6 +807,14 @@ pub fn paste_text(
     crate::clipboard::paste_text(&text, delay_ms, method)
 }
 
+/// Write text to the pasteboard without pasting. Cancels a pending clipboard
+/// restore so a failed ⌘V cannot wipe the transcription 400 ms later.
+#[tauri::command]
+#[specta::specta]
+pub fn copy_text(text: String) -> Result<(), String> {
+    crate::clipboard::copy_text(&text)
+}
+
 /// Pure decision: notification text for a failed paste, split out from
 /// `notify_paste_failed` so it's testable without a live AppHandle (mirrors
 /// `copy_notification_text` in `tray.rs`).
@@ -815,8 +823,8 @@ fn paste_failure_notification_text(
     error: &str,
     saved_to_history: bool,
 ) -> (&'static str, &'static str) {
-    let accessibility_missing = error.contains("Accessibility permission missing");
-    match (french, accessibility_missing, saved_to_history) {
+    let accessibility_copied = error == crate::clipboard::ACCESSIBILITY_STALE_ERROR;
+    match (french, accessibility_copied, saved_to_history) {
         (false, true, true) => (
             "Copied — press ⌘V",
             "Accessibility permission is needed to paste automatically. Your dictation was saved to history.",
@@ -1117,6 +1125,18 @@ mod tests {
         assert_eq!(title_not_saved, "Paste failed");
         assert!(!body_not_saved.contains("Accessibility permission"));
         assert!(!body_not_saved.contains("saved to history"));
+    }
+
+    #[test]
+    fn paste_failure_notification_does_not_claim_copied_when_copy_failed() {
+        let copy_failed = format!(
+            "{} (no pasteboard)",
+            crate::clipboard::ACCESSIBILITY_STALE_ERROR
+        );
+        let (title, body) = paste_failure_notification_text(false, &copy_failed, true);
+        assert_eq!(title, "Paste failed");
+        assert!(!body.contains("Copied"));
+        assert!(body.contains("saved to history"));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -94,6 +94,7 @@ fn specta_builder() -> Builder<tauri::Wry> {
             commands::is_laptop,
             commands::test_transcribe_wav,
             commands::paste_text,
+            commands::copy_text,
             commands::notify_paste_failed,
             commands::frontmost_app_name,
             commands::read_selected_text,

--- a/src-tauri/src/permissions.rs
+++ b/src-tauri/src/permissions.rs
@@ -12,6 +12,8 @@
 use serde::{Deserialize, Serialize};
 use specta::Type;
 
+use crate::constants::APP_IDENTIFIER;
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum PermState {
@@ -45,6 +47,16 @@ pub enum PermissionKind {
     SystemAudio,
     Accessibility,
     Calendar,
+}
+
+/// Outcome of `repair_accessibility`. Distinct from `PermState` because a
+/// successful `tccutil reset` plus prompt cannot observe the user's grant:
+/// `AXIsProcessTrustedWithOptions` returns the *current* trust, which is
+/// necessarily false a few milliseconds after the TCC entry was deleted.
+#[derive(Debug, Clone, Serialize, Deserialize, Type, PartialEq, Eq)]
+pub struct RepairAccessibilityResult {
+    pub reset_performed: bool,
+    pub prompt_shown: bool,
 }
 
 /// Cheap, non-prompting snapshot for the initial onboarding render. Microphone
@@ -135,16 +147,50 @@ fn accessibility_trusted_with_prompt(_prompt: bool) -> bool {
 /// still shows as "checked" in System Settings but no longer matches, so
 /// `AXIsProcessTrusted` keeps returning false. Resetting the TCC entry and
 /// re-prompting lets macOS create a fresh, correctly-keyed one.
-pub fn repair_accessibility() -> PermState {
-    let _ = std::process::Command::new("tccutil")
-        .args(["reset", "Accessibility", "com.souffle.desktop"])
-        .output();
+///
+/// Returns what the repair *did*, not a permission verdict. The AX check
+/// after a successful reset is almost always false (the user hasn't ticked
+/// the fresh prompt yet); treating that as `Denied` made the UI claim every
+/// repair had failed, including the ones that worked (SOU-054).
+pub fn repair_accessibility() -> Result<RepairAccessibilityResult, String> {
+    repair_accessibility_with(
+        APP_IDENTIFIER,
+        tccutil_reset_accessibility,
+        accessibility_trusted_with_prompt,
+    )
+}
 
-    if accessibility_trusted_with_prompt(true) {
-        PermState::Granted
-    } else {
-        PermState::Denied
+fn tccutil_reset_accessibility(bundle_id: &str) -> Result<(), String> {
+    let output = std::process::Command::new("tccutil")
+        .args(["reset", "Accessibility", bundle_id])
+        .output()
+        .map_err(|e| format!("Failed to run tccutil: {e}"))?;
+    if output.status.success() {
+        return Ok(());
     }
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let code = output.status.code().unwrap_or(-1);
+    tracing::error!(bundle_id, code, %stderr, "tccutil reset Accessibility failed");
+    Err(if stderr.is_empty() {
+        format!("tccutil reset Accessibility failed (exit {code})")
+    } else {
+        format!("tccutil reset Accessibility failed (exit {code}): {stderr}")
+    })
+}
+
+fn repair_accessibility_with(
+    bundle_id: &str,
+    reset: impl FnOnce(&str) -> Result<(), String>,
+    prompt: impl FnOnce(bool) -> bool,
+) -> Result<RepairAccessibilityResult, String> {
+    reset(bundle_id)?;
+    // Always ask macOS to show the prompt. The boolean it returns is the
+    // *current* trust, not whether the user accepted — ignore it as a verdict.
+    let _trusted = prompt(true);
+    Ok(RepairAccessibilityResult {
+        reset_performed: true,
+        prompt_shown: true,
+    })
 }
 
 // --- Microphone ---
@@ -432,5 +478,65 @@ mod tests {
             || true,
         );
         assert_eq!(result, PermState::Granted);
+    }
+
+    #[test]
+    fn repair_reports_reset_not_denied_when_ax_is_still_false() {
+        let prompted = Cell::new(false);
+        let result = repair_accessibility_with(
+            APP_IDENTIFIER,
+            |id| {
+                assert_eq!(id, APP_IDENTIFIER);
+                Ok(())
+            },
+            |prompt| {
+                assert!(prompt, "repair must request the system prompt");
+                prompted.set(true);
+                false
+            },
+        )
+        .expect("successful tccutil must not become an error");
+
+        assert!(result.reset_performed);
+        assert!(result.prompt_shown);
+        assert!(prompted.get());
+    }
+
+    #[test]
+    fn repair_surfaces_tccutil_failure_and_skips_the_prompt() {
+        let prompted = Cell::new(false);
+        let result = repair_accessibility_with(
+            "com.example.unknown",
+            |id| {
+                Err(format!(
+                    "tccutil reset Accessibility failed (exit 64): No such bundle identifier \"{id}\""
+                ))
+            },
+            |_| {
+                prompted.set(true);
+                false
+            },
+        );
+
+        assert!(result.is_err(), "a failed reset must not look like success");
+        let err = result.unwrap_err();
+        assert!(err.contains("64"), "{err}");
+        assert!(err.contains("com.example.unknown"), "{err}");
+        assert!(!prompted.get(), "do not prompt after a failed reset");
+    }
+
+    #[test]
+    fn repair_uses_the_app_bundle_id() {
+        let mut seen = None;
+        let _ = repair_accessibility_with(
+            APP_IDENTIFIER,
+            |id| {
+                seen = Some(id.to_string());
+                Ok(())
+            },
+            |_| false,
+        );
+        assert_eq!(seen.as_deref(), Some(APP_IDENTIFIER));
+        assert_eq!(APP_IDENTIFIER, "com.souffle.desktop");
     }
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -13,6 +13,7 @@
   import { bootstrapAppState } from "./lib/bootstrap";
   import { findTranscriptionModel } from "./lib/features/transcription/catalog";
   import OnboardingView from "./lib/features/onboarding/OnboardingView.svelte";
+  import PermissionsOnboarding from "./lib/features/onboarding/PermissionsOnboarding.svelte";
   import WhatsNewDialog from "./lib/features/onboarding/WhatsNewDialog.svelte";
   import UpdateAvailableDialog from "./lib/features/onboarding/UpdateAvailableDialog.svelte";
   import {
@@ -431,6 +432,10 @@
     releaseUrl={updateAvailable.releaseUrl}
     onDismiss={() => (updateAvailable = null)}
   />
+{/if}
+
+{#if app.permissionsPanelOpen}
+  <PermissionsOnboarding onClose={() => (app.permissionsPanelOpen = false)} />
 {/if}
 
 {#if !app.showOnboarding && routeToast && routeToastCopy}

--- a/src/lib/api/permissions.ts
+++ b/src/lib/api/permissions.ts
@@ -1,5 +1,5 @@
 import { commands, unwrap } from "./generated";
-import type { PermissionKind, PermissionStatus, PermState } from "../types";
+import type { PermissionKind, PermissionStatus, PermState, RepairAccessibilityResult } from "../types";
 
 export type { PermissionKind };
 
@@ -11,6 +11,6 @@ export async function requestPermission(kind: PermissionKind): Promise<PermState
   return unwrap(commands.requestPermission(kind));
 }
 
-export async function repairAccessibilityPermission(): Promise<PermState> {
+export async function repairAccessibilityPermission(): Promise<RepairAccessibilityResult> {
   return unwrap(commands.repairAccessibilityPermission());
 }

--- a/src/lib/api/transcription.ts
+++ b/src/lib/api/transcription.ts
@@ -75,6 +75,11 @@ export async function pasteText(
   await unwrap(commands.pasteText(text, delayMs, method));
 }
 
+/** Write text to the pasteboard without pasting. Cancels a pending restore. */
+export async function copyText(text: string): Promise<void> {
+  await unwrap(commands.copyText(text));
+}
+
 /** Surface a shortcut dictation's paste failure outside the app window with
  * a system notification (SOU-053): the window is usually not what the user
  * is looking at when a shortcut dictation runs. */

--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -16,6 +16,7 @@
   import { createTranscriptionController } from "../features/transcription/controller.svelte";
   import StatusBanner from "./ui/StatusBanner.svelte";
   import StatusChip from "./ui/StatusChip.svelte";
+  import { openSettings } from "../features/settings/open";
 
   const app = createTimelineController().app;
   const timeline = createTimelineController();
@@ -114,7 +115,12 @@
       />
     {/if}
     {#if meeting.statusMessage}
-      <StatusBanner message={meeting.statusMessage} variant="warning" />
+      <StatusBanner
+        message={meeting.statusMessage}
+        actionLabel={meeting.statusActionLabel}
+        onAction={meeting.statusAction}
+        variant="warning"
+      />
     {/if}
 
     {#if recordingMode === "idle"}
@@ -178,10 +184,7 @@
         onStartEvent={(event) => void calendar.startFromEvent(event)}
         calendarEnabled={calendar.enabled}
         calendarPermission={calendar.permission}
-        onSetupCalendar={() => {
-          app.settingsInitialTab = "meetings";
-          app.settingsOpen = true;
-        }}
+        onSetupCalendar={() => openSettings({ tab: "meetings" })}
       />
     {:else}
       <!-- During a live session, the session card is the only focus. -->

--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -106,7 +106,12 @@
     <MeetingDetail controller={meeting} />
   {:else}
     {#if transcription.statusMessage}
-      <StatusBanner message={transcription.statusMessage} variant="warning" />
+      <StatusBanner
+        message={transcription.statusMessage}
+        actionLabel={transcription.statusActionLabel}
+        onAction={transcription.statusAction}
+        variant="warning"
+      />
     {/if}
     {#if meeting.statusMessage}
       <StatusBanner message={meeting.statusMessage} variant="warning" />

--- a/src/lib/components/SettingsView.svelte
+++ b/src/lib/components/SettingsView.svelte
@@ -16,12 +16,11 @@
   import PermissionsSettingsSection from "../features/settings/components/PermissionsSettingsSection.svelte";
   import SummaryTemplatesSettingsSection from "../features/settings/components/SummaryTemplatesSettingsSection.svelte";
   import { createSettingsController } from "../features/settings/controller.svelte";
+  import { type SettingsTab } from "../features/settings/open";
   import { formatSelectedTranscriptionLabel } from "../features/transcription/catalog";
   import { events } from "../api/generated";
   import ConfirmAction from "./ui/ConfirmAction.svelte";
   import StatusBanner from "./ui/StatusBanner.svelte";
-
-  type SettingsTab = "transcription" | "ai" | "audio" | "interface" | "meetings" | "system";
 
   const TABS: { id: SettingsTab; labelKey: string }[] = [
     { id: "transcription", labelKey: "settings.tab_transcription" },
@@ -311,6 +310,8 @@
               confirmLabel={$t("settings_advanced.delete_model_confirm")}
               confirmMessage={$t("settings_advanced.delete_model_msg")}
               variant="danger"
+              disabled={controller.modelOperationState !== "idle"}
+              disabledReason={$t("settings_advanced.delete_model_busy")}
               onConfirm={controller.handleDeleteModel}
             />
           </div>

--- a/src/lib/components/ui/ConfirmAction.svelte
+++ b/src/lib/components/ui/ConfirmAction.svelte
@@ -7,12 +7,16 @@
     confirmLabel,
     confirmMessage,
     variant = "danger",
+    disabled = false,
+    disabledReason,
     onConfirm,
   }: {
     label: string;
     confirmLabel?: string;
     confirmMessage?: string;
     variant?: "danger" | "ghost";
+    disabled?: boolean;
+    disabledReason?: string;
     onConfirm: () => void;
   } = $props();
 
@@ -39,6 +43,8 @@
     class={`btn btn-ghost gap-[7px] px-2.5 py-1.5 text-[12.5px] ${
       variant === "danger" ? "!text-danger-strong hover:!bg-danger/10" : ""
     }`}
+    {disabled}
+    title={disabled ? disabledReason : undefined}
   >
     {#if variant === "danger"}
       <Trash2 size={14} aria-hidden="true" />

--- a/src/lib/components/ui/ConfirmAction.test.ts
+++ b/src/lib/components/ui/ConfirmAction.test.ts
@@ -48,4 +48,14 @@ describe('ConfirmAction', () => {
 
     expect(screen.getByText('Confirm removal')).toBeTruthy();
   });
+
+  it("disables the trigger when disabled is set", () => {
+    render(ConfirmAction, {
+      props: { label: "Delete", onConfirm: vi.fn(), disabled: true, disabledReason: "busy" },
+    });
+
+    const button = screen.getByRole("button", { name: /Delete/ }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button.title).toBe("busy");
+  });
 });

--- a/src/lib/components/ui/StatusBanner.svelte
+++ b/src/lib/components/ui/StatusBanner.svelte
@@ -1,9 +1,19 @@
 <script lang="ts">
-  let { message, variant = "info" }: { message: string; variant?: "warning" | "danger" | "info" } = $props();
+  let {
+    message,
+    variant = "info",
+    actionLabel,
+    onAction
+  }: {
+    message: string;
+    variant?: "warning" | "danger" | "info";
+    actionLabel?: string;
+    onAction?: () => void;
+  } = $props();
 </script>
 
 <div
-  class={`rounded-default bg-surface-3 px-4 py-3 outline-1 ${
+  class={`rounded-default bg-surface-3 px-4 py-3 outline-1 flex items-center justify-between gap-4 ${
     variant === "warning"
       ? "outline-warning/30"
       : variant === "danger"
@@ -12,4 +22,9 @@
   }`}
 >
   <p class="text-sm">{message}</p>
+  {#if actionLabel && onAction}
+    <button class="btn btn-primary btn-sm shrink-0" onclick={onAction}>
+      {actionLabel}
+    </button>
+  {/if}
 </div>

--- a/src/lib/components/ui/StatusBanner.test.ts
+++ b/src/lib/components/ui/StatusBanner.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/svelte';
 import StatusBanner from './StatusBanner.svelte';
+import { fireEvent } from '@testing-library/svelte';
 
 describe('StatusBanner', () => {
   it('renders message text', () => {
@@ -28,5 +29,21 @@ describe('StatusBanner', () => {
 
     const banner = container.querySelector('div');
     expect(banner?.className).toContain('outline-ghost-border');
+  });
+
+  it('renders an action button when provided and calls it', async () => {
+    const onAction = vi.fn();
+    render(StatusBanner, {
+      props: { message: 'Copied — press ⌘V', actionLabel: 'Repair permission', onAction },
+    });
+
+    const button = screen.getByRole('button', { name: 'Repair permission' });
+    await fireEvent.click(button);
+    expect(onAction).toHaveBeenCalledOnce();
+  });
+
+  it('omits the action button when no handler is given', () => {
+    render(StatusBanner, { props: { message: 'Just a message', actionLabel: 'Repair' } });
+    expect(screen.queryByRole('button')).toBeNull();
   });
 });

--- a/src/lib/features/meeting/components/MeetingDetail.svelte
+++ b/src/lib/features/meeting/components/MeetingDetail.svelte
@@ -35,7 +35,12 @@
 
 <div class="flex flex-col gap-[18px]">
   {#if controller.statusMessage}
-    <StatusBanner message={controller.statusMessage} variant="warning" />
+    <StatusBanner
+      message={controller.statusMessage}
+      actionLabel={controller.statusActionLabel}
+      onAction={controller.statusAction}
+      variant="warning"
+    />
   {/if}
 
   {#if controller.isLoadingMeeting || !controller.meeting}

--- a/src/lib/features/meeting/controller.svelte.test.ts
+++ b/src/lib/features/meeting/controller.svelte.test.ts
@@ -14,6 +14,8 @@ import { mockSettings } from "../../test-helpers/fixtures";
 
 const mockGetSummaryProvidersStatus = vi.fn<() => Promise<SummaryProvidersStatus>>();
 const mockGetTranscriptionCatalog = vi.fn<() => Promise<TranscriptionCatalog>>();
+const mockLoadModel = vi.fn<(selection: unknown) => Promise<void>>();
+const mockGetModelStatus = vi.fn<(selection: unknown) => Promise<{ phase: string; profile: unknown }>>();
 const mockStartMeetingRecording = vi.fn<
   (
     title: string,
@@ -84,6 +86,8 @@ vi.mock("../../api/summary", () => ({
 vi.mock("../../api/transcription", () => ({
   getTranscriptionCatalog: (...a: unknown[]) =>
     mockGetTranscriptionCatalog(...(a as [])),
+  loadModel: (...a: unknown[]) => mockLoadModel(...(a as [unknown])),
+  getModelStatus: (...a: unknown[]) => mockGetModelStatus(...(a as [unknown])),
 }));
 
 // ── App state mock ───────────────────────────────────────────────────
@@ -95,6 +99,10 @@ function createMockAppState() {
     isRecording: false,
     recordingMode: "idle" as string,
     transcriptionRuntimePhase: "ready" as string,
+    transcriptionModelOperationState: "idle" as string,
+    settingsOpen: false,
+    settingsInitialTab: null as string | null,
+    permissionsPanelOpen: false,
     settings: { ...mockSettings },
     selectedDevice: "",
     openMeeting: vi.fn(),
@@ -116,6 +124,11 @@ vi.mock("../transcription/catalog", () => ({
     model_label: "STT 1B",
     backend_id: "candle",
     backend_label: "Candle",
+  }),
+  toSelectedTranscriptionProfileSelection: () => ({
+    engine_id: "kyutai",
+    model_id: "stt-1b-en_fr",
+    backend_id: "candle",
   }),
 }));
 
@@ -353,6 +366,54 @@ describe("MeetingController", () => {
     expect(mockStartMeetingRecording.mock.calls[0][0]).toMatch(/^Meeting /);
     expect(mockStartMeetingRecording.mock.calls[0][1]).toBeNull();
     expect(ctrl.meeting?.title).toMatch(/^Meeting /);
+  });
+
+  it("does not double-launch when two starts overlap while the model is loading", async () => {
+    mockGetSummaryProvidersStatus.mockResolvedValue(makeSummaryProvidersStatus());
+    mockGetTranscriptionCatalog.mockResolvedValue(makeCatalog());
+    mockStartMeetingRecording.mockResolvedValue(undefined);
+    mockApp.transcriptionRuntimePhase = "load_required";
+    mockApp.transcriptionModelOperationState = "idle";
+
+    let resolveLoad: (() => void) | undefined;
+    mockLoadModel.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveLoad = resolve;
+        }),
+    );
+    mockGetModelStatus.mockImplementation(async () => {
+      mockApp.transcriptionRuntimePhase = "ready";
+      return {
+        phase: "ready",
+        profile: {
+          engine_id: "kyutai",
+          engine_label: "Kyutai",
+          model_id: "stt-1b-en_fr",
+          model_label: "STT 1B",
+          backend_id: "candle",
+          backend_label: "Candle",
+        },
+      };
+    });
+
+    const ctrl = createMeetingController();
+    await ctrl.mount();
+
+    const first = ctrl.startRecording();
+    const second = ctrl.startRecording();
+
+    await vi.waitFor(() => {
+      expect(resolveLoad).toBeTypeOf("function");
+    });
+    expect(mockLoadModel).toHaveBeenCalledOnce();
+    expect(mockStartMeetingRecording).not.toHaveBeenCalled();
+
+    resolveLoad!();
+    await first;
+    await second;
+
+    expect(mockStartMeetingRecording).toHaveBeenCalledOnce();
   });
 
   it("startRecording from a calendar event uses the event title and carries participants", async () => {

--- a/src/lib/features/meeting/controller.svelte.ts
+++ b/src/lib/features/meeting/controller.svelte.ts
@@ -288,6 +288,9 @@ function createMeetingControllerInstance() {
     title?: string;
     calendar?: MeetingCalendarContext;
   }) {
+    if (app.recordingMode !== "idle") {
+      return;
+    }
     if (app.transcriptionRuntimePhase !== "ready") {
       // Model may have been unloaded by the idle timeout; reload through the
       // normal load flow before recording rather than failing on start.
@@ -352,6 +355,7 @@ function createMeetingControllerInstance() {
 
   async function resumeRecording() {
     if (!meeting || !meeting.id) return;
+    if (app.recordingMode !== "idle") return;
 
     // Resuming (whether from the wake-resume banner or the ordinary flow)
     // goes through launch_meeting, which clears the backend's sleep-pause

--- a/src/lib/features/meeting/controller.svelte.ts
+++ b/src/lib/features/meeting/controller.svelte.ts
@@ -19,10 +19,12 @@ import {
 import { getSummaryProvidersStatus } from "../../api/summary";
 import { getTranscriptionCatalog } from "../../api/transcription";
 import { getAppState } from "../../stores/app.svelte";
+import { tr } from "../../i18n";
 import type { AppStateMachine, ExportFormat, MeetingAudioSession, MeetingCalendarContext, MeetingIdle, MeetingTranscript, SummaryModelDescriptor, SummaryProviderChoice, SummarizeProgress, TranscriptionCatalog, TranscriptionSegment } from "../../types";
 import { errorMessage } from "../../utils";
 import { toSelectedTranscriptionProfile } from "../transcription/catalog";
 import { ensureModelLoaded } from "../transcription/runtime";
+import { openSettings } from "../settings/open";
 import { type AudioSeekTarget, resolveAudioSeekTarget } from "./audio-map";
 import { createLiveTranscript } from "./live-transcript.svelte";
 import { redistributeSegmentTexts } from "./live-edit";
@@ -63,6 +65,8 @@ function createMeetingControllerInstance() {
   const app = getAppState();
 
   let statusMessage = $state("");
+  let statusActionLabel = $state<string | undefined>();
+  let statusAction = $state<(() => void) | undefined>();
   let ollamaAvailable = $state(false);
   let appleIntelligenceAvailable = $state(false);
   let summaryModels = $state<SummaryModelDescriptor[]>([]);
@@ -171,7 +175,7 @@ function createMeetingControllerInstance() {
     try {
       transcriptionCatalog = await getTranscriptionCatalog();
     } catch (e) {
-      statusMessage = errorMessage(e);
+      setBanner(errorMessage(e));
     }
   }
 
@@ -215,7 +219,7 @@ function createMeetingControllerInstance() {
       // block loading the meeting itself, the player bar just stays hidden.
       audioSessions = await getMeetingAudio(id).catch(() => []);
     } catch (e) {
-      statusMessage = errorMessage(e);
+      setBanner(errorMessage(e));
     } finally {
       isLoadingMeeting = false;
     }
@@ -258,7 +262,7 @@ function createMeetingControllerInstance() {
       await saveMeetingNotes(id, notesDraft.trim() || null);
       notesSaveState = "saved";
     } catch (e) {
-      statusMessage = errorMessage(e);
+      setBanner(errorMessage(e));
       notesSaveState = "idle";
     }
   }
@@ -284,28 +288,54 @@ function createMeetingControllerInstance() {
     }
   }
 
+  function setBanner(message: string, action?: { label: string; run: () => void }) {
+    statusMessage = message;
+    statusActionLabel = action?.label;
+    statusAction = action?.run;
+  }
+
+  function clearBanner() {
+    setBanner("");
+  }
+
+  function modelRequiredBanner(message: string) {
+    setBanner(message, { label: tr("home.open_model"), run: () => openSettings({ tab: "transcription" }) });
+  }
+
+  /** Shared by start and resume so overlapping clicks cannot both pass idle
+   * and both enter launch_meeting after ensureModelLoaded. */
+  let launchInFlight = false;
+
+  function beginLaunch(): boolean {
+    if (app.recordingMode !== "idle" || launchInFlight) return false;
+    launchInFlight = true;
+    return true;
+  }
+
+  function endLaunch() {
+    launchInFlight = false;
+  }
+
   async function startRecording(options?: {
     title?: string;
     calendar?: MeetingCalendarContext;
   }) {
-    if (app.recordingMode !== "idle") {
-      return;
-    }
-    if (app.transcriptionRuntimePhase !== "ready") {
-      // Model may have been unloaded by the idle timeout; reload through the
-      // normal load flow before recording rather than failing on start.
-      statusMessage = "";
-      const ready = await ensureModelLoaded(app, transcriptionCatalog, (message) => { statusMessage = message; });
-      if (!ready) {
-        if (!statusMessage) statusMessage = "Load the model before starting a meeting.";
-        return;
-      }
-    }
+    if (!beginLaunch()) return;
+    clearBanner();
     try {
+      if (app.transcriptionRuntimePhase !== "ready") {
+        // Model may have been unloaded by the idle timeout; reload through the
+        // normal load flow before recording rather than failing on start.
+        const ready = await ensureModelLoaded(app, transcriptionCatalog, (message) => { setBanner(message); });
+        if (!ready) {
+          modelRequiredBanner(statusMessage || tr("home.model_required_meeting"));
+          return;
+        }
+      }
       const title = options?.title?.trim() || defaultMeetingTitle();
       const calendar = options?.calendar ?? null;
       resetLiveBuffers();
-      statusMessage = "";
+      clearBanner();
       summaryStream = "";
       meeting = null;
       notesDraft = "";
@@ -348,14 +378,16 @@ function createMeetingControllerInstance() {
         participants: calendar?.participants ?? [],
       };
     } catch (e) {
-      statusMessage = errorMessage(e);
+      setBanner(errorMessage(e));
       resetLiveBuffers();
+    } finally {
+      endLaunch();
     }
   }
 
   async function resumeRecording() {
     if (!meeting || !meeting.id) return;
-    if (app.recordingMode !== "idle") return;
+    if (!beginLaunch()) return;
 
     // Resuming (whether from the wake-resume banner or the ordinary flow)
     // goes through launch_meeting, which clears the backend's sleep-pause
@@ -363,10 +395,13 @@ function createMeetingControllerInstance() {
     if (wakeResumeFallbackMeetingId === meeting.id) wakeResumeFallbackMeetingId = null;
 
     try {
-      const ready = await ensureModelLoaded(app, transcriptionCatalog, (message) => { statusMessage = message; });
-      if (!ready) return;
+      const ready = await ensureModelLoaded(app, transcriptionCatalog, (message) => { setBanner(message); });
+      if (!ready) {
+        modelRequiredBanner(statusMessage || tr("home.model_required_meeting"));
+        return;
+      }
       resetLiveBuffers();
-      statusMessage = "";
+      clearBanner();
       summaryStream = "";
       clearIdleState();
 
@@ -378,8 +413,10 @@ function createMeetingControllerInstance() {
         clearIdleState();
       });
     } catch (e) {
-      statusMessage = errorMessage(e);
+      setBanner(errorMessage(e));
       resetLiveBuffers();
+    } finally {
+      endLaunch();
     }
   }
 
@@ -407,7 +444,7 @@ function createMeetingControllerInstance() {
         // Header may not be queryable yet in a rare race; finalize reloads it.
       }
     } catch (e) {
-      statusMessage = errorMessage(e);
+      setBanner(errorMessage(e));
     } finally {
       stopRequested = false;
     }
@@ -431,8 +468,9 @@ function createMeetingControllerInstance() {
     audioSessions = [];
     app.currentMeetingId = null;
     clearIdleState();
-    statusMessage =
-      "Recording was interrupted — the meeting recorded so far was saved to history.";
+    setBanner(
+      "Recording was interrupted — the meeting recorded so far was saved to history.",
+    );
   }
 
   /** The backend detected the meeting has probably ended (silence or the
@@ -442,7 +480,7 @@ function createMeetingControllerInstance() {
 
     if (payload.reason === "max_duration") {
       if (isStopping) return;
-      statusMessage = "Maximum meeting duration reached. Stopping the recording.";
+      setBanner("Maximum meeting duration reached. Stopping the recording.");
       void stopRecording();
       return;
     }
@@ -487,7 +525,7 @@ function createMeetingControllerInstance() {
         }
       }
     } catch (e) {
-      statusMessage = errorMessage(e);
+      setBanner(errorMessage(e));
       throw e;
     }
   }
@@ -529,7 +567,7 @@ function createMeetingControllerInstance() {
       for (let i = 0; i < indices.length; i++) {
         liveMeetingSegments[indices[i]].text = previousSegmentTexts[i];
       }
-      statusMessage = errorMessage(e);
+      setBanner(errorMessage(e));
     }
   }
 
@@ -561,7 +599,7 @@ function createMeetingControllerInstance() {
         try {
           meetingId = await peekSleepPausedMeeting();
         } catch (e) {
-          statusMessage = errorMessage(e);
+          setBanner(errorMessage(e));
           return;
         }
         if (!meetingId) return;
@@ -619,7 +657,7 @@ function createMeetingControllerInstance() {
     // the meeting loaded (canResumeRecording) so the user can retry by hand.
     await resumeRecording();
     if (!statusMessage) {
-      statusMessage = "Recording resumed after sleep.";
+      setBanner("Recording resumed after sleep.");
     }
   }
 
@@ -631,7 +669,7 @@ function createMeetingControllerInstance() {
     wakeResumeFallbackMeetingId = meetingId;
     await loadMeeting(meetingId);
     if (!meeting || meeting.id !== meetingId) return; // load failed; loadMeeting already reported it
-    statusMessage = "Sleep interrupted this meeting. Resume recording to continue.";
+    setBanner("Sleep interrupted this meeting. Resume recording to continue.");
   }
 
   /** Leave the detail view: clear the open meeting and return to the list. */
@@ -648,7 +686,7 @@ function createMeetingControllerInstance() {
     audioSessions = [];
     seekTarget = null;
     resetLiveBuffers();
-    statusMessage = "";
+    clearBanner();
     summaryStream = "";
     app.currentMeetingId = null;
   }
@@ -668,7 +706,7 @@ function createMeetingControllerInstance() {
       await applyMeetingRename(id, trimmed);
       meeting = { ...meeting, title: trimmed };
     } catch (e) {
-      statusMessage = errorMessage(e);
+      setBanner(errorMessage(e));
     }
   }
 
@@ -681,7 +719,7 @@ function createMeetingControllerInstance() {
     summaryStage = null;
     summaryStageCurrent = null;
     summaryStageTotal = null;
-    statusMessage = "";
+    clearBanner();
 
     try {
       // Stream tokens for live preview only. Completion is driven by the
@@ -700,7 +738,7 @@ function createMeetingControllerInstance() {
       meeting = loadedMeeting;
       syncSelectedModel(meeting.summary_model);
     } catch (e) {
-      statusMessage = errorMessage(e);
+      setBanner(errorMessage(e));
     } finally {
       isSummarizing = false;
       summaryStage = null;
@@ -731,7 +769,7 @@ function createMeetingControllerInstance() {
       isEditingTranscript = false;
       editedTranscriptDraft = "";
     } catch (e) {
-      statusMessage = errorMessage(e);
+      setBanner(errorMessage(e));
     }
   }
 
@@ -748,7 +786,7 @@ function createMeetingControllerInstance() {
       await saveEditedTranscript(meeting.id, null);
       meeting = await getMeeting(meeting.id);
     } catch (e) {
-      statusMessage = errorMessage(e);
+      setBanner(errorMessage(e));
     }
   }
 
@@ -758,7 +796,7 @@ function createMeetingControllerInstance() {
       await removeMeeting(meeting.id);
       closeMeeting();
     } catch (e) {
-      statusMessage = errorMessage(e);
+      setBanner(errorMessage(e));
     }
   }
 
@@ -770,11 +808,11 @@ function createMeetingControllerInstance() {
   async function exportMeeting(format: ExportFormat) {
     if (!meeting || !meeting.id || isRecordingMeeting) return;
     isExporting = true;
-    statusMessage = "";
+    clearBanner();
     try {
       await saveMeetingExport(meeting.id, format);
     } catch (e) {
-      statusMessage = errorMessage(e);
+      setBanner(errorMessage(e));
     } finally {
       isExporting = false;
     }
@@ -788,11 +826,11 @@ function createMeetingControllerInstance() {
   async function exportMeetingAudio() {
     if (!meeting || !meeting.id || isRecordingMeeting || audioSessions.length === 0) return;
     isExporting = true;
-    statusMessage = "";
+    clearBanner();
     try {
       await saveMeetingAudioExport(meeting.id);
     } catch (e) {
-      statusMessage = errorMessage(e);
+      setBanner(errorMessage(e));
     } finally {
       isExporting = false;
     }
@@ -801,6 +839,8 @@ function createMeetingControllerInstance() {
   return {
     get app() { return app; },
     get statusMessage() { return statusMessage; },
+    get statusActionLabel() { return statusActionLabel; },
+    get statusAction() { return statusAction; },
     get ollamaAvailable() { return ollamaAvailable; },
     get appleIntelligenceAvailable() { return appleIntelligenceAvailable; },
     get summaryAvailable() { return summaryModels.length > 0; },

--- a/src/lib/features/onboarding/PermissionsStep.svelte
+++ b/src/lib/features/onboarding/PermissionsStep.svelte
@@ -24,6 +24,8 @@
   let error = $state("");
   let repairing = $state(false);
   let repairSuccess = $state(false);
+  let repairCooldown = $state(false);
+  let repairCooldownTimer: ReturnType<typeof setTimeout> | undefined;
 
   /** Every write to `status` goes through here so the parent (which cannot
    * see this component's local state otherwise) learns the real permission
@@ -103,13 +105,19 @@
     repairSuccess = false;
     error = "";
     try {
-      const next = await repairAccessibilityPermission();
-      setStatus({ ...status, accessibility: next });
-      // The repair always resets TCC and prompts, so it usually returns "denied" immediately.
-      // Announce success so the user knows it worked.
+      await repairAccessibilityPermission();
+      // Don't overwrite accessibility with Denied: a successful reset plus
+      // prompt cannot observe the grant yet (SOU-054). The focus re-check
+      // below is what turns the row green.
       repairSuccess = true;
+      repairCooldown = true;
+      clearTimeout(repairCooldownTimer);
+      repairCooldownTimer = setTimeout(() => {
+        repairCooldown = false;
+      }, 2500);
     } catch (e) {
       error = errorMessage(e);
+      repairSuccess = false;
     } finally {
       repairing = false;
     }
@@ -129,7 +137,10 @@
         .catch(() => {});
     };
     window.addEventListener("focus", onFocus);
-    return () => window.removeEventListener("focus", onFocus);
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      clearTimeout(repairCooldownTimer);
+    };
   });
 </script>
 
@@ -178,7 +189,7 @@
           </p>
           <button
             class="btn btn-ghost shrink-0 gap-1.5"
-            disabled={repairing || busy[row.kind]}
+            disabled={repairing || busy[row.kind] || repairCooldown}
             onclick={repairAccessibility}
           >
             {#if repairing}

--- a/src/lib/features/onboarding/PermissionsStep.svelte
+++ b/src/lib/features/onboarding/PermissionsStep.svelte
@@ -23,12 +23,15 @@
   let busy = $state<Record<string, boolean>>({});
   let error = $state("");
   let repairing = $state(false);
+  let repairSuccess = $state(false);
 
   /** Every write to `status` goes through here so the parent (which cannot
    * see this component's local state otherwise) learns the real permission
    * state, e.g. to gate the onboarding auto-paste default (SOU-053). */
   function setStatus(next: PermissionStatus) {
     status = next;
+    // Reset success banner if accessibility state changes back/forth
+    if (next.accessibility === "granted") repairSuccess = false;
     onStatusChange?.(next);
   }
 
@@ -97,10 +100,14 @@
    */
   async function repairAccessibility() {
     repairing = true;
+    repairSuccess = false;
     error = "";
     try {
       const next = await repairAccessibilityPermission();
       setStatus({ ...status, accessibility: next });
+      // The repair always resets TCC and prompts, so it usually returns "denied" immediately.
+      // Announce success so the user knows it worked.
+      repairSuccess = true;
     } catch (e) {
       error = errorMessage(e);
     } finally {
@@ -162,7 +169,13 @@
 
       {#if row.kind === "accessibility" && s === "denied"}
         <div class="flex items-center justify-between gap-3 pl-8">
-          <p class="text-xs text-text-muted">{$t("permissions.accessibility_stale_hint")}</p>
+          <p class="text-xs text-text-muted">
+            {#if repairSuccess}
+              {$t("permissions.accessibility_repair_success")}
+            {:else}
+              {$t("permissions.accessibility_stale_hint")}
+            {/if}
+          </p>
           <button
             class="btn btn-ghost shrink-0 gap-1.5"
             disabled={repairing || busy[row.kind]}
@@ -171,6 +184,9 @@
             {#if repairing}
               <Spinner />
               {$t("permissions.checking")}
+            {:else if repairSuccess}
+              <Check size={14} />
+              {$t("permissions.repair")}
             {:else}
               {$t("permissions.repair")}
             {/if}

--- a/src/lib/features/onboarding/PermissionsStep.test.ts
+++ b/src/lib/features/onboarding/PermissionsStep.test.ts
@@ -71,6 +71,56 @@ describe("PermissionsStep microphone denial", () => {
   });
 });
 
+describe("PermissionsStep accessibility repair", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  function accessibilityDenied(): PermissionStatus {
+    return {
+      microphone: "granted",
+      system_audio: "unknown",
+      accessibility: "denied",
+      calendar: "unknown",
+    };
+  }
+
+  it("announces success when tccutil reset succeeds", async () => {
+    permissionsApi.getPermissionStatus.mockResolvedValue(accessibilityDenied());
+    permissionsApi.repairAccessibilityPermission.mockResolvedValue({
+      reset_performed: true,
+      prompt_shown: true,
+    });
+    render(PermissionsStep);
+
+    await waitFor(() => expect(permissionsApi.getPermissionStatus).toHaveBeenCalled());
+    const axRow = rowFor("Accessibility");
+    await fireEvent.click(within(axRow).getByRole("button", { name: "Repair permission" }));
+
+    await waitFor(() => {
+      expect(within(axRow).getByText(/new prompt should appear/i)).toBeTruthy();
+    });
+    expect(permissionsApi.repairAccessibilityPermission).toHaveBeenCalledOnce();
+  });
+
+  it("does not claim success when the repair command fails", async () => {
+    permissionsApi.getPermissionStatus.mockResolvedValue(accessibilityDenied());
+    permissionsApi.repairAccessibilityPermission.mockRejectedValue("tccutil reset Accessibility failed (exit 64)");
+    render(PermissionsStep);
+
+    await waitFor(() => expect(permissionsApi.getPermissionStatus).toHaveBeenCalled());
+    const axRow = rowFor("Accessibility");
+    await fireEvent.click(within(axRow).getByRole("button", { name: "Repair permission" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/tccutil reset Accessibility failed/)).toBeTruthy();
+    });
+    expect(within(axRow).queryByText(/new prompt should appear/i)).toBeNull();
+    expect(within(axRow).getByText(/stale entry/i)).toBeTruthy();
+  });
+});
+
 describe("PermissionsStep per-row busy state", () => {
   afterEach(() => {
     cleanup();

--- a/src/lib/features/settings/components/PermissionsSettingsSection.svelte
+++ b/src/lib/features/settings/components/PermissionsSettingsSection.svelte
@@ -2,9 +2,7 @@
   import { ShieldCheck } from "@lucide/svelte";
   import { t } from "svelte-i18n";
   import SettingsField from "../../../components/ui/SettingsField.svelte";
-  import PermissionsOnboarding from "../../onboarding/PermissionsOnboarding.svelte";
-
-  let showPanel = $state(false);
+  import { openPermissionsRepair } from "../open";
 </script>
 
 <section class="settings-group">
@@ -17,7 +15,7 @@
       {#snippet control()}
         <button
           class="btn btn-ghost gap-1.5 px-2.5 py-[5px] text-[12.5px]"
-          onclick={() => (showPanel = true)}
+          onclick={() => openPermissionsRepair()}
         >
           <ShieldCheck size={14} aria-hidden="true" />
           {$t("permissions.review")}
@@ -26,7 +24,3 @@
     </SettingsField>
   </div>
 </section>
-
-{#if showPanel}
-  <PermissionsOnboarding onClose={() => (showPanel = false)} />
-{/if}

--- a/src/lib/features/settings/controller.svelte.test.ts
+++ b/src/lib/features/settings/controller.svelte.test.ts
@@ -1000,4 +1000,27 @@ describe("settings controller", () => {
 
     expect(ctrl.inputSampleRate).toBe(48_000);
   });
+
+  it("refuses to delete a model while a download or load is in flight", async () => {
+    const ctrl = createSettingsController();
+    await ctrl.mount();
+    ctrl.app.machineState = {
+      state: "downloading",
+      data: {
+        profile: {
+          engine_id: "kyutai",
+          engine_label: "Kyutai",
+          model_id: "stt-1b-en_fr",
+          model_label: "STT 1B",
+          backend_id: "candle",
+          backend_label: "Candle",
+        },
+      },
+    };
+
+    await ctrl.handleDeleteModel();
+
+    expect(mockInvoke).not.toHaveBeenCalledWith("delete_model", expect.anything());
+    expect(ctrl.statusMessage).toMatch(/downloading or loading/i);
+  });
 });

--- a/src/lib/features/settings/controller.svelte.test.ts
+++ b/src/lib/features/settings/controller.svelte.test.ts
@@ -1021,6 +1021,31 @@ describe("settings controller", () => {
     await ctrl.handleDeleteModel();
 
     expect(mockInvoke).not.toHaveBeenCalledWith("delete_model", expect.anything());
-    expect(ctrl.statusMessage).toMatch(/downloading or loading/i);
+    expect(ctrl.statusMessage).toMatch(/downloading, loading, or unloading/i);
+  });
+
+  it("refuses to delete a model while it is unloading", async () => {
+    const ctrl = createSettingsController();
+    await ctrl.mount();
+    ctrl.app.machineState = {
+      state: "unloading",
+      data: {
+        profile: {
+          engine_id: "kyutai",
+          engine_label: "Kyutai",
+          model_id: "stt-1b-en_fr",
+          model_label: "STT 1B",
+          backend_id: "candle",
+          backend_label: "Candle",
+        },
+        next_profile: null,
+      },
+    };
+
+    expect(ctrl.modelOperationState).toBe("unloading");
+    await ctrl.handleDeleteModel();
+
+    expect(mockInvoke).not.toHaveBeenCalledWith("delete_model", expect.anything());
+    expect(ctrl.statusMessage).toMatch(/unloading/i);
   });
 });

--- a/src/lib/features/settings/controller.svelte.ts
+++ b/src/lib/features/settings/controller.svelte.ts
@@ -23,7 +23,7 @@ import {
 } from "../../api/dictionary";
 import { listCalendars } from "../../api/calendar";
 import { requestPermission } from "../../api/permissions";
-import { setLocale } from "../../i18n";
+import { setLocale, tr } from "../../i18n";
 import { getAppState } from "../../stores/app.svelte";
 import type {
   AppSettings,
@@ -505,6 +505,10 @@ export function createSettingsController() {
   }
 
   async function handleDeleteModel() {
+    if (app.transcriptionModelOperationState !== "idle") {
+      statusMessage = tr("settings_advanced.delete_model_busy");
+      return;
+    }
     try {
       const selection = currentTranscriptionSelection(app, catalog);
       await deleteModel(selection);

--- a/src/lib/features/settings/open.test.ts
+++ b/src/lib/features/settings/open.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { getAppState } from "../../stores/app.svelte";
+import { openPermissionsRepair, openSettings } from "./open";
+
+describe("openSettings", () => {
+  it("opens settings on the requested tab", () => {
+    const app = getAppState();
+    app.settingsOpen = false;
+    app.settingsInitialTab = null;
+
+    openSettings({ tab: "transcription" });
+
+    expect(app.settingsOpen).toBe(true);
+    expect(app.settingsInitialTab).toBe("transcription");
+  });
+
+  it("opens the permissions repair panel without requiring a settings tab", () => {
+    const app = getAppState();
+    app.permissionsPanelOpen = false;
+
+    openPermissionsRepair();
+
+    expect(app.permissionsPanelOpen).toBe(true);
+  });
+});

--- a/src/lib/features/settings/open.ts
+++ b/src/lib/features/settings/open.ts
@@ -1,0 +1,18 @@
+import { getAppState } from "../../stores/app.svelte";
+
+export type SettingsTab = "transcription" | "ai" | "audio" | "interface" | "meetings" | "system";
+
+/** Open Settings on a tab. One-shot: SettingsView consumes the tab and
+ * forgets it, so the next ordinary open still lands on Transcription. */
+export function openSettings(options: { tab: SettingsTab }) {
+  const app = getAppState();
+  app.settingsInitialTab = options.tab;
+  app.settingsOpen = true;
+}
+
+/** Open the permissions repair panel directly — not an itinerary through
+ * Settings → System → Review. */
+export function openPermissionsRepair() {
+  const app = getAppState();
+  app.permissionsPanelOpen = true;
+}

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -137,6 +137,8 @@ describe("transcription controller", () => {
         return Promise.resolve(null);
       case "paste_text":
         return Promise.resolve(null);
+      case "copy_text":
+        return Promise.resolve(null);
       case "polish_dictation":
         return Promise.resolve({ text: args?.text ?? "", skipped: true, warning: null });
       case "pill_hold":
@@ -282,6 +284,8 @@ describe("transcription controller", () => {
     await ctrl.toggleRecording(true);
 
     expect(mockInvoke).toHaveBeenCalledWith("paste_text", expect.anything());
+    expect(mockInvoke).not.toHaveBeenCalledWith("copy_text", expect.anything());
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
     expect(mockInvoke).toHaveBeenCalledWith("notify_paste_failed", {
       error: "Accessibility permission missing.",
       savedToHistory: true,
@@ -329,6 +333,8 @@ describe("transcription controller", () => {
     await ctrl.toggleRecording(true);
 
     expect(mockInvoke).toHaveBeenCalledWith("paste_text", expect.anything());
+    expect(mockInvoke).not.toHaveBeenCalledWith("copy_text", expect.anything());
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
     expect(mockInvoke).toHaveBeenCalledWith("notify_paste_failed", {
       error: "Accessibility permission missing.",
       savedToHistory: false,
@@ -365,7 +371,91 @@ describe("transcription controller", () => {
     await ctrl.toggleRecording(true);
 
     expect(mockInvoke).toHaveBeenCalledWith("paste_text", expect.anything());
+    expect(mockInvoke).not.toHaveBeenCalledWith("copy_text", expect.anything());
     expect(mockInvoke).not.toHaveBeenCalledWith("notify_paste_failed", expect.anything());
+  });
+
+  it("copies via Rust and reports paste_failed when paste fails for a non-AX reason", async () => {
+    let transcriptionChannel: { onmessage: ((msg: unknown) => void) | null } | null = null;
+    mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "start_transcription") {
+        transcriptionChannel = args?.channel as { onmessage: ((msg: unknown) => void) | null };
+        return Promise.resolve(null);
+      }
+      if (cmd === "paste_text") {
+        return Promise.reject("Enigo init: some OS error");
+      }
+      return defaultInvoke(cmd, args);
+    });
+
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+    ctrl.app.settings = {
+      ...ctrl.app.settings,
+      auto_paste: true,
+      dictation_polish_enabled: false,
+    };
+
+    await ctrl.toggleRecording(true);
+    simulateRecordingStarted(ctrl.app);
+    (transcriptionChannel as { onmessage: ((msg: unknown) => void) | null } | null)?.onmessage?.({
+      text: "hello world",
+      is_final: true,
+      start_ms: 0,
+      end_ms: 1000,
+    });
+
+    await ctrl.toggleRecording(true);
+
+    expect(mockInvoke).toHaveBeenCalledWith("paste_text", expect.anything());
+    expect(mockInvoke).toHaveBeenCalledWith("copy_text", { text: "hello world" });
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    expect(ctrl.statusMessage).toBe("Paste failed: Enigo init: some OS error");
+    expect(ctrl.statusActionLabel).toBeUndefined();
+    expect(mockInvoke).toHaveBeenCalledWith("notify_paste_failed", {
+      error: "Enigo init: some OS error",
+      savedToHistory: true,
+    });
+  });
+
+  it("does not claim Copied when Accessibility paste fails after a failed copy", async () => {
+    let transcriptionChannel: { onmessage: ((msg: unknown) => void) | null } | null = null;
+    mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "start_transcription") {
+        transcriptionChannel = args?.channel as { onmessage: ((msg: unknown) => void) | null };
+        return Promise.resolve(null);
+      }
+      if (cmd === "paste_text") {
+        return Promise.reject("Accessibility permission missing. (no pasteboard)");
+      }
+      return defaultInvoke(cmd, args);
+    });
+
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+    ctrl.app.settings = {
+      ...ctrl.app.settings,
+      auto_paste: true,
+      dictation_polish_enabled: false,
+    };
+
+    await ctrl.toggleRecording(true);
+    simulateRecordingStarted(ctrl.app);
+    (transcriptionChannel as { onmessage: ((msg: unknown) => void) | null } | null)?.onmessage?.({
+      text: "hello world",
+      is_final: true,
+      start_ms: 0,
+      end_ms: 1000,
+    });
+
+    await ctrl.toggleRecording(true);
+
+    expect(mockInvoke).toHaveBeenCalledWith("copy_text", { text: "hello world" });
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    expect(ctrl.statusMessage).toBe(
+      "Paste failed: Accessibility permission missing. (no pasteboard)",
+    );
+    expect(ctrl.statusActionLabel).toBeUndefined();
   });
 
   it("toggleRecording stop skips polish IPC when polish disabled", async () => {
@@ -544,6 +634,8 @@ describe("transcription controller", () => {
     });
     await ctrl.toggleRecording(true);
 
+    expect(mockInvoke).not.toHaveBeenCalledWith("copy_text", expect.anything());
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
     expect(ctrl.statusActionLabel).toBe("Repair permission");
 
     ctrl.app.machineState = { state: "idle" };

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -182,6 +182,9 @@ describe("transcription controller", () => {
     app.downloadTotalFiles = 0;
     app.selectedDevice = "";
     app.settings = { ...mockSettings };
+    app.settingsOpen = false;
+    app.settingsInitialTab = null;
+    app.permissionsPanelOpen = false;
 
     Object.assign(navigator, {
       clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
@@ -283,7 +286,11 @@ describe("transcription controller", () => {
       error: "Accessibility permission missing.",
       savedToHistory: true,
     });
-    expect(ctrl.statusMessage).toContain("Paste failed");
+    expect(ctrl.statusMessage).toBe("Copied — press ⌘V");
+    expect(ctrl.statusActionLabel).toBe("Repair permission");
+    expect(ctrl.statusAction).toBeTypeOf("function");
+    ctrl.statusAction?.();
+    expect(ctrl.app.permissionsPanelOpen).toBe(true);
   });
 
   it("notifies outside the window when a shortcut paste fails and history fails", async () => {
@@ -473,6 +480,10 @@ describe("transcription controller", () => {
 
     expect(mockInvoke).not.toHaveBeenCalledWith("start_transcription", expect.anything());
     expect(ctrl.statusMessage).toContain("Download and load");
+    expect(ctrl.statusActionLabel).toBe("Open model");
+    ctrl.statusAction?.();
+    expect(ctrl.app.settingsOpen).toBe(true);
+    expect(ctrl.app.settingsInitialTab).toBe("transcription");
   });
 
   it("toggleRecording guards double start", async () => {
@@ -499,6 +510,82 @@ describe("transcription controller", () => {
 
     const startCalls = mockInvoke.mock.calls.filter((call) => call[0] === "start_transcription");
     expect(startCalls).toHaveLength(1);
+  });
+
+  it("clears a stale Repair action at the start of a start attempt", async () => {
+    let transcriptionChannel: { onmessage: ((msg: unknown) => void) | null } | null = null;
+    mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "start_transcription") {
+        transcriptionChannel = args?.channel as { onmessage: ((msg: unknown) => void) | null };
+        return Promise.resolve(null);
+      }
+      if (cmd === "paste_text") {
+        return Promise.reject("Accessibility permission missing.");
+      }
+      return defaultInvoke(cmd, args);
+    });
+
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+    ctrl.app.settings = {
+      ...ctrl.app.settings,
+      auto_paste: true,
+      dictation_polish_enabled: false,
+    };
+    ctrl.app.transcriptionRuntimePhase = "ready";
+
+    await ctrl.toggleRecording(true);
+    simulateRecordingStarted(ctrl.app);
+    (transcriptionChannel as { onmessage: ((msg: unknown) => void) | null } | null)?.onmessage?.({
+      text: "hello world",
+      is_final: true,
+      start_ms: 0,
+      end_ms: 1000,
+    });
+    await ctrl.toggleRecording(true);
+
+    expect(ctrl.statusActionLabel).toBe("Repair permission");
+
+    ctrl.app.machineState = { state: "idle" };
+    ctrl.app.transcriptionRuntimePhase = "download_required";
+    await ctrl.toggleRecording();
+
+    expect(ctrl.statusMessage).toContain("Download and load");
+    expect(ctrl.statusActionLabel).toBe("Open model");
+    expect(ctrl.statusActionLabel).not.toBe("Repair permission");
+  });
+
+  it("does not double-start while ensureModelLoaded is still pending", async () => {
+    let resolveLoad: (() => void) | undefined;
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === "get_model_status") {
+        return Promise.resolve({ ...fakeStatus, phase: "load_required" });
+      }
+      if (cmd === "load_model") {
+        return new Promise<void>((r) => {
+          resolveLoad = r;
+        });
+      }
+      return defaultInvoke(cmd);
+    });
+
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+    ctrl.app.transcriptionRuntimePhase = "load_required";
+
+    const first = ctrl.toggleRecording();
+    const second = ctrl.toggleRecording();
+
+    await vi.waitFor(() => {
+      expect(resolveLoad).toBeTypeOf("function");
+    });
+    expect(mockInvoke.mock.calls.filter((call) => call[0] === "load_model")).toHaveLength(1);
+
+    resolveLoad!();
+    await first;
+    await second;
+
+    expect(mockInvoke.mock.calls.filter((call) => call[0] === "load_model")).toHaveLength(1);
   });
 
   it("model download (runtime) tracks progress", async () => {

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -1,6 +1,7 @@
 import { getAppState } from "../../stores/app.svelte";
 import {
   addDictationEntry,
+  copyText,
   getTranscriptionCatalog,
   notifyPasteFailed,
   pasteText,
@@ -22,6 +23,10 @@ import { ensureModelLoaded, refreshTranscriptionRuntimeStatus } from "./runtime"
 
 const LEARN_FROM_EDIT_DELAY_MS = 4000;
 const MAX_LEARN_FROM_EDIT_PAIRS = 8;
+
+/** Exact `ACCESSIBILITY_STALE_ERROR` from clipboard.rs — copy succeeded, ⌘V is the recovery.
+ * A parenthetical suffix means the copy itself failed; that is not "Copied". */
+const ACCESSIBILITY_PASTE_COPIED = "Accessibility permission missing.";
 
 type SessionMode = "insert" | "rewrite";
 
@@ -359,16 +364,19 @@ function createTranscriptionControllerInstance() {
               );
               scheduleLearnFromEdit(finalized.text, sessionFocusedApp);
             } catch (e) {
-              // SOU-033: Rust already left the text on the pasteboard when
-              // Accessibility is missing. The web clipboard is a fallback
-              // for other paste failures (and for tests that stub paste_text).
-              try {
-                await navigator.clipboard.writeText(finalized.text);
-              } catch {
-                // Ignored
-              }
               const message = errorMessage(e);
-              if (message.includes("Accessibility permission missing")) {
+              // AX-missing already wrote via Rust copy_text and skipped restore.
+              // Any other paste_text failure may have scheduled RestoreBurst:
+              // copy_text cancels that restore. Never use the web clipboard
+              // here — it races the 400 ms restore.
+              if (message !== ACCESSIBILITY_PASTE_COPIED) {
+                try {
+                  await copyText(finalized.text);
+                } catch {
+                  // Best-effort; the banner still reports the paste failure.
+                }
+              }
+              if (message === ACCESSIBILITY_PASTE_COPIED) {
                 setBanner(tr("home.paste_copied"), {
                   label: tr("permissions.repair"),
                   run: openPermissionsRepair,

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -15,6 +15,8 @@ import { events } from "../../api/generated";
 import { createTimelineController } from "../timeline/controller.svelte";
 import type { TranscriptionCatalog, TranscriptionSegment } from "../../types";
 import { errorMessage, segmentGap } from "../../utils";
+import { tr } from "../../i18n";
+import { openPermissionsRepair, openSettings } from "../settings/open";
 import { formatSelectedTranscriptionLabel } from "./catalog";
 import { ensureModelLoaded, refreshTranscriptionRuntimeStatus } from "./runtime";
 
@@ -22,15 +24,6 @@ const LEARN_FROM_EDIT_DELAY_MS = 4000;
 const MAX_LEARN_FROM_EDIT_PAIRS = 8;
 
 type SessionMode = "insert" | "rewrite";
-
-/**
- * Matches the accessibility error clipboard.rs returns when
- * `permissions::accessibility_granted()` fails at paste time (see
- * `ACCESSIBILITY_STALE_ERROR` in src-tauri/src/clipboard.rs). Distinct from
- * a raw Enigo error, so we can point the user at the repair action instead
- * of just relaying the OS string.
- */
-
 
 function tokenizeWords(text: string): string[] {
   return text
@@ -137,6 +130,20 @@ function createTranscriptionControllerInstance() {
   let statusActionLabel = $state<string | undefined>();
   let statusAction = $state<(() => void) | undefined>();
   let catalog = $state<TranscriptionCatalog | null>(null);
+
+  function setBanner(message: string, action?: { label: string; run: () => void }) {
+    statusMessage = message;
+    statusActionLabel = action?.label;
+    statusAction = action?.run;
+  }
+
+  function clearBanner() {
+    setBanner("");
+  }
+
+  function modelRequiredBanner(message: string) {
+    setBanner(message, { label: tr("home.open_model"), run: () => openSettings({ tab: "transcription" }) });
+  }
 
   // Incremented for every session start (and on abort) so segment-channel
   // callbacks from a previous session can never write into a new one.
@@ -281,7 +288,7 @@ function createTranscriptionControllerInstance() {
         transcription_backend_id: catalog.selected_backend_id,
       };
     } catch (e) {
-      statusMessage = errorMessage(e);
+      setBanner(errorMessage(e));
     }
   }
 
@@ -289,7 +296,7 @@ function createTranscriptionControllerInstance() {
     try {
       await refreshTranscriptionRuntimeStatus(app, catalog);
     } catch (e) {
-      statusMessage = errorMessage(e);
+      setBanner(errorMessage(e));
     }
   }
 
@@ -337,7 +344,7 @@ function createTranscriptionControllerInstance() {
           sessionRewriteOf,
         );
         if (finalized.warning) {
-          statusMessage = finalized.warning;
+          setBanner(finalized.warning);
         }
 
         const saved = await saveToHistory(finalized.text);
@@ -352,7 +359,9 @@ function createTranscriptionControllerInstance() {
               );
               scheduleLearnFromEdit(finalized.text, sessionFocusedApp);
             } catch (e) {
-              // SOU-033: Graceful degradation. If auto-paste fails, still place the text on the clipboard.
+              // SOU-033: Rust already left the text on the pasteboard when
+              // Accessibility is missing. The web clipboard is a fallback
+              // for other paste failures (and for tests that stub paste_text).
               try {
                 await navigator.clipboard.writeText(finalized.text);
               } catch {
@@ -360,14 +369,12 @@ function createTranscriptionControllerInstance() {
               }
               const message = errorMessage(e);
               if (message.includes("Accessibility permission missing")) {
-                statusMessage = "Paste failed: accessibility permission needed.";
-                statusActionLabel = "Repair";
-                statusAction = () => {
-                  app.settingsInitialTab = "advanced";
-                  app.settingsOpen = true;
-                };
+                setBanner(tr("home.paste_copied"), {
+                  label: tr("permissions.repair"),
+                  run: openPermissionsRepair,
+                });
               } else {
-                statusMessage = `Paste failed: ${message}`;
+                setBanner(tr("home.paste_failed", { error: message }));
               }
               // A shortcut dictation runs from another app, so the status
               // banner above is likely not on screen: also notify outside
@@ -388,7 +395,7 @@ function createTranscriptionControllerInstance() {
           }
         }
       } catch (e) {
-        statusMessage = errorMessage(e);
+        setBanner(errorMessage(e));
       } finally {
         clearSessionContext();
         if (holdForPolish) {
@@ -403,34 +410,35 @@ function createTranscriptionControllerInstance() {
       return;
     }
 
-    if (app.transcriptionRuntimePhase === "download_required") {
-      statusMessage = "Download and load the model before starting dictation.";
-      return;
-    }
-    if (app.transcriptionRuntimePhase !== "ready") {
-      // Model was unloaded (e.g. the idle timeout freed it); reload through
-      // the normal load flow before recording instead of leaving the user
-      // stuck with a disabled button.
-      statusMessage = "";
-      const ready = await ensureModelLoaded(app, catalog, (message) => { statusMessage = message; });
-      if (!ready) {
-        if (!statusMessage) statusMessage = "Load the model before starting dictation.";
+    // Flip before any await so overlapping starts cannot both pass idle and
+    // both enter start_transcription / ensureModelLoaded.
+    isStartingRecording = true;
+    clearBanner();
+    let generation = sessionGeneration;
+    try {
+      if (app.transcriptionRuntimePhase === "download_required") {
+        modelRequiredBanner(tr("home.model_required_dictation"));
         return;
       }
-    }
+      if (app.transcriptionRuntimePhase !== "ready") {
+        // Model was unloaded (e.g. the idle timeout freed it); reload through
+        // the normal load flow before recording instead of leaving the user
+        // stuck with a disabled button.
+        const ready = await ensureModelLoaded(app, catalog, (message) => { setBanner(message); });
+        if (!ready) {
+          modelRequiredBanner(statusMessage || tr("home.model_required_dictation"));
+          return;
+        }
+      }
 
-    cancelLearnFromEditPoll();
-    if (!fromShortcut) sessionMode = "insert";
-    transcript = "";
-    tentative = "";
-    statusMessage = "";
-    statusActionLabel = undefined;
-    statusAction = undefined;
-    isStartingRecording = true;
-    sessionGeneration += 1;
-    const generation = sessionGeneration;
+      cancelLearnFromEditPoll();
+      if (!fromShortcut) sessionMode = "insert";
+      transcript = "";
+      tentative = "";
+      clearBanner();
+      sessionGeneration += 1;
+      generation = sessionGeneration;
 
-    try {
       await captureStartContext();
       await startStreamingTranscription((segment: TranscriptionSegment) => {
         if (generation !== sessionGeneration) return; // stale session
@@ -442,7 +450,7 @@ function createTranscriptionControllerInstance() {
         transcript += segmentGap(transcript, segment.text) + segment.text;
       });
     } catch (e) {
-      statusMessage = errorMessage(e);
+      setBanner(errorMessage(e));
       clearSessionContext();
     } finally {
       isStartingRecording = false;
@@ -471,16 +479,16 @@ function createTranscriptionControllerInstance() {
     cancelLearnFromEditPoll();
     if (transcript.trim()) {
       void finalizeDictationText(transcript, sessionFocusedApp, sessionRewriteOf).then(({ text, warning }) => {
-        if (warning) statusMessage = warning;
+        if (warning) setBanner(warning);
         if (text) {
           void saveToHistory(text);
-          statusMessage = "Recording was interrupted — the partial transcript was saved to history.";
+          setBanner("Recording was interrupted — the partial transcript was saved to history.");
         } else {
-          statusMessage = "Recording was interrupted.";
+          setBanner("Recording was interrupted.");
         }
       });
     } else {
-      statusMessage = "Recording was interrupted.";
+      setBanner("Recording was interrupted.");
     }
     clearSessionContext();
   }

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -30,12 +30,7 @@ type SessionMode = "insert" | "rewrite";
  * a raw Enigo error, so we can point the user at the repair action instead
  * of just relaying the OS string.
  */
-function accessibilityPasteFailureMessage(rawMessage: string): string {
-  if (rawMessage.includes("Accessibility permission missing")) {
-    return "Paste failed: accessibility permission needed. Open Settings > Advanced > Permissions and use Repair permission.";
-  }
-  return `Paste failed: ${rawMessage}`;
-}
+
 
 function tokenizeWords(text: string): string[] {
   return text
@@ -139,6 +134,8 @@ function createTranscriptionControllerInstance() {
   let transcript = $state("");
   let tentative = $state("");
   let statusMessage = $state("");
+  let statusActionLabel = $state<string | undefined>();
+  let statusAction = $state<(() => void) | undefined>();
   let catalog = $state<TranscriptionCatalog | null>(null);
 
   // Incremented for every session start (and on abort) so segment-channel
@@ -355,8 +352,23 @@ function createTranscriptionControllerInstance() {
               );
               scheduleLearnFromEdit(finalized.text, sessionFocusedApp);
             } catch (e) {
+              // SOU-033: Graceful degradation. If auto-paste fails, still place the text on the clipboard.
+              try {
+                await navigator.clipboard.writeText(finalized.text);
+              } catch {
+                // Ignored
+              }
               const message = errorMessage(e);
-              statusMessage = accessibilityPasteFailureMessage(message);
+              if (message.includes("Accessibility permission missing")) {
+                statusMessage = "Paste failed: accessibility permission needed.";
+                statusActionLabel = "Repair";
+                statusAction = () => {
+                  app.settingsInitialTab = "advanced";
+                  app.settingsOpen = true;
+                };
+              } else {
+                statusMessage = `Paste failed: ${message}`;
+              }
               // A shortcut dictation runs from another app, so the status
               // banner above is likely not on screen: also notify outside
               // the window (SOU-053). Best-effort: a notification failure
@@ -412,6 +424,8 @@ function createTranscriptionControllerInstance() {
     transcript = "";
     tentative = "";
     statusMessage = "";
+    statusActionLabel = undefined;
+    statusAction = undefined;
     isStartingRecording = true;
     sessionGeneration += 1;
     const generation = sessionGeneration;
@@ -478,6 +492,8 @@ function createTranscriptionControllerInstance() {
     get transcript() { return transcript; },
     get tentative() { return tentative; },
     get statusMessage() { return statusMessage; },
+    get statusActionLabel() { return statusActionLabel; },
+    get statusAction() { return statusAction; },
     get catalog() { return catalog; },
     get runtimePhase() { return app.transcriptionRuntimePhase; },
     get modelOperationState() { return app.transcriptionModelOperationState; },

--- a/src/lib/features/transcription/state.ts
+++ b/src/lib/features/transcription/state.ts
@@ -1,5 +1,9 @@
 import type { TranscriptionRuntimePhase } from "../../types";
 
-export type TranscriptionModelOperationState = "idle" | "downloading" | "loading";
+export type TranscriptionModelOperationState =
+  | "idle"
+  | "downloading"
+  | "loading"
+  | "unloading";
 
 

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -442,7 +442,7 @@
     "delete_model": "Delete downloaded model",
     "delete_model_confirm": "Delete",
     "delete_model_msg": "The model files will be removed; you'll need to download them again.",
-    "delete_model_busy": "Can't delete while the model is downloading or loading."
+    "delete_model_busy": "Can't delete while the model is downloading, loading, or unloading."
   },
   "pill": {
     "dictation": "Dictating",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -510,6 +510,7 @@
     "skip_hint": "You can grant these later when prompted.",
     "accessibility_stale_hint": "Already checked in Settings but still failing? macOS can keep a stale entry after an app update. Try Repair, or remove Souffle with the minus button and re-add it.",
     "repair": "Repair permission",
+    "accessibility_repair_success": "A new prompt should appear shortly. Check the box to finish the repair.",
     "settings_title": "Permissions",
     "settings_desc": "Re-check or repair macOS permissions if pasting or recording stops working after an update.",
     "review": "Review permissions"

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -329,7 +329,6 @@
     "generating": "Generating...",
     "regenerate_summary": "Re-generate Summary",
     "generate_summary": "Generate Summary",
-    "connect_ollama": "Connect Ollama in Settings to enable summaries.",
     "no_summary_provider": "No summarization provider is available. Enable Apple Intelligence or connect Ollama in Settings.",
     "no_compatible_model": "No compatible Ollama model found. Install a model like Llama or Mistral to enable summaries.",
     "generate_hint": "Key points and action items, generated on device",
@@ -442,7 +441,8 @@
     "model_storage_desc": "Remove the downloaded model files from disk.",
     "delete_model": "Delete downloaded model",
     "delete_model_confirm": "Delete",
-    "delete_model_msg": "The model files will be removed; you'll need to download them again."
+    "delete_model_msg": "The model files will be removed; you'll need to download them again.",
+    "delete_model_busy": "Can't delete while the model is downloading or loading."
   },
   "pill": {
     "dictation": "Dictating",
@@ -488,7 +488,12 @@
     "idle_keep_recording": "Keep recording",
     "live_edit_hint": "Double-click a paragraph to fix a misheard word. Later occurrences are corrected automatically.",
     "live_edit_save": "Save",
-    "live_edit_cancel": "Cancel"
+    "live_edit_cancel": "Cancel",
+    "paste_copied": "Copied — press ⌘V",
+    "paste_failed": "Paste failed: {error}",
+    "model_required_dictation": "Download and load the model to start dictation.",
+    "model_required_meeting": "Load the model to start a meeting.",
+    "open_model": "Open model"
   },
   "permissions": {
     "title": "Grant permissions",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -329,7 +329,6 @@
     "generating": "Génération...",
     "regenerate_summary": "Régénérer le résumé",
     "generate_summary": "Générer le résumé",
-    "connect_ollama": "Connectez Ollama dans les Paramètres pour activer les résumés.",
     "no_summary_provider": "Aucun fournisseur de résumé disponible. Activez Apple Intelligence ou connectez Ollama dans les Paramètres.",
     "no_compatible_model": "Aucun modèle Ollama compatible trouvé. Installez un modèle comme Llama ou Mistral pour activer les résumés.",
     "generate_hint": "Points clés et actions, générés sur l'appareil",
@@ -442,7 +441,8 @@
     "model_storage_desc": "Supprimer les fichiers du modèle téléchargé du disque.",
     "delete_model": "Supprimer le modèle téléchargé",
     "delete_model_confirm": "Supprimer",
-    "delete_model_msg": "Les fichiers du modèle seront supprimés ; il faudra les retélécharger."
+    "delete_model_msg": "Les fichiers du modèle seront supprimés ; il faudra les retélécharger.",
+    "delete_model_busy": "Impossible de supprimer pendant un téléchargement ou un chargement."
   },
   "pill": {
     "dictation": "Dictée",
@@ -488,7 +488,12 @@
     "idle_keep_recording": "Continuer l'enregistrement",
     "live_edit_hint": "Double-cliquez sur un paragraphe pour corriger un mot mal entendu. Les occurrences suivantes seront corrigées automatiquement.",
     "live_edit_save": "Enregistrer",
-    "live_edit_cancel": "Annuler"
+    "live_edit_cancel": "Annuler",
+    "paste_copied": "Copié — presse ⌘V",
+    "paste_failed": "Collage impossible : {error}",
+    "model_required_dictation": "Télécharge et charge le modèle pour dicter.",
+    "model_required_meeting": "Charge le modèle pour lancer une réunion.",
+    "open_model": "Ouvrir le modèle"
   },
   "permissions": {
     "title": "Autoriser les permissions",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -510,6 +510,7 @@
     "skip_hint": "Vous pourrez les accorder plus tard.",
     "accessibility_stale_hint": "Déjà coché dans Réglages mais toujours refusé ? macOS peut conserver une entrée obsolète après une mise à jour. Essayez Réparer, ou retirez Souffle avec le bouton moins puis rajoutez-le.",
     "repair": "Réparer la permission",
+    "accessibility_repair_success": "Une nouvelle demande va s'afficher. Cochez la case pour terminer la réparation.",
     "settings_title": "Permissions",
     "settings_desc": "Revérifier ou réparer les permissions macOS si le collage ou l'enregistrement cesse de fonctionner après une mise à jour.",
     "review": "Vérifier les permissions"

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -442,7 +442,7 @@
     "delete_model": "Supprimer le modèle téléchargé",
     "delete_model_confirm": "Supprimer",
     "delete_model_msg": "Les fichiers du modèle seront supprimés ; il faudra les retélécharger.",
-    "delete_model_busy": "Impossible de supprimer pendant un téléchargement ou un chargement."
+    "delete_model_busy": "Impossible de supprimer pendant un téléchargement, un chargement ou un déchargement."
   },
   "pill": {
     "dictation": "Dictée",

--- a/src/lib/i18n/index.ts
+++ b/src/lib/i18n/index.ts
@@ -1,4 +1,5 @@
-import { addMessages, init, getLocaleFromNavigator, locale } from "svelte-i18n";
+import { get } from "svelte/store";
+import { addMessages, init, getLocaleFromNavigator, locale, t } from "svelte-i18n";
 import en from "./en.json";
 import fr from "./fr.json";
 
@@ -26,6 +27,11 @@ export function setLocale(loc: string) {
   if (SUPPORTED_LOCALES.some((l) => l.id === loc)) {
     locale.set(loc);
   }
+}
+
+/** Translate from a `.ts` module (controllers) the same way `$t` does in Svelte. */
+export function tr(key: string, values?: Record<string, string | number>): string {
+  return get(t)(key, values ? { values } : undefined);
 }
 
 export { locale } from "svelte-i18n";

--- a/src/lib/stores/app.svelte.test.ts
+++ b/src/lib/stores/app.svelte.test.ts
@@ -22,6 +22,7 @@ describe('app store', () => {
     expect(state.settings.theme).toBe('dark');
     expect(state.settings.auto_paste).toBe(false);
     expect(state.settings.transcription_engine_id).toBe('');
+    expect(state.permissionsPanelOpen).toBe(false);
   });
 
   it('openMeeting sets id and navigates to the meetings view', () => {

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -17,6 +17,10 @@ let settingsOpen = $state(false);
 // deep-linking into the meetings tab). Consumed once by SettingsView.
 let settingsInitialTab = $state<string | null>(null);
 
+// Permissions repair panel, mounted once in App so banners can open it
+// without going through Settings → System → Review (SOU-089).
+let permissionsPanelOpen = $state(false);
+
 // Current meeting ID (when viewing a specific meeting)
 let currentMeetingId = $state<string | null>(null);
 
@@ -206,6 +210,9 @@ export function getAppState() {
 
     get settingsInitialTab() { return settingsInitialTab; },
     set settingsInitialTab(v: string | null) { settingsInitialTab = v; },
+
+    get permissionsPanelOpen() { return permissionsPanelOpen; },
+    set permissionsPanelOpen(v: boolean) { permissionsPanelOpen = v; },
 
     get currentMeetingId() { return currentMeetingId; },
     set currentMeetingId(id: string | null) { currentMeetingId = id; },

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -199,6 +199,7 @@ function deriveModelOperationState(state: AppStateMachine): TranscriptionModelOp
   switch (state.state) {
     case "downloading": return "downloading";
     case "loading": return "loading";
+    case "unloading": return "unloading";
     default: return "idle";
   }
 }

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -788,7 +788,7 @@ async requestPermission(kind: PermissionKind) : Promise<Result<PermState, string
  * the TCC entry is keyed to the previous code-signing identity. Runs off
  * the command thread since it shells out and may block on the prompt.
  */
-async repairAccessibilityPermission() : Promise<Result<PermState, string>> {
+async repairAccessibilityPermission() : Promise<Result<RepairAccessibilityResult, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("repair_accessibility_permission") };
 } catch (e) {
@@ -1512,6 +1512,13 @@ export type PipelineErrorScope =
  */
 "session"
 export type RecordingKind = "dictation" | { meeting: { meeting_id: string } }
+/**
+ * Outcome of `repair_accessibility`. Distinct from `PermState` because a
+ * successful `tccutil reset` plus prompt cannot observe the user's grant:
+ * `AXIsProcessTrustedWithOptions` returns the *current* trust, which is
+ * necessarily false a few milliseconds after the TCC entry was deleted.
+ */
+export type RepairAccessibilityResult = { reset_performed: boolean; prompt_shown: boolean }
 /**
  * Search result from FTS5 full-text search
  */

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -171,6 +171,18 @@ async pasteText(text: string, delayMs: number, method: PasteMethod) : Promise<Re
 }
 },
 /**
+ * Write text to the pasteboard without pasting. Cancels a pending clipboard
+ * restore so a failed ⌘V cannot wipe the transcription 400 ms later.
+ */
+async copyText(text: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("copy_text", { text }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
  * Called by the frontend when a shortcut-triggered dictation fails to
  * paste. A shortcut dictation is by definition run from another app, so
  * Soufflé's window is usually not what the user is looking at: the in-app

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -39,6 +39,7 @@ export type {
   PermState,
   PermissionKind,
   PermissionStatus,
+  RepairAccessibilityResult,
   PillHoldChanged,
   PillHoldKind,
   RecordingKind,


### PR DESCRIPTION
Fixes SOU-054. Partial SOU-033 / SOU-089 / SOU-090 — those tickets stay open.

- **SOU-033 (partial):** Accessibility paste failure writes the transcription and does not restore the previous clipboard. Banner/HUD: “Copied — press ⌘V” + Repair. Full NSPasteboard snapshot (images/files) is **not** in this PR.
- **SOU-054:** `tccutil` failure is an error (no fake success). Successful reset + AX still denied shows the prompt-to-check copy. Repair button cooldown after success.
- **SOU-089 (partial):** Paste-failure and “load the model” banners are a short sentence + action button. The rest of the itinerary inventory is untouched.
- **SOU-090 (partial):** Atomic in-flight guard on meeting start/resume so overlapping calls cannot double-launch. Delete-model refused while downloading/loading. The full UI-action audit is **not** done.

Do not close SOU-033, SOU-089, or SOU-090 off this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added actionable status banners for transcription and meeting errors.
  - Added fallback copying when automatic pasting fails, with guidance to paste manually.
  - Added accessibility permission repair feedback and a dedicated repair panel.
  - Added direct navigation to relevant Settings tabs.

- **Bug Fixes**
  - Prevented model deletion while operations are active, including unloading.
  - Prevented overlapping recording starts and resumes.
  - Improved accessibility repair feedback and prevented repeated repairs during cooldown.

- **Localization**
  - Added English and French messages for model, paste, and accessibility repair states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->