### PR TITLE
Fix batch Audio/VAD issues

### DIFF
--- a/src-tauri/src/audio/aec.rs
+++ b/src-tauri/src/audio/aec.rs
@@ -56,7 +56,10 @@ fn build_apm(sample_rate: u32) -> AudioProcessing {
     let stream = StreamConfig::new(sample_rate, 1);
     AudioProcessing::builder()
         .config(Config {
-            echo_canceller: Some(EchoCanceller::default()),
+            echo_canceller: Some(EchoCanceller {
+                transparent_mode: sonora::config::TransparentModeType::Hmm,
+                ..EchoCanceller::default()
+            }),
             ..Config::default()
         })
         .capture_config(stream)

--- a/src-tauri/src/audio/aec.rs
+++ b/src-tauri/src/audio/aec.rs
@@ -54,12 +54,9 @@ fn decide_rearm(attempts_so_far: u32) -> RearmDecision {
 
 fn build_apm(sample_rate: u32) -> AudioProcessing {
     let stream = StreamConfig::new(sample_rate, 1);
-    // SOU-063: configure AEC for ASR, not telephony. A swallowed word is
-    // a permanent transcript loss; residual echo is at worst a duplicate
-    // a text filter can drop. sonora's `Config` defaults already leave NS
-    // and AGC2 off (`None`). `EchoCanceller` has no NLP-level knob —
-    // HMM transparent mode is the exposed way to back off suppression
-    // when the filter sees no (or poorly correlated) echo.
+    // SOU-063: NS and AGC2 stay off (`Config` defaults). `EchoCanceller`
+    // has no NLP-level knob — `transparent_mode: Hmm` is a no-echo
+    // classifier swap vs Legacy, not NLP-off. Residual NLP still runs.
     AudioProcessing::builder()
         .config(Config {
             echo_canceller: Some(EchoCanceller {

--- a/src-tauri/src/audio/aec.rs
+++ b/src-tauri/src/audio/aec.rs
@@ -9,7 +9,7 @@
 //! processing module) so the backend can be swapped without touching the
 //! mixer. Works on 10ms mono frames at the mixer rate.
 
-use sonora::config::EchoCanceller;
+use sonora::config::{EchoCanceller, TransparentModeType};
 use sonora::{AudioProcessing, Config, StreamConfig};
 
 /// Coarse estimate of the delay between a render frame reaching sonora and
@@ -54,12 +54,20 @@ fn decide_rearm(attempts_so_far: u32) -> RearmDecision {
 
 fn build_apm(sample_rate: u32) -> AudioProcessing {
     let stream = StreamConfig::new(sample_rate, 1);
+    // SOU-063: configure AEC for ASR, not telephony. A swallowed word is
+    // a permanent transcript loss; residual echo is at worst a duplicate
+    // a text filter can drop. sonora's `Config` defaults already leave NS
+    // and AGC2 off (`None`). `EchoCanceller` has no NLP-level knob —
+    // HMM transparent mode is the exposed way to back off suppression
+    // when the filter sees no (or poorly correlated) echo.
     AudioProcessing::builder()
         .config(Config {
             echo_canceller: Some(EchoCanceller {
-                transparent_mode: sonora::config::TransparentModeType::Hmm,
+                transparent_mode: TransparentModeType::Hmm,
                 ..EchoCanceller::default()
             }),
+            noise_suppression: None,
+            gain_controller2: None,
             ..Config::default()
         })
         .capture_config(stream)

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -641,14 +641,17 @@ impl MeetingState {
     fn check_output_route(&mut self, _app: Option<&tauri::AppHandle>) {
         use super::{aec, mixer, output_route};
 
-        let can_leak = self.tap.is_some() && output_route::output_can_leak_into_mic();
+        let speakers_can_leak = self.tap.is_some() && output_route::output_can_leak_into_mic();
+        // SOU-063: speakers-on with nothing playing is the common damage
+        // case — AEC has no echo to cancel and suppresses the mic instead.
+        let can_leak = speakers_can_leak && self.mixer.tap_has_energy();
         if can_leak != self.aec_active {
             if can_leak {
-                info!("Speakers audible, echo cancellation engaged");
+                info!("Speakers audible and far-end present, echo cancellation engaged");
                 self.mixer
                     .set_aec(Some(aec::Aec::new_with_default_delay_hint(mixer::MIX_RATE)));
             } else {
-                info!("Output muted or off speakers, echo cancellation disengaged");
+                info!("Output muted, off speakers, or silent, echo cancellation disengaged");
                 self.mixer.set_aec(None);
             }
             self.aec_active = can_leak;
@@ -1472,9 +1475,11 @@ impl AudioCapture {
         // system-audio reference signal to cancel against.
         #[cfg(target_os = "macos")]
         let aec_active = {
-            let can_leak = tap.is_some() && super::output_route::output_can_leak_into_mic();
+            let can_leak = tap.is_some()
+                && super::output_route::output_can_leak_into_mic()
+                && mixer.tap_has_energy();
             if can_leak {
-                info!("Speakers audible, echo cancellation engaged");
+                info!("Speakers audible and far-end present, echo cancellation engaged");
                 mixer.set_aec(Some(super::aec::Aec::new_with_default_delay_hint(
                     super::mixer::MIX_RATE,
                 )));

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -634,24 +634,26 @@ struct MeetingState {
 }
 
 impl MeetingState {
-    /// Engage/disengage echo cancellation when whether speaker output can
-    /// leak into the mic changes: built-in speakers versus anything else
-    /// (headphones, Bluetooth), and muted or silent versus audible.
+    /// Engage/disengage echo cancellation when the HAL output route
+    /// changes: built-in speakers versus anything else (headphones,
+    /// Bluetooth), and muted versus audible. Far-end silence is not a
+    /// route change — the mixer keeps the instance and bypasses output.
     #[cfg(target_os = "macos")]
     fn check_output_route(&mut self, _app: Option<&tauri::AppHandle>) {
         use super::{aec, mixer, output_route};
 
-        let speakers_can_leak = self.tap.is_some() && output_route::output_can_leak_into_mic();
-        // SOU-063: speakers-on with nothing playing is the common damage
-        // case — AEC has no echo to cancel and suppresses the mic instead.
-        let can_leak = speakers_can_leak && self.mixer.tap_has_energy();
+        // HAL route only (speakers vs headphones / mute / volume). Tap
+        // energy must not destroy the instance — a far-end pause would
+        // wipe convergence and come back as raw echo (SOU-063). The mixer
+        // keeps AEC fed and chooses cancelled vs raw mic per frame.
+        let can_leak = self.tap.is_some() && output_route::output_can_leak_into_mic();
         if can_leak != self.aec_active {
             if can_leak {
-                info!("Speakers audible and far-end present, echo cancellation engaged");
+                info!("Speakers audible, echo cancellation engaged");
                 self.mixer
                     .set_aec(Some(aec::Aec::new_with_default_delay_hint(mixer::MIX_RATE)));
             } else {
-                info!("Output muted, off speakers, or silent, echo cancellation disengaged");
+                info!("Output muted or off speakers, echo cancellation disengaged");
                 self.mixer.set_aec(None);
             }
             self.aec_active = can_leak;
@@ -1475,11 +1477,9 @@ impl AudioCapture {
         // system-audio reference signal to cancel against.
         #[cfg(target_os = "macos")]
         let aec_active = {
-            let can_leak = tap.is_some()
-                && super::output_route::output_can_leak_into_mic()
-                && mixer.tap_has_energy();
+            let can_leak = tap.is_some() && super::output_route::output_can_leak_into_mic();
             if can_leak {
-                info!("Speakers audible and far-end present, echo cancellation engaged");
+                info!("Speakers audible, echo cancellation engaged");
                 mixer.set_aec(Some(super::aec::Aec::new_with_default_delay_hint(
                     super::mixer::MIX_RATE,
                 )));

--- a/src-tauri/src/audio/mixer.rs
+++ b/src-tauri/src/audio/mixer.rs
@@ -23,6 +23,13 @@ pub const FRAME_SAMPLES: usize = 480;
 /// are discarded. Bounds clock drift between the two devices; transcription
 /// tolerates the resulting sub-frame discontinuity.
 const MAX_TAP_LEAD_SAMPLES: usize = MIX_RATE as usize / 4;
+/// RMS floor on the tap leg below which AEC must not run (SOU-063).
+/// Speakers-on / nothing-playing is the common damage case: the canceller
+/// has a silent reference and suppresses the mic instead. ~-42 dBFS —
+/// above dither, below any real playback.
+const TAP_AEC_RMS_THRESHOLD: f32 = 0.008;
+const TAP_RMS_ATTACK: f32 = 0.3;
+const TAP_RMS_DECAY: f32 = 0.9;
 
 pub struct MeetingMixer {
     mic: HeapCons<f32>,
@@ -41,6 +48,9 @@ pub struct MeetingMixer {
     aec: Option<Aec>,
     /// Tap samples discarded to bound drift; logged at session end.
     tap_discarded: u64,
+    /// Recent far-end level, for skipping AEC when speakers can leak but
+    /// nothing is actually playing (SOU-063).
+    tap_rms_ema: f32,
 }
 
 impl MeetingMixer {
@@ -68,7 +78,23 @@ impl MeetingMixer {
             scratch: vec![0.0; 4096],
             aec: None,
             tap_discarded: 0,
+            tap_rms_ema: 0.0,
         }
+    }
+
+    /// True when the tap recently carried real far-end energy.
+    pub fn tap_has_energy(&self) -> bool {
+        self.tap_rms_ema >= TAP_AEC_RMS_THRESHOLD
+    }
+
+    fn note_tap_samples(&mut self, samples: &[f32]) {
+        if samples.is_empty() {
+            self.tap_rms_ema *= TAP_RMS_DECAY;
+            return;
+        }
+        let mean_sq = samples.iter().map(|s| s * s).sum::<f32>() / samples.len() as f32;
+        self.tap_rms_ema =
+            TAP_RMS_ATTACK * mean_sq.sqrt() + (1.0 - TAP_RMS_ATTACK) * self.tap_rms_ema;
     }
 
     /// Enable/disable echo cancellation (e.g. when the output route changes
@@ -239,13 +265,19 @@ impl MeetingMixer {
             let resampled = self.mic_to_mix.process(&self.scratch[..n]);
             self.mic_fifo.extend(resampled);
         }
+        let mut tap_added = 0usize;
         loop {
             let n = self.tap.pop_slice(&mut self.scratch);
             if n == 0 {
                 break;
             }
             let resampled = self.tap_to_mix.process(&self.scratch[..n]);
+            self.note_tap_samples(&resampled);
+            tap_added += resampled.len();
             self.tap_fifo.extend(resampled);
+        }
+        if tap_added == 0 {
+            self.note_tap_samples(&[]);
         }
 
         // Bound how far the tap leg can run ahead of the mic (clock drift).
@@ -340,6 +372,26 @@ mod tests {
         // Steady-state samples carry both sources (0.1 + 0.2).
         let mid = out[out.len() / 2];
         assert!((mid - 0.3).abs() < 0.05, "expected ~0.3, got {mid}");
+    }
+
+    #[test]
+    fn tap_energy_tracks_playback_then_decays() {
+        let (mut mic, mut tap, mut mixer) = make_mixer(48_000, 48_000, 16_000);
+        assert!(!mixer.tap_has_energy());
+
+        tap.push_slice(&vec![0.2f32; 4_800]);
+        mic.push_slice(&vec![0.1f32; 4_800]);
+        mixer.tick();
+        assert!(mixer.tap_has_energy(), "line-level tap must engage AEC");
+
+        for _ in 0..80 {
+            mic.push_slice(&vec![0.1f32; 480]);
+            mixer.tick();
+        }
+        assert!(
+            !mixer.tap_has_energy(),
+            "silence after playback must drop below the AEC floor"
+        );
     }
 
     #[test]

--- a/src-tauri/src/audio/mixer.rs
+++ b/src-tauri/src/audio/mixer.rs
@@ -48,8 +48,8 @@ pub struct MeetingMixer {
     aec: Option<Aec>,
     /// Tap samples discarded to bound drift; logged at session end.
     tap_discarded: u64,
-    /// Recent far-end level, for skipping AEC when speakers can leak but
-    /// nothing is actually playing (SOU-063).
+    /// Recent far-end level. Gates *applying* AEC output, not whether
+    /// the instance lives (SOU-063). A pause must not `set_aec(None)`.
     tap_rms_ema: f32,
 }
 
@@ -83,6 +83,8 @@ impl MeetingMixer {
     }
 
     /// True when the tap recently carried real far-end energy.
+    /// The AEC instance stays up; this only decides whether its output
+    /// replaces the raw mic this frame.
     pub fn tap_has_energy(&self) -> bool {
         self.tap_rms_ema >= TAP_AEC_RMS_THRESHOLD
     }
@@ -324,11 +326,20 @@ impl MeetingMixer {
 
         // AEC works on exact 10ms frames; the only shorter frames are the
         // final flush tail, where skipping cancellation is harmless.
+        // Always feed the canceller while it exists so a far-end pause
+        // does not dump convergence. Apply the output only when the tap
+        // is actually playing — otherwise emit raw mic (SOU-063 lever 2).
+        let apply_aec = self.tap_has_energy();
         if n == FRAME_SAMPLES
             && let Some(aec) = self.aec.as_mut()
         {
             aec.process_render(&tap);
-            aec.process_capture(&mut mic);
+            if apply_aec {
+                aec.process_capture(&mut mic);
+            } else {
+                let mut discarded = mic.clone();
+                aec.process_capture(&mut discarded);
+            }
         }
 
         (mic, tap)
@@ -382,7 +393,7 @@ mod tests {
         tap.push_slice(&vec![0.2f32; 4_800]);
         mic.push_slice(&vec![0.1f32; 4_800]);
         mixer.tick();
-        assert!(mixer.tap_has_energy(), "line-level tap must engage AEC");
+        assert!(mixer.tap_has_energy(), "line-level tap is above the apply floor");
 
         for _ in 0..80 {
             mic.push_slice(&vec![0.1f32; 480]);
@@ -391,6 +402,46 @@ mod tests {
         assert!(
             !mixer.tap_has_energy(),
             "silence after playback must drop below the AEC floor"
+        );
+    }
+
+    #[test]
+    fn aec_instance_survives_far_end_pause() {
+        let (mut mic, mut tap, mut mixer) = make_mixer(48_000, 48_000, MIX_RATE);
+        mixer.set_aec(Some(Aec::new(MIX_RATE)));
+
+        tap.push_slice(&vec![0.2f32; 4_800]);
+        mic.push_slice(&vec![0.1f32; 4_800]);
+        mixer.tick();
+        assert!(mixer.aec.is_some());
+        assert!(mixer.tap_has_energy());
+
+        for _ in 0..80 {
+            mic.push_slice(&vec![0.1f32; 480]);
+            mixer.tick();
+        }
+        assert!(!mixer.tap_has_energy());
+        assert!(
+            mixer.aec.is_some(),
+            "far-end pause must not destroy the canceller"
+        );
+    }
+
+    #[test]
+    fn silent_tap_emits_raw_mic_while_aec_stays_fed() {
+        let (mut mic, _tap, mut mixer) = make_mixer(48_000, 48_000, MIX_RATE);
+        mixer.set_aec(Some(Aec::new(MIX_RATE)));
+        assert!(!mixer.tap_has_energy());
+
+        mic.push_slice(&vec![0.5f32; 4_800]);
+        let mut out = mixer.tick();
+        out.extend(mixer.flush());
+
+        assert!(mixer.aec.is_some());
+        let mid = out[out.len() / 2];
+        assert!(
+            (mid - 0.5).abs() < 0.05,
+            "below the energy floor the mic must pass through raw, got {mid}"
         );
     }
 

--- a/src-tauri/src/engine/kyutai.rs
+++ b/src-tauri/src/engine/kyutai.rs
@@ -947,6 +947,9 @@ impl KyutaiEngine {
                     // clock belongs to the epoch that reset is about to close.
                     let raw_start = Self::word_start_time(model, *start_time, *batch_idx);
                     let start_time = Self::monotonic_time(model, *batch_idx, raw_start);
+                    // SOU-060: `on_word` only requests a KV wipe when Auto
+                    // inferred a prior (model lock-in). Explicit Fr/En still
+                    // labels the segment above and never wipes a healthy lane.
                     let mismatch_reset = model.language_tracker.on_word(&text, *batch_idx);
                     if mismatch_reset
                         && let Err(e) =

--- a/src-tauri/src/filter/audio_vad.rs
+++ b/src-tauri/src/filter/audio_vad.rs
@@ -138,12 +138,19 @@ impl AudioFilter for SileroVadFilter {
 
         // Process complete Silero frames (480 samples = 30ms at 16kHz)
         let mut result = self.in_speech || self.hangover_remaining > 0;
+        let mut processed_any = false;
         while self.buffer.len() >= VAD_FRAME_SAMPLES {
+            processed_any = true;
             let frame: Vec<f32> = self.buffer.drain(..VAD_FRAME_SAMPLES).collect();
-            result = self.process_frame(&frame);
+            let frame_result = self.process_frame(&frame);
+            result = result || frame_result;
         }
 
-        result
+        if !processed_any {
+            self.in_speech || self.hangover_remaining > 0
+        } else {
+            result
+        }
     }
 
     fn reset(&mut self) {

--- a/src-tauri/src/filter/audio_vad.rs
+++ b/src-tauri/src/filter/audio_vad.rs
@@ -136,21 +136,17 @@ impl AudioFilter for SileroVadFilter {
 
         self.buffer.extend_from_slice(input);
 
-        // Process complete Silero frames (480 samples = 30ms at 16kHz)
-        let mut result = self.in_speech || self.hangover_remaining > 0;
-        let mut processed_any = false;
+        // Process complete Silero frames (480 samples = 30ms at 16kHz).
+        // OR-accumulate: a Whisper/Parakeet 5s block must be fed if *any*
+        // 30ms frame was speech. Overwriting with the last frame was
+        // SOU-067 — 165 of 166 verdicts discarded.
+        let already = self.in_speech || self.hangover_remaining > 0;
+        let mut frame_speech = false;
         while self.buffer.len() >= VAD_FRAME_SAMPLES {
-            processed_any = true;
             let frame: Vec<f32> = self.buffer.drain(..VAD_FRAME_SAMPLES).collect();
-            let frame_result = self.process_frame(&frame);
-            result = result || frame_result;
+            frame_speech |= self.process_frame(&frame);
         }
-
-        if !processed_any {
-            self.in_speech || self.hangover_remaining > 0
-        } else {
-            result
-        }
+        block_is_speech(already, [frame_speech])
     }
 
     fn reset(&mut self) {
@@ -158,5 +154,25 @@ impl AudioFilter for SileroVadFilter {
         self.hangover_remaining = 0;
         self.onset_count = 0;
         self.in_speech = false;
+    }
+}
+
+/// Reduce per-frame VAD decisions for one engine block: any speech frame
+/// (or an already-open hangover) feeds the whole block (SOU-067).
+fn block_is_speech(already_in_speech: bool, frame_speech: impl IntoIterator<Item = bool>) -> bool {
+    already_in_speech || frame_speech.into_iter().any(|s| s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mixed_block_is_speech_if_any_frame_is() {
+        // First 30ms speech, last 30ms silence — overwrite returned silence.
+        assert!(block_is_speech(false, [true, false]));
+        assert!(block_is_speech(false, [true, false, false]));
+        assert!(!block_is_speech(false, [false, false]));
+        assert!(block_is_speech(true, [false, false]));
     }
 }

--- a/src-tauri/src/filter/mod.rs
+++ b/src-tauri/src/filter/mod.rs
@@ -250,6 +250,60 @@ mod tests {
         );
     }
 
+    /// Speech in the first 90 ms, silence in the last 480 ms: the block
+    /// must be fed. Overwriting with the last 30 ms (SOU-067) returned
+    /// silence once hangover expired inside the same call.
+    #[test]
+    fn silero_mixed_block_feeds_when_speech_is_not_last_frame() {
+        let Some(model_path) = resolve_vad_model_path() else {
+            eprintln!("skipping: silero_vad_v4.onnx not found");
+            return;
+        };
+        if crate::ort_runtime::resolve_resource("libonnxruntime.dylib").is_none() {
+            eprintln!("skipping: libonnxruntime.dylib not found");
+            return;
+        }
+
+        let mut vad = match audio_vad::SileroVadFilter::new(&model_path, 16_000) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("skipping: Silero VAD init failed: {e}");
+                return;
+            }
+        };
+
+        // 90 ms of a voiced-ish harmonic stack (onset is 2 frames), then
+        // 480 ms of silence — hangover is 450 ms, so the last 30 ms is
+        // true silence and would have overwritten the verdict.
+        let mut block = Vec::with_capacity(480 * 19);
+        for i in 0..(480 * 3) {
+            let t = i as f32 / 16_000.0;
+            block.push(
+                (t * 120.0 * std::f32::consts::TAU).sin() * 0.35
+                    + (t * 240.0 * std::f32::consts::TAU).sin() * 0.2
+                    + (t * 360.0 * std::f32::consts::TAU).sin() * 0.1,
+            );
+        }
+        block.extend(std::iter::repeat(0.0f32).take(480 * 16));
+
+        let mut probe = match audio_vad::SileroVadFilter::new(&model_path, 16_000) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("skipping: Silero VAD init failed: {e}");
+                return;
+            }
+        };
+        if !probe.process(&block[..480 * 3]) {
+            eprintln!("skipping: synthetic voice not detected by Silero");
+            return;
+        }
+
+        assert!(
+            vad.process(&block),
+            "mixed block with early speech must be fed (SOU-067 OR-accumulate)"
+        );
+    }
+
     #[test]
     fn build_text_filters_includes_whitespace_always() {
         let config = PipelineConfig {

--- a/src-tauri/src/lid.rs
+++ b/src-tauri/src/lid.rs
@@ -76,6 +76,13 @@ fn normalize_token(raw: &str) -> String {
         .to_lowercase()
 }
 
+fn is_french_accent(ch: char) -> bool {
+    matches!(
+        ch,
+        'é' | 'è' | 'ê' | 'ë' | 'à' | 'â' | 'ù' | 'û' | 'ô' | 'î' | 'ï' | 'ç' | 'œ' | 'æ'
+    )
+}
+
 fn score_token(token: &str) -> LangScore {
     let mut score = LangScore::default();
     if token.is_empty() {
@@ -83,11 +90,8 @@ fn score_token(token: &str) -> LangScore {
     }
 
     for ch in token.chars() {
-        match ch {
-            'é' | 'è' | 'ê' | 'ë' | 'à' | 'â' | 'ù' | 'û' | 'ô' | 'î' | 'ï' | 'ç' | 'œ' | 'æ' => {
-                score.fr += 2;
-            }
-            _ => {}
+        if is_french_accent(ch) {
+            score.fr += 2;
         }
     }
 
@@ -99,9 +103,9 @@ fn score_token(token: &str) -> LangScore {
     }
 
     // `-ment` / `-tion` are weak FR cues and collide with English
-    // (`development`, `nation`). Require an accent, same as the intended
-    // grouping before `&&` bound tighter than `||` (SOU-060).
-    if (token.ends_with("ment") || token.ends_with("tion")) && token.contains('é') {
+    // (`development`, `nation`). Require any French accent, not just `é`
+    // (`bâtiment`, `façonnement`).
+    if (token.ends_with("ment") || token.ends_with("tion")) && token.chars().any(is_french_accent) {
         score.fr += 1;
     }
     if token.ends_with("ing") || token.ends_with("ness") || token.ends_with("tion") {
@@ -327,6 +331,7 @@ mod tests {
         assert_ne!(detect_word("development"), Some(LanguageCode::Fr));
         assert_eq!(detect_word("development"), None);
         assert_eq!(detect_word("développement"), Some(LanguageCode::Fr));
+        assert_eq!(detect_word("bâtiment"), Some(LanguageCode::Fr));
     }
 
     #[test]

--- a/src-tauri/src/lid.rs
+++ b/src-tauri/src/lid.rs
@@ -1,8 +1,10 @@
 //! Lightweight French/English language identification for meeting segments.
 //!
 //! Heuristic-only: accent density plus stopword hits. Used to populate
-//! `segment.language` when Kyutai leaves it unset and to drive per-lane
-//! mismatch resets. Never passed to moshi as a forced language.
+//! `segment.language` when Kyutai leaves it unset. A per-lane KV wipe on
+//! mismatch is reserved for Auto (inferred prior) — an explicit Français/
+//! Anglais setting is a code-switch, not a model lock-in (SOU-060). Never
+//! passed to moshi as a forced language.
 
 use crate::settings::MeetingTranscriptionLanguage;
 
@@ -71,7 +73,7 @@ const EN_STOPWORDS: &[&str] = &[
 fn normalize_token(raw: &str) -> String {
     raw.trim()
         .trim_matches(|c: char| !c.is_alphanumeric())
-        .to_ascii_lowercase()
+        .to_lowercase()
 }
 
 fn score_token(token: &str) -> LangScore {
@@ -96,7 +98,10 @@ fn score_token(token: &str) -> LangScore {
         score.en += 3;
     }
 
-    if token.ends_with("ment") || token.ends_with("tion") && token.contains('é') {
+    // `-ment` / `-tion` are weak FR cues and collide with English
+    // (`development`, `nation`). Require an accent, same as the intended
+    // grouping before `&&` bound tighter than `||` (SOU-060).
+    if (token.ends_with("ment") || token.ends_with("tion")) && token.contains('é') {
         score.fr += 1;
     }
     if token.ends_with("ing") || token.ends_with("ness") || token.ends_with("tion") {
@@ -136,6 +141,16 @@ pub fn detect_text(text: &str) -> Option<LanguageCode> {
 
 /// Consecutive words that disagree with the lane prior before forcing reset.
 pub const MISMATCH_STREAK_THRESHOLD: usize = 3;
+
+/// Whether a mismatch streak should wipe the lane KV cache.
+///
+/// Labeling (`segment.language`) always uses the detector. A wipe is only
+/// justified when Auto inferred a prior the model may have locked itself
+/// into — not when the user set Français/Anglais and someone code-switches
+/// (SOU-060).
+pub fn decide_mismatch_reset(setting: MeetingTranscriptionLanguage, streak_reached: bool) -> bool {
+    streak_reached && LanguageCode::from_setting(setting).is_none()
+}
 
 /// Rolling per-lane language state with hysteresis for mismatch resets.
 #[derive(Debug, Clone)]
@@ -193,6 +208,11 @@ impl LanguageLaneTracker {
     /// Record a word; returns true when a lane reset should be forced.
     pub fn on_word(&mut self, text: &str) -> bool {
         let Some(detected) = detect_word(text) else {
+            // Neutral / unidentifiable: expire the streak. Three English
+            // function words scattered through a minute must not accumulate
+            // to a wipe (SOU-060).
+            self.mismatch_lang = None;
+            self.mismatch_streak = 0;
             return false;
         };
 
@@ -217,7 +237,10 @@ impl LanguageLaneTracker {
             self.mismatch_streak = 1;
         }
 
-        self.mismatch_streak >= MISMATCH_STREAK_THRESHOLD
+        decide_mismatch_reset(
+            self.setting_prior,
+            self.mismatch_streak >= MISMATCH_STREAK_THRESHOLD,
+        )
     }
 }
 
@@ -290,9 +313,47 @@ mod tests {
         assert_eq!(detect_word("12"), None);
     }
 
+    fn infer_english_prior() -> LanguageLaneTracker {
+        let mut lane = LanguageLaneTracker::new(MeetingTranscriptionLanguage::Auto);
+        for _ in 0..5 {
+            assert!(!lane.on_word("the"));
+        }
+        assert_eq!(lane.effective_prior(), Some(LanguageCode::En));
+        lane
+    }
+
+    #[test]
+    fn english_ment_is_not_french() {
+        assert_ne!(detect_word("development"), Some(LanguageCode::Fr));
+        assert_eq!(detect_word("development"), None);
+        assert_eq!(detect_word("développement"), Some(LanguageCode::Fr));
+    }
+
+    #[test]
+    fn accented_capital_counts_as_french() {
+        assert_eq!(detect_word("École"), Some(LanguageCode::Fr));
+        assert_eq!(detect_word("Ça"), Some(LanguageCode::Fr));
+    }
+
+    #[test]
+    fn decide_mismatch_reset_only_for_inferred_prior() {
+        assert!(!decide_mismatch_reset(MeetingTranscriptionLanguage::En, true));
+        assert!(!decide_mismatch_reset(MeetingTranscriptionLanguage::Fr, true));
+        assert!(decide_mismatch_reset(MeetingTranscriptionLanguage::Auto, true));
+        assert!(!decide_mismatch_reset(MeetingTranscriptionLanguage::Auto, false));
+    }
+
+    #[test]
+    fn explicit_prior_never_resets_lane() {
+        let mut lane = LanguageLaneTracker::new(MeetingTranscriptionLanguage::En);
+        let words = ["bonjour", "merci", "réunion", "bonjour", "merci", "réunion"];
+        let resets = words.iter().filter(|w| lane.on_word(w)).count();
+        assert_eq!(resets, 0);
+    }
+
     #[test]
     fn mismatch_streak_triggers_after_threshold() {
-        let mut lane = LanguageLaneTracker::new(MeetingTranscriptionLanguage::En);
+        let mut lane = infer_english_prior();
         assert!(!lane.on_word("bonjour"));
         assert!(!lane.on_word("merci"));
         assert!(lane.on_word("réunion"));
@@ -300,12 +361,32 @@ mod tests {
 
     #[test]
     fn mismatch_streak_clears_on_agreement() {
-        let mut lane = LanguageLaneTracker::new(MeetingTranscriptionLanguage::En);
+        let mut lane = infer_english_prior();
         assert!(!lane.on_word("bonjour"));
         assert!(!lane.on_word("merci"));
         assert!(!lane.on_word("the"));
         assert!(!lane.on_word("réunion"));
         assert!(!lane.on_word("encore"));
+    }
+
+    #[test]
+    fn mismatch_streak_clears_on_neutral_word() {
+        let mut lane = infer_english_prior();
+        let words = [
+            "bonjour", "project", "project", "merci", "project", "réunion",
+        ];
+        let resets = words.iter().filter(|w| lane.on_word(w)).count();
+        assert_eq!(resets, 0);
+    }
+
+    #[test]
+    fn explicit_en_scattered_french_does_not_trigger() {
+        let mut lane = LanguageLaneTracker::new(MeetingTranscriptionLanguage::En);
+        let words = [
+            "bonjour", "project", "project", "merci", "project", "réunion",
+        ];
+        let resets = words.iter().filter(|w| lane.on_word(w)).count();
+        assert_eq!(resets, 0);
     }
 
     #[test]
@@ -319,5 +400,4 @@ mod tests {
         }
         assert_eq!(lane.effective_prior(), Some(LanguageCode::En));
     }
-
 }

--- a/src-tauri/src/pipeline/actor.rs
+++ b/src-tauri/src/pipeline/actor.rs
@@ -756,10 +756,16 @@ impl EngineActor {
             // Bounded window (in engine frames) to keep feeding the engine
             // after VAD gates speech, so the emission-delayed tail word
             // drains instead of staying stuck behind the next utterance.
-            let frames_per_second = sample_rate as f64 / info.audio.chunk_size_samples as f64;
-            let drain_window_frames =
-                ((engine.emission_delay_seconds() + 0.5) * frames_per_second).ceil() as usize;
-            let lookback_frames = (VAD_LOOKBACK_SECONDS * frames_per_second).ceil() as usize;
+            let drain_window_frames = vad_hold_frames(
+                engine.emission_delay_seconds() + 0.5,
+                sample_rate,
+                info.audio.chunk_size_samples,
+            );
+            let lookback_frames = vad_hold_frames(
+                VAD_LOOKBACK_SECONDS,
+                sample_rate,
+                info.audio.chunk_size_samples,
+            );
             Box::new(SingleMode::new(
                 audio_filters,
                 drain_window_frames,
@@ -881,6 +887,19 @@ trait SessionMode {
 /// (~60ms) at the start of the word that resumes speech, plus whatever gets
 /// gated after the hangover has run out. ~4 frames at Kyutai's 80ms chunk size.
 const VAD_LOOKBACK_SECONDS: f64 = 0.3;
+
+/// Convert a hold duration into engine-frame counts.
+///
+/// Batch engines (Whisper/Parakeet) advertise 5 s chunks, so a 0.3 s
+/// lookback still rounds up to one 5 s frame — that overshoot is
+/// documented, not a 0.3 s ring. A true 30 ms gate is SOU-067/068.
+fn vad_hold_frames(hold_seconds: f64, sample_rate: u32, chunk_size_samples: u32) -> usize {
+    if sample_rate == 0 || chunk_size_samples == 0 {
+        return 1;
+    }
+    let chunk_seconds = f64::from(chunk_size_samples) / f64::from(sample_rate);
+    (hold_seconds / chunk_seconds).ceil().max(1.0) as usize
+}
 
 /// Single mixed-stream session: one buffer gated by the configured audio
 /// filter chain (Silero VAD when enabled).
@@ -2658,6 +2677,25 @@ mod tests {
         mode.step(&mut engine, chunk_size).unwrap();
         assert_eq!(mode.vad_replayed, 1);
         assert!(mode.lookback.is_empty());
+    }
+
+    #[test]
+    fn vad_hold_frames_covers_lookback_for_kyutai_and_batch() {
+        // Kyutai: 1920 @ 24 kHz = 80 ms → 0.3 s ≈ 4 frames.
+        let kyutai = super::vad_hold_frames(super::VAD_LOOKBACK_SECONDS, 24_000, 1_920);
+        assert_eq!(kyutai, 4);
+        assert!((kyutai as f64) * (1_920.0 / 24_000.0) >= super::VAD_LOOKBACK_SECONDS);
+
+        // Whisper/Parakeet: 80_000 @ 16 kHz = 5 s. One frame covers 0.3 s
+        // but the ring is 5 s, not 0.3 s — point 2 of SOU-067.
+        let batch = super::vad_hold_frames(super::VAD_LOOKBACK_SECONDS, 16_000, 80_000);
+        assert_eq!(batch, 1);
+        assert!((batch as f64) * (80_000.0 / 16_000.0) >= super::VAD_LOOKBACK_SECONDS);
+        assert_eq!(
+            super::vad_hold_frames(0.5, 16_000, 80_000),
+            1,
+            "0.5 s drain on a 5 s chunk is still one frame"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes SOU-060. Partial SOU-063 / SOU-067 — those tickets stay open.

- **SOU-060:** LID still labels `segment.language`. KV wipe on language mismatch only in Auto (inferred prior). Explicit Fr/En never reset a healthy lane. `-ment`/`-tion` require an accent (`development` is not French). Neutral words clear the streak. Unicode lowercase so `École` counts.
- **SOU-063 (partial):** HMM transparent-mode classifier (NLP still runs). AEC stays alive across far-end pauses; tap energy chooses cancelled vs raw mic per frame. No ERLE measurement, no fade, mute/volume still rebuilds the instance.
- **SOU-067 (partial):** VAD ORs 30 ms frames in a engine block instead of keeping only the last. Mixed-block test added. 30 ms gating and Whisper/Parakeet lookback sizing are **not** done (couples to SOU-068).

Do not close SOU-063 or SOU-067 off this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved echo cancellation convergence during conversations and far-end silence, while preserving natural microphone audio when no remote audio is present.
  - Fixed voice activity detection across mixed speech and silence, including brief speech segments and incomplete audio frames.
  - Improved recognition of French-accented words and language mismatch handling.
  - Improved voice activity timing across different audio frame sizes and sample rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->