### PR TITLE
Unfreeze the home timeline and live session after Svelte 5.57

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -29,7 +29,7 @@
     notifyDictationAborted,
     notifyDictationStopRequested,
   } from "./lib/features/transcription/controller.svelte";
-  import { getAppState } from "./lib/stores/app.svelte";
+  import { getAppState, deriveRecordingMode } from "./lib/stores/app.svelte";
   import { openSettings } from "./lib/features/settings/open";
   import { applyTheme, errorMessage } from "./lib/utils";
   import { micToast, micToastCopy } from "./lib/features/audio/mic-toast.svelte";
@@ -59,6 +59,7 @@
   const healthDegraded = $derived(
     app.transcriptionHealth !== null && app.transcriptionHealth.status !== "healthy",
   );
+  const recordingMode = $derived(deriveRecordingMode(app.machineState));
 
   const machineError = $derived(
     app.machineState.state === "error" ? app.machineState.data : null,
@@ -315,7 +316,7 @@
       <span class="font-heading text-[14.5px] font-semibold" data-tauri-drag-region>Soufflé</span>
     </div>
     <span class="flex-1" data-tauri-drag-region></span>
-    {#if app.recordingMode !== "idle"}
+    {#if recordingMode !== "idle"}
       <span
         class="inline-flex items-center gap-[7px] rounded-full bg-danger/14 px-[11px] py-[5px] text-xs font-semibold text-danger-soft outline-1 outline-danger/30"
       >
@@ -355,6 +356,12 @@
 
   <div class="flex flex-1 flex-col min-w-0 overflow-hidden">
     <main class="flex-1 overflow-y-auto px-7 pb-[34px] pt-[26px]">
+      <!-- Keep HomeView mounted. Its singleton controllers own `$derived`
+           values; destroying the view (settings `{#if}`) froze them on
+           Svelte 5.55+ and left the live session card stuck after stop. -->
+      <div class:hidden={app.settingsOpen}>
+        <HomeView />
+      </div>
       {#if app.settingsOpen}
         <div class="mx-auto flex w-full max-w-[720px] flex-col gap-[22px]">
           <button
@@ -367,8 +374,6 @@
           <h1 class="text-[23px] font-bold">{$t("settings.title")}</h1>
           <SettingsView />
         </div>
-      {:else}
-        <HomeView />
       {/if}
     </main>
 

--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -14,6 +14,7 @@
   import { createTimelineController } from "../features/timeline/controller.svelte";
   import TimelineSection from "../features/timeline/components/TimelineSection.svelte";
   import { createTranscriptionController } from "../features/transcription/controller.svelte";
+  import { deriveRecordingMode } from "../stores/app.svelte";
   import StatusBanner from "./ui/StatusBanner.svelte";
   import StatusChip from "./ui/StatusChip.svelte";
   import { openSettings } from "../features/settings/open";
@@ -26,7 +27,7 @@
 
   let dictationShortcut = $state("");
 
-  const recordingMode = $derived(app.recordingMode);
+  const recordingMode = $derived(deriveRecordingMode(app.machineState));
   // While recording, the live card on the home screen is the surface;
   // the meeting detail only takes over once the session has stopped.
   const showMeetingDetail = $derived(
@@ -37,6 +38,7 @@
   // still allows starting: the start flow reloads it on demand. Only
   // "download_required" (nothing on disk yet) truly blocks starting.
   const modelReady = $derived(app.transcriptionRuntimePhase !== "download_required");
+  const kindFilter = $derived(timeline.kindFilter);
 
   onMount(() => {
     void timeline.refresh();
@@ -93,7 +95,9 @@
     settingsWasOpen = open;
   });
 
-  // Refresh the timeline whenever a recording ends or a detail closes.
+  // Refresh when a recording ends or a detail closes. Dictation save also
+  // refreshes after the insert; a stale idle fetch must not win (see
+  // timeline refresh generation).
   $effect(() => {
     if (recordingMode === "idle" && !showMeetingDetail) {
       void timeline.refresh();
@@ -161,8 +165,8 @@
           <button
             type="button"
             class="btn btn-sm btn-ghost"
-            class:btn-active={timeline.kindFilter === kind}
-            aria-pressed={timeline.kindFilter === kind}
+            class:btn-active={kindFilter === kind}
+            aria-pressed={kindFilter === kind}
             onclick={() => { timeline.kindFilter = kind; }}
           >
             {$t(`home.filter_${kind}`)}

--- a/src/lib/features/meeting/controller.svelte.ts
+++ b/src/lib/features/meeting/controller.svelte.ts
@@ -115,11 +115,13 @@ function createMeetingControllerInstance() {
   // recording"); suppresses further banners until a segment re-arms it.
   let idleDismissed = $state(false);
 
-  let isRecordingMeeting = $derived(
-    app.machineState.state === "recording_meeting"
-    || (app.machineState.state === "stopping"
-        && typeof app.machineState.data?.was_recording === "object"),
-  );
+  function recordingMeetingActive(): boolean {
+    const state = app.machineState;
+    return (
+      state.state === "recording_meeting"
+      || (state.state === "stopping" && typeof state.data?.was_recording === "object")
+    );
+  }
   // Incremental grouper for the compact live view (LiveSessionCard): bounded
   // work per segment instead of re-grouping the whole meeting each time.
   const liveTranscript = createLiveTranscript(1.5);
@@ -155,17 +157,17 @@ function createMeetingControllerInstance() {
   // guards against double-stop. `stopRequested` covers the brief gap before the
   // machine reports "stopping".
   let stopRequested = $state(false);
-  let isStopping = $derived(stopRequested || app.machineState.state === "stopping");
-  // "load_required" stays resumable: resumeRecording reloads the model on
-  // demand, same as a fresh start after an idle unload.
-  let canResumeRecording = $derived(
-    Boolean(meeting?.id)
-    && !isRecordingMeeting
-    && !isLoadingMeeting
-    && !isSummarizing
-    && (app.transcriptionRuntimePhase === "ready"
-      || app.transcriptionRuntimePhase === "load_required"),
-  );
+  function stoppingNow(): boolean {
+    return stopRequested || app.machineState.state === "stopping";
+  }
+  function canResumeNow(): boolean {
+    return Boolean(meeting?.id)
+      && !recordingMeetingActive()
+      && !isLoadingMeeting
+      && !isSummarizing
+      && (app.transcriptionRuntimePhase === "ready"
+        || app.transcriptionRuntimePhase === "load_required");
+  }
 
   async function mount() {
     await Promise.all([refreshSummaryProviders(), loadTranscriptionCatalog()]);
@@ -180,7 +182,7 @@ function createMeetingControllerInstance() {
   }
 
   async function onMeetingSelectionChange(id: string | null) {
-    if (id && (!meeting || meeting.id !== id) && !isRecordingMeeting) {
+    if (id && (!meeting || meeting.id !== id) && !recordingMeetingActive()) {
       await loadMeeting(id);
     }
   }
@@ -421,7 +423,7 @@ function createMeetingControllerInstance() {
   }
 
   async function stopRecording() {
-    if (isStopping) return; // guard against double-stop
+    if (stoppingNow()) return; // guard against double-stop
     stopRequested = true;
     clearIdleState();
     try {
@@ -476,10 +478,10 @@ function createMeetingControllerInstance() {
   /** The backend detected the meeting has probably ended (silence or the
    * max-duration failsafe). Ignored outside an active meeting recording. */
   function handleMeetingIdle(payload: MeetingIdle) {
-    if (!isRecordingMeeting) return;
+    if (!recordingMeetingActive()) return;
 
     if (payload.reason === "max_duration") {
-      if (isStopping) return;
+      if (stoppingNow()) return;
       setBanner("Maximum meeting duration reached. Stopping the recording.");
       void stopRecording();
       return;
@@ -514,7 +516,7 @@ function createMeetingControllerInstance() {
     try {
       await addDictionaryEntry(trimmedTerm, trimmedPronunciation, null);
       if (
-        isRecordingMeeting
+        recordingMeetingActive()
         && trimmedPronunciation
         && trimmedPronunciation.toLowerCase() !== trimmedTerm.toLowerCase()
       ) {
@@ -532,7 +534,7 @@ function createMeetingControllerInstance() {
 
   async function applyLiveParagraphEdit(paragraphId: number, newText: string) {
     const trimmed = newText.trim();
-    if (!trimmed || !isRecordingMeeting) return;
+    if (!trimmed || !recordingMeetingActive()) return;
 
     const current = [...liveTranscript.committed, ...liveTranscript.tail]
       .find((paragraph) => paragraph.id === paragraphId);
@@ -604,7 +606,7 @@ function createMeetingControllerInstance() {
         }
         if (!meetingId) return;
 
-        if (isRecordingMeeting) {
+        if (recordingMeetingActive()) {
           armPendingWakeResume(meetingId);
           return;
         }
@@ -806,7 +808,7 @@ function createMeetingControllerInstance() {
    * panel cannot swallow it.
    */
   async function exportMeeting(format: ExportFormat) {
-    if (!meeting || !meeting.id || isRecordingMeeting) return;
+    if (!meeting || !meeting.id || recordingMeetingActive()) return;
     isExporting = true;
     clearBanner();
     try {
@@ -824,7 +826,7 @@ function createMeetingControllerInstance() {
    * webview parenting issue as markdown/subtitle export.
    */
   async function exportMeetingAudio() {
-    if (!meeting || !meeting.id || isRecordingMeeting || audioSessions.length === 0) return;
+    if (!meeting || !meeting.id || recordingMeetingActive() || audioSessions.length === 0) return;
     isExporting = true;
     clearBanner();
     try {
@@ -855,7 +857,7 @@ function createMeetingControllerInstance() {
     get summaryStage() { return summaryStage; },
     get summaryStageCurrent() { return summaryStageCurrent; },
     get summaryStageTotal() { return summaryStageTotal; },
-    get isRecordingMeeting() { return isRecordingMeeting; },
+    get isRecordingMeeting() { return recordingMeetingActive(); },
     get liveTranscript() { return liveTranscript; },
     get liveMeetingSegments() { return liveMeetingSegments; },
     get meeting() { return meeting; },
@@ -864,8 +866,8 @@ function createMeetingControllerInstance() {
     get seekRequestId() { return seekRequestId; },
     requestAudioSeek,
     get isLoadingMeeting() { return isLoadingMeeting; },
-    get isStopping() { return isStopping; },
-    get canResumeRecording() { return canResumeRecording; },
+    get isStopping() { return stoppingNow(); },
+    get canResumeRecording() { return canResumeNow(); },
     get isEditingTranscript() { return isEditingTranscript; },
     get isExporting() { return isExporting; },
     get editedTranscriptDraft() { return editedTranscriptDraft; },

--- a/src/lib/features/timeline/components/TimelineSection.svelte
+++ b/src/lib/features/timeline/components/TimelineSection.svelte
@@ -25,6 +25,15 @@
     onSetupCalendar?: () => void;
   } = $props();
 
+  // `$props()` `controller` is a stable singleton. Direct template reads of
+  // its getters are not subscribed (unlike LiveSessionCard, which wraps
+  // `transcription.transcript` in `$derived`). Without this, filters and
+  // post-stop inserts never repaint.
+  const groups = $derived(controller.groups);
+  const isEmpty = $derived(controller.isEmpty);
+  const hasMatches = $derived(controller.hasMatches);
+  const expandedDictationId = $derived(controller.expandedDictationId);
+
   // Show the CTA when nothing today's calendar section could show:
   // integration off, or on but macOS hasn't granted access.
   const showCalendarSetupCta = $derived(
@@ -141,18 +150,18 @@
     </button>
   {/if}
 
-  {#if controller.isEmpty}
+  {#if isEmpty}
     <EmptyState
       title={$t("timeline.empty_title")}
       message={$t("timeline.empty_msg")}
     />
-  {:else if !controller.hasMatches}
+  {:else if !hasMatches}
     <EmptyState
       title={$t("timeline.no_matches_title")}
       message={$t("timeline.no_matches_msg")}
     />
   {:else}
-    {#each controller.groups as group (group.day)}
+    {#each groups as group (group.day)}
       <section class="flex flex-col gap-2.5">
         <h4 class="px-1 text-[11px] font-semibold uppercase tracking-[0.15em] text-text-muted">
           {dayLabel(group.day)}
@@ -161,7 +170,7 @@
           {#each group.items as item (item.kind + item.id)}
             <TimelineItem
               {item}
-              expanded={item.kind === "dictation" && controller.expandedDictationId === item.id}
+              expanded={item.kind === "dictation" && expandedDictationId === item.id}
               isLive={item.kind === "meeting" && controller.isLiveMeeting(item.id)}
               onOpen={() => controller.openItem(item)}
               onRemove={() => void controller.removeItem(item)}

--- a/src/lib/features/timeline/controller.refresh.test.ts
+++ b/src/lib/features/timeline/controller.refresh.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DictationEntry, MeetingListItem } from "../../types";
+
+const listDictationEntries = vi.fn<(limit?: number) => Promise<DictationEntry[]>>();
+const listMeetings = vi.fn<() => Promise<MeetingListItem[]>>();
+
+vi.mock("../../api/transcription", () => ({
+  listDictationEntries: (...args: unknown[]) =>
+    listDictationEntries(...(args as [])),
+  deleteDictationEntry: vi.fn(),
+}));
+
+vi.mock("../../api/meetings", () => ({
+  listMeetings: (...args: unknown[]) => listMeetings(...(args as [])),
+  deleteMeeting: vi.fn(),
+}));
+
+const { createTimelineController, resetTimelineControllerForTest } = await import(
+  "./controller.svelte"
+);
+
+function entry(id: string): DictationEntry {
+  return { id, text: `text ${id}`, timestamp: `2026-09-08T00:00:0${id}Z` };
+}
+
+describe("timeline refresh generation", () => {
+  beforeEach(() => {
+    resetTimelineControllerForTest();
+    listDictationEntries.mockReset();
+    listMeetings.mockReset();
+    listMeetings.mockResolvedValue([]);
+  });
+
+  it("does not let an earlier idle fetch hide a dictation saved after it started", async () => {
+    let resolveStale: ((entries: DictationEntry[]) => void) | undefined;
+    listDictationEntries.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveStale = resolve;
+        }),
+    );
+
+    const timeline = createTimelineController();
+    const stale = timeline.refresh();
+
+    listDictationEntries.mockResolvedValueOnce([entry("2")]);
+    await timeline.refresh();
+    expect(timeline.groups.flatMap((group) => group.items.map((item) => item.id))).toEqual([
+      "2",
+    ]);
+
+    resolveStale!([entry("1")]);
+    await stale;
+
+    expect(timeline.groups.flatMap((group) => group.items.map((item) => item.id))).toEqual([
+      "2",
+    ]);
+  });
+});

--- a/src/lib/features/timeline/controller.svelte.ts
+++ b/src/lib/features/timeline/controller.svelte.ts
@@ -99,13 +99,16 @@ function createTimelineControllerInstance() {
   let expandedDictationId = $state<string | null>(null);
   const search = createDebouncedSearch(250, 40);
 
-  const items = $derived(toTimelineItems(dictations, meetings));
+  function currentItems(): TimelineItem[] {
+    return toTimelineItems(dictations, meetings);
+  }
 
-  const filteredItems = $derived.by(() => {
+  function currentFilteredItems(): TimelineItem[] {
     const query = searchQuery.trim().toLowerCase();
+    const source = currentItems();
     const byKind = kindFilter === "all"
-      ? items
-      : items.filter((item) => item.kind === kindFilter);
+      ? source
+      : source.filter((item) => item.kind === kindFilter);
 
     if (!query) return byKind;
 
@@ -119,22 +122,28 @@ function createTimelineControllerInstance() {
       );
     }
 
-    // Local fallback while the FTS query is in flight.
     return byKind.filter((item) => item.title.toLowerCase().includes(query));
-  });
+  }
 
-  const groups = $derived(groupByDay(filteredItems));
+  // HomeView refreshes as soon as the machine goes idle; dictation save
+  // refreshes after the row is written. Without a generation token the
+  // idle fetch (started before the insert) can land last and hide the
+  // new entry until the next launch.
+  let refreshGeneration = 0;
 
   async function refresh() {
+    const generation = ++refreshGeneration;
     try {
       const [dictationEntries, meetingItems] = await Promise.all([
         listDictationEntries(200),
         listMeetings(),
       ]);
+      if (generation !== refreshGeneration) return;
       dictations = dictationEntries;
       meetings = meetingItems;
       statusMessage = "";
     } catch (e) {
+      if (generation !== refreshGeneration) return;
       statusMessage = errorMessage(e);
     }
   }
@@ -180,9 +189,12 @@ function createTimelineControllerInstance() {
   return {
     get app() { return app; },
     get statusMessage() { return statusMessage; },
-    get groups() { return groups; },
-    get isEmpty() { return items.length === 0; },
-    get hasMatches() { return filteredItems.length > 0; },
+    // Getters, not `$derived`: this controller is a singleton. `$derived`
+    // created while HomeView is mounted is owned by that view; Svelte 5.55+
+    // freezes it when the view unmounts (settings used to destroy HomeView).
+    get groups() { return groupByDay(currentFilteredItems()); },
+    get isEmpty() { return currentItems().length === 0; },
+    get hasMatches() { return currentFilteredItems().length > 0; },
     get searchQuery() { return searchQuery; },
     set searchQuery(value: string) { onSearchQueryChange(value); },
     get kindFilter() { return kindFilter; },

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -122,7 +122,7 @@ let settings = $state<AppSettings>({
   dictation_ceiling_seconds: 300,
 });
 
-function deriveRecordingMode(state: AppStateMachine): "idle" | "dictation" | "meeting" {
+export function deriveRecordingMode(state: AppStateMachine): "idle" | "dictation" | "meeting" {
   switch (state.state) {
     case "recording_dictation":
       return "dictation";


### PR DESCRIPTION
## Summary
- Opening Settings destroyed HomeView and froze singleton `$derived` values (Svelte 5.55+). The live card could stay on “recording” after stop, and the home list/filters stopped updating even though rows were in SQLite.
- Keep HomeView mounted under Settings. Drive `recordingMode` from `machineState`. Timeline/meeting session flags are getters. TimelineSection subscribes via `$derived`. Ignore stale idle list fetches.

## Test plan
- [ ] Start a meeting, Stop: home (or meeting detail) appears; the live card does not stay stuck.
- [ ] Dictate, stop: the new dictation shows in the list without relaunching.
- [ ] All / Meeting / Dictation filters update the list immediately.
- [ ] Open Settings and close it; filters and a new dictation still work.
- [ ] `npx vitest run src/lib/features/timeline src/lib/features/meeting/controller.svelte.test.ts`