### PR TITLE
fix(onboarding): do not accuse fresh install of stale TCC entry

### DIFF
--- a/src/lib/features/onboarding/PermissionsStep.svelte
+++ b/src/lib/features/onboarding/PermissionsStep.svelte
@@ -27,13 +27,36 @@
   let repairCooldown = $state(false);
   let repairCooldownTimer: ReturnType<typeof setTimeout> | undefined;
 
+  /**
+   * The "stale TCC entry" diagnosis is only plausible once the user has tried
+   * to grant Accessibility and come back with it still refused. On a fresh
+   * install nothing was ever granted: there is no stale entry, no row to
+   * remove with the minus button, and the Repair it advertises resets an
+   * entry that does not exist, so it can only fail (SOU-055).
+   *
+   * Two independent triggers, because the click on Open Settings alone is not
+   * one: `request_permission` returns Denied synchronously while System
+   * Settings is still opening. A blur/focus pair is the honest signal ("you
+   * went there and came back without it"); the attempt count is the fallback
+   * for a webview that never sees one, so Repair stays reachable either way.
+   */
+  let accessibilityAttempts = $state(0);
+  let leftAfterAttempt = $state(false);
+  let returnedStillDenied = $state(false);
+  const showStaleHint = $derived(returnedStillDenied || accessibilityAttempts >= 2);
+
   /** Every write to `status` goes through here so the parent (which cannot
    * see this component's local state otherwise) learns the real permission
    * state, e.g. to gate the onboarding auto-paste default (SOU-053). */
   function setStatus(next: PermissionStatus) {
     status = next;
     // Reset success banner if accessibility state changes back/forth
-    if (next.accessibility === "granted") repairSuccess = false;
+    if (next.accessibility === "granted") {
+      repairSuccess = false;
+      accessibilityAttempts = 0;
+      leftAfterAttempt = false;
+      returnedStillDenied = false;
+    }
     onStatusChange?.(next);
   }
 
@@ -87,6 +110,7 @@
   async function grant(kind: PermissionKind) {
     busy[kind] = true;
     error = "";
+    if (kind === "accessibility") accessibilityAttempts += 1;
     try {
       const next = await requestPermission(kind);
       setStatus({ ...status, [kind]: next });
@@ -159,9 +183,26 @@
         });
     }, 600);
 
+    // "Went to System Settings and came back without it" is the only moment
+    // the stale-entry diagnosis is worth showing. Tracked as a pair so a
+    // window that regains focus without ever having lost it (the synchronous
+    // Denied that `request_permission` returns) does not count as a return.
+    const onBlur = () => {
+      if (accessibilityAttempts > 0) leftAfterAttempt = true;
+    };
+    const onFocus = () => {
+      if (leftAfterAttempt && status.accessibility === "denied") {
+        returnedStillDenied = true;
+      }
+    };
+    window.addEventListener("blur", onBlur);
+    window.addEventListener("focus", onFocus);
+
     return () => {
       clearInterval(timer);
       clearTimeout(repairCooldownTimer);
+      window.removeEventListener("blur", onBlur);
+      window.removeEventListener("focus", onFocus);
     };
   });
 </script>
