### PR TITLE
Fix SOU-046: Latch auto-paste intent at dictation start

### DIFF
--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -1080,6 +1080,36 @@ describe("transcription controller", () => {
     }));
   });
 
+  it("shortcut start then window stop still auto-pastes (SOU-046)", async () => {
+    const channel = captureTranscriptionChannel();
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+    ctrl.app.settings = { ...ctrl.app.settings, auto_paste: true, dictation_polish_enabled: false };
+
+    await ctrl.toggleRecording(true);
+    simulateRecordingStarted(ctrl.app);
+    channel.emit({ text: "hello", is_final: true });
+    await ctrl.toggleRecording(false);
+
+    expect(mockInvoke).toHaveBeenCalledWith("paste_text", expect.objectContaining({ text: "hello" }));
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+  });
+
+  it("window start then shortcut stop does not auto-paste (SOU-046)", async () => {
+    const channel = captureTranscriptionChannel();
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+    ctrl.app.settings = { ...ctrl.app.settings, auto_paste: true, dictation_polish_enabled: false };
+
+    await ctrl.toggleRecording(false);
+    simulateRecordingStarted(ctrl.app);
+    channel.emit({ text: "hello", is_final: true });
+    await ctrl.toggleRecording(true);
+
+    expect(mockInvoke).not.toHaveBeenCalledWith("paste_text", expect.anything());
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith("hello");
+  });
+
   it("abort clears tentative and saves transcript only", async () => {
     const channel = captureTranscriptionChannel();
     const ctrl = createTranscriptionController();

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -1136,7 +1136,12 @@ describe("transcription controller", () => {
 
     await ctrl.toggleRecording(true);
     simulateRecordingStarted(ctrl.app);
-    transcriptionChannel?.onmessage?.({ text: "hello", is_final: true, start_ms: 0, end_ms: 500 });
+    (transcriptionChannel as { onmessage: ((msg: unknown) => void) | null } | null)?.onmessage?.({
+      text: "hello",
+      is_final: true,
+      start_ms: 0,
+      end_ms: 500,
+    });
 
     const stopPromise = ctrl.toggleRecording(false);
     await vi.waitFor(() => {

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -1110,6 +1110,46 @@ describe("transcription controller", () => {
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith("hello");
   });
 
+  it("abort during finalization still pastes a shortcut-started session (SOU-046)", async () => {
+    let transcriptionChannel: { onmessage: ((msg: unknown) => void) | null } | null = null;
+    let resolvePolish: ((value: unknown) => void) | undefined;
+    mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "start_transcription") {
+        transcriptionChannel = args?.channel as { onmessage: ((msg: unknown) => void) | null };
+        return Promise.resolve(null);
+      }
+      if (cmd === "polish_dictation") {
+        return new Promise((resolve) => {
+          resolvePolish = resolve;
+        });
+      }
+      return defaultInvoke(cmd, args);
+    });
+
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+    ctrl.app.settings = {
+      ...ctrl.app.settings,
+      auto_paste: true,
+      dictation_polish_enabled: true,
+    };
+
+    await ctrl.toggleRecording(true);
+    simulateRecordingStarted(ctrl.app);
+    transcriptionChannel?.onmessage?.({ text: "hello", is_final: true, start_ms: 0, end_ms: 500 });
+
+    const stopPromise = ctrl.toggleRecording(false);
+    await vi.waitFor(() => {
+      expect(resolvePolish).toBeTypeOf("function");
+    });
+    ctrl.handleRecordingAborted();
+    resolvePolish!({ text: "hello", skipped: false, warning: null });
+    await stopPromise;
+
+    expect(mockInvoke).toHaveBeenCalledWith("paste_text", expect.objectContaining({ text: "hello" }));
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+  });
+
   it("abort clears tentative and saves transcript only", async () => {
     const channel = captureTranscriptionChannel();
     const ctrl = createTranscriptionController();

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -154,6 +154,7 @@ function createTranscriptionControllerInstance() {
   // callbacks from a previous session can never write into a new one.
   let sessionGeneration = 0;
   let sessionMode: SessionMode = "insert";
+  let sessionAutoPaste = false;
   let focusedApp: string | null = null;
   let rewriteOf: string | null = null;
   let learnFromEditTimer: ReturnType<typeof setTimeout> | null = null;
@@ -193,6 +194,7 @@ function createTranscriptionControllerInstance() {
     focusedApp = null;
     rewriteOf = null;
     sessionMode = "insert";
+    sessionAutoPaste = false;
     if (ceilingTimer) {
       clearTimeout(ceilingTimer);
       ceilingTimer = null;
@@ -375,7 +377,7 @@ function createTranscriptionControllerInstance() {
         const saved = await saveToHistory(finalized.text);
 
         if (finalized.text) {
-          if (fromShortcut && app.settings.auto_paste) {
+          if (sessionAutoPaste && app.settings.auto_paste) {
             try {
               await pasteText(
                 finalized.text,
@@ -460,6 +462,7 @@ function createTranscriptionControllerInstance() {
       }
 
       cancelLearnFromEditPoll();
+      sessionAutoPaste = fromShortcut;
       if (!fromShortcut) sessionMode = "insert";
       transcript = "";
       tentative = "";
@@ -562,7 +565,7 @@ export function notifyDictationAborted() {
 }
 
 /** The native HUD asked to stop the active dictation; run the full stop
- * pipeline (polish + paste) so HUD stop matches the shortcut (SOU-046).
+ * pipeline. Paste follows the session start latch, not this call (SOU-046).
  * Stop-only: a no-op when not dictating, so this cannot start a session
  * or take down a meeting (SOU-044). */
 export function notifyDictationStopRequested() {

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -354,6 +354,7 @@ function createTranscriptionControllerInstance() {
       const holdForPolish = app.settings.dictation_polish_enabled;
       const sessionFocusedApp = focusedApp;
       const sessionRewriteOf = rewriteOf;
+      const sessionShouldAutoPaste = sessionAutoPaste;
       if (holdForPolish) {
         try {
           await pillHold("polishing");
@@ -377,7 +378,7 @@ function createTranscriptionControllerInstance() {
         const saved = await saveToHistory(finalized.text);
 
         if (finalized.text) {
-          if (sessionAutoPaste && app.settings.auto_paste) {
+          if (sessionShouldAutoPaste && app.settings.auto_paste) {
             try {
               await pasteText(
                 finalized.text,


### PR DESCRIPTION
## Summary
- Auto-paste now follows how the dictation session started, not which control stopped it.
- Shortcut start then window Stop still pastes; window Dicter then HUD/shortcut stop no longer pastes into the frontmost app.

## Test plan
- [ ] `auto_paste` on: cursor in another app, shortcut start, dictate, Stop in the Soufflé window. Text should land in the original app.
- [ ] `auto_paste` on: Dicter in the Soufflé window, switch to an editor, stop from the HUD or shortcut. Text should not paste there (clipboard only).
- [ ] Nominal path unchanged: shortcut start and shortcut/HUD stop still pastes.
- [ ] `npx vitest run src/lib/features/transcription/controller.svelte.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dictation behavior when starting and stopping recordings through different controls.
  - Text now auto-pastes after finalized processing when recording begins via shortcut, even if stopped from the native control.
  - Recordings started from the native control continue to copy finalized text without automatically pasting it.
  - Fixed an issue where stopping a shortcut-started session during asynchronous polishing could prevent the finalized text from being pasted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->