### PR TITLE
fix(ui): attach tentative meeting words per-speaker (SOU-061)

### DIFF
--- a/src/lib/features/home/LiveSessionCard.svelte
+++ b/src/lib/features/home/LiveSessionCard.svelte
@@ -47,16 +47,25 @@
       ? windowedParagraphs(meeting.liveTranscript.committed, meeting.liveTranscript.tail)
       : [],
   );
-  const liveTentative = $derived(
-    mode === "meeting" ? meeting.liveTranscript.tentative : transcription.tentative,
+  const liveTentativeDictation = $derived(
+    mode === "dictation" ? transcription.tentative : "",
+  );
+  const liveTentativeMeeting = $derived(
+    mode === "meeting" ? meeting.liveTranscript.tentative : [],
   );
 
+  const lastIndexBySpeaker = $derived.by(() => {
+    const map = new Map<string | null, number>();
+    liveParagraphs.forEach((p, i) => map.set(p.speaker ?? null, i));
+    return map;
+  });
 
   const hasLiveContent = $derived(
     mode === "dictation"
-      ? Boolean(liveText) || Boolean(liveTentative)
-      : liveParagraphs.length > 0 || Boolean(liveTentative),
+      ? Boolean(liveText) || Boolean(liveTentativeDictation)
+      : liveParagraphs.length > 0 || liveTentativeMeeting.length > 0,
   );
+
 
   const elapsed = $derived(
     formatDuration(elapsedSecondsSince(meeting.app.recordingStartedAtMs, nowMs)),
@@ -85,8 +94,9 @@
     if (stopping || editSaving) return false;
     const isCommitted = meeting.liveTranscript.committed.some((item) => item.id === paragraph.id);
     if (!isCommitted) return false;
-    const isLast = index === liveParagraphs.length - 1;
-    return !(isLast && Boolean(liveTentative));
+    const isLastForSpeaker = lastIndexBySpeaker.get(paragraph.speaker ?? null) === index;
+    const hasTentative = isLastForSpeaker && liveTentativeMeeting.some(t => t.speaker === (paragraph.speaker ?? null));
+    return !hasTentative;
   }
 
   function startParagraphEdit(paragraph: LiveParagraph) {
@@ -159,7 +169,8 @@
   $effect(() => {
     void liveText;
     void liveParagraphs;
-    void liveTentative;
+    void liveTentativeDictation;
+    void liveTentativeMeeting;
     const el = transcriptEl;
     if (el && pendingRemovedHeight > 0) {
       el.scrollTop = scrollTopAfterLeadingUnmount(el.scrollTop, pendingRemovedHeight);
@@ -220,7 +231,7 @@
   {#if mode === "dictation"}
     <div class="flex min-h-[340px] flex-col rounded-[18px] bg-surface-1 p-[30px] px-8 outline-1 outline-ghost-border">
       <p class="m-0 text-[19px] font-normal leading-[1.85] text-text-secondary">
-        {liveText}{#if liveTentative}<span class="opacity-50">{segmentGap(liveText, liveTentative)}{liveTentative}</span>{/if}<span
+        {liveText}{#if liveTentativeDictation}<span class="opacity-50">{segmentGap(liveText, liveTentativeDictation)}{liveTentativeDictation}</span>{/if}<span
           class="ml-0.5 inline-block h-5 w-0.5 bg-accent align-[-3px]"
           style="animation: blink 1s step-end infinite;"
         ></span>
@@ -270,6 +281,8 @@
         {:else}
           {#each liveParagraphs as paragraph, i (paragraph.id)}
             {@const label = resolveSpeakerLabel(paragraph.speaker)}
+            {@const isLastForSpeaker = lastIndexBySpeaker.get(paragraph.speaker ?? null) === i}
+            {@const speakerTentative = isLastForSpeaker ? liveTentativeMeeting.find(t => t.speaker === (paragraph.speaker ?? null))?.text : null}
             <div class="flex flex-col gap-[3px]" style="animation: rise-in 240ms ease;">
               <div class="flex items-center gap-2">
                 {#if label}
@@ -320,16 +333,30 @@
                     onAddAlias={meeting.addDictionaryAlias}
                     class="m-0 inline text-[15px] leading-[1.75] text-text-secondary"
                   />
-                  {#if i === liveParagraphs.length - 1 && liveTentative}
-                    <span class="opacity-50">{segmentGap(paragraph.text, liveTentative)}{liveTentative}</span>
+                  {#if speakerTentative}
+                    <span class="opacity-50">{segmentGap(paragraph.text, speakerTentative)}{speakerTentative}</span>
                   {/if}
                 </p>
               {/if}
             </div>
           {/each}
-          {#if liveParagraphs.length === 0 && liveTentative}
-            <p class="m-0 text-[15px] leading-[1.75] text-text-secondary opacity-50">{liveTentative}</p>
-          {/if}
+          {#each liveTentativeMeeting as tentative (tentative.speaker)}
+            {#if !lastIndexBySpeaker.has(tentative.speaker)}
+              {@const label = resolveSpeakerLabel(tentative.speaker)}
+              <div class="flex flex-col gap-[3px]" style="animation: rise-in 240ms ease;">
+                <div class="flex items-center gap-2">
+                  {#if label}
+                    <span
+                      class="text-[11.5px] font-semibold"
+                      class:text-accent={label.kind === "me"}
+                      class:text-secondary={label.kind === "them"}
+                    >{label.kind === "me" ? $t("transcript.me") : $t("transcript.them")}</span>
+                  {/if}
+                </div>
+                <p class="m-0 text-[15px] leading-[1.75] text-text-secondary opacity-50">{tentative.text}</p>
+              </div>
+            {/if}
+          {/each}
         {/if}
       </div>
     </div>

--- a/src/lib/features/meeting/live-transcript.svelte.test.ts
+++ b/src/lib/features/meeting/live-transcript.svelte.test.ts
@@ -130,12 +130,12 @@ describe("createLiveTranscript tentative text", () => {
   it("sets tentative on a non-final segment and clears it on the next final", () => {
     const live = createLiveTranscript(PAUSE_THRESHOLD);
     live.append(seg("Hello wor", 0, { is_final: false }), 0);
-    expect(live.tentative).toBe("Hello wor");
+    expect(live.tentative).toEqual([{ speaker: null, text: "Hello wor" }]);
     expect(live.committed).toEqual([]);
     expect(live.tail).toEqual([]);
 
     live.append(seg("Hello world.", 0), 0);
-    expect(live.tentative).toBe("");
+    expect(live.tentative).toEqual([]);
     expect(live.tail).toHaveLength(1);
     expect(live.tail[0].text).toBe("Hello world.");
   });
@@ -161,13 +161,13 @@ describe("createLiveTranscript reset", () => {
     live.append(seg("partial", 8.0, { is_final: false }), 4);
 
     expect(live.committed.length + live.tail.length).toBeGreaterThan(0);
-    expect(live.tentative).toBe("partial");
+    expect(live.tentative).toEqual([{ speaker: null, text: "partial" }]);
 
     live.reset();
 
     expect(live.committed).toEqual([]);
     expect(live.tail).toEqual([]);
-    expect(live.tentative).toBe("");
+    expect(live.tentative).toEqual([]);
     expect(live.segmentCount).toBe(0);
 
     // Grouper is fully usable again after reset.

--- a/src/lib/features/meeting/live-transcript.svelte.test.ts
+++ b/src/lib/features/meeting/live-transcript.svelte.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { createLiveTranscript } from "./live-transcript.svelte";
 import { groupIntoParagraphs } from "../../utils/paragraphs";
 import type { Speaker, TranscriptionSegment } from "../../types";
@@ -138,6 +138,27 @@ describe("createLiveTranscript tentative text", () => {
     expect(live.tentative).toEqual([]);
     expect(live.tail).toHaveLength(1);
     expect(live.tail[0].text).toBe("Hello world.");
+  });
+
+  it("a final on Me does not clear Them's tentative (SOU-061)", () => {
+    const live = createLiveTranscript(PAUSE_THRESHOLD);
+    live.append(dseg("hello", 0, "them"), 0);
+    live.append(seg("wor", 2.0, { is_final: false, speaker: "them" }), 1);
+    live.append(dseg("my turn", 2.1, "me"), 1);
+    expect(live.tentative).toEqual([{ speaker: "them", text: "wor" }]);
+  });
+
+  it("expires a tentative after 5s if no final arrives", () => {
+    vi.useFakeTimers();
+    try {
+      const live = createLiveTranscript(PAUSE_THRESHOLD);
+      live.append(seg("wor", 0, { is_final: false, speaker: "them" }), 0);
+      expect(live.tentative).toEqual([{ speaker: "them", text: "wor" }]);
+      vi.advanceTimersByTime(5000);
+      expect(live.tentative).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("does not increment segmentCount for non-final segments", () => {

--- a/src/lib/features/meeting/live-transcript.svelte.ts
+++ b/src/lib/features/meeting/live-transcript.svelte.ts
@@ -94,7 +94,7 @@ function paragraphIsFrozen(
 export function createLiveTranscript(pauseThreshold: number) {
   let committed = $state<LiveParagraph[]>([]);
   let tail = $state<LiveParagraph[]>([]);
-  let tentative = $state("");
+  let tentative = $state<{ speaker: string | null; text: string }[]>([]);
   let segmentCount = $state(0);
 
   // Not reactive state on purpose: only the derived paragraphs need to drive
@@ -102,6 +102,31 @@ export function createLiveTranscript(pauseThreshold: number) {
   // outside the (bounded) tail.
   let tailSegments: IndexedSegment[] = [];
   let nextParagraphId = 0;
+  let tentativeTimeouts = new Map<string | null, ReturnType<typeof setTimeout>>();
+
+  function setTentative(speaker: string | null, text: string) {
+    const existing = tentative.find(t => t.speaker === speaker);
+    if (existing) {
+      existing.text = text;
+    } else {
+      tentative.push({ speaker, text });
+    }
+    const existingTimeout = tentativeTimeouts.get(speaker);
+    if (existingTimeout) clearTimeout(existingTimeout);
+    tentativeTimeouts.set(speaker, setTimeout(() => {
+      clearTentative(speaker);
+    }, 5000));
+  }
+
+  function clearTentative(speaker: string | null) {
+    const idx = tentative.findIndex(t => t.speaker === speaker);
+    if (idx !== -1) tentative.splice(idx, 1);
+    const existingTimeout = tentativeTimeouts.get(speaker);
+    if (existingTimeout) {
+      clearTimeout(existingTimeout);
+      tentativeTimeouts.delete(speaker);
+    }
+  }
 
   function globalIndices(
     range: ParagraphRange,
@@ -182,11 +207,12 @@ export function createLiveTranscript(pauseThreshold: number) {
   }
 
   function append(segment: TranscriptionSegment, segmentIndex: number) {
+    const speaker = segment.speaker ?? null;
     if (!segment.is_final) {
-      tentative = segment.text;
+      setTentative(speaker, segment.text);
       return;
     }
-    tentative = "";
+    clearTentative(speaker);
     segmentCount++;
 
     tailSegments.push({ segment, index: segmentIndex });
@@ -213,9 +239,11 @@ export function createLiveTranscript(pauseThreshold: number) {
     tailSegments = [];
     committed = [];
     tail = [];
-    tentative = "";
+    tentative = [];
     segmentCount = 0;
     nextParagraphId = 0;
+    for (const timeout of tentativeTimeouts.values()) clearTimeout(timeout);
+    tentativeTimeouts.clear();
   }
 
   return {


### PR DESCRIPTION
## Summary
Closes SOU-061.

In diarized meetings, Kyutai properly emits tentative words per speaker. However, the frontend tracked only a single global tentative string, resulting in the tentative word from one speaker appearing under the other speaker's paragraph on every turn alternation (and flickering if both speak simultaneously).

## Changes
- `live-transcript.svelte.ts`: Replaced the global `tentative` string with a per-speaker tracking array. Added a 5-second expiration timeout to prevent a tentative word from getting stuck if the backend fails to emit a final segment.
- `LiveSessionCard.svelte`: Reads the per-speaker tentative text. Appends it strictly to the last paragraph belonging to that specific speaker. If the speaker has no existing paragraphs, renders their tentative word in isolation with the proper label.
- Ensured dictation (single-lane) remains unaffected.

## Testing
- `npm run check` and `npm test` passed.
- All components cleanly re-render according to Svelte 5 reactivity rules.