### PR TITLE
fix(pipeline): dynamically downgrade to single-stream if system tap fails

### DIFF
--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -965,6 +965,10 @@ impl AudioCapture {
                             capture_system_audio,
                             diarize,
                             record_path,
+                            #[cfg(target_os = "macos")]
+                            tap,
+                            #[cfg(target_os = "macos")]
+                            tap_cons,
                         } => {
                             if let Err(e) = capture.start(
                                 session_id,
@@ -973,6 +977,10 @@ impl AudioCapture {
                                 capture_system_audio,
                                 diarize,
                                 record_path,
+                                #[cfg(target_os = "macos")]
+                                tap,
+                                #[cfg(target_os = "macos")]
+                                tap_cons,
                             ) {
                                 warn!("Failed to start audio capture: {e}");
                             }
@@ -1097,6 +1105,8 @@ impl AudioCapture {
         capture_system_audio: bool,
         diarize: bool,
         record_path: Option<PathBuf>,
+        #[cfg(target_os = "macos")] tap: Option<crate::audio::system_tap::TapHandle>,
+        #[cfg(target_os = "macos")] tap_cons: Option<ringbuf::HeapCons<f32>>,
     ) -> Result<(), String> {
         let is_new_session = self
             .active_params
@@ -1177,6 +1187,10 @@ impl AudioCapture {
                 target_sample_rate,
                 mic_gain,
                 diarize,
+                #[cfg(target_os = "macos")]
+                tap,
+                #[cfg(target_os = "macos")]
+                tap_cons,
             );
         }
 
@@ -1382,6 +1396,8 @@ impl AudioCapture {
         target_sample_rate: u32,
         mic_gain: f32,
         diarize: bool,
+        #[cfg(target_os = "macos")] pre_spawned_tap: Option<crate::audio::system_tap::TapHandle>,
+        #[cfg(target_os = "macos")] pre_spawned_tap_cons: Option<ringbuf::HeapCons<f32>>,
     ) -> Result<(), String> {
         let sample_rate = config.sample_rate;
         let channels = config.channels;
@@ -1441,25 +1457,34 @@ impl AudioCapture {
             return Ok(());
         }
 
-        let (tap_prod, tap_cons) = HeapRb::<f32>::new(super::mixer::MIX_RATE as usize * 2).split();
-
         #[cfg(target_os = "macos")]
-        let (tap, tap_rate) = match super::system_tap::spawn_tap(tap_prod, Duration::from_secs(5)) {
-            Ok(tap) => {
-                let rate = tap.sample_rate;
-                emit_system_audio_status(self.app.as_ref(), true, None);
-                (Some(tap), rate)
-            }
-            Err(e) => {
-                warn!("System audio capture unavailable, recording mic only: {e}");
-                emit_system_audio_status(self.app.as_ref(), false, Some(e));
-                (None, super::mixer::MIX_RATE)
+        let (tap, tap_rate, tap_cons) = if let Some(tap) = pre_spawned_tap {
+            let rate = tap.sample_rate;
+            emit_system_audio_status(self.app.as_ref(), true, None);
+            (Some(tap), rate, pre_spawned_tap_cons.unwrap())
+        } else {
+            let (tap_prod, tap_cons) =
+                HeapRb::<f32>::new(super::mixer::MIX_RATE as usize * 2).split();
+            match super::system_tap::spawn_tap(tap_prod, Duration::from_secs(5)) {
+                Ok(tap) => {
+                    let rate = tap.sample_rate;
+                    emit_system_audio_status(self.app.as_ref(), true, None);
+                    (Some(tap), rate, tap_cons)
+                }
+                Err(e) => {
+                    warn!("System audio capture unavailable, recording mic only: {e}");
+                    emit_system_audio_status(self.app.as_ref(), false, Some(e));
+                    (None, super::mixer::MIX_RATE, tap_cons)
+                }
             }
         };
+
         #[cfg(not(target_os = "macos"))]
-        let tap_rate = {
+        let (tap_rate, tap_cons) = {
+            let (tap_prod, tap_cons) =
+                HeapRb::<f32>::new(super::mixer::MIX_RATE as usize * 2).split();
             drop(tap_prod);
-            super::mixer::MIX_RATE
+            (super::mixer::MIX_RATE, tap_cons)
         };
 
         let mut mixer = MeetingMixer::new(

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -1388,6 +1388,7 @@ impl AudioCapture {
     /// Meeting mode: the cpal callback only pushes raw samples into a ring
     /// buffer; a system-audio tap fills a second ring; `meeting_tick()` on
     /// this thread resamples, mixes, and forwards to the engine.
+    #[allow(clippy::too_many_arguments)]
     fn start_meeting(
         &mut self,
         device: &Device,
@@ -1601,6 +1602,10 @@ impl AudioCapture {
             params.capture_system_audio,
             params.diarize,
             params.record_path.clone(),
+            #[cfg(target_os = "macos")]
+            None,
+            #[cfg(target_os = "macos")]
+            None,
         ) {
             Ok(()) => {
                 self.clear_mic_loss_ladder();

--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -261,18 +261,46 @@ fn start_pipeline_blocking(
     // own thread to keep ONNX/Metal work off the command thread.
     let settings = crate::settings::AppSettings::load(db)?;
 
-    // Meetings also capture system audio (the other participants) when the
-    // setting is on and the OS supports Core Audio taps.
     let capture_system_audio = mode == PipelineMode::Meeting
         && settings.capture_system_audio
         && crate::platform::system_audio_capture_supported();
+
+    // SOU-082: Try to acquire the system audio tap *before* starting the session
+    // so we can downgrade to single-stream (diarize = false) if the tap fails.
+    #[cfg(target_os = "macos")]
+    let (tap_handle, tap_cons) = if capture_system_audio {
+        use ringbuf::traits::Split;
+        let (tap_prod, tap_cons) =
+            ringbuf::HeapRb::<f32>::new(crate::audio::mixer::MIX_RATE as usize * 2).split();
+        match crate::audio::system_tap::spawn_tap(tap_prod, std::time::Duration::from_secs(5)) {
+            Ok(tap) => (Some(tap), Some(tap_cons)),
+            Err(e) => {
+                tracing::warn!("System audio tap probe failed, downgrading to mic only: {e}");
+                (None, None)
+            }
+        }
+    } else {
+        (None, None)
+    };
+
+    let actual_capture_system_audio = {
+        #[cfg(target_os = "macos")]
+        {
+            capture_system_audio && tap_handle.is_some()
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            capture_system_audio
+        }
+    };
+
     // Speaker labelling (Me/Them) needs a distinct system-audio leg AND an
     // engine that can transcribe two batched lanes. Only Kyutai can today; other
     // engines record meetings as a single mixed stream with no labels. This must
     // match the engine's own capability so capture and the actor agree on
     // whether to split the audio.
-    let diarize =
-        capture_system_audio && settings.transcription_engine_id == crate::engine::KYUTAI_ENGINE_ID;
+    let diarize = actual_capture_system_audio
+        && settings.transcription_engine_id == crate::engine::KYUTAI_ENGINE_ID;
 
     // Auto-stop detection only applies to meetings: dictation sessions are
     // short and user-driven, so "meeting is over" doesn't apply. This is a
@@ -321,9 +349,13 @@ fn start_pipeline_blocking(
             session_id,
             target_sample_rate: info.audio.sample_rate_hz,
             mic_gain: info.mic_gain,
-            capture_system_audio,
+            capture_system_audio: actual_capture_system_audio,
             diarize,
             record_path,
+            #[cfg(target_os = "macos")]
+            tap: tap_handle,
+            #[cfg(target_os = "macos")]
+            tap_cons,
         })
         .map_err(|e| format!("Audio start: {e}"))?;
 

--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -10,7 +10,7 @@ use tauri_specta::Event;
 use tracing::{info, warn};
 use uuid::Uuid;
 
-use crate::app_events::{MeetingFinalized, SystemWokeUp};
+use crate::app_events::{MeetingFinalized, SystemAudioStatus, SystemWokeUp};
 use crate::constants::STOP_REPLY_TIMEOUT_SECS;
 use crate::db::Database;
 use crate::engine::TranscriptionSegment;
@@ -172,6 +172,7 @@ async fn launch_meeting(
     let audio = state.audio_cmd_sender.clone();
     let db = Arc::clone(&state.db);
     let acc = Arc::clone(&state.meeting_accumulator);
+    let app = state.app_handle().ok();
     let res = tauri::async_runtime::spawn_blocking(move || {
         start_pipeline_blocking(
             &actor,
@@ -182,6 +183,7 @@ async fn launch_meeting(
             session_terms,
             Some(recording_target),
             on_segment,
+            app,
         )
     })
     .await
@@ -242,6 +244,18 @@ struct RecordingTarget {
     session_index: usize,
 }
 
+/// Capture + diarize after the system-audio tap probe. A failed tap must not
+/// leave the actor in dual-lane mode (SOU-082).
+fn capture_and_diarize_after_probe(
+    capture_requested: bool,
+    tap_alive: bool,
+    engine_id: &str,
+) -> (bool, bool) {
+    let capture = capture_requested && tap_alive;
+    let diarize = capture && engine_id == crate::engine::KYUTAI_ENGINE_ID;
+    (capture, diarize)
+}
+
 /// Blocking core of starting a recording session, run via `spawn_blocking` so
 /// the long crossbeam reply wait (engine reset + filter-chain build) never
 /// blocks the Tauri command thread / window event loop. Preconditions and
@@ -256,10 +270,13 @@ fn start_pipeline_blocking(
     session_terms: Vec<String>,
     recording_target: Option<RecordingTarget>,
     on_segment: SegmentCallback,
+    app: Option<AppHandle>,
 ) -> Result<(), String> {
     // Snapshot settings and dictionary; the actor builds filter chains on its
     // own thread to keep ONNX/Metal work off the command thread.
     let settings = crate::settings::AppSettings::load(db)?;
+    #[cfg(not(target_os = "macos"))]
+    let _ = &app;
 
     let capture_system_audio = mode == PipelineMode::Meeting
         && settings.capture_system_audio
@@ -275,7 +292,15 @@ fn start_pipeline_blocking(
         match crate::audio::system_tap::spawn_tap(tap_prod, std::time::Duration::from_secs(5)) {
             Ok(tap) => (Some(tap), Some(tap_cons)),
             Err(e) => {
-                tracing::warn!("System audio tap probe failed, downgrading to mic only: {e}");
+                let reason = e.to_string();
+                tracing::warn!("System audio tap probe failed, downgrading to mic only: {reason}");
+                if let Some(app) = &app {
+                    let _ = SystemAudioStatus {
+                        active: false,
+                        reason: Some(reason),
+                    }
+                    .emit(app);
+                }
                 (None, None)
             }
         }
@@ -283,24 +308,21 @@ fn start_pipeline_blocking(
         (None, None)
     };
 
-    let actual_capture_system_audio = {
+    let tap_alive = {
         #[cfg(target_os = "macos")]
         {
-            capture_system_audio && tap_handle.is_some()
+            !capture_system_audio || tap_handle.is_some()
         }
         #[cfg(not(target_os = "macos"))]
         {
-            capture_system_audio
+            true
         }
     };
-
-    // Speaker labelling (Me/Them) needs a distinct system-audio leg AND an
-    // engine that can transcribe two batched lanes. Only Kyutai can today; other
-    // engines record meetings as a single mixed stream with no labels. This must
-    // match the engine's own capability so capture and the actor agree on
-    // whether to split the audio.
-    let diarize = actual_capture_system_audio
-        && settings.transcription_engine_id == crate::engine::KYUTAI_ENGINE_ID;
+    let (actual_capture_system_audio, diarize) = capture_and_diarize_after_probe(
+        capture_system_audio,
+        tap_alive,
+        &settings.transcription_engine_id,
+    );
 
     // Auto-stop detection only applies to meetings: dictation sessions are
     // short and user-driven, so "meeting is over" doesn't apply. This is a
@@ -500,6 +522,7 @@ pub async fn start_transcription(
     let actor = Arc::clone(&state.engine_actor);
     let audio = state.audio_cmd_sender.clone();
     let db = Arc::clone(&state.db);
+    let app = state.app_handle().ok();
     tauri::async_runtime::spawn_blocking(move || {
         start_pipeline_blocking(
             &actor,
@@ -510,6 +533,7 @@ pub async fn start_transcription(
             Vec::new(),
             None,
             on_segment,
+            app,
         )
     })
     .await
@@ -1002,8 +1026,8 @@ pub fn clear_sleep_paused_meeting(state: State<'_, AppState>) {
 #[cfg(test)]
 mod tests {
     use super::{
-        MEETING_FLUSH_THRESHOLD, build_meeting_on_segment, dictation_live_preview,
-        paste_failure_notification_text,
+        MEETING_FLUSH_THRESHOLD, build_meeting_on_segment, capture_and_diarize_after_probe,
+        dictation_live_preview, paste_failure_notification_text,
     };
     use crate::engine::{TranscriptionSegment, default_transcription_profile};
     use crate::state::MeetingAccumulator;
@@ -1190,5 +1214,25 @@ mod tests {
         assert_eq!(title_not_saved, "Copié — presse ⌘V");
         assert!(body_not_saved.contains("Accessibilité"));
         assert!(!body_not_saved.contains("l'historique"));
+    }
+
+    #[test]
+    fn tap_probe_failure_downgrades_to_single_stream() {
+        assert_eq!(
+            capture_and_diarize_after_probe(true, false, crate::engine::KYUTAI_ENGINE_ID),
+            (false, false)
+        );
+        assert_eq!(
+            capture_and_diarize_after_probe(true, true, crate::engine::KYUTAI_ENGINE_ID),
+            (true, true)
+        );
+        assert_eq!(
+            capture_and_diarize_after_probe(true, true, "whisper"),
+            (true, false)
+        );
+        assert_eq!(
+            capture_and_diarize_after_probe(false, true, crate::engine::KYUTAI_ENGINE_ID),
+            (false, false)
+        );
     }
 }

--- a/src-tauri/src/filter/mod.rs
+++ b/src-tauri/src/filter/mod.rs
@@ -284,7 +284,7 @@ mod tests {
                     + (t * 360.0 * std::f32::consts::TAU).sin() * 0.1,
             );
         }
-        block.extend(std::iter::repeat_n(0.0f32, 480 * 16));
+        block.extend(std::iter::repeat(0.0f32).take(480 * 16));
 
         let mut probe = match audio_vad::SileroVadFilter::new(&model_path, 16_000) {
             Ok(v) => v,

--- a/src-tauri/src/filter/mod.rs
+++ b/src-tauri/src/filter/mod.rs
@@ -284,7 +284,7 @@ mod tests {
                     + (t * 360.0 * std::f32::consts::TAU).sin() * 0.1,
             );
         }
-        block.extend(std::iter::repeat(0.0f32).take(480 * 16));
+        block.extend(std::iter::repeat_n(0.0f32, 480 * 16));
 
         let mut probe = match audio_vad::SileroVadFilter::new(&model_path, 16_000) {
             Ok(v) => v,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -31,6 +31,12 @@ pub enum AudioCommand {
         /// setting is not off. `None` for dictation and for meetings
         /// recorded with retention off.
         record_path: Option<std::path::PathBuf>,
+        /// The pre-spawned system audio tap, if any (macOS only).
+        #[cfg(target_os = "macos")]
+        tap: Option<crate::audio::system_tap::TapHandle>,
+        /// The consumer side of the pre-spawned tap, if any (macOS only).
+        #[cfg(target_os = "macos")]
+        tap_cons: Option<ringbuf::HeapCons<f32>>,
     },
     Stop,
     SelectDevice(String),


### PR DESCRIPTION
## Summary
Closes SOU-082.

When "capture system audio" is on but the system audio tap fails to start (e.g., TCC denied or CoreAudio wedged), the engine actor would previously still be placed in `DiarizedMode` (batch size 2). This resulted in dual-lane inferences running continuously, with the second lane just being zero-padded silence, wasting 50% of the GPU capacity.

## Changes
- **Inverted tap start sequence**: In `transcription.rs`, we probe/spawn the system audio tap *before* sending `AudioCommand::Start`.
- **Dynamic Downgrade**: If the tap fails, `diarize` and `capture_system_audio` are explicitly forced to `false` before the actor starts. The engine falls back gracefully to `SingleMode`.
- **Reusing pre-spawned tap**: The successfully spawned tap is passed within `AudioCommand::Start` so `capture.rs` can consume it, avoiding double prompts or races.

## Testing
- Tests checked. Clippy clean.