### PR TITLE
fix(filters): fix filler orphan punctuation and document Kyutai per-word limit

### DIFF
--- a/src-tauri/src/filter/mod.rs
+++ b/src-tauri/src/filter/mod.rs
@@ -284,7 +284,7 @@ mod tests {
                     + (t * 360.0 * std::f32::consts::TAU).sin() * 0.1,
             );
         }
-        block.extend(std::iter::repeat(0.0f32).take(480 * 16));
+        block.extend(std::iter::repeat_n(0.0f32, 480 * 16));
 
         let mut probe = match audio_vad::SileroVadFilter::new(&model_path, 16_000) {
             Ok(v) => v,

--- a/src-tauri/src/filter/text_dictionary.rs
+++ b/src-tauri/src/filter/text_dictionary.rs
@@ -657,4 +657,16 @@ mod tests {
             "the Kubernetes cluster"
         );
     }
+
+    #[test]
+    fn kyutai_multi_word_alias_limitation() {
+        // Multi-word aliases do not fire when processed word-by-word (like Kyutai segments).
+        // This is a known limitation.
+        let f = DictionaryFilter::with_session_terms(
+            vec![entry_with_pronunciation("FluidVoice", "fluid boys")],
+            &[],
+        );
+        assert_eq!(f.apply("fluid"), "fluid");
+        assert_eq!(f.apply("boys"), "boys");
+    }
 }

--- a/src-tauri/src/filter/text_filler.rs
+++ b/src-tauri/src/filter/text_filler.rs
@@ -6,7 +6,8 @@ use super::{TextFilter, TextFilterKind};
 
 /// Filler word pattern: English + French fillers, case-insensitive, word-boundary.
 static FILLER_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)\b(uh+|um+|euh+|heu+|hm+|hmm+|hum+|ah+|hein)\b").expect("filler regex must compile")
+    Regex::new(r"(?i)\b(uh+|um+|euh+|heu+|hm+|hmm+|hum+|ah+|hein)\b")
+        .expect("filler regex must compile")
 });
 
 pub struct FillerRemovalFilter;
@@ -27,19 +28,21 @@ impl TextFilter for FillerRemovalFilter {
         if replaced == text {
             return text.to_string();
         }
-        
+
         let collapsed = crate::engine::collapse_whitespace(&replaced);
         let mut result = collapsed;
-        
-        static MULTI_COMMA: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?:,\s*){2,}").unwrap());
+
+        static MULTI_COMMA: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"(?:,\s*){2,}").unwrap());
         result = MULTI_COMMA.replace_all(&result, ", ").into_owned();
-        
+
         static MULTI_DOT: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?:\.\s*){2,}").unwrap());
         result = MULTI_DOT.replace_all(&result, ". ").into_owned();
-        
-        static LEADING_PUNC: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\s*[,\.;]\s*").unwrap());
+
+        static LEADING_PUNC: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"^\s*[,\.;]\s*").unwrap());
         result = LEADING_PUNC.replace_all(&result, "").into_owned();
-        
+
         result.trim().to_string()
     }
 }
@@ -98,7 +101,10 @@ mod tests {
     #[test]
     fn orphan_punctuation_cleanup() {
         let f = FillerRemovalFilter::new();
-        assert_eq!(f.apply("Euh, je pense que, euh, c'est bon."), "je pense que, c'est bon.");
+        assert_eq!(
+            f.apply("Euh, je pense que, euh, c'est bon."),
+            "je pense que, c'est bon."
+        );
         assert_eq!(f.apply("So, um, I think"), "So, I think");
     }
 }

--- a/src-tauri/src/filter/text_filler.rs
+++ b/src-tauri/src/filter/text_filler.rs
@@ -6,7 +6,7 @@ use super::{TextFilter, TextFilterKind};
 
 /// Filler word pattern: English + French fillers, case-insensitive, word-boundary.
 static FILLER_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)\b(uh+|um+|euh+|hm+|hmm+|ah+|hein)\b").expect("filler regex must compile")
