### PR TITLE
investigation(asr): SOU-030 punctuation threshold is emergent from Kyutai weights

### DIFF
--- a/src-tauri/src/engine/kyutai.rs
+++ b/src-tauri/src/engine/kyutai.rs
@@ -29,7 +29,7 @@ const ENERGY_PAUSE_RMS: f32 = 0.01;
 const EXTRA_HEADS_PROBE_TENSOR: &str = "extra_heads.0.weight";
 /// Safety margin (frames) on top of the ASR delay before trusting the VAD
 /// pause streak: semantic VAD can fire slightly before speech fully clears.
-const VAD_FLUSH_MARGIN_FRAMES: usize = 6;
+const VAD_FLUSH_MARGIN_FRAMES: usize = 10;
 /// Soft refresh fires at this fraction of `config.context` when pausing
 /// (Kyutai/Unmute recommend clearing KV between speech turns).
 const REFRESH_SOFT_CONTEXT_NUM: usize = 6;


### PR DESCRIPTION
## Summary
Addresses SOU-030.

The ticket assumed that the early punctuation (300-400ms) on hesitations was driven by `VAD_FLUSH_MARGIN_FRAMES`.
This PR increases the margin to 10 (800ms) as an experiment.

## Finding
The test `punctuation_threshold` **still breaks at 300 ms** for `hesitation-a` and **400 ms** for `hesitation-b`. 
Extensive investigation reveals:
1. `decide_refresh` does **not** trigger a `SoftPause` during the 300ms gap because `frames_since_refresh` is well below the threshold.
2. The KV cache is **not cleared** at 300ms.
3. The string returned natively from `engine.transcribe()` inside the 300ms gap already contains a period (`.`) emitted by the language model's predictions.

Since Kyutai is natively emitting a period, simply changing the VAD margin constants does not "move the threshold". The threshold is an emergent property of the model's weights reacting to short silences. 

**Conclusion**: This lever is dead. If we want to suppress these periods, we must do it via a post-processing text filter (stripping periods on short VAD streaks), rather than tuning the engine's pause constants.