### PR TITLE
fix: Remove Rewrite selection feature (SOU-013)

### DIFF
--- a/src-tauri/src/app_events.rs
+++ b/src-tauri/src/app_events.rs
@@ -17,10 +17,6 @@ pub struct Navigate(pub AppView);
 #[derive(Debug, Clone, Serialize, Deserialize, Type, Event)]
 pub struct ShortcutToggle;
 
-/// Toggle-style rewrite: capture the current selection, dictate, paste over it.
-#[derive(Debug, Clone, Serialize, Deserialize, Type, Event)]
-pub struct ShortcutRewrite;
-
 #[derive(Debug, Clone, Serialize, Deserialize, Type, Event)]
 pub struct ShortcutPttStart;
 

--- a/src-tauri/src/commands/dictation.rs
+++ b/src-tauri/src/commands/dictation.rs
@@ -68,7 +68,6 @@ pub async fn polish_dictation(
     state: State<'_, AppState>,
     text: String,
     focused_app: Option<String>,
-    rewrite_of: Option<String>,
 ) -> Result<DictationPolishResult, String> {
     let settings = AppSettings::load(&state.db)?;
     if let Some(result) = early_polish_dictation_result(&settings, &text) {
@@ -83,7 +82,6 @@ pub async fn polish_dictation(
         &providers.models,
         &dictionary,
         focused_app.as_deref(),
-        rewrite_of.as_deref(),
     )
     .await)
 }

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -5,7 +5,7 @@ use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
 use tauri_specta::Event;
 use tracing::info;
 
-use crate::app_events::{ShortcutPttStart, ShortcutPttStop, ShortcutRewrite, ShortcutToggle};
+use crate::app_events::{ShortcutPttStart, ShortcutPttStop, ShortcutToggle};
 use crate::modifier_shortcut::is_native_ptt_shortcut;
 use crate::settings::{AppSettings, ShortcutSettings};
 use crate::state::AppState;
@@ -90,16 +90,6 @@ pub fn register_shortcuts(app: &AppHandle, shortcuts: &ShortcutSettings) -> Resu
         })
         .map_err(|e| format!("Register toggle shortcut '{}': {e}", shortcuts.toggle))?;
         info!(shortcut = shortcuts.toggle, "Toggle shortcut registered");