@@ -205,25 +246,29 @@
           <p class="text-xs text-text-muted">
             {#if repairSuccess}
               {$t("permissions.accessibility_repair_success")}
-            {:else}
+            {:else if showStaleHint}
               {$t("permissions.accessibility_stale_hint")}
+            {:else}
+              {$t("permissions.accessibility_denied_hint")}
             {/if}
           </p>
-          <button
-            class="btn btn-ghost shrink-0 gap-1.5"
-            disabled={repairing || busy[row.kind] || repairCooldown}
-            onclick={repairAccessibility}
-          >
-            {#if repairing}
-              <Spinner />
-              {$t("permissions.checking")}
-            {:else if repairSuccess}
-              <Check size={14} />
-              {$t("permissions.repair")}
-            {:else}
-              {$t("permissions.repair")}
-            {/if}
-          </button>
+          {#if repairSuccess || showStaleHint}
+            <button
+              class="btn btn-ghost shrink-0 gap-1.5"
+              disabled={repairing || busy[row.kind] || repairCooldown}
+              onclick={repairAccessibility}
+            >
+              {#if repairing}
+                <Spinner />
+                {$t("permissions.checking")}
+              {:else if repairSuccess}
+                <Check size={14} />
+                {$t("permissions.repair")}
+              {:else}
+                {$t("permissions.repair")}
+              {/if}
+            </button>
+          {/if}
         </div>
       {:else if row.kind === "microphone" && s === "denied"}
         <div class="flex items-center justify-between gap-3 pl-8">

--- a/src/lib/features/onboarding/PermissionsStep.test.ts
+++ b/src/lib/features/onboarding/PermissionsStep.test.ts
@@ -86,6 +86,20 @@ describe("PermissionsStep accessibility repair", () => {
     };
   }
 
+  /** Repair is only offered once the stale-entry diagnosis applies: the user
+   * clicked Open Settings, left, and came back with it still refused. */
+  async function reachRepair(): Promise<HTMLElement> {
+    const axRow = rowFor("Accessibility");
+    permissionsApi.requestPermission.mockResolvedValue("denied");
+    await fireEvent.click(within(axRow).getByRole("button", { name: "Open Settings" }));
+    await fireEvent.blur(window);
+    await fireEvent.focus(window);
+    await waitFor(() =>
+      expect(within(axRow).getByRole("button", { name: "Repair permission" })).toBeTruthy(),
+    );
+    return axRow;
+  }
+
   it("announces success when tccutil reset succeeds", async () => {
     permissionsApi.getPermissionStatus.mockResolvedValue(accessibilityDenied());
     permissionsApi.repairAccessibilityPermission.mockResolvedValue({
@@ -95,7 +109,7 @@ describe("PermissionsStep accessibility repair", () => {
     render(PermissionsStep);
 
     await waitFor(() => expect(permissionsApi.getPermissionStatus).toHaveBeenCalled());
-    const axRow = rowFor("Accessibility");
+    const axRow = await reachRepair();
     await fireEvent.click(within(axRow).getByRole("button", { name: "Repair permission" }));
 
     await waitFor(() => {
@@ -110,7 +124,7 @@ describe("PermissionsStep accessibility repair", () => {
     render(PermissionsStep);
 
     await waitFor(() => expect(permissionsApi.getPermissionStatus).toHaveBeenCalled());
-    const axRow = rowFor("Accessibility");
+    const axRow = await reachRepair();
     await fireEvent.click(within(axRow).getByRole("button", { name: "Repair permission" }));
 
     await waitFor(() => {
@@ -118,6 +132,112 @@ describe("PermissionsStep accessibility repair", () => {
     });
     expect(within(axRow).queryByText(/new prompt should appear/i)).toBeNull();
     expect(within(axRow).getByText(/stale entry/i)).toBeTruthy();
+  });
+});
+
+describe("PermissionsStep accessibility on a fresh install (SOU-055)", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  function accessibilityDenied(): PermissionStatus {
+    return {
+      microphone: "granted",
+      system_audio: "unknown",
+      accessibility: "denied",
+      calendar: "unknown",
+    };
+  }
+
+  it("does not diagnose a stale TCC entry before the user has tried anything", async () => {
+    permissionsApi.getPermissionStatus.mockResolvedValue(accessibilityDenied());
+    render(PermissionsStep);
+
+    await waitFor(() => expect(permissionsApi.getPermissionStatus).toHaveBeenCalled());
+
+    const axRow = rowFor("Accessibility");
+    expect(within(axRow).queryByText(/stale entry/i)).toBeNull();
+    expect(within(axRow).queryByRole("button", { name: "Repair permission" })).toBeNull();
+    expect(within(axRow).getByText(/tick Soufflé in the Accessibility list/i)).toBeTruthy();
+  });
+
+  it("still does not diagnose it right after Open Settings, before the user comes back", async () => {
+    permissionsApi.getPermissionStatus.mockResolvedValue(accessibilityDenied());
+    // request_permission answers Denied synchronously while System Settings
+    // is still opening; that answer says nothing about the user's intent.
+    permissionsApi.requestPermission.mockResolvedValue("denied");
+    render(PermissionsStep);
+
+    await waitFor(() => expect(permissionsApi.getPermissionStatus).toHaveBeenCalled());
+    const axRow = rowFor("Accessibility");
+    await fireEvent.click(within(axRow).getByRole("button", { name: "Open Settings" }));
+
+    await waitFor(() => expect(permissionsApi.requestPermission).toHaveBeenCalledWith("accessibility"));
+    expect(within(axRow).queryByText(/stale entry/i)).toBeNull();
+    expect(within(axRow).queryByRole("button", { name: "Repair permission" })).toBeNull();
+  });
+
+  it("diagnoses it once the user has left for Settings and come back still refused", async () => {
+    permissionsApi.getPermissionStatus.mockResolvedValue(accessibilityDenied());
+    permissionsApi.requestPermission.mockResolvedValue("denied");
+    render(PermissionsStep);
+
+    await waitFor(() => expect(permissionsApi.getPermissionStatus).toHaveBeenCalled());
+    const axRow = rowFor("Accessibility");
+    await fireEvent.click(within(axRow).getByRole("button", { name: "Open Settings" }));
+    await fireEvent.blur(window);
+    await fireEvent.focus(window);
+
+    await waitFor(() => {
+      expect(within(axRow).getByText(/stale entry/i)).toBeTruthy();
+    });
+    expect(within(axRow).getByRole("button", { name: "Repair permission" })).toBeTruthy();
+  });
+
+  it("diagnoses it on a second attempt even without a blur/focus pair", async () => {
+    permissionsApi.getPermissionStatus.mockResolvedValue(accessibilityDenied());
+    permissionsApi.requestPermission.mockResolvedValue("denied");
+    render(PermissionsStep);
+
+    await waitFor(() => expect(permissionsApi.getPermissionStatus).toHaveBeenCalled());
+    const axRow = rowFor("Accessibility");
+    const openSettings = () =>
+      fireEvent.click(within(axRow).getByRole("button", { name: "Open Settings" }));
+
+    await openSettings();
+    expect(within(axRow).queryByText(/stale entry/i)).toBeNull();
+    await openSettings();
+
+    await waitFor(() => {
+      expect(within(axRow).getByText(/stale entry/i)).toBeTruthy();
+    });
+  });
+
+  it("drops the diagnosis again once the permission is granted", async () => {
+    permissionsApi.getPermissionStatus.mockResolvedValue(accessibilityDenied());
+    permissionsApi.requestPermission.mockResolvedValue("denied");
+    render(PermissionsStep);
+
+    await waitFor(() => expect(permissionsApi.getPermissionStatus).toHaveBeenCalled());
+    const axRow = rowFor("Accessibility");
+    await fireEvent.click(within(axRow).getByRole("button", { name: "Open Settings" }));
+    await fireEvent.blur(window);
+    await fireEvent.focus(window);
+    await waitFor(() => expect(within(axRow).getByText(/stale entry/i)).toBeTruthy());
+
+    // The 600 ms poll reports the grant.
+    permissionsApi.getPermissionStatus.mockResolvedValue({
+      ...accessibilityDenied(),
+      accessibility: "granted",
+    });
+    await waitFor(
+      () => {
+        expect(within(axRow).getByText("Granted")).toBeTruthy();
+      },
+      { timeout: 3000 },
+    );
+    expect(within(axRow).queryByText(/stale entry/i)).toBeNull();
   });
 });
 

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -519,6 +519,7 @@
     "checking": "Checking…",
     "continue": "Continue",
     "skip_hint": "You can grant these later when prompted.",
+    "accessibility_denied_hint": "Soufflé is not allowed yet. Click Open Settings, then tick Soufflé in the Accessibility list and come back here.",
     "accessibility_stale_hint": "Already checked in Settings but still failing? macOS can keep a stale entry after an app update. Try Repair, or remove Souffle with the minus button and re-add it.",
     "repair": "Repair permission",
     "accessibility_repair_success": "A new prompt should appear shortly. Check the box to finish the repair.",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -519,6 +519,7 @@
     "checking": "Vérification…",
     "continue": "Continuer",
     "skip_hint": "Vous pourrez les accorder plus tard.",
+    "accessibility_denied_hint": "Soufflé n'est pas encore autorisé. Cliquez sur Ouvrir Réglages, cochez Soufflé dans la liste Accessibilité, puis revenez ici.",
     "accessibility_stale_hint": "Déjà coché dans Réglages mais toujours refusé ? macOS peut conserver une entrée obsolète après une mise à jour. Essayez Réparer, ou retirez Souffle avec le bouton moins puis rajoutez-le.",
     "repair": "Réparer la permission",
     "accessibility_repair_success": "Une nouvelle demande va s'afficher. Cochez la case pour terminer la réparation.",


### PR DESCRIPTION
## Summary
Closes SOU-055.

On a fresh install, the first screen would falsely diagnose a "stale TCC entry" and offer a Repair button that would inevitably fail. Now it waits for the user to actually attempt granting the permission before suggesting repair.