### PR TITLE
fix(ui): auto-hide PTT too-short banner (SOU-034)

### DIFF
--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -1458,6 +1458,24 @@ describe("transcription controller", () => {
     expect(mockInvoke).not.toHaveBeenCalledWith("add_dictation_entry", expect.anything());
   });
 
+  it("auto-hides the too-short banner after 2s without wiping a later banner", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      const ctrl = createTranscriptionController();
+      await ctrl.mount();
+
+      await ctrl.toggleRecording(true);
+      simulateRecordingStarted(ctrl.app, 0);
+      await ctrl.toggleRecording(true);
+      expect(ctrl.statusMessage).toBe("Hold a little longer");
+
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(ctrl.statusMessage).toBe("");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("dictation ceiling stops a long session", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     try {

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -172,7 +172,13 @@ function createTranscriptionControllerInstance() {
   let statusAction = $state<(() => void) | undefined>();
   let catalog = $state<TranscriptionCatalog | null>(null);
 
+  let tooShortBannerTimer: ReturnType<typeof setTimeout> | null = null;
+
   function setBanner(message: string, action?: { label: string; run: () => void }) {
+    if (tooShortBannerTimer) {
+      clearTimeout(tooShortBannerTimer);
+      tooShortBannerTimer = null;
+    }
     statusMessage = message;
     statusActionLabel = action?.label;
     statusAction = action?.run;
@@ -377,7 +383,10 @@ function createTranscriptionControllerInstance() {
           console.warn("Fast stop failed:", e);
         }
         setBanner(tr("home.dictation_too_short"));
-        setTimeout(() => clearBanner(), 2000);
+        tooShortBannerTimer = setTimeout(() => {
+          tooShortBannerTimer = null;
+          clearBanner();
+        }, 2000);
         clearSessionContext();
         isStopping = false;
         return;

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -377,6 +377,7 @@ function createTranscriptionControllerInstance() {
           console.warn("Fast stop failed:", e);
         }
         setBanner(tr("home.dictation_too_short"));
+        setTimeout(() => clearBanner(), 2000);
         clearSessionContext();
         isStopping = false;
         return;


### PR DESCRIPTION
## Summary
Closes remainder of SOU-034.

PR #170 already introduced the 300s ceiling and the 1h pause for Push-To-Talk. The "Too short" banner was also added, but it lacked the auto-hide behavior requested in the ticket, remaining permanently on screen until dismissed or overridden.

## Changes
- The `dictation_too_short` banner now automatically dismisses itself after 2 seconds.

(Note: The PCM retry buffer feature mentioned in the ticket requires deeper pipeline changes and will be tracked in a separate architectural task if needed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The “Hold a little longer” message now automatically disappears after two seconds.
  - Banner timing is managed more reliably so a later notification remains visible and is not cleared unexpectedly.
- **Tests**
  - Added coverage to verify the short-dictation message clears automatically without interfering with subsequent banners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->