-    }
-
-    if !shortcuts.rewrite.is_empty() {
-        gs.on_shortcut(shortcuts.rewrite.as_str(), move |app, _shortcut, event| {
-            if event.state == ShortcutState::Pressed {
-                let _ = ShortcutRewrite.emit(app);
-            }
-        })
-        .map_err(|e| format!("Register rewrite shortcut '{}': {e}", shortcuts.rewrite))?;
-        info!(shortcut = shortcuts.rewrite, "Rewrite shortcut registered");
     }
 
     let is_native = is_native_ptt_shortcut(&shortcuts.push_to_talk);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -175,7 +175,6 @@ fn specta_builder() -> Builder<tauri::Wry> {
         .events(collect_events![
             app_events::Navigate,
             app_events::ShortcutToggle,
-            app_events::ShortcutRewrite,
             app_events::ShortcutPttStart,
             app_events::ShortcutPttStop,
             app_events::StateChanged,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -61,7 +61,6 @@ const PASTE_METHOD_KEY: &str = "paste_method";
 const LAST_SEEN_VERSION_KEY: &str = "last_seen_version";
 const DICTATION_LEARN_FROM_EDIT_KEY: &str = "dictation_learn_from_edit";
 const DICTATION_CEILING_SECONDS_KEY: &str = "dictation_ceiling_seconds";
-const SHORTCUT_REWRITE_KEY: &str = "shortcut_rewrite";
 const MEETING_AUDIO_RETENTION_KEY: &str = "meeting_audio_retention";
 const MEETING_TRANSCRIPTION_LANGUAGE_KEY: &str = "meeting_transcription_language";
 
@@ -964,8 +963,6 @@ fn dedupe_known_devices(known: &mut Vec<crate::audio::KnownDevice>) {
 pub struct ShortcutSettings {
     pub toggle: String,
     pub push_to_talk: String,
-    /// Toggle-style shortcut that rewrites the current selection.
-    pub rewrite: String,
 }
 
 impl Default for ShortcutSettings {
@@ -973,7 +970,6 @@ impl Default for ShortcutSettings {
         Self {
             toggle: crate::DEFAULT_TOGGLE_SHORTCUT.to_string(),
             push_to_talk: String::new(),
-            rewrite: String::new(),
         }
     }
 }
@@ -988,9 +984,6 @@ impl ShortcutSettings {
         if let Some(push_to_talk) = read_json_setting::<String>(db, SHORTCUT_PUSH_TO_TALK_KEY)? {
             shortcuts.push_to_talk = push_to_talk;
         }
-        if let Some(rewrite) = read_json_setting::<String>(db, SHORTCUT_REWRITE_KEY)? {
-            shortcuts.rewrite = rewrite;
-        }
 
         Ok(shortcuts.sanitized())
     }
@@ -999,13 +992,9 @@ impl ShortcutSettings {
         let normalized = Self {
             toggle: self.toggle.trim().to_string(),
             push_to_talk: self.push_to_talk.trim().to_string(),
-            rewrite: self.rewrite.trim().to_string(),
         };
 
-        if conflicting_pair(&normalized.toggle, &normalized.push_to_talk)
-            || conflicting_pair(&normalized.toggle, &normalized.rewrite)
-            || conflicting_pair(&normalized.push_to_talk, &normalized.rewrite)
-        {
+        if conflicting_pair(&normalized.toggle, &normalized.push_to_talk) {
             return Err("Dictation shortcuts must be different".into());
         }
 
@@ -1016,16 +1005,10 @@ impl ShortcutSettings {
         let mut normalized = Self {
             toggle: self.toggle.trim().to_string(),
             push_to_talk: self.push_to_talk.trim().to_string(),
-            rewrite: self.rewrite.trim().to_string(),
         };
 
         if conflicting_pair(&normalized.toggle, &normalized.push_to_talk) {
             normalized.push_to_talk.clear();
-        }
-        if conflicting_pair(&normalized.toggle, &normalized.rewrite)
-            || conflicting_pair(&normalized.push_to_talk, &normalized.rewrite)
-        {
-            normalized.rewrite.clear();
         }
 
         normalized
@@ -1035,7 +1018,6 @@ impl ShortcutSettings {
         let normalized = self.normalize()?;
         write_json_setting(db, SHORTCUT_TOGGLE_KEY, &normalized.toggle)?;
         write_json_setting(db, SHORTCUT_PUSH_TO_TALK_KEY, &normalized.push_to_talk)?;
-        write_json_setting(db, SHORTCUT_REWRITE_KEY, &normalized.rewrite)?;
         Ok(())
     }
 }
@@ -1237,24 +1219,10 @@ mod tests {
     }
 
     #[test]
-    fn shortcut_rewrite_duplicate_is_cleared_on_load() {
-        let (db, _dir) = test_db();
-        db.set_setting("shortcut_toggle", "\"F6\"")
-            .expect("save toggle");
-        db.set_setting("shortcut_rewrite", "\"F6\"")
-            .expect("save rewrite");
-
-        let shortcuts = ShortcutSettings::load(&db).expect("load shortcuts");
-        assert_eq!(shortcuts.toggle, "F6");
-        assert_eq!(shortcuts.rewrite, "");
-    }
-
-    #[test]
     fn shortcut_settings_reject_duplicate_bindings() {
         let shortcuts = ShortcutSettings {
             toggle: "CommandOrControl+Shift+Space".into(),
             push_to_talk: "CommandOrControl+Shift+Space".into(),
-            rewrite: String::new(),
         };
 
         assert!(shortcuts.normalize().is_err());
@@ -1477,7 +1445,6 @@ mod tests {
         let s = ShortcutSettings {
             toggle: String::new(),
             push_to_talk: String::new(),
-            rewrite: String::new(),
         };
         assert!(s.normalize().is_ok());
     }
@@ -1488,7 +1455,6 @@ mod tests {
         let s = ShortcutSettings {
             toggle: "CommandOrControl+Shift+Space".to_string(),
             push_to_talk: "CommandOrControl+Shift+S".to_string(),
-            rewrite: "CommandOrControl+Shift+R".to_string(),
         };
         s.save(&db).unwrap();
         let loaded = ShortcutSettings::load(&db).unwrap();

--- a/src-tauri/src/summary/polish.rs
+++ b/src-tauri/src/summary/polish.rs
@@ -329,7 +329,6 @@ pub fn build_polish_user_prompt(
     transcript: &str,
     dictionary: &[DictionaryEntry],
     focused_app: Option<&str>,
-    rewrite_of: Option<&str>,
 ) -> String {
     // Context first, transcript last, nothing after. Putting "Target app:"
     // after the transcript made Apple Intelligence echo it (or keep writing).
@@ -352,12 +351,6 @@ pub fn build_polish_user_prompt(
         prompt.push_str(
             "\nMatch that app's usual tone and formatting conventions. Do not mention the app name in the output.",
         );
-    }
-    if let Some(selection) = rewrite_of.filter(|selection| !selection.trim().is_empty()) {
-        prompt.push_str("\n\n");
-        prompt.push_str("Rewrite this selected text (replace it; keep meaning unless the dictation changes it):\n---\n");
-        prompt.push_str(selection);
-        prompt.push_str("\n---\nThe dictation transcript below is the user's spoken rewrite instructions. Output only the rewritten selection.");
     }
     prompt.push_str("\n\nDictation transcript:\n---\n");
     prompt.push_str(transcript.trim());
@@ -386,9 +379,6 @@ const PROMPT_LEAK_MARKERS: &[&str] = &[
     "Do not mention the app name",
     "Dictation transcript:",
     "Preferred spellings / vocabulary:",
-    "Rewrite this selected text",
-    "The dictation transcript below is the user's spoken rewrite instructions",
-    "The dictation transcript is the user's spoken rewrite instructions",
     "Reply with the cleaned dictation only",
     "Instructions:",
 ];
@@ -479,12 +469,6 @@ fn format_dictionary_vocabulary(entries: &[DictionaryEntry]) -> Option<String> {
     ))
 }
 
-fn polish_output_basis<'a>(stripped: &'a str, rewrite_of: Option<&'a str>) -> &'a str {
-    rewrite_of
-        .filter(|selection| !selection.trim().is_empty())
-        .unwrap_or(stripped)
-}
-
 fn polish_system_prompt(provider: SummaryProviderKind) -> &'static str {
     match provider {
         SummaryProviderKind::Ollama => super::ollama::DICTATION_POLISH_SYSTEM_PROMPT,
@@ -500,7 +484,6 @@ pub async fn polish_dictation_text(
     available_models: &[super::SummaryModelDescriptor],
     dictionary: &[DictionaryEntry],
     focused_app: Option<&str>,
-    rewrite_of: Option<&str>,
 ) -> DictationPolishResult {
     let stripped = strip_invisible_chars(raw_text);
 
@@ -553,13 +536,7 @@ pub async fn polish_dictation_text(
         }
     };
 
-    let prompt = build_polish_user_prompt(
-        &template_prompt,
-        &stripped,
-        dictionary,
-        focused_app,
-        rewrite_of,
-    );
+    let prompt = build_polish_user_prompt(&template_prompt, &stripped, dictionary, focused_app);
     let no_op = |_: SummarizeProgress| {};
     let raw = match generate_with_provider(
         provider,
@@ -568,9 +545,7 @@ pub async fn polish_dictation_text(
         polish_system_prompt(provider),
         prompt,
         0.1,
-        super::ollama::polish_budget(super::estimate_tokens(polish_output_basis(
-            &stripped, rewrite_of,
-        ))),
+        super::ollama::polish_budget(super::estimate_tokens(&stripped)),
         &no_op,
         false,
     )
@@ -591,8 +566,7 @@ pub async fn polish_dictation_text(
         Ok(text) => {
             let text = super::formatters::apply_post_polish_formatters(&text);
             let text = strip_prompt_leakage(&text, &stripped);
-            let basis = polish_output_basis(&stripped, rewrite_of);
-            let text = clamp_polish_expansion(template.id.as_str(), basis, &text);
+            let text = clamp_polish_expansion(template.id.as_str(), &stripped, &text);
             if text.trim().is_empty() {
                 DictationPolishResult {
                     text: stripped.trim().to_string(),
@@ -622,8 +596,7 @@ mod tests {
         TEMPLATE_NO_FILLERS, build_polish_user_prompt, clamp_polish_expansion,
         default_polish_templates, early_polish_dictation_result, effective_template_prompt,
         is_blank_for_polish, is_own_app_name, merge_polish_templates, parse_polish_response,
-        polish_output_basis, strip_invisible_chars, strip_prompt_leakage,
-        superseded_default_prompts,
+        strip_invisible_chars, strip_prompt_leakage, superseded_default_prompts,
     };
     use crate::filter::DictionaryEntry;
     use crate::settings::{AppSettings, DictationPolishTemplate};
@@ -806,12 +779,11 @@ mod tests {
 
     #[test]
     fn build_polish_user_prompt_includes_template_and_transcript() {
-        let prompt = build_polish_user_prompt("Make bullets", "hello world", &[], None, None);
+        let prompt = build_polish_user_prompt("Make bullets", "hello world", &[], None);
         assert!(prompt.contains("Make bullets"));
         assert!(prompt.contains("hello world"));
         assert!(!prompt.contains("Preferred spellings"));
         assert!(!prompt.contains("Target app:"));
-        assert!(!prompt.contains("Rewrite this selected text"));
     }
 
     #[test]
@@ -824,7 +796,6 @@ mod tests {
                 dict_entry("Kubernetes", None),
             ],
             None,
-            None,
         );
         assert!(prompt.contains("Preferred spellings / vocabulary:"));
         assert!(prompt.contains("- V6 (also heard as: vésix, vee six)"));
@@ -835,18 +806,17 @@ mod tests {
     #[test]
     fn build_polish_user_prompt_skips_empty_dictionary_section() {
         let prompt =
-            build_polish_user_prompt("Clean this", "hello", &[dict_entry("  ", None)], None, None);
+            build_polish_user_prompt("Clean this", "hello", &[dict_entry("  ", None)], None);
         assert!(!prompt.contains("Preferred spellings"));
     }
 
     #[test]
     fn build_polish_user_prompt_includes_focused_app() {
-        let prompt = build_polish_user_prompt("Clean this", "hello", &[], Some("Mail"), None);
+        let prompt = build_polish_user_prompt("Clean this", "hello", &[], Some("Mail"));
         assert!(prompt.contains("Target app: Mail"));
         assert!(prompt.contains(
             "Match that app's usual tone and formatting conventions. Do not mention the app name in the output."
         ));
-        assert!(!prompt.contains("Rewrite this selected text"));
         let target_at = prompt.find("Target app: Mail").unwrap();
         let transcript_at = prompt.find("Dictation transcript:").unwrap();
         assert!(
@@ -858,7 +828,7 @@ mod tests {
     #[test]
     fn build_polish_user_prompt_omits_souffle_as_target_app() {
         for name in ["Soufflé", "Souffle", "soufflé", " souffle "] {
-            let prompt = build_polish_user_prompt("Clean this", "hello", &[], Some(name), None);
+            let prompt = build_polish_user_prompt("Clean this", "hello", &[], Some(name));
             assert!(
                 !prompt.contains("Target app:"),
                 "own app {name:?} must not be injected as polish context"
@@ -903,38 +873,9 @@ mod tests {
     }
 
     #[test]
-    fn build_polish_user_prompt_includes_rewrite_of() {
-        let prompt = build_polish_user_prompt(
-            "Clean this",
-            "make it shorter",
-            &[],
-            None,
-            Some("The original paragraph."),
-        );
-        assert!(prompt.contains(
-            "Rewrite this selected text (replace it; keep meaning unless the dictation changes it):"
-        ));
-        assert!(prompt.contains("---\nThe original paragraph.\n---"));
-        assert!(prompt.contains(
-            "The dictation transcript below is the user's spoken rewrite instructions. Output only the rewritten selection."
-        ));
+    fn build_polish_user_prompt_omits_blank_app_context() {
+        let prompt = build_polish_user_prompt("Clean this", "hello", &[], Some("  "));
         assert!(!prompt.contains("Target app:"));
-    }
-
-    #[test]
-    fn polish_output_basis_uses_the_selection_when_rewriting() {
-        let instruction = "make it shorter";
-        let selection = "A long selected passage that must survive the rewrite.";
-        assert_eq!(polish_output_basis(instruction, Some(selection)), selection);
-        assert_eq!(polish_output_basis(instruction, None), instruction);
-        assert_eq!(polish_output_basis(instruction, Some("  \n")), instruction);
-    }
-
-    #[test]
-    fn build_polish_user_prompt_omits_blank_app_and_rewrite_context() {
-        let prompt = build_polish_user_prompt("Clean this", "hello", &[], Some("  "), Some("\n"));
-        assert!(!prompt.contains("Target app:"));
-        assert!(!prompt.contains("Rewrite this selected text"));
     }
 
     #[test]

--- a/src/lib/api/dictation.ts
+++ b/src/lib/api/dictation.ts
@@ -4,7 +4,6 @@ import type { DictationPolishResult } from "../types";
 export async function polishDictation(
   text: string,
   focusedApp?: string | null,
-  rewriteOf?: string | null,
 ): Promise<DictationPolishResult> {
-  return unwrap(commands.polishDictation(text, focusedApp ?? null, rewriteOf ?? null));
+  return unwrap(commands.polishDictation(text, focusedApp ?? null));
 }

--- a/src/lib/api/settings.test.ts
+++ b/src/lib/api/settings.test.ts
@@ -48,7 +48,7 @@ describe('settings API', () => {
   });
 
   it('getShortcuts returns shortcut settings', async () => {
-    const shortcuts = { toggle: 'CmdOrCtrl+Shift+S', push_to_talk: 'CmdOrCtrl+Shift+Space', rewrite: '' };
+    const shortcuts = { toggle: 'CmdOrCtrl+Shift+S', push_to_talk: 'CmdOrCtrl+Shift+Space' };
     mockInvoke.mockResolvedValue(shortcuts);
 
     const result = await getShortcuts();
@@ -59,7 +59,7 @@ describe('settings API', () => {
 
   it('saveShortcuts passes shortcuts object', async () => {
     mockInvoke.mockResolvedValue(null);
-    const shortcuts = { toggle: 'CmdOrCtrl+Shift+D', push_to_talk: 'CmdOrCtrl+Space', rewrite: '' };
+    const shortcuts = { toggle: 'CmdOrCtrl+Shift+D', push_to_talk: 'CmdOrCtrl+Space' };
 
     await saveShortcuts(shortcuts);
 

--- a/src/lib/components/SettingsView.svelte
+++ b/src/lib/components/SettingsView.svelte
@@ -262,7 +262,6 @@
         pasteMethod={controller.app.settings.paste_method}
         toggleShortcut={controller.toggleShortcut}
         pttShortcut={controller.pttShortcut}
-        rewriteShortcut={controller.rewriteShortcut}
         recordingField={controller.recordingField}
         shortcutError={controller.shortcutError}
         onThemeChange={controller.onThemeChange}

--- a/src/lib/features/onboarding/controller.svelte.test.ts
+++ b/src/lib/features/onboarding/controller.svelte.test.ts
@@ -144,7 +144,6 @@ describe("createOnboardingController", () => {
       expect(settingsApi.saveShortcuts).toHaveBeenCalledWith({
         toggle: "CommandOrControl+Shift+Space",
         push_to_talk: mockShortcuts.push_to_talk,
-        rewrite: mockShortcuts.rewrite,
       });
     });
     expect(ctrl.recordingShortcut).toBe(false);

--- a/src/lib/features/onboarding/controller.svelte.ts
+++ b/src/lib/features/onboarding/controller.svelte.ts
@@ -48,7 +48,6 @@ export function createOnboardingController() {
 
   let toggleShortcut = $state("CommandOrControl+Shift+Space");
   let pushToTalk = $state("");
-  let rewrite = $state("");
   let recordingShortcut = $state(false);
   let shortcutError = $state("");
   // Mirrors the backend default (settings.rs) until the real Accessibility
@@ -119,7 +118,6 @@ export function createOnboardingController() {
       const shortcuts = await getShortcuts();
       toggleShortcut = shortcuts.toggle || "CommandOrControl+Shift+Space";
       pushToTalk = shortcuts.push_to_talk;
-      rewrite = shortcuts.rewrite;
     } catch {
       // Keep the built-in default.
     }
@@ -204,7 +202,6 @@ export function createOnboardingController() {
       await saveShortcuts({
         toggle: value,
         push_to_talk: pushToTalk,
-        rewrite,
       });
     } catch (e) {
       shortcutError = errorMessage(e);

--- a/src/lib/features/settings/components/InterfaceSettingsSection.svelte
+++ b/src/lib/features/settings/components/InterfaceSettingsSection.svelte
@@ -21,7 +21,6 @@
     pasteMethod,
     toggleShortcut,
     pttShortcut,
-    rewriteShortcut,
     recordingField,
     shortcutError,
     onThemeChange,
@@ -42,16 +41,15 @@
     pasteMethod: PasteMethod;
     toggleShortcut: string;
     pttShortcut: string;
-    rewriteShortcut: string;
-    recordingField: "toggle" | "ptt" | "rewrite" | null;
+    recordingField: "toggle" | "ptt" | null;
     shortcutError: string;
     onThemeChange: (theme: Theme) => void;
     onLocaleChange: (locale: string) => void;
     onAutoPasteChange: (event: Event) => void;
     onPasteDelayChange: (event: Event) => void;
     onPasteMethodChange: (event: Event) => void;
-    onStartRecording: (field: "toggle" | "ptt" | "rewrite") => void;
-    onClearShortcut: (field: "toggle" | "ptt" | "rewrite") => void | Promise<void>;
+    onStartRecording: (field: "toggle" | "ptt") => void;
+    onClearShortcut: (field: "toggle" | "ptt") => void | Promise<void>;
     formatShortcut: (shortcut: string) => string;
     pillHidden: boolean;
     onPillHiddenChange: (event: Event) => void;
@@ -183,26 +181,6 @@
         </button>
         {#if pttShortcut}
           <button onclick={() => onClearShortcut("ptt")} class="btn btn-ghost text-sm">{$t("settings_interface.clear")}</button>
-        {/if}
-      </div>
-    {/snippet}
-  </SettingsField>
-
-  <SettingsField
-    label={$t("settings_interface.rewrite")}
-    description={$t("settings_interface.rewrite_desc")}
-  >
-    {#snippet control()}
-      <div class="flex gap-2 items-center">
-        <button
-          onclick={() => onStartRecording("rewrite")}
-          class="shortcut-button"
-          class:is-recording={recordingField === "rewrite"}
-        >
-          {recordingField === "rewrite" ? $t("settings_interface.press_keys") : formatShortcut(rewriteShortcut)}
-        </button>
-        {#if rewriteShortcut}
-          <button onclick={() => onClearShortcut("rewrite")} class="btn btn-ghost text-sm">{$t("settings_interface.clear")}</button>
         {/if}
       </div>
     {/snippet}

--- a/src/lib/features/settings/controller.svelte.test.ts
+++ b/src/lib/features/settings/controller.svelte.test.ts
@@ -110,7 +110,6 @@ const fakeDevices: AudioInputDevice[] = [
 const fakeShortcuts: ShortcutSettings = {
   toggle: "CommandOrControl+Shift+Space",
   push_to_talk: "",
-  rewrite: "",
 };
 
 const fakeCatalog: TranscriptionCatalog = {
@@ -567,38 +566,6 @@ describe("settings controller", () => {
     await vi.waitFor(() => {
       expect(mockInvoke).toHaveBeenCalledWith("save_shortcuts", {
         shortcuts: expect.objectContaining({ toggle: "CommandOrControl+Shift+K" }),
-      });
-    });
-  });
-
-  it("shortcut recording flow covers rewrite field", async () => {
-    const ctrl = createSettingsController();
-    await ctrl.mount();
-    expect(ctrl.rewriteShortcut).toBe("");
-
-    ctrl.startRecording("rewrite");
-    expect(ctrl.recordingField).toBe("rewrite");
-
-    const event = new KeyboardEvent("keydown", {
-      key: "r",
-      code: "KeyR",
-      metaKey: true,
-      shiftKey: true,
-    });
-    Object.defineProperty(event, "preventDefault", { value: vi.fn() });
-    Object.defineProperty(event, "stopPropagation", { value: vi.fn() });
-
-    ctrl.handleKeyDown(event);
-
-    expect(ctrl.rewriteShortcut).toBe("CommandOrControl+Shift+R");
-    expect(ctrl.recordingField).toBeNull();
-    await vi.waitFor(() => {
-      expect(mockInvoke).toHaveBeenCalledWith("save_shortcuts", {
-        shortcuts: expect.objectContaining({
-          rewrite: "CommandOrControl+Shift+R",
-          toggle: "CommandOrControl+Shift+Space",
-          push_to_talk: "",
-        }),
       });
     });
   });

--- a/src/lib/features/settings/controller.svelte.ts
+++ b/src/lib/features/settings/controller.svelte.ts
@@ -96,8 +96,7 @@ export function createSettingsController() {
 
   let toggleShortcut = $state("CommandOrControl+Shift+Space");
   let pttShortcut = $state("");
-  let rewriteShortcut = $state("");
-  let recordingField = $state<"toggle" | "ptt" | "rewrite" | null>(null);
+  let recordingField = $state<"toggle" | "ptt" | null>(null);
   let shortcutError = $state("");
 
   let dictionaryEntries = $state<DictionaryEntry[]>([]);
@@ -166,7 +165,6 @@ export function createSettingsController() {
       const shortcuts = await getShortcuts();
       toggleShortcut = shortcuts.toggle;
       pttShortcut = shortcuts.push_to_talk;
-      rewriteShortcut = shortcuts.rewrite;
     } catch (e) {
       console.warn("Failed to load shortcuts:", e);
     }
@@ -945,15 +943,14 @@ export function createSettingsController() {
     return formatShortcutLabel(shortcut) || "Not set";
   }
 
-  function startRecording(field: "toggle" | "ptt" | "rewrite") {
+  function startRecording(field: "toggle" | "ptt") {
     recordingField = field;
     shortcutError = "";
   }
 
-  function applyShortcutValue(field: "toggle" | "ptt" | "rewrite", value: string) {
+  function applyShortcutValue(field: "toggle" | "ptt", value: string) {
     if (field === "toggle") toggleShortcut = value;
-    else if (field === "ptt") pttShortcut = value;
-    else rewriteShortcut = value;
+    else pttShortcut = value;
   }
 
   let modifierDownEvent: KeyboardEvent | null = null;
@@ -1015,14 +1012,13 @@ export function createSettingsController() {
       await persistShortcutSettings({
         toggle: toggleShortcut,
         push_to_talk: pttShortcut,
-        rewrite: rewriteShortcut,
       } satisfies ShortcutSettings);
     } catch (e) {
       shortcutError = errorMessage(e);
     }
   }
 
-  async function clearShortcut(field: "toggle" | "ptt" | "rewrite") {
+  async function clearShortcut(field: "toggle" | "ptt") {
     applyShortcutValue(field, "");
     await saveShortcutSettings();
   }
@@ -1060,7 +1056,6 @@ export function createSettingsController() {
     get downloadTotalBytes() { return app.downloadTotalBytes; },
     get toggleShortcut() { return toggleShortcut; },
     get pttShortcut() { return pttShortcut; },
-    get rewriteShortcut() { return rewriteShortcut; },
     get recordingField() { return recordingField; },
     get shortcutError() { return shortcutError; },
     get dictionaryEntries() { return dictionaryEntries; },

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -951,48 +951,7 @@ describe("transcription controller", () => {
     expect(ctrl.modelOperationState).toBe("idle");
   });
 
-  it("rewrite shortcut captures selection and polishes with extra args", async () => {
-    let transcriptionChannel: { onmessage: ((msg: unknown) => void) | null } | null = null;
-    mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
-      if (cmd === "start_transcription") {
-        transcriptionChannel = args?.channel as { onmessage: ((msg: unknown) => void) | null };
-        return Promise.resolve(null);
-      }
-      if (cmd === "frontmost_app_name") return Promise.resolve("Safari");
-      if (cmd === "read_selected_text") return Promise.resolve("old selection");
-      return defaultInvoke(cmd, args);
-    });
-
-    const ctrl = createTranscriptionController();
-    await ctrl.mount();
-    ctrl.app.settings = { ...ctrl.app.settings, dictation_polish_enabled: true };
-
-    eventListeners["shortcut-rewrite"]?.({ payload: null });
-    await vi.waitFor(() => {
-      expect(mockInvoke).toHaveBeenCalledWith("start_transcription", expect.anything());
-    });
-    expect(mockInvoke).toHaveBeenCalledWith("frontmost_app_name");
-    expect(mockInvoke).toHaveBeenCalledWith("read_selected_text");
-
-    simulateRecordingStarted(ctrl.app);
-    (transcriptionChannel as { onmessage: ((msg: unknown) => void) | null } | null)?.onmessage?.({
-      text: "hello world",
-      is_final: true,
-      start_ms: 0,
-      end_ms: 1000,
-    });
-
-    eventListeners["shortcut-rewrite"]?.({ payload: null });
-    await vi.waitFor(() => {
-      expect(mockInvoke).toHaveBeenCalledWith("polish_dictation", expect.objectContaining({
-        text: "hello world",
-        focusedApp: "Safari",
-        rewriteOf: "old selection",
-      }));
-    });
-  });
-
-  it("insert start polishes with focusedApp and null rewriteOf", async () => {
+  it("insert start polishes with focusedApp", async () => {
     let transcriptionChannel: { onmessage: ((msg: unknown) => void) | null } | null = null;
     mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
       if (cmd === "start_transcription") {
@@ -1023,7 +982,6 @@ describe("transcription controller", () => {
     expect(mockInvoke).toHaveBeenCalledWith("polish_dictation", expect.objectContaining({
       text: "hello world",
       focusedApp: "Mail",
-      rewriteOf: null,
     }));
   });
 
@@ -1768,49 +1726,6 @@ describe("transcription controller", () => {
     });
     // A matched snippet never reaches the LLM (AC3).
     expect(mockInvoke).not.toHaveBeenCalledWith("polish_dictation", expect.anything());
-  });
-
-  it("does not expand snippets in rewrite mode", async () => {
-    let transcriptionChannel: { onmessage: ((msg: unknown) => void) | null } | null = null;
-    mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
-      if (cmd === "list_snippets") {
-        return Promise.resolve([{ id: 1, trigger: "corrige", expansion: "EXPANSION", created_at: "" }]);
-      }
-      if (cmd === "start_transcription") {
-        transcriptionChannel = args?.channel as { onmessage: ((msg: unknown) => void) | null };
-        return Promise.resolve(null);
-      }
-      if (cmd === "read_selected_text") return Promise.resolve("old selection");
-      return defaultInvoke(cmd, args);
-    });
-
-    const ctrl = createTranscriptionController();
-    await ctrl.mount();
-    ctrl.app.settings = { ...ctrl.app.settings, dictation_polish_enabled: true };
-
-    eventListeners["shortcut-rewrite"]?.({ payload: null });
-    await vi.waitFor(() => {
-      expect(mockInvoke).toHaveBeenCalledWith("start_transcription", expect.anything());
-    });
-    simulateRecordingStarted(ctrl.app);
-    (transcriptionChannel as { onmessage: ((msg: unknown) => void) | null } | null)?.onmessage?.({
-      text: "Corrige la faute de frappe.",
-      is_final: true,
-      start_ms: 0,
-      end_ms: 1000,
-    });
-    eventListeners["shortcut-rewrite"]?.({ payload: null });
-
-    // The spoken text is a rewrite instruction, not a trigger: it goes to polish untouched.
-    await vi.waitFor(() => {
-      expect(mockInvoke).toHaveBeenCalledWith("polish_dictation", expect.objectContaining({
-        text: "Corrige la faute de frappe.",
-        rewriteOf: "old selection",
-      }));
-    });
-    expect(mockInvoke).not.toHaveBeenCalledWith("update_dictation_entry", expect.objectContaining({
-      text: expect.stringContaining("EXPANSION"),
-    }));
   });
 
   it("finalization makes no snippet IPC call when no trigger matches", async () => {

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -12,7 +12,7 @@ import {
   updateDictationEntry,
 } from "../../api/transcription";
 import { learnFromEdit } from "../../api/dictionary";
-import { frontmostAppName, readFocusedText, readSelectedText } from "../../api/focus";
+import { frontmostAppName, readFocusedText } from "../../api/focus";
 import { events } from "../../api/generated";
 import { createTimelineController } from "../timeline/controller.svelte";
 import type { TranscriptionCatalog, TranscriptionSegment } from "../../types";
@@ -31,8 +31,6 @@ const POLISH_TIMEOUT_MS = 25_000;
 /** Exact `ACCESSIBILITY_STALE_ERROR` from clipboard.rs — copy succeeded, ⌘V is the recovery.
  * A parenthetical suffix means the copy itself failed; that is not "Copied". */
 const ACCESSIBILITY_PASTE_COPIED = "Accessibility permission missing.";
-
-type SessionMode = "insert" | "rewrite";
 
 function tokenizeWords(text: string): string[] {
   return text
@@ -90,7 +88,6 @@ function countCorrectionPairs(original: string, corrected: string): number {
 async function finalizeDictationText(
   rawText: string,
   focusedApp: string | null,
-  rewriteOf: string | null,
 ): Promise<{ text: string; warning?: string }> {
   const trimmed = rawText.trim();
   if (!trimmed) {
@@ -100,13 +97,10 @@ async function finalizeDictationText(
   const app = getAppState();
 
   // Voice snippet (SOU-035): a registered trigger at the start of the raw
-  // transcript pastes its expansion as-is and skips the polish. Rewrite mode
-  // dictates an instruction over a selection, not a trigger, so it is exempt.
-  if (!rewriteOf) {
-    const expanded = applySnippet(trimmed, app.snippets);
-    if (expanded !== null) {
-      return { text: expanded };
-    }
+  // transcript pastes its expansion as-is and skips the polish.
+  const expanded = applySnippet(trimmed, app.snippets);
+  if (expanded !== null) {
+    return { text: expanded };
   }
 
   if (!app.settings.dictation_polish_enabled) {
@@ -118,7 +112,7 @@ async function finalizeDictationText(
     let timer: ReturnType<typeof setTimeout> | undefined;
     try {
       // Settle polish so a late reject after timeout cannot become unhandled.
-      const polish = polishDictation(trimmed, focusedApp, rewriteOf).then(
+      const polish = polishDictation(trimmed, focusedApp).then(
         (result) => ({ kind: "ok" as const, result }),
         (error: unknown) => ({ kind: "error" as const, error }),
       );
@@ -218,10 +212,8 @@ function createTranscriptionControllerInstance() {
   // Incremented for every session start (and on abort) so segment-channel
   // callbacks from a previous session can never write into a new one.
   let sessionGeneration = 0;
-  let sessionMode: SessionMode = "insert";
   let sessionAutoPaste = false;
   let focusedApp: string | null = null;
-  let rewriteOf: string | null = null;
   let learnFromEditTimer: ReturnType<typeof setTimeout> | null = null;
   let ceilingTimer: ReturnType<typeof setTimeout> | null = null;
   let sessionStartTime = 0;
@@ -257,8 +249,6 @@ function createTranscriptionControllerInstance() {
    */
   function clearSessionContext() {
     focusedApp = null;
-    rewriteOf = null;
-    sessionMode = "insert";
     sessionAutoPaste = false;
     if (ceilingTimer) {
       clearTimeout(ceilingTimer);
@@ -275,15 +265,6 @@ function createTranscriptionControllerInstance() {
       focusedApp = await frontmostAppName();
     } catch {
       focusedApp = null;
-    }
-    if (sessionMode === "rewrite") {
-      try {
-        rewriteOf = await readSelectedText();
-      } catch {
-        rewriteOf = null;
-      }
-    } else {
-      rewriteOf = null;
     }
   }
 
@@ -325,14 +306,6 @@ function createTranscriptionControllerInstance() {
         // not a way to stop someone else's recording.
         if (app.recordingMode === "meeting") return;
         if (!isStartingRecording && !isStopping) {
-          if (!isDictating) sessionMode = "insert";
-          void toggleRecording(true);
-        }
-      }),
-      events.shortcutRewrite.listen(() => {
-        if (app.recordingMode === "meeting") return;
-        if (!isStartingRecording && !isStopping) {
-          if (!isDictating) sessionMode = "rewrite";
           void toggleRecording(true);
         }
       }),
@@ -340,7 +313,6 @@ function createTranscriptionControllerInstance() {
         // Push-to-talk only starts from a fully idle machine: a meeting (or
         // an already-running dictation) must not be interrupted.
         if (app.recordingMode === "idle" && !isStartingRecording && !isStopping) {
-          sessionMode = "insert";
           void toggleRecording(true);
         }
       }),
@@ -420,7 +392,6 @@ function createTranscriptionControllerInstance() {
       // polish or paste never leaves a zombie pill.
       const holdForPolish = app.settings.dictation_polish_enabled;
       const sessionFocusedApp = focusedApp;
-      const sessionRewriteOf = rewriteOf;
       const sessionShouldAutoPaste = sessionAutoPaste;
       if (holdForPolish) {
         try {
@@ -440,7 +411,6 @@ function createTranscriptionControllerInstance() {
         const finalized = await finalizeDictationText(
           rawText,
           sessionFocusedApp,
-          sessionRewriteOf,
         );
         if (finalized.warning) {
           setBanner(finalized.warning);
@@ -538,7 +508,6 @@ function createTranscriptionControllerInstance() {
 
       cancelLearnFromEditPoll();
       sessionAutoPaste = fromShortcut;
-      if (!fromShortcut) sessionMode = "insert";
       transcript = "";
       tentative = "";
       clearBanner();
@@ -584,7 +553,6 @@ function createTranscriptionControllerInstance() {
   /** The backend aborted the recording session (machine went to Error). */
   function handleRecordingAborted() {
     const sessionFocusedApp = focusedApp;
-    const sessionRewriteOf = rewriteOf;
     const rawText = transcript.trim();
     sessionGeneration += 1; // cut off in-flight segments from the dead session
     isStartingRecording = false;
@@ -603,7 +571,6 @@ function createTranscriptionControllerInstance() {
         const { text, warning } = await finalizeDictationText(
           rawText,
           sessionFocusedApp,
-          sessionRewriteOf,
         );
         if (warning) setBanner(warning);
         if (savedId && text && text !== rawText) {

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -141,8 +141,6 @@
     "paste_method_clipboard": "Clipboard (⌘V)",
     "paste_method_type": "Simulated typing",
     "paste_method_ax": "Focused field",
-    "rewrite": "Rewrite selection",
-    "rewrite_desc": "Press to dictate a rewrite of the selected text. Pastes over the selection instead of inserting.",
     "paste_delay": "Paste delay (ms)",
     "paste_delay_desc": "Wait time before pasting. Increase if the text lands in the wrong app.",
     "toggle_recording": "Toggle recording",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -141,8 +141,6 @@
     "paste_method_clipboard": "Presse-papiers (⌘V)",
     "paste_method_type": "Frappe simulée",
     "paste_method_ax": "Champ ciblé",
-    "rewrite": "Réécrire la sélection",
-    "rewrite_desc": "Appuyez pour dicter une réécriture du texte sélectionné. Colle par-dessus la sélection au lieu d'insérer.",
     "paste_delay": "Délai de collage (ms)",
     "paste_delay_desc": "Temps d'attente avant le collage. Augmentez si le texte arrive dans la mauvaise application.",
     "toggle_recording": "Basculer l'enregistrement",

--- a/src/lib/test-helpers/fixtures.ts
+++ b/src/lib/test-helpers/fixtures.ts
@@ -237,7 +237,6 @@ export const mockSettings: AppSettings = {
 export const mockShortcuts: ShortcutSettings = {
   toggle: "CommandOrControl+Shift+S",
   push_to_talk: "CommandOrControl+Shift+Space",
-  rewrite: "",
 };
 
 // ---------------------------------------------------------------------------

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -606,9 +606,9 @@ async clearDictationHistory() : Promise<Result<null, string>> {
 /**
  * Optional LLM polish pass for dictation text before paste/history.
  */
-async polishDictation(text: string, focusedApp: string | null, rewriteOf: string | null) : Promise<Result<DictationPolishResult, string>> {
+async polishDictation(text: string, focusedApp: string | null) : Promise<Result<DictationPolishResult, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("polish_dictation", { text, focusedApp, rewriteOf }) };
+    return { status: "ok", data: await TAURI_INVOKE("polish_dictation", { text, focusedApp }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -1074,7 +1074,6 @@ pillHoldChanged: PillHoldChanged,
 pipelineError: PipelineError,
 shortcutPttStart: ShortcutPttStart,
 shortcutPttStop: ShortcutPttStop,
-shortcutRewrite: ShortcutRewrite,
 shortcutToggle: ShortcutToggle,
 stateChanged: StateChanged,
 systemAudioStatus: SystemAudioStatus,
@@ -1100,7 +1099,6 @@ pillHoldChanged: "pill-hold-changed",
 pipelineError: "pipeline-error",
 shortcutPttStart: "shortcut-ptt-start",
 shortcutPttStop: "shortcut-ptt-stop",
-shortcutRewrite: "shortcut-rewrite",
 shortcutToggle: "shortcut-toggle",
 stateChanged: "state-changed",
 systemAudioStatus: "system-audio-status",
@@ -1619,15 +1617,7 @@ export type RepairAccessibilityResult = { reset_performed: boolean; prompt_shown
 export type SearchResult = { source_type: string; source_id: string; snippet: string; rank: number }
 export type ShortcutPttStart = null
 export type ShortcutPttStop = null
-/**
- * Toggle-style rewrite: capture the current selection, dictate, paste over it.
- */
-export type ShortcutRewrite = null
-export type ShortcutSettings = { toggle: string; push_to_talk: string; 
-/**
- * Toggle-style shortcut that rewrites the current selection.
- */
-rewrite: string }
+export type ShortcutSettings = { toggle: string; push_to_talk: string }
 export type ShortcutToggle = null
 export type SnippetEntry = { id: number; trigger: string; expansion: string; created_at: string }
 export type StateChanged = AppStateMachine


### PR DESCRIPTION
## Summary
Product decision: **drop Rewrite selection** (and the planned voice prompt mode) instead of finishing the unfinished wiring.

The half-built path could paste spoken instructions over the user's selection when polish was off or degraded. Rather than ship more guards and a third mode, this PR removes the feature end-to-end.

## Context
Ticket SOU-013 (internal tracker, not mirrored on GitHub).
Original goal was a rewrite/prompt refonte. After an audit of the partial implementation, the product call is to remove the feature for now.

## Acceptance criteria
- AC1 · `ShortcutSettings` has no `rewrite` field; no rewrite global shortcut is registered · met by `settings.rs`, `commands/settings.rs`, `app_events.rs`
- AC2 · Settings Interface tab no longer shows Rewrite selection · met by `InterfaceSettingsSection.svelte` + i18n key removal
- AC3 · Transcription controller has no rewrite session mode / `shortcut-rewrite` listener · met by `controller.svelte.ts` + tests
- AC4 · `polish_dictation` no longer takes `rewrite_of`; polish prompt has no selection-rewrite block · met by `dictation.rs`, `polish.rs`, regenerated types
- AC5 · Insert/dictation polish path unchanged · met by existing polish tests + frontend insert tests still green
- AC6 · i18n parity: `settings_interface.rewrite` / `rewrite_desc` removed in FR and EN · met by `en.json` / `fr.json`

## Out of scope
- Reintroducing rewrite/prompt later (new ticket when wanted)
- Changing normal dictation polish beyond removing `rewrite_of`
- Accessibility / clipboard restoration

## Risk zones
- Settings IPC shape change (`ShortcutSettings` loses `rewrite`) — clients must use regenerated types
- Orphaned `shortcut_rewrite` DB key left unread (harmless)

## Verification
- `npm run check:generated-types` · OK (types committed after regenerate)
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check` · OK
- `cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings` · OK
- `cargo test --manifest-path src-tauri/Cargo.toml --workspace` · OK
- `npm test` · OK (527)
- `npm run check` · OK

## Deliberate decisions
- Drop entirely rather than default-bind ⌘⇧R before paste guards exist.
- Keep `read_selected_text` and polish style templates that say "Rewrite as email" — unrelated to this feature.