+    Regex::new(r"(?i)\b(uh+|um+|euh+|heu+|hm+|hmm+|hum+|ah+|hein)\b").expect("filler regex must compile")
 });
 
 pub struct FillerRemovalFilter;
@@ -23,9 +23,24 @@ impl TextFilter for FillerRemovalFilter {
     }
 
     fn apply(&self, text: &str) -> String {
-        let result = FILLER_PATTERN.replace_all(text, "");
-        // Collapse whitespace left behind by removed fillers
-        crate::engine::collapse_whitespace(&result)
+        let replaced = FILLER_PATTERN.replace_all(text, "");
+        if replaced == text {
+            return text.to_string();
+        }
+        
+        let collapsed = crate::engine::collapse_whitespace(&replaced);
+        let mut result = collapsed;
+        
+        static MULTI_COMMA: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?:,\s*){2,}").unwrap());
+        result = MULTI_COMMA.replace_all(&result, ", ").into_owned();
+        
+        static MULTI_DOT: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?:\.\s*){2,}").unwrap());
+        result = MULTI_DOT.replace_all(&result, ". ").into_owned();
+        
+        static LEADING_PUNC: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\s*[,\.;]\s*").unwrap());
+        result = LEADING_PUNC.replace_all(&result, "").into_owned();
+        
+        result.trim().to_string()
     }
 }
 
@@ -43,6 +58,8 @@ mod tests {
     fn removes_french_fillers() {
         let f = FillerRemovalFilter::new();
         assert_eq!(f.apply("euh je pense que hein"), "je pense que");
+        assert_eq!(f.apply("hum je crois"), "je crois");
+        assert_eq!(f.apply("heu oui"), "oui");
     }
 
     #[test]
@@ -55,6 +72,8 @@ mod tests {
     fn preserves_normal_text() {
         let f = FillerRemovalFilter::new();
         assert_eq!(f.apply("the umbrella is useful"), "the umbrella is useful");
+        // No fillers, so punctuation is untouched
+        assert_eq!(f.apply(","), ",");
     }
 
     #[test]
@@ -73,5 +92,13 @@ mod tests {
     fn only_fillers_returns_empty() {
         let f = FillerRemovalFilter::new();
         assert_eq!(f.apply("uh um hmm"), "");
+        assert_eq!(f.apply("euh,"), "");
+    }
+
+    #[test]
+    fn orphan_punctuation_cleanup() {
+        let f = FillerRemovalFilter::new();
+        assert_eq!(f.apply("Euh, je pense que, euh, c'est bon."), "je pense que, c'est bon.");
+        assert_eq!(f.apply("So, um, I think"), "So, I think");
     }
 }

--- a/src-tauri/src/filter/text_stutter.rs
+++ b/src-tauri/src/filter/text_stutter.rs
@@ -85,4 +85,14 @@ mod tests {
         let f = StutterCollapseFilter::new();
         assert_eq!(f.apply(""), "");
     }
+
+    #[test]
+    fn kyutai_stutter_limitation() {
+        // Stutter collapse only works within a single call.
+        // When processed word-by-word (like Kyutai), it cannot see the repetition across segments.
+        let f = StutterCollapseFilter::new();
+        assert_eq!(f.apply("le"), "le");
+        assert_eq!(f.apply("le"), "le");
+        assert_eq!(f.apply("le"), "le");
+    }
 }

--- a/src/lib/features/meeting/components/DictionaryAliasPopover.svelte
+++ b/src/lib/features/meeting/components/DictionaryAliasPopover.svelte
@@ -93,6 +93,9 @@
         }}
       />
     </div>
+    {#if pronunciationDraft.includes(" ")}
+      <p class="mb-2 text-[11px] text-warning-soft leading-tight">{$t("settings_dictionary.kyutai_space_warning")}</p>
+    {/if}
 
     {#if saveError}
       <p class="mb-2 text-xs text-danger-soft">{saveError}</p>

--- a/src/lib/features/settings/components/DictionarySettingsSection.svelte
+++ b/src/lib/features/settings/components/DictionarySettingsSection.svelte
@@ -137,6 +137,9 @@
       <Plus size={16} />
     </button>
   </div>
+  {#if newPronunciation.includes(" ")}
+    <p class="text-warning-soft text-xs mt-1">{$t("settings_dictionary.kyutai_space_warning")}</p>
+  {/if}
   {#if addError}
     <p class="text-danger-soft text-xs">{addError}</p>
   {/if}

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -89,9 +89,10 @@
     "empty": "No custom dictionary entries yet.",
     "pronunciation": "Pronunciation",
     "pronunciation_placeholder": "e.g. vaysix",
-    "pronunciation_desc": "How the term sounds, spelled out. Exact matches and similar-sounding words are rewritten to the term. Comma-separate several heard spellings, e.g. vaysix, vee six.",
+    "pronunciation_desc": "How the term sounds, spelled out. Exact matches and similar-sounding words are rewritten to the term. Comma-separate several heard spellings, e.g. vaysix, veysix.",
     "learn_from_edit": "Learn from edits after paste",
-    "learn_from_edit_desc": "When auto-paste is on, remember word-level fixes you make in the target app so later dictations match."
+    "learn_from_edit_desc": "When auto-paste is on, remember word-level fixes you make in the target app so later dictations match.",
+    "kyutai_space_warning": "⚠️ Multi-word aliases won't match on the fast model (Kyutai) which outputs word by word."
   },
   "settings_calendar": {
     "title": "Calendar",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -89,9 +89,10 @@
     "empty": "Aucune entrée dans le dictionnaire personnalisé.",
     "pronunciation": "Prononciation",
     "pronunciation_placeholder": "ex. vésix",
-    "pronunciation_desc": "Comment le terme s'entend, orthographié. Les correspondances exactes et les mots proches sont réécrits vers le terme. Séparez plusieurs graphies par des virgules, ex. vésix, vé six.",
+    "pronunciation_desc": "Comment le terme s'entend, orthographié. Les correspondances exactes et les mots proches sont réécrits vers le terme. Séparez plusieurs graphies par des virgules, ex. vésix, vézix.",
     "learn_from_edit": "Apprendre des corrections après collage",
-    "learn_from_edit_desc": "Quand le collage auto est actif, mémoriser les corrections mot à mot dans l'app cible pour les dictées suivantes."
+    "learn_from_edit_desc": "Quand le collage auto est actif, mémoriser les corrections mot à mot dans l'app cible pour les dictées suivantes.",
+    "kyutai_space_warning": "⚠️ Les alias de plusieurs mots ne fonctionneront pas sur le modèle rapide (Kyutai) qui sort mot par mot."
   },
   "settings_calendar": {
     "title": "Calendrier",


### PR DESCRIPTION
## Summary

Closes SOU-069 and SOU-070.

## SOU-070 — Filler removal leaves orphan punctuation

`FillerRemovalFilter` removed filler words but left their surrounding punctuation, producing `", ,"` and leading commas. Active by default.

**Fix**:
- After `replace_all`, a cleanup pass collapses ``, ,`` → ``,``, ``. .`` → ``.``, and strips leading `[,;.]`
- `hum` and `heu` added to the French filler pattern (previously matched by neither `hm+` nor `euh+` due to word-boundary rules)
- New tests: `"Euh, je pense que, euh, c'est bon."` → `"je pense que, c'est bon."`; `"So, um, I think"` → `"So, I think"`; `"euh,"` → `""`

## SOU-069 — Kyutai emits one segment per word; multi-word aliases never fire

`DictionaryFilter` and `StutterCollapseFilter` require multi-word context. On Kyutai, each segment is one word, so multi-word pronunciations and stutter collapse are structurally inoperable.

**Fix** (honest minimal — option 3 from the ticket):
- UI warning shown reactively in `DictionarySettingsSection` and `DictionaryAliasPopover` when a pronunciation contains a space
- i18n strings updated: examples changed from multi-word (`vé six`) to single-word forms (`vézix`/`veysix`) in both `fr.json` and `en.json`
- New tests pin the known per-word limitation in `text_dictionary.rs` and `text_stutter.rs`

## Testing

- `cargo test --lib filter`: all tests pass
- `cargo clippy -- -D warnings`: clean
- `npm run check`: passes