### PR TITLE
Fix HUD Stop clicks, black rim, and polish prompt leakage

### DIFF
--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -152,6 +152,8 @@ Rules:
 - Preserve the speaker's intent and original language. Do not translate.
 - Restore the conventional spelling of technical terms, proper nouns, and anglicisms when it is obvious.
 - Do not add content. Do not rewrite for style. Do not greet or comment.
+- If the dictation is incomplete, leave it incomplete. Do not finish the speaker's sentence.
+- Never copy labels, fences, or lines such as \"Target app:\" into the output.
 
 Repairs look like this:
 \"petit maitre a jour également les document confluence s'il te plait\" becomes \"Peux-tu mettre à jour également les documents Confluence s'il te plaît ?\"

--- a/src-tauri/src/pill.rs
+++ b/src-tauri/src/pill.rs
@@ -30,7 +30,7 @@ use crate::app_events::{
 use crate::db::Database;
 use crate::settings::PILL_POSITION_KEY;
 use crate::state::AppState;
-use crate::state_machine::AppStateMachine;
+use crate::state_machine::{AppStateMachine, RecordingKind};
 
 // ---------------------------------------------------------------------------
 // FFI (pill_bridge.h / pill_panel.swift)
@@ -135,29 +135,66 @@ pub fn create_panel(app: &AppHandle) {
 fn install_stop_callback(app: AppHandle) {
     STOP_APP_HANDLE.set(std::sync::Mutex::new(Some(app))).ok();
 
-    unsafe extern "C" fn on_stop(recording_mode: i32) {
-        let Some(guard) = STOP_APP_HANDLE.get() else {
-            return;
-        };
-        let Ok(guard) = guard.lock() else {
-            return;
-        };
-        let Some(app) = guard.as_ref() else {
-            return;
+    unsafe extern "C" fn on_stop(_recording_mode: i32) {
+        let app = {
+            let Some(guard) = STOP_APP_HANDLE.get() else {
+                return;
+            };
+            let Ok(guard) = guard.lock() else {
+                return;
+            };
+            let Some(app) = guard.as_ref() else {
+                return;
+            };
+            app.clone()
         };
 
-        if recording_mode == PillPanelMode::Meeting as i32 {
-            let _ = MeetingStopRequested.emit(app);
-        } else {
-            // Stop-only. Never ShortcutToggle: that can start a new dictation
-            // or (historically) take down a meeting (SOU-044 / SOU-046).
-            let _ = DictationStopRequested.emit(app);
+        let Ok(machine) = app.state::<AppState>().current_machine_state() else {
+            return;
+        };
+        // Trust the machine, not Swift's latched mode. A stale dictation
+        // mode during a meeting made HUD Stop a no-op (logs: session 8
+        // died without ever seeing stop_meeting_recording).
+        match hud_stop_target(&machine) {
+            Some(HudStopTarget::Meeting) => {
+                tracing::info!("HUD stop routed to meeting");
+                let _ = MeetingStopRequested.emit(&app);
+            }
+            Some(HudStopTarget::Dictation) => {
+                tracing::info!("HUD stop routed to dictation");
+                let _ = DictationStopRequested.emit(&app);
+            }
+            None => {
+                tracing::info!("HUD stop ignored (not recording)");
+            }
         }
     }
 
     // SAFETY: `on_stop` is a plain C function pointer; Swift may call it
     // from the main thread. AppHandle is Send + Sync.
     unsafe { pill_panel_set_stop_callback(Some(on_stop)) };
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HudStopTarget {
+    Meeting,
+    Dictation,
+}
+
+fn hud_stop_target(machine: &AppStateMachine) -> Option<HudStopTarget> {
+    match machine {
+        AppStateMachine::RecordingMeeting { .. }
+        | AppStateMachine::Stopping {
+            was_recording: RecordingKind::Meeting { .. },
+            ..
+        } => Some(HudStopTarget::Meeting),
+        AppStateMachine::RecordingDictation { .. }
+        | AppStateMachine::Stopping {
+            was_recording: RecordingKind::Dictation,
+            ..
+        } => Some(HudStopTarget::Dictation),
+        _ => None,
+    }
 }
 
 static STOP_APP_HANDLE: std::sync::OnceLock<std::sync::Mutex<Option<AppHandle>>> =
@@ -520,6 +557,47 @@ mod tests {
         assert_eq!(custom_origin(), Some((100.5, 200.25)));
         set_hidden(false);
         store_custom_origin(None);
+    }
+
+    #[test]
+    fn hud_stop_follows_the_machine_not_swift_mode() {
+        let profile = crate::engine::TranscriptionProfile::default();
+        assert_eq!(
+            hud_stop_target(&AppStateMachine::RecordingMeeting {
+                profile: profile.clone(),
+                session_id: 1,
+                meeting_id: "m1".into(),
+            }),
+            Some(HudStopTarget::Meeting)
+        );
+        assert_eq!(
+            hud_stop_target(&AppStateMachine::Stopping {
+                profile: profile.clone(),
+                was_recording: RecordingKind::Meeting {
+                    meeting_id: "m1".into(),
+                },
+            }),
+            Some(HudStopTarget::Meeting)
+        );
+        assert_eq!(
+            hud_stop_target(&AppStateMachine::RecordingDictation {
+                profile: profile.clone(),
+                session_id: 1,
+            }),
+            Some(HudStopTarget::Dictation)
+        );
+        assert_eq!(
+            hud_stop_target(&AppStateMachine::Stopping {
+                profile: profile.clone(),
+                was_recording: RecordingKind::Dictation,
+            }),
+            Some(HudStopTarget::Dictation)
+        );
+        assert_eq!(
+            hud_stop_target(&AppStateMachine::Ready { profile }),
+            None,
+            "a zombie HUD click after stop must not start a session"
+        );
     }
 
     #[test]

--- a/src-tauri/src/summary/ollama.rs
+++ b/src-tauri/src/summary/ollama.rs
@@ -53,11 +53,12 @@ pub const REDUCE_BUDGET: GenerationBudget = GenerationBudget {
 /// Polish rewrites its input, so its output length tracks the input's. A fixed
 /// bound would cut a long dictation off mid-sentence, which is worse than the
 /// unbounded generation this guard rail replaces. Twice the input estimate
-/// leaves room for the punctuation and formatting polish adds.
+/// leaves room for the punctuation and formatting polish adds. The floor used
+/// to be 512, which on a 10-word greeting was an invitation to invent a speech.
 pub fn polish_budget(input_tokens: usize) -> GenerationBudget {
     GenerationBudget {
         num_ctx: REDUCE_BUDGET.num_ctx,
-        num_predict: input_tokens.saturating_mul(2).clamp(512, 8192) as u32,
+        num_predict: input_tokens.saturating_mul(2).clamp(96, 8192) as u32,
     }
 }
 
@@ -812,7 +813,7 @@ mod tests {
         // A long dictation must not be cut off mid-sentence.
         assert_eq!(polish_budget(3000).num_predict, 6000);
         // A one-line dictation still gets room for punctuation and casing.
-        assert_eq!(polish_budget(1).num_predict, 512);
+        assert_eq!(polish_budget(1).num_predict, 96);
         // Bounded, so a runaway cannot reach the context window.
         assert!(polish_budget(usize::MAX).num_predict < REDUCE_BUDGET.num_ctx);
     }

--- a/src-tauri/src/summary/polish.rs
+++ b/src-tauri/src/summary/polish.rs
@@ -331,16 +331,21 @@ pub fn build_polish_user_prompt(
     focused_app: Option<&str>,
     rewrite_of: Option<&str>,
 ) -> String {
-    let mut prompt = format!(
-        "Instructions:\n{}\n\nDictation transcript:\n---\n{}\n---",
-        template_prompt.trim(),
-        transcript.trim()
+    // Context first, transcript last, nothing after. Putting "Target app:"
+    // after the transcript made Apple Intelligence echo it (or keep writing).
+    let mut prompt = String::from(
+        "Reply with the cleaned dictation only. No labels, no markdown fences, no commentary.\n\n",
     );
+    prompt.push_str("Instructions:\n");
+    prompt.push_str(template_prompt.trim());
     if let Some(vocab) = format_dictionary_vocabulary(dictionary) {
         prompt.push_str("\n\n");
         prompt.push_str(&vocab);
     }
-    if let Some(name) = focused_app.map(str::trim).filter(|name| !name.is_empty()) {
+    if let Some(name) = focused_app
+        .map(str::trim)
+        .filter(|name| !name.is_empty() && !is_own_app_name(name))
+    {
         prompt.push_str("\n\n");
         prompt.push_str("Target app: ");
         prompt.push_str(name);
@@ -352,9 +357,103 @@ pub fn build_polish_user_prompt(
         prompt.push_str("\n\n");
         prompt.push_str("Rewrite this selected text (replace it; keep meaning unless the dictation changes it):\n---\n");
         prompt.push_str(selection);
-        prompt.push_str("\n---\nThe dictation transcript is the user's spoken rewrite instructions. Output only the rewritten selection.");
+        prompt.push_str("\n---\nThe dictation transcript below is the user's spoken rewrite instructions. Output only the rewritten selection.");
     }
+    prompt.push_str("\n\nDictation transcript:\n---\n");
+    prompt.push_str(transcript.trim());
+    prompt.push_str("\n---");
     prompt
+}
+
+/// Localized names of this app. Matching Mail's tone is useful; matching
+/// Soufflé's is not, and it is what the model echoed when polish ran from
+/// the main window.
+fn is_own_app_name(name: &str) -> bool {
+    let folded: String = name
+        .trim()
+        .chars()
+        .map(|c| match c {
+            'é' | 'É' => 'e',
+            other => other,
+        })
+        .collect();
+    folded.eq_ignore_ascii_case("souffle")
+}
+
+const PROMPT_LEAK_MARKERS: &[&str] = &[
+    "Target app:",
+    "Match that app's usual tone",
+    "Do not mention the app name",
+    "Dictation transcript:",
+    "Preferred spellings / vocabulary:",
+    "Rewrite this selected text",
+    "The dictation transcript below is the user's spoken rewrite instructions",
+    "The dictation transcript is the user's spoken rewrite instructions",
+    "Reply with the cleaned dictation only",
+    "Instructions:",
+];
+
+fn find_ignore_ascii_case(hay: &str, needle: &str) -> Option<usize> {
+    hay.to_ascii_lowercase().find(&needle.to_ascii_lowercase())
+}
+
+/// Drop instruction text the model copied out of the user prompt. Markers
+/// that were actually dictated are left alone.
+fn strip_prompt_leakage(output: &str, transcript: &str) -> String {
+    let mut cut = output.len();
+    for marker in PROMPT_LEAK_MARKERS {
+        if find_ignore_ascii_case(transcript, marker).is_some() {
+            continue;
+        }
+        if let Some(idx) = find_ignore_ascii_case(output, marker) {
+            cut = cut.min(idx);
+        }
+    }
+    if find_ignore_ascii_case(transcript, "---").is_none() {
+        let mut offset = 0;
+        for line in output.split_inclusive('\n') {
+            if line.trim_end_matches(['\n', '\r']).trim() == "---" {
+                cut = cut.min(offset);
+                break;
+            }
+            offset += line.len();
+        }
+    }
+    let mut kept = output.get(..cut).unwrap_or(output).trim().to_string();
+    while let Some(stripped) = kept.strip_suffix("---") {
+        kept = stripped.trim_end().to_string();
+    }
+    kept
+}
+
+fn word_count(text: &str) -> usize {
+    text.split_whitespace()
+        .filter(|word| word.chars().any(char::is_alphanumeric))
+        .count()
+}
+
+fn expanded_too_much(input: &str, output: &str) -> bool {
+    let inn = word_count(input);
+    let out = word_count(output);
+    out > inn.saturating_add(inn / 2).saturating_add(8)
+}
+
+/// Clean / no-fillers must not invent a closing. If the model added a new
+/// paragraph, keep the first one when it still matches the dictation length.
+fn clamp_polish_expansion(template_id: &str, input: &str, output: &str) -> String {
+    if !matches!(template_id, TEMPLATE_CLEAN | TEMPLATE_NO_FILLERS) {
+        return output.to_string();
+    }
+    if !expanded_too_much(input, output) {
+        return output.to_string();
+    }
+    if let Some((first, rest)) = output.split_once("\n\n") {
+        let first = first.trim();
+        if !first.is_empty() && !rest.trim().is_empty() && !expanded_too_much(input, first) {
+            return first.to_string();
+        }
+    }
+    input.trim().to_string()
 }
 
 fn format_dictionary_vocabulary(entries: &[DictionaryEntry]) -> Option<String> {
@@ -489,11 +588,25 @@ pub async fn polish_dictation_text(
     };
 
     match parse_polish_response(&raw) {
-        Ok(text) => DictationPolishResult {
-            text: super::formatters::apply_post_polish_formatters(&text),
-            skipped: false,
-            warning: None,
-        },
+        Ok(text) => {
+            let text = super::formatters::apply_post_polish_formatters(&text);
+            let text = strip_prompt_leakage(&text, &stripped);
+            let basis = polish_output_basis(&stripped, rewrite_of);
+            let text = clamp_polish_expansion(template.id.as_str(), basis, &text);
+            if text.trim().is_empty() {
+                DictationPolishResult {
+                    text: stripped.trim().to_string(),
+                    skipped: false,
+                    warning: Some("Dictation polish returned empty text".into()),
+                }
+            } else {
+                DictationPolishResult {
+                    text,
+                    skipped: false,
+                    warning: None,
+                }
+            }
+        }
         Err(err) => DictationPolishResult {
             text: stripped.trim().to_string(),
             skipped: false,
@@ -506,9 +619,10 @@ pub async fn polish_dictation_text(
 mod tests {
     use super::{
         SUPERSEDED_CLEAN_PROMPTS, TEMPLATE_BULLETS, TEMPLATE_CLEAN, TEMPLATE_EMAIL,
-        TEMPLATE_NO_FILLERS, build_polish_user_prompt, default_polish_templates,
-        early_polish_dictation_result, effective_template_prompt, is_blank_for_polish,
-        merge_polish_templates, parse_polish_response, polish_output_basis, strip_invisible_chars,
+        TEMPLATE_NO_FILLERS, build_polish_user_prompt, clamp_polish_expansion,
+        default_polish_templates, early_polish_dictation_result, effective_template_prompt,
+        is_blank_for_polish, is_own_app_name, merge_polish_templates, parse_polish_response,
+        polish_output_basis, strip_invisible_chars, strip_prompt_leakage,
         superseded_default_prompts,
     };
     use crate::filter::DictionaryEntry;
@@ -733,6 +847,59 @@ mod tests {
             "Match that app's usual tone and formatting conventions. Do not mention the app name in the output."
         ));
         assert!(!prompt.contains("Rewrite this selected text"));
+        let target_at = prompt.find("Target app: Mail").unwrap();
+        let transcript_at = prompt.find("Dictation transcript:").unwrap();
+        assert!(
+            target_at < transcript_at,
+            "target-app context must precede the transcript so the model cannot echo it"
+        );
+    }
+
+    #[test]
+    fn build_polish_user_prompt_omits_souffle_as_target_app() {
+        for name in ["Soufflé", "Souffle", "soufflé", " souffle "] {
+            let prompt = build_polish_user_prompt("Clean this", "hello", &[], Some(name), None);
+            assert!(
+                !prompt.contains("Target app:"),
+                "own app {name:?} must not be injected as polish context"
+            );
+        }
+        assert!(is_own_app_name("Soufflé"));
+        assert!(!is_own_app_name("Mail"));
+    }
+
+    #[test]
+    fn strip_prompt_leakage_drops_echoed_target_app_block() {
+        let transcript = "Bonjour mesdames et messieurs, chers enfants,";
+        let leaked = "Bonjour mesdames et messieurs, chers enfants,\n\n---\n\nTarget app: Soufflé\nMatch that app's usual tone and formatting conventions. Do not mention the app name in the output.";
+        assert_eq!(strip_prompt_leakage(leaked, transcript), transcript);
+    }
+
+    #[test]
+    fn strip_prompt_leakage_keeps_a_dictated_target_app_line() {
+        let transcript = "Target app: Mail\nPlease send this";
+        let output = "Target app: Mail\nPlease send this.";
+        assert_eq!(strip_prompt_leakage(output, transcript), output);
+    }
+
+    #[test]
+    fn clamp_polish_expansion_keeps_the_first_paragraph() {
+        let input = "Bonjour mesdames et messieurs, chers enfants,";
+        let output = "Bonjour, mesdames et messieurs, chers enfants,\n\nChers enfants, je vous souhaite une excellente journée. Je vous remercie pour votre attention et votre participation.";
+        assert_eq!(
+            clamp_polish_expansion(TEMPLATE_CLEAN, input, output),
+            "Bonjour, mesdames et messieurs, chers enfants,"
+        );
+    }
+
+    #[test]
+    fn clamp_polish_expansion_does_not_touch_email_template() {
+        let input = "hello";
+        let output = "Subject: Hello\n\nHello,\n\nI wanted to follow up.\n\nBest regards";
+        assert_eq!(
+            clamp_polish_expansion(TEMPLATE_EMAIL, input, output),
+            output
+        );
     }
 
     #[test]
@@ -749,7 +916,7 @@ mod tests {
         ));
         assert!(prompt.contains("---\nThe original paragraph.\n---"));
         assert!(prompt.contains(
-            "The dictation transcript is the user's spoken rewrite instructions. Output only the rewritten selection."
+            "The dictation transcript below is the user's spoken rewrite instructions. Output only the rewritten selection."
         ));
         assert!(!prompt.contains("Target app:"));
     }

--- a/src-tauri/swift/pill_panel.swift
+++ b/src-tauri/swift/pill_panel.swift
@@ -44,6 +44,22 @@ private func onMain(_ body: @escaping () -> Void) {
     }
 }
 
+/// Stretchable rounded-rect mask for `NSVisualEffectView`.
+/// Clipping vibrancy with `layer.cornerRadius` + `masksToBounds` composites
+/// against black and leaves a dark fringe; `maskImage` punches real alpha.
+private func stretchableRoundedMask(radius: CGFloat) -> NSImage {
+    let cap = ceil(radius)
+    let side = cap * 2 + 1
+    let image = NSImage(size: NSSize(width: side, height: side), flipped: true) { rect in
+        NSColor.black.setFill()
+        NSBezierPath(roundedRect: rect, xRadius: radius, yRadius: radius).fill()
+        return true
+    }
+    image.resizingMode = .stretch
+    image.capInsets = NSEdgeInsets(top: cap, left: cap, bottom: cap, right: cap)
+    return image
+}
+
 // ---------------------------------------------------------------------------
 // MARK: - Waveform view
 // ---------------------------------------------------------------------------
@@ -168,7 +184,7 @@ private final class PillContentView: NSView {
     private let recordingDot = NSView()
     private let modeLabel = NSTextField(labelWithString: "")
     private let liveLabel = NSTextField(wrappingLabelWithString: "")
-    private let stopButton = NSButton()
+    private let stopButton = FirstMouseButton()
     private let waveform = WaveformView()
     private let spinner = NSProgressIndicator()
 
@@ -177,8 +193,13 @@ private final class PillContentView: NSView {
     var isExpanded: Bool = false
     var stopLabel: String = "Stop recording"
     var a11yLabel: String = "Dictation in progress"
+    private var chromeRadius: CGFloat = -1
 
     override var isFlipped: Bool { true }
+    override var isOpaque: Bool { false }
+    /// The old Tauri pill window set `acceptFirstMouse: true`. Without it a
+    /// click on a non-activating HUD is eaten (focus only, no Stop).
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 
     override init(frame: NSRect) {
         super.init(frame: frame)
@@ -194,18 +215,16 @@ private final class PillContentView: NSView {
         blurView.material = .hudWindow
         blurView.blendingMode = .behindWindow
         blurView.state = .active
-        blurView.wantsLayer = true
-        blurView.layer?.cornerRadius = kCornerRadiusFull
-        blurView.layer?.masksToBounds = true
         addSubview(blurView)
 
         borderView.wantsLayer = true
         borderView.layer?.backgroundColor = NSColor.clear.cgColor
         borderView.layer?.borderColor = NSColor.white.withAlphaComponent(0.12).cgColor
         borderView.layer?.borderWidth = 1
-        borderView.layer?.cornerRadius = kCornerRadiusFull
         borderView.layer?.masksToBounds = true
         addSubview(borderView)
+
+        applyChrome(radius: kCornerRadiusFull)
 
         recordingDot.wantsLayer = true
         recordingDot.layer?.backgroundColor = NSColor.systemRed.cgColor
@@ -284,9 +303,7 @@ private final class PillContentView: NSView {
         self.a11yLabel = a11yLabel
 
         let compact = (mode == .meeting && !expanded)
-        let radius = compact ? kCornerRadiusMeet : kCornerRadiusFull
-        blurView.layer?.cornerRadius = radius
-        borderView.layer?.cornerRadius = radius
+        applyChrome(radius: compact ? kCornerRadiusMeet : kCornerRadiusFull)
 
         recordingDot.isHidden = (mode == .polishing)
         if !recordingDot.isHidden {
@@ -338,6 +355,14 @@ private final class PillContentView: NSView {
 
     func pushRMS(_ level: Float) {
         waveform.push(rms: level)
+    }
+
+    private func applyChrome(radius: CGFloat) {
+        guard radius != chromeRadius else { return }
+        chromeRadius = radius
+        blurView.maskImage = stretchableRoundedMask(radius: radius)
+        borderView.layer?.cornerRadius = radius
+        borderView.layer?.cornerCurve = .continuous
     }
 
     /// Wrapped-line height for the live tail, capped at 5 lines.
@@ -443,9 +468,30 @@ private final class PillContentView: NSView {
         }
     }
 
+    /// Chrome clicks drag; only the Stop button is a real control. Child
+    /// views (blur, border, waveform) must not eat the first mouse-down.
+    /// `point` is in this view's coordinates (`frame` of the button is too).
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        if !stopButton.isHidden, stopButton.frame.contains(point) {
+            return stopButton
+        }
+        return self
+    }
+
     override func mouseDown(with event: NSEvent) {
+        let loc = convert(event.locationInWindow, from: nil)
+        if !stopButton.isHidden, stopButton.frame.contains(loc) {
+            stopButton.mouseDown(with: event)
+            return
+        }
         window?.performDrag(with: event)
     }
+}
+
+/// Same `acceptsFirstMouse` as the pill window: a background NSButton
+/// otherwise swallows the first click.
+private final class FirstMouseButton: NSButton {
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
 }
 
 /// Borderless panels return `canBecomeKey == false`. Override so VoiceOver
@@ -495,8 +541,12 @@ private final class PillPanel {
         p.isFloatingPanel = true
         p.becomesKeyOnlyIfNeeded = true
         p.worksWhenModal = true
-        p.isMovableByWindowBackground = true
-        p.hasShadow = true
+        // Drag is handled in `PillContentView.mouseDown` (chrome only).
+        // `isMovableByWindowBackground` eats the first click on Stop.
+        p.isMovableByWindowBackground = false
+        // The old Tauri pill window was `"shadow": false`. A native window
+        // shadow on a 64pt HUD reads as a hard black rim, not a drop shadow.
+        p.hasShadow = false
         p.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.statusWindow)))
         p.backgroundColor = .clear
         p.isOpaque = false


### PR DESCRIPTION
## Summary
- HUD Stop now accepts the first click on a non-activating NSPanel and routes from the app state machine, not Swift's latched mode — meetings no longer keep recording after a missed Stop.
- Drop the native pill window shadow and clip vibrancy with a stretchable mask so the HUD no longer draws a hard black rim.
- Polish: context before the transcript, omit Soufflé as the target app, strip leaked prompt labels, clamp `clean`/`no_fillers` expansion, and lower the Ollama `num_predict` floor so a greeting is not finished as a speech.

## Test plan
- [ ] Start a meeting, click HUD Stop once (first click, window not focused). Recording must stop; log line `HUD stop routed to meeting`.
- [ ] Dictate from the main window with polish on: `Bonjour mesdames et messieurs, chers enfants,` — output must not append `Target app:` or invent a closing paragraph.
- [ ] HUD has no black rim against a light desktop.
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml --lib hud_stop`
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml --lib polish`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dictation polishing to preserve unfinished speech, prevent prompt text from appearing in results, and avoid excessive expansion.
  * Improved recording stop behavior so the correct recording mode is stopped reliably, including protection against unintended “zombie” clicks.
  * Fixed HUD visual artifacts, including dark edging around rounded panels.
  * Improved first-click behavior and window dragging: only the Stop button acts as a control, while chrome areas drag the window.
  * Removed the HUD window shadow and background-based window movement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->