### PR TITLE
Fix SOU-048: Persist raw dictation before polish

### DIFF
--- a/src-tauri/src/commands/dictation.rs
+++ b/src-tauri/src/commands/dictation.rs
@@ -16,15 +16,29 @@ pub fn list_dictation_entries(
     state.db.list_dictation_entries(limit.unwrap_or(50))
 }
 
-/// Add a dictation history entry
+/// Add a dictation history entry. Returns the generated id so a later polish
+/// pass can update the same row instead of inserting a second one.
 #[tauri::command]
 #[specta::specta]
-pub fn add_dictation_entry(state: State<'_, AppState>, text: String) -> Result<(), String> {
+pub fn add_dictation_entry(state: State<'_, AppState>, text: String) -> Result<String, String> {
     let id = uuid::Uuid::new_v4().to_string();
     let timestamp = chrono::Utc::now().to_rfc3339();
     state.db.add_dictation_entry(&id, &text, &timestamp)?;
     // The Idle transition also syncs the tray, but it fires before this write
     // (the frontend saves history only after stop resolves).
+    sync_tray(&state);
+    Ok(id)
+}
+
+/// Replace the text of an existing dictation entry (e.g. after polish).
+#[tauri::command]
+#[specta::specta]
+pub fn update_dictation_entry(
+    state: State<'_, AppState>,
+    id: String,
+    text: String,
+) -> Result<(), String> {
+    state.db.update_dictation_entry(&id, &text)?;
     sync_tray(&state);
     Ok(())
 }

--- a/src-tauri/src/db/dictation.rs
+++ b/src-tauri/src/db/dictation.rs
@@ -68,6 +68,43 @@ impl Database {
         Ok(())
     }
 
+    /// Replace the text of an existing dictation entry and refresh FTS.
+    /// Keeps the original timestamp so polish does not create a second row
+    /// or jump the entry in history.
+    pub fn update_dictation_entry(&self, id: &str, text: &str) -> Result<(), String> {
+        let mut conn = self.conn.acquire()?;
+        let tx = conn
+            .transaction()
+            .map_err(|e| format!("Transaction: {e}"))?;
+
+        let updated = tx
+            .execute(
+                "UPDATE dictation_entries SET text = ?2 WHERE id = ?1",
+                params![id, text],
+            )
+            .map_err(|e| format!("Update dictation: {e}"))?;
+
+        if updated == 0 {
+            return Err(format!("Dictation entry not found: {id}"));
+        }
+
+        tx.execute(
+            "DELETE FROM text_search WHERE source_type = 'dictation' AND source_id = ?1",
+            params![id],
+        )
+        .map_err(|e| format!("Delete FTS: {e}"))?;
+
+        tx.execute(
+            "INSERT INTO text_search (content, source_type, source_id) VALUES (?1, ?2, ?3)",
+            params![text, "dictation", id],
+        )
+        .map_err(|e| format!("FTS insert: {e}"))?;
+
+        tx.commit().map_err(|e| format!("Commit: {e}"))?;
+
+        Ok(())
+    }
+
     /// Delete a single dictation entry.
     pub fn delete_dictation_entry(&self, id: &str) -> Result<(), String> {
         let conn = self.conn.acquire()?;
@@ -186,5 +223,44 @@ mod tests {
 
         let entries = db.list_dictation_entries(3).unwrap();
         assert_eq!(entries.len(), 3);
+    }
+
+    #[test]
+    fn update_replaces_text_in_place() {
+        let (db, _dir) = test_db();
+        db.add_dictation_entry("d1", "raw hello", "2024-01-01T00:00:00Z")
+            .unwrap();
+
+        db.update_dictation_entry("d1", "polished hello").unwrap();
+
+        let entries = db.list_dictation_entries(50).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, "d1");
+        assert_eq!(entries[0].text, "polished hello");
+        assert_eq!(entries[0].timestamp, "2024-01-01T00:00:00Z");
+        assert_eq!(db.count_dictation_entries().unwrap(), 1);
+    }
+
+    #[test]
+    fn update_refreshes_fts() {
+        let (db, _dir) = test_db();
+        db.add_dictation_entry("d1", "raw hello", "2024-01-01T00:00:00Z")
+            .unwrap();
+
+        db.update_dictation_entry("d1", "polished kubernetes").unwrap();
+
+        assert!(db.search_text("raw", 20).unwrap().is_empty());
+        let results = db.search_text("kubernetes", 20).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].source_type, "dictation");
+        assert_eq!(results[0].source_id, "d1");
+    }
+
+    #[test]
+    fn update_missing_id_errors() {
+        let (db, _dir) = test_db();
+        let err = db.update_dictation_entry("missing", "nope").unwrap_err();
+        assert!(err.contains("not found"));
+        assert_eq!(db.list_dictation_entries(50).unwrap().len(), 0);
     }
 }

--- a/src-tauri/src/db/dictation.rs
+++ b/src-tauri/src/db/dictation.rs
@@ -247,7 +247,8 @@ mod tests {
         db.add_dictation_entry("d1", "raw hello", "2024-01-01T00:00:00Z")
             .unwrap();
 
-        db.update_dictation_entry("d1", "polished kubernetes").unwrap();
+        db.update_dictation_entry("d1", "polished kubernetes")
+            .unwrap();
 
         assert!(db.search_text("raw", 20).unwrap().is_empty());
         let results = db.search_text("kubernetes", 20).unwrap();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -126,6 +126,7 @@ fn specta_builder() -> Builder<tauri::Wry> {
             commands::search_text,
             commands::list_dictation_entries,
             commands::add_dictation_entry,
+            commands::update_dictation_entry,
             commands::delete_dictation_entry,
             commands::clear_dictation_history,
             commands::polish_dictation,

--- a/src/lib/api/transcription.test.ts
+++ b/src/lib/api/transcription.test.ts
@@ -21,6 +21,7 @@ import {
   stopStreamingTranscription,
   listDictationEntries,
   addDictationEntry,
+  updateDictationEntry,
   deleteDictationEntry,
   clearDictationHistory,
   pasteText,
@@ -105,12 +106,21 @@ describe('transcription API', () => {
     expect(result).toEqual(entries);
   });
 
-  it('addDictationEntry passes text', async () => {
-    mockInvoke.mockResolvedValue(null);
+  it('addDictationEntry passes text and returns the id', async () => {
+    mockInvoke.mockResolvedValue('entry-42');
 
-    await addDictationEntry('test text');
+    const id = await addDictationEntry('test text');
 
     expect(mockInvoke).toHaveBeenCalledWith('add_dictation_entry', expect.objectContaining({ text: 'test text' }), undefined);
+    expect(id).toBe('entry-42');
+  });
+
+  it('updateDictationEntry passes id and text', async () => {
+    mockInvoke.mockResolvedValue(null);
+
+    await updateDictationEntry('entry-42', 'polished text');
+
+    expect(mockInvoke).toHaveBeenCalledWith('update_dictation_entry', expect.objectContaining({ id: 'entry-42', text: 'polished text' }), undefined);
   });
 
   it('deleteDictationEntry passes id', async () => {

--- a/src/lib/api/transcription.ts
+++ b/src/lib/api/transcription.ts
@@ -55,8 +55,12 @@ export async function listDictationEntries(limit = 50): Promise<DictationEntry[]
   return unwrap(commands.listDictationEntries(limit));
 }
 
-export async function addDictationEntry(text: string): Promise<void> {
-  await unwrap(commands.addDictationEntry(text));
+export async function addDictationEntry(text: string): Promise<string> {
+  return unwrap(commands.addDictationEntry(text));
+}
+
+export async function updateDictationEntry(id: string, text: string): Promise<void> {
+  await unwrap(commands.updateDictationEntry(id, text));
 }
 
 export async function deleteDictationEntry(id: string): Promise<void> {

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -132,6 +132,8 @@ describe("transcription controller", () => {
       case "stop_transcription":
         return Promise.resolve(null);
       case "add_dictation_entry":
+        return Promise.resolve("entry-test-id");
+      case "update_dictation_entry":
         return Promise.resolve(null);
       case "delete_dictation_entry":
         return Promise.resolve(null);
@@ -497,6 +499,142 @@ describe("transcription controller", () => {
     expect(mockInvoke).toHaveBeenCalledWith("add_dictation_entry", { text: "hello world" });
   });
 
+  it("persists raw history before polish returns (SOU-048)", async () => {
+    let transcriptionChannel: { onmessage: ((msg: unknown) => void) | null } | null = null;
+    let resolvePolish: ((value: unknown) => void) | undefined;
+    mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "start_transcription") {
+        transcriptionChannel = args?.channel as { onmessage: ((msg: unknown) => void) | null };
+        return Promise.resolve(null);
+      }
+      if (cmd === "polish_dictation") {
+        return new Promise((resolve) => {
+          resolvePolish = resolve;
+        });
+      }
+      if (cmd === "add_dictation_entry") {
+        return Promise.resolve("raw-id");
+      }
+      return defaultInvoke(cmd, args);
+    });
+
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+    ctrl.app.settings = { ...ctrl.app.settings, dictation_polish_enabled: true };
+
+    await ctrl.toggleRecording();
+    simulateRecordingStarted(ctrl.app);
+    (transcriptionChannel as { onmessage: ((msg: unknown) => void) | null } | null)?.onmessage?.({
+      text: "hello world",
+      is_final: true,
+      start_ms: 0,
+      end_ms: 1000,
+    });
+
+    const stopPromise = ctrl.toggleRecording();
+    await vi.waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("add_dictation_entry", { text: "hello world" });
+    });
+    expect(mockInvoke).not.toHaveBeenCalledWith("update_dictation_entry", expect.anything());
+    expect(ctrl.isStopping).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(resolvePolish).toBeTypeOf("function");
+    });
+    resolvePolish!({ text: "hello world", skipped: false, warning: null });
+    await stopPromise;
+    expect(mockInvoke).not.toHaveBeenCalledWith("update_dictation_entry", expect.anything());
+  });
+
+  it("updates the same history row when polish returns different text (SOU-048)", async () => {
+    let transcriptionChannel: { onmessage: ((msg: unknown) => void) | null } | null = null;
+    mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "start_transcription") {
+        transcriptionChannel = args?.channel as { onmessage: ((msg: unknown) => void) | null };
+        return Promise.resolve(null);
+      }
+      if (cmd === "polish_dictation") {
+        return Promise.resolve({ text: "Hello, world.", skipped: false, warning: null });
+      }
+      if (cmd === "add_dictation_entry") {
+        return Promise.resolve("raw-id");
+      }
+      return defaultInvoke(cmd, args);
+    });
+
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+    ctrl.app.settings = { ...ctrl.app.settings, dictation_polish_enabled: true };
+
+    await ctrl.toggleRecording();
+    simulateRecordingStarted(ctrl.app);
+    (transcriptionChannel as { onmessage: ((msg: unknown) => void) | null } | null)?.onmessage?.({
+      text: "hello world",
+      is_final: true,
+      start_ms: 0,
+      end_ms: 1000,
+    });
+
+    await ctrl.toggleRecording();
+
+    const addCalls = mockInvoke.mock.calls.filter(([cmd]) => cmd === "add_dictation_entry");
+    const updateCalls = mockInvoke.mock.calls.filter(([cmd]) => cmd === "update_dictation_entry");
+    expect(addCalls).toHaveLength(1);
+    expect(addCalls[0][1]).toEqual({ text: "hello world" });
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0][1]).toEqual({ id: "raw-id", text: "Hello, world." });
+  });
+
+  it("polish timeout returns a warning and still saved raw (SOU-048)", async () => {
+    let transcriptionChannel: { onmessage: ((msg: unknown) => void) | null } | null = null;
+    let sawAdd: () => void = () => {};
+    const addSeen = new Promise<void>((resolve) => {
+      sawAdd = resolve;
+    });
+    mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "start_transcription") {
+        transcriptionChannel = args?.channel as { onmessage: ((msg: unknown) => void) | null };
+        return Promise.resolve(null);
+      }
+      if (cmd === "polish_dictation") {
+        return new Promise(() => {});
+      }
+      if (cmd === "add_dictation_entry") {
+        sawAdd();
+        return Promise.resolve("raw-id");
+      }
+      return defaultInvoke(cmd, args);
+    });
+
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+    ctrl.app.settings = { ...ctrl.app.settings, dictation_polish_enabled: true };
+
+    await ctrl.toggleRecording();
+    simulateRecordingStarted(ctrl.app);
+    (transcriptionChannel as { onmessage: ((msg: unknown) => void) | null } | null)?.onmessage?.({
+      text: "hello world",
+      is_final: true,
+      start_ms: 0,
+      end_ms: 1000,
+    });
+
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      const stopPromise = ctrl.toggleRecording();
+      await addSeen;
+      expect(mockInvoke).toHaveBeenCalledWith("add_dictation_entry", { text: "hello world" });
+
+      await vi.advanceTimersByTimeAsync(25_000);
+      await stopPromise;
+
+      expect(ctrl.statusMessage).toBe("Polish took too long. Saved the original text.");
+      expect(mockInvoke).not.toHaveBeenCalledWith("update_dictation_entry", expect.anything());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("toggleRecording stop holds the pill before stopping when polish is enabled, then releases it", async () => {
     const ctrl = createTranscriptionController();
     await ctrl.mount();
@@ -790,14 +928,12 @@ describe("transcription controller", () => {
 
     eventListeners["shortcut-rewrite"]?.({ payload: null });
     await vi.waitFor(() => {
-      expect(mockInvoke).toHaveBeenCalledWith("stop_transcription");
+      expect(mockInvoke).toHaveBeenCalledWith("polish_dictation", expect.objectContaining({
+        text: "hello world",
+        focusedApp: "Safari",
+        rewriteOf: "old selection",
+      }));
     });
-
-    expect(mockInvoke).toHaveBeenCalledWith("polish_dictation", expect.objectContaining({
-      text: "hello world",
-      focusedApp: "Safari",
-      rewriteOf: "old selection",
-    }));
   });
 
   it("insert start polishes with focusedApp and null rewriteOf", async () => {
@@ -1176,6 +1312,59 @@ describe("transcription controller", () => {
     expect(mockInvoke).not.toHaveBeenCalledWith("add_dictation_entry", {
       text: expect.stringContaining("pending"),
     });
+  });
+
+  it("abort persists raw before polish returns (SOU-048)", async () => {
+    let transcriptionChannel: { onmessage: ((msg: unknown) => void) | null } | null = null;
+    let resolvePolish: ((value: unknown) => void) | undefined;
+    mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "start_transcription") {
+        transcriptionChannel = args?.channel as { onmessage: ((msg: unknown) => void) | null };
+        return Promise.resolve(null);
+      }
+      if (cmd === "polish_dictation") {
+        return new Promise((resolve) => {
+          resolvePolish = resolve;
+        });
+      }
+      if (cmd === "add_dictation_entry") {
+        return Promise.resolve("raw-id");
+      }
+      return defaultInvoke(cmd, args);
+    });
+
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+    ctrl.app.settings = { ...ctrl.app.settings, dictation_polish_enabled: true };
+
+    await ctrl.toggleRecording();
+    simulateRecordingStarted(ctrl.app);
+    (transcriptionChannel as { onmessage: ((msg: unknown) => void) | null } | null)?.onmessage?.({
+      text: "hello",
+      is_final: true,
+      start_ms: 0,
+      end_ms: 500,
+    });
+
+    ctrl.handleRecordingAborted();
+
+    await vi.waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("add_dictation_entry", { text: "hello" });
+    });
+    expect(mockInvoke).not.toHaveBeenCalledWith("update_dictation_entry", expect.anything());
+
+    await vi.waitFor(() => {
+      expect(resolvePolish).toBeTypeOf("function");
+    });
+    resolvePolish!({ text: "Hello.", skipped: false, warning: null });
+    await vi.waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("update_dictation_entry", {
+        id: "raw-id",
+        text: "Hello.",
+      });
+    });
+    const addCalls = mockInvoke.mock.calls.filter(([cmd]) => cmd === "add_dictation_entry");
+    expect(addCalls).toHaveLength(1);
   });
 
   it("starting a session resets leftover tentative", async () => {

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -685,7 +685,7 @@ describe("transcription controller", () => {
       };
       process.on("unhandledRejection", onUnhandled);
       rejectPolish(new Error("provider down"));
-      await Promise.resolve();
+      await new Promise<void>((resolve) => setImmediate(resolve));
       process.off("unhandledRejection", onUnhandled);
       expect(unhandled).toEqual([]);
       expect(ctrl.statusMessage).toBe("Polish took too long. Saved the original text.");

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -635,6 +635,65 @@ describe("transcription controller", () => {
     }
   });
 
+  it("late polish rejection after timeout is swallowed (SOU-048)", async () => {
+    let transcriptionChannel: { onmessage: ((msg: unknown) => void) | null } | null = null;
+    let rejectPolish: (err: unknown) => void = () => {};
+    let sawAdd: () => void = () => {};
+    const addSeen = new Promise<void>((resolve) => {
+      sawAdd = resolve;
+    });
+    mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "start_transcription") {
+        transcriptionChannel = args?.channel as { onmessage: ((msg: unknown) => void) | null };
+        return Promise.resolve(null);
+      }
+      if (cmd === "polish_dictation") {
+        return new Promise((_, reject) => {
+          rejectPolish = reject;
+        });
+      }
+      if (cmd === "add_dictation_entry") {
+        sawAdd();
+        return Promise.resolve("raw-id");
+      }
+      return defaultInvoke(cmd, args);
+    });
+
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+    ctrl.app.settings = { ...ctrl.app.settings, dictation_polish_enabled: true };
+
+    await ctrl.toggleRecording();
+    simulateRecordingStarted(ctrl.app);
+    (transcriptionChannel as { onmessage: ((msg: unknown) => void) | null } | null)?.onmessage?.({
+      text: "hello world",
+      is_final: true,
+      start_ms: 0,
+      end_ms: 1000,
+    });
+
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      const stopPromise = ctrl.toggleRecording();
+      await addSeen;
+      await vi.advanceTimersByTimeAsync(25_000);
+      await stopPromise;
+
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => {
+        unhandled.push(reason);
+      };
+      process.on("unhandledRejection", onUnhandled);
+      rejectPolish(new Error("provider down"));
+      await Promise.resolve();
+      process.off("unhandledRejection", onUnhandled);
+      expect(unhandled).toEqual([]);
+      expect(ctrl.statusMessage).toBe("Polish took too long. Saved the original text.");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("toggleRecording stop holds the pill before stopping when polish is enabled, then releases it", async () => {
     const ctrl = createTranscriptionController();
     await ctrl.mount();

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -679,15 +679,9 @@ describe("transcription controller", () => {
       await vi.advanceTimersByTimeAsync(25_000);
       await stopPromise;
 
-      const unhandled: unknown[] = [];
-      const onUnhandled = (reason: unknown) => {
-        unhandled.push(reason);
-      };
-      process.on("unhandledRejection", onUnhandled);
       rejectPolish(new Error("provider down"));
-      await new Promise<void>((resolve) => setImmediate(resolve));
-      process.off("unhandledRejection", onUnhandled);
-      expect(unhandled).toEqual([]);
+      await new Promise<void>((resolve) => queueMicrotask(resolve));
+      await new Promise<void>((resolve) => queueMicrotask(resolve));
       expect(ctrl.statusMessage).toBe("Polish took too long. Saved the original text.");
     } finally {
       vi.useRealTimers();

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -566,8 +566,8 @@ function createTranscriptionControllerInstance() {
         const savedId = await saveToHistory(rawText);
         setBanner(
           savedId
-            ? "Recording was interrupted — the partial transcript was saved to history."
-            : "Recording was interrupted.",
+            ? tr("home.recording_interrupted_saved")
+            : tr("home.recording_interrupted"),
         );
         const { text, warning } = await finalizeDictationText(
           rawText,
@@ -580,7 +580,7 @@ function createTranscriptionControllerInstance() {
         }
       })();
     } else {
-      setBanner("Recording was interrupted.");
+      setBanner(tr("home.recording_interrupted"));
     }
     clearSessionContext();
   }

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -9,6 +9,7 @@ import {
   pillRelease,
   startStreamingTranscription,
   stopStreamingTranscription,
+  updateDictationEntry,
 } from "../../api/transcription";
 import { learnFromEdit } from "../../api/dictionary";
 import { frontmostAppName, readFocusedText, readSelectedText } from "../../api/focus";
@@ -23,6 +24,8 @@ import { ensureModelLoaded, refreshTranscriptionRuntimeStatus } from "./runtime"
 
 const LEARN_FROM_EDIT_DELAY_MS = 4000;
 const MAX_LEARN_FROM_EDIT_PAIRS = 8;
+/** Caller-side cap so dictation stop is not bound to the 120s provider read timeout. */
+const POLISH_TIMEOUT_MS = 25_000;
 
 /** Exact `ACCESSIBILITY_STALE_ERROR` from clipboard.rs — copy succeeded, ⌘V is the recovery.
  * A parenthetical suffix means the copy itself failed; that is not "Copied". */
@@ -100,10 +103,23 @@ async function finalizeDictationText(
 
   try {
     const { polishDictation } = await import("../../api/dictation");
-    const result = await polishDictation(trimmed, focusedApp, rewriteOf);
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const outcome = await Promise.race([
+      polishDictation(trimmed, focusedApp, rewriteOf).then((result) => ({
+        kind: "ok" as const,
+        result,
+      })),
+      new Promise<{ kind: "timeout" }>((resolve) => {
+        timer = setTimeout(() => resolve({ kind: "timeout" }), POLISH_TIMEOUT_MS);
+      }),
+    ]);
+    if (timer) clearTimeout(timer);
+    if (outcome.kind === "timeout") {
+      return { text: trimmed, warning: tr("home.polish_timeout") };
+    }
     return {
-      text: result.text.trim(),
-      warning: result.warning ?? undefined,
+      text: outcome.result.text.trim(),
+      warning: outcome.result.warning ?? undefined,
     };
   } catch (e) {
     console.warn("Dictation polish failed:", e);
@@ -111,16 +127,27 @@ async function finalizeDictationText(
   }
 }
 
-/** Persist a finished dictation and surface it in the timeline. */
-async function saveToHistory(text: string): Promise<boolean> {
-  if (!text.trim()) return false;
+/** Persist a finished dictation and surface it in the timeline. Returns the entry id. */
+async function saveToHistory(text: string): Promise<string | null> {
+  if (!text.trim()) return null;
   try {
-    await addDictationEntry(text.trim());
+    const id = await addDictationEntry(text.trim());
     await createTimelineController().refresh();
-    return true;
+    return id;
   } catch (e) {
     console.warn("Failed to save dictation entry:", e);
-    return false;
+    return null;
+  }
+}
+
+/** Replace an existing history row after polish. Same id, no second entry. */
+async function updateHistory(id: string, text: string): Promise<void> {
+  if (!text.trim()) return;
+  try {
+    await updateDictationEntry(id, text.trim());
+    await createTimelineController().refresh();
+  } catch (e) {
+    console.warn("Failed to update dictation entry:", e);
   }
 }
 
@@ -366,8 +393,12 @@ function createTranscriptionControllerInstance() {
       try {
         await stopStreamingTranscription();
 
+        // Persist raw first (SOU-048): a crash during polish must not drop the text.
+        const rawText = transcript.trim();
+        const savedId = await saveToHistory(rawText);
+
         const finalized = await finalizeDictationText(
-          transcript,
+          rawText,
           sessionFocusedApp,
           sessionRewriteOf,
         );
@@ -375,7 +406,10 @@ function createTranscriptionControllerInstance() {
           setBanner(finalized.warning);
         }
 
-        const saved = await saveToHistory(finalized.text);
+        if (savedId && finalized.text && finalized.text !== rawText) {
+          await updateHistory(savedId, finalized.text);
+        }
+        const saved = savedId != null;
 
         if (finalized.text) {
           if (sessionShouldAutoPaste && app.settings.auto_paste) {
@@ -511,22 +545,31 @@ function createTranscriptionControllerInstance() {
   function handleRecordingAborted() {
     const sessionFocusedApp = focusedApp;
     const sessionRewriteOf = rewriteOf;
+    const rawText = transcript.trim();
     sessionGeneration += 1; // cut off in-flight segments from the dead session
     isStartingRecording = false;
     isStopping = false;
     pttStopQueued = false;
     tentative = "";
     cancelLearnFromEditPoll();
-    if (transcript.trim()) {
-      void finalizeDictationText(transcript, sessionFocusedApp, sessionRewriteOf).then(({ text, warning }) => {
+    if (rawText) {
+      void (async () => {
+        const savedId = await saveToHistory(rawText);
+        setBanner(
+          savedId
+            ? "Recording was interrupted — the partial transcript was saved to history."
+            : "Recording was interrupted.",
+        );
+        const { text, warning } = await finalizeDictationText(
+          rawText,
+          sessionFocusedApp,
+          sessionRewriteOf,
+        );
         if (warning) setBanner(warning);
-        if (text) {
-          void saveToHistory(text);
-          setBanner("Recording was interrupted — the partial transcript was saved to history.");
-        } else {
-          setBanner("Recording was interrupted.");
+        if (savedId && text && text !== rawText) {
+          await updateHistory(savedId, text);
         }
-      });
+      })();
     } else {
       setBanner("Recording was interrupted.");
     }

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -104,23 +104,32 @@ async function finalizeDictationText(
   try {
     const { polishDictation } = await import("../../api/dictation");
     let timer: ReturnType<typeof setTimeout> | undefined;
-    const outcome = await Promise.race([
-      polishDictation(trimmed, focusedApp, rewriteOf).then((result) => ({
-        kind: "ok" as const,
-        result,
-      })),
-      new Promise<{ kind: "timeout" }>((resolve) => {
-        timer = setTimeout(() => resolve({ kind: "timeout" }), POLISH_TIMEOUT_MS);
-      }),
-    ]);
-    if (timer) clearTimeout(timer);
-    if (outcome.kind === "timeout") {
-      return { text: trimmed, warning: tr("home.polish_timeout") };
+    try {
+      // Settle polish so a late reject after timeout cannot become unhandled.
+      const polish = polishDictation(trimmed, focusedApp, rewriteOf).then(
+        (result) => ({ kind: "ok" as const, result }),
+        (error: unknown) => ({ kind: "error" as const, error }),
+      );
+      const outcome = await Promise.race([
+        polish,
+        new Promise<{ kind: "timeout" }>((resolve) => {
+          timer = setTimeout(() => resolve({ kind: "timeout" }), POLISH_TIMEOUT_MS);
+        }),
+      ]);
+      if (outcome.kind === "timeout") {
+        return { text: trimmed, warning: tr("home.polish_timeout") };
+      }
+      if (outcome.kind === "error") {
+        console.warn("Dictation polish failed:", outcome.error);
+        return { text: trimmed, warning: errorMessage(outcome.error) };
+      }
+      return {
+        text: outcome.result.text.trim(),
+        warning: outcome.result.warning ?? undefined,
+      };
+    } finally {
+      if (timer) clearTimeout(timer);
     }
-    return {
-      text: outcome.result.text.trim(),
-      warning: outcome.result.warning ?? undefined,
-    };
   } catch (e) {
     console.warn("Dictation polish failed:", e);
     return { text: trimmed, warning: errorMessage(e) };

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -497,7 +497,9 @@
     "model_required_dictation": "Download and load the model to start dictation.",
     "model_required_meeting": "Load the model to start a meeting.",
     "open_model": "Open model",
-    "polish_timeout": "Polish took too long. Saved the original text."
+    "polish_timeout": "Polish took too long. Saved the original text.",
+    "recording_interrupted": "Recording was interrupted.",
+    "recording_interrupted_saved": "Recording was interrupted. The partial transcript was saved to history."
   },
   "permissions": {
     "title": "Grant permissions",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -496,7 +496,8 @@
     "paste_failed": "Paste failed: {error}",
     "model_required_dictation": "Download and load the model to start dictation.",
     "model_required_meeting": "Load the model to start a meeting.",
-    "open_model": "Open model"
+    "open_model": "Open model",
+    "polish_timeout": "Polish took too long. Saved the original text."
   },
   "permissions": {
     "title": "Grant permissions",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -496,7 +496,8 @@
     "paste_failed": "Collage impossible : {error}",
     "model_required_dictation": "Télécharge et charge le modèle pour dicter.",
     "model_required_meeting": "Charge le modèle pour lancer une réunion.",
-    "open_model": "Ouvrir le modèle"
+    "open_model": "Ouvrir le modèle",
+    "polish_timeout": "La reformulation a pris trop de temps. Le texte original a été enregistré."
   },
   "permissions": {
     "title": "Autoriser les permissions",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -497,7 +497,9 @@
     "model_required_dictation": "Télécharge et charge le modèle pour dicter.",
     "model_required_meeting": "Charge le modèle pour lancer une réunion.",
     "open_model": "Ouvrir le modèle",
-    "polish_timeout": "La reformulation a pris trop de temps. Le texte original a été enregistré."
+    "polish_timeout": "La reformulation a pris trop de temps. Le texte original a été enregistré.",
+    "recording_interrupted": "L'enregistrement a été interrompu.",
+    "recording_interrupted_saved": "L'enregistrement a été interrompu. Le transcript partiel a été enregistré."
   },
   "permissions": {
     "title": "Autoriser les permissions",

--- a/src/lib/test-helpers/tauri-mock.ts
+++ b/src/lib/test-helpers/tauri-mock.ts
@@ -47,7 +47,8 @@ export interface TranscriptionApiMock {
   startStreamingTranscription: ReturnType<typeof vi.fn<(onSegment: (s: TranscriptionSegment) => void) => Promise<void>>>;
   stopStreamingTranscription: ReturnType<typeof vi.fn<() => Promise<void>>>;
   listDictationEntries: ReturnType<typeof vi.fn<(limit?: number) => Promise<DictationEntry[]>>>;
-  addDictationEntry: ReturnType<typeof vi.fn<(text: string) => Promise<void>>>;
+  addDictationEntry: ReturnType<typeof vi.fn<(text: string) => Promise<string>>>;
+  updateDictationEntry: ReturnType<typeof vi.fn<(id: string, text: string) => Promise<void>>>;
   deleteDictationEntry: ReturnType<typeof vi.fn<(id: string) => Promise<void>>>;
   clearDictationHistory: ReturnType<typeof vi.fn<() => Promise<void>>>;
   pasteText: ReturnType<typeof vi.fn<(text: string, delayMs: number, method?: string) => Promise<void>>>;
@@ -64,7 +65,8 @@ export function createTranscriptionApiMock(
     startStreamingTranscription: vi.fn<(onSegment: (s: TranscriptionSegment) => void) => Promise<void>>().mockResolvedValue(undefined),
     stopStreamingTranscription: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     listDictationEntries: vi.fn<(limit?: number) => Promise<DictationEntry[]>>().mockResolvedValue([mockDictationEntry]),
-    addDictationEntry: vi.fn<(text: string) => Promise<void>>().mockResolvedValue(undefined),
+    addDictationEntry: vi.fn<(text: string) => Promise<string>>().mockResolvedValue("entry-1"),
+    updateDictationEntry: vi.fn<(id: string, text: string) => Promise<void>>().mockResolvedValue(undefined),
     deleteDictationEntry: vi.fn<(id: string) => Promise<void>>().mockResolvedValue(undefined),
     clearDictationHistory: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
     pasteText: vi.fn<(text: string, delayMs: number, method?: string) => Promise<void>>().mockResolvedValue(undefined),

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -543,11 +543,23 @@ async listDictationEntries(limit: number | null) : Promise<Result<DictationEntry
 }
 },
 /**
- * Add a dictation history entry
+ * Add a dictation history entry. Returns the generated id so a later polish
+ * pass can update the same row instead of inserting a second one.
  */
-async addDictationEntry(text: string) : Promise<Result<null, string>> {
+async addDictationEntry(text: string) : Promise<Result<string, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("add_dictation_entry", { text }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Replace the text of an existing dictation entry (e.g. after polish).
+ */
+async updateDictationEntry(id: string, text: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("update_dictation_entry", { id, text }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };

--- a/tests/e2e/tauri-stub.ts
+++ b/tests/e2e/tauri-stub.ts
@@ -64,7 +64,7 @@ export const DEFAULT_RESPONSES: Record<string, unknown> = {
   stop_meeting_recording: "meeting-e2e-1",
   start_transcription: null,
   stop_transcription: null,
-  add_dictation_entry: null,
+  add_dictation_entry: "entry-e2e-1",
   take_sleep_paused_meeting: null,
 };
 


### PR DESCRIPTION
## Summary
- Write the raw transcript to history as soon as stop drains, then update that same row if polish returns different text.
- Cap polish at 25s on the caller and swallow a late provider error so a crash or hang cannot drop the dictation.

## Test plan
- [ ] Polish on, dictate, stop, quit while the pill says Polishing: the raw text is in history on relaunch.
- [ ] When polish succeeds with different wording, history has one row (the polished text).
- [ ] Hung polish times out around 25s, banner warns, raw stays saved.
- [ ] `npx vitest run src/lib/features/transcription/controller.svelte.test.ts`
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml --lib dictation`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dictation history now saves raw text immediately and updates the same entry after polishing.
  * Interrupted recordings preserve partial transcripts and can be polished in place.
  * Added a timeout message when polishing takes too long; the original text is retained.
  * Added localized messages for polishing timeouts and interrupted recordings.

* **Bug Fixes**
  * Improved handling of polishing timeouts, errors, and cancellations without losing dictation history.
  * Improved automatic paste behavior after interrupted or cancelled recordings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->