### PR TITLE
Fix: SOU-073 - Bootstrap State Resync

### DIFF
--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -16,19 +16,35 @@ use crate::audio::device::AudioInputDevice;
 use crate::audio::priority::{InputPriority, ResolveInputParams, resolve_input};
 use crate::state::AudioCommand;
 
-/// Tell the frontend whether the system-audio leg of a meeting is live.
-pub fn get_system_audio_status() -> Option<(bool, Option<String>)> {
-    SYSTEM_AUDIO_STATUS.lock().unwrap().clone()
-}
-static SYSTEM_AUDIO_STATUS: std::sync::Mutex<Option<(bool, Option<String>)>> = std::sync::Mutex::new(None);
+/// Last `SystemAudioStatus` emitted for the current meeting session. The
+/// event is edge-triggered (only `spawn_tap` emits it), so a webview that
+/// reloads mid-meeting has nothing to listen to until the next leg rebuild;
+/// bootstrap reads this snapshot instead (SOU-073). Cleared in `stop` so a
+/// stale reason can't outlive its session.
+static SYSTEM_AUDIO_STATUS: Mutex<Option<crate::app_events::SystemAudioStatus>> = Mutex::new(None);
 
+/// Snapshot of the system-audio leg for `commands::get_system_audio_status`.
+/// A read, never a rebuild: it does not touch the capture thread.
+pub fn system_audio_status() -> Option<crate::app_events::SystemAudioStatus> {
+    SYSTEM_AUDIO_STATUS
+        .lock()
+        .ok()
+        .and_then(|guard| guard.clone())
+}
+
+fn store_system_audio_status(status: Option<crate::app_events::SystemAudioStatus>) {
+    if let Ok(mut guard) = SYSTEM_AUDIO_STATUS.lock() {
+        *guard = status;
+    }
+}
 
 /// Tell the frontend whether the system-audio leg of a meeting is live.
 fn emit_system_audio_status(app: Option<&tauri::AppHandle>, active: bool, reason: Option<String>) {
-    *SYSTEM_AUDIO_STATUS.lock().unwrap() = Some((active, reason.clone()));
     use tauri_specta::Event;
+    let status = crate::app_events::SystemAudioStatus { active, reason };
+    store_system_audio_status(Some(status.clone()));
     if let Some(app) = app {
-        let _ = crate::app_events::SystemAudioStatus { active, reason }.emit(app);
+        let _ = status.emit(app);
     }
 }
 
@@ -1997,6 +2013,7 @@ impl AudioCapture {
         // and a Bluetooth headset can leave HFP/mono for A2DP stereo.
         let had_stream = self.release_capture_stream();
 
+        store_system_audio_status(None);
         if let Some(mut meeting) = self.meeting.take() {
             // Tear down the tap first so its ring stops filling; then one
             // final flush drains both rings and all resampler tails.

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -17,7 +17,15 @@ use crate::audio::priority::{InputPriority, ResolveInputParams, resolve_input};
 use crate::state::AudioCommand;
 
 /// Tell the frontend whether the system-audio leg of a meeting is live.
+pub fn get_system_audio_status() -> Option<(bool, Option<String>)> {
+    SYSTEM_AUDIO_STATUS.lock().unwrap().clone()
+}
+static SYSTEM_AUDIO_STATUS: std::sync::Mutex<Option<(bool, Option<String>)>> = std::sync::Mutex::new(None);
+
+
+/// Tell the frontend whether the system-audio leg of a meeting is live.
 fn emit_system_audio_status(app: Option<&tauri::AppHandle>, active: bool, reason: Option<String>) {
+    *SYSTEM_AUDIO_STATUS.lock().unwrap() = Some((active, reason.clone()));
     use tauri_specta::Event;
     if let Some(app) = app {
         let _ = crate::app_events::SystemAudioStatus { active, reason }.emit(app);

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -236,8 +236,11 @@ fn record_system_audio_wav(_seconds: u32) -> Result<String, String> {
     Err("System audio capture is only supported on macOS".into())
 }
 
+/// Last system-audio leg status of the current meeting, for a webview that
+/// reloaded after the `SystemAudioStatus` event already fired (SOU-073).
+/// `None` outside a meeting session or before the tap was first attempted.
 #[tauri::command]
 #[specta::specta]
-pub fn get_system_audio_status() -> Option<(bool, Option<String>)> {
-    crate::audio::capture::get_system_audio_status()
+pub fn get_system_audio_status() -> Option<crate::app_events::SystemAudioStatus> {
+    crate::audio::capture::system_audio_status()
 }

--- a/src-tauri/src/commands/audio.rs
+++ b/src-tauri/src/commands/audio.rs
@@ -235,3 +235,9 @@ fn record_system_audio_wav(seconds: u32) -> Result<String, String> {
 fn record_system_audio_wav(_seconds: u32) -> Result<String, String> {
     Err("System audio capture is only supported on macOS".into())
 }
+
+#[tauri::command]
+#[specta::specta]
+pub fn get_system_audio_status() -> Option<(bool, Option<String>)> {
+    crate::audio::capture::get_system_audio_status()
+}

--- a/src-tauri/src/commands/model.rs
+++ b/src-tauri/src/commands/model.rs
@@ -1,3 +1,5 @@
+use std::sync::Mutex;
+
 use tauri::Manager;
 use tauri::State;
 use tauri::ipc::Channel;
@@ -93,12 +95,29 @@ pub fn recover_state(state: State<'_, AppState>) -> Result<AppStateMachine, Stri
     state.apply_transition(StateAction::Recover)
 }
 
-static LAST_DOWNLOAD_PROGRESS: std::sync::Mutex<Option<crate::models::DownloadProgress>> = std::sync::Mutex::new(None);
+/// Last progress report of the current download thread. The Channel a
+/// download streams to dies with the webview that opened it, so a reload
+/// mid-download would otherwise show a gauge stuck at zero (SOU-073).
+/// Reset when a download starts, so an earlier download's `Complete` can
+/// never be read as the new one's.
+static LAST_DOWNLOAD_PROGRESS: Mutex<Option<models::DownloadProgress>> = Mutex::new(None);
 
+fn record_download_progress(progress: Option<&models::DownloadProgress>) {
+    if let Ok(mut guard) = LAST_DOWNLOAD_PROGRESS.lock() {
+        *guard = progress.cloned();
+    }
+}
+
+/// Snapshot of the in-flight model download, for a webview that reloaded
+/// while the machine was `Downloading` and lost its progress Channel.
+/// `None` until the first download of the process starts.
 #[tauri::command]
 #[specta::specta]
-pub fn get_download_progress() -> Option<crate::models::DownloadProgress> {
-    LAST_DOWNLOAD_PROGRESS.lock().unwrap().clone()
+pub fn get_download_progress() -> Option<models::DownloadProgress> {
+    LAST_DOWNLOAD_PROGRESS
+        .lock()
+        .ok()
+        .and_then(|guard| guard.clone())
 }
 
 /// Download the selected transcription model.
@@ -131,16 +150,15 @@ pub fn download_model(
             let _ = state.apply_transition(StateAction::DownloadComplete);
         }
 
-        let prog = models::DownloadProgress {
-            file: "all".into(),
-            downloaded_bytes: 0,
-            total_bytes: None,
-            completed_files: 1,
-            total_files: 1,
-            status: models::DownloadStatus::Complete,
-        };
-        *LAST_DOWNLOAD_PROGRESS.lock().unwrap() = Some(prog.clone());
-        channel.send(prog)
+        channel
+            .send(models::DownloadProgress {
+                file: "all".into(),
+                downloaded_bytes: 0,
+                total_bytes: None,
+                completed_files: 1,
+                total_files: 1,
+                status: models::DownloadStatus::Complete,
+            })
             .map_err(|e| format!("Channel send: {e}"))?;
         return Ok(());
     }
@@ -163,6 +181,7 @@ pub fn download_model(
     state.apply_transition(StateAction::StartDownload {
         profile: profile.clone(),
     })?;
+    record_download_progress(None);
 
     // Clone what we need for the thread
     let channel_clone = channel.clone();
@@ -173,7 +192,7 @@ pub fn download_model(
         .name("model-download".into())
         .spawn(move || {
             let result = models::download_model(&profile, |progress| {
-                *LAST_DOWNLOAD_PROGRESS.lock().unwrap() = Some(progress.clone());
+                record_download_progress(Some(&progress));
                 let _ = channel_clone.send(progress);
             });
 
@@ -188,7 +207,7 @@ pub fn download_model(
             match result {
                 Ok(()) => {
                     apply(StateAction::DownloadComplete);
-                    let prog = models::DownloadProgress {
+                    let progress = models::DownloadProgress {
                         file: "all".into(),
                         downloaded_bytes: 0,
                         total_bytes: None,
@@ -196,21 +215,21 @@ pub fn download_model(
                         total_files: 1,
                         status: models::DownloadStatus::Complete,
                     };
-                    *LAST_DOWNLOAD_PROGRESS.lock().unwrap() = Some(prog.clone());
-                    let _ = channel_clone.send(prog);
+                    record_download_progress(Some(&progress));
+                    let _ = channel_clone.send(progress);
                 }
                 Err(e) => {
                     apply(StateAction::Fail { message: e.clone() });
-                    let prog = models::DownloadProgress {
+                    let progress = models::DownloadProgress {
                         file: "error".into(),
                         downloaded_bytes: 0,
                         total_bytes: None,
                         completed_files: 0,
                         total_files: 1,
-                        status: models::DownloadStatus::Error(e.clone()),
+                        status: models::DownloadStatus::Error(e),
                     };
-                    *LAST_DOWNLOAD_PROGRESS.lock().unwrap() = Some(prog.clone());
-                    let _ = channel_clone.send(prog);
+                    record_download_progress(Some(&progress));
+                    let _ = channel_clone.send(progress);
                 }
             }
         })

--- a/src-tauri/src/commands/model.rs
+++ b/src-tauri/src/commands/model.rs
@@ -93,6 +93,14 @@ pub fn recover_state(state: State<'_, AppState>) -> Result<AppStateMachine, Stri
     state.apply_transition(StateAction::Recover)
 }
 
+static LAST_DOWNLOAD_PROGRESS: std::sync::Mutex<Option<crate::models::DownloadProgress>> = std::sync::Mutex::new(None);
+
+#[tauri::command]
+#[specta::specta]
+pub fn get_download_progress() -> Option<crate::models::DownloadProgress> {
+    LAST_DOWNLOAD_PROGRESS.lock().unwrap().clone()
+}
+
 /// Download the selected transcription model.
 /// Progress is streamed back via the Channel API.
 #[tauri::command]
@@ -123,15 +131,16 @@ pub fn download_model(
             let _ = state.apply_transition(StateAction::DownloadComplete);
         }
 
-        channel
-            .send(models::DownloadProgress {
-                file: "all".into(),
-                downloaded_bytes: 0,
-                total_bytes: None,
-                completed_files: 1,
-                total_files: 1,
-                status: models::DownloadStatus::Complete,
-            })
+        let prog = models::DownloadProgress {
+            file: "all".into(),
+            downloaded_bytes: 0,
+            total_bytes: None,
+            completed_files: 1,
+            total_files: 1,
+            status: models::DownloadStatus::Complete,
+        };
+        *LAST_DOWNLOAD_PROGRESS.lock().unwrap() = Some(prog.clone());
+        channel.send(prog)
             .map_err(|e| format!("Channel send: {e}"))?;
         return Ok(());
     }
@@ -164,6 +173,7 @@ pub fn download_model(
         .name("model-download".into())
         .spawn(move || {
             let result = models::download_model(&profile, |progress| {
+                *LAST_DOWNLOAD_PROGRESS.lock().unwrap() = Some(progress.clone());
                 let _ = channel_clone.send(progress);
             });
 
@@ -178,25 +188,29 @@ pub fn download_model(
             match result {
                 Ok(()) => {
                     apply(StateAction::DownloadComplete);
-                    let _ = channel_clone.send(models::DownloadProgress {
+                    let prog = models::DownloadProgress {
                         file: "all".into(),
                         downloaded_bytes: 0,
                         total_bytes: None,
                         completed_files: 1,
                         total_files: 1,
                         status: models::DownloadStatus::Complete,
-                    });
+                    };
+                    *LAST_DOWNLOAD_PROGRESS.lock().unwrap() = Some(prog.clone());
+                    let _ = channel_clone.send(prog);
                 }
                 Err(e) => {
                     apply(StateAction::Fail { message: e.clone() });
-                    let _ = channel_clone.send(models::DownloadProgress {
+                    let prog = models::DownloadProgress {
                         file: "error".into(),
                         downloaded_bytes: 0,
                         total_bytes: None,
                         completed_files: 0,
                         total_files: 1,
-                        status: models::DownloadStatus::Error(e),
-                    });
+                        status: models::DownloadStatus::Error(e.clone()),
+                    };
+                    *LAST_DOWNLOAD_PROGRESS.lock().unwrap() = Some(prog.clone());
+                    let _ = channel_clone.send(prog);
                 }
             }
         })

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -84,6 +84,8 @@ fn specta_builder() -> Builder<tauri::Wry> {
             commands::get_transcription_catalog,
             commands::get_model_status,
             commands::download_model,
+            commands::get_download_progress,
+            commands::get_system_audio_status,
             commands::delete_model,
             commands::load_model,
             commands::start_transcription,

--- a/src-tauri/src/pill.rs
+++ b/src-tauri/src/pill.rs
@@ -454,6 +454,15 @@ fn persist_position(app: &tauri::AppHandle) {
 mod tests {
     use super::*;
 
+    /// `HOLD` is process-global and tests run in parallel: every test that
+    /// touches it takes this guard so they cannot observe each other's hold.
+    fn hold_test_guard() -> std::sync::MutexGuard<'static, ()> {
+        static SERIAL: Mutex<()> = Mutex::new(());
+        SERIAL
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     #[test]
     fn should_show_pill_when_recording_or_held() {
         assert!(should_show_pill(true, false, false));
@@ -479,8 +488,25 @@ mod tests {
         assert!(!should_clear_hold_on_sync(true, false));
         assert!(!should_clear_hold_on_sync(false, false));
 
-        // The bug: HOLD active + Ready + no rising edge = pill stays visible
-        assert!(should_show_pill(false, true, false), "Pill zombie until clear_hold (fixed by bootstrap)");
+        // SOU-073: the webview reloads while dictation polish holds the pill.
+        // The machine is already Ready and stays there, so `sync` sees no
+        // rising edge and never clears the hold: the pill stays up with no
+        // dictation controller left to release it.
+        let _serial = hold_test_guard();
+        set_hold_state(PillHoldKind::Polishing);
+        let cleared_by_sync = should_clear_hold_on_sync(false, false);
+        assert!(!cleared_by_sync);
+        assert!(
+            should_show_pill(false, is_held(), false),
+            "a hold left over from before the reload keeps the pill visible"
+        );
+        // Bootstrap calls `pill_release` when the machine is not recording,
+        // which is what finally hides it.
+        assert!(clear_hold_state());
+        assert!(
+            !should_show_pill(false, is_held(), false),
+            "after the explicit release the pill is hidden"
+        );
     }
 
     #[test]
@@ -530,6 +556,7 @@ mod tests {
 
     #[test]
     fn hold_state_lifecycle_is_failure_safe() {
+        let _serial = hold_test_guard();
         assert!(!is_held(), "starts unheld");
 
         set_hold_state(PillHoldKind::Polishing);

--- a/src-tauri/src/pill.rs
+++ b/src-tauri/src/pill.rs
@@ -478,6 +478,9 @@ mod tests {
         );
         assert!(!should_clear_hold_on_sync(true, false));
         assert!(!should_clear_hold_on_sync(false, false));
+
+        // The bug: HOLD active + Ready + no rising edge = pill stays visible
+        assert!(should_show_pill(false, true, false), "Pill zombie until clear_hold (fixed by bootstrap)");
     }
 
     #[test]

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -34,6 +34,7 @@
   import { applyTheme, errorMessage } from "./lib/utils";
   import { micToast, micToastCopy } from "./lib/features/audio/mic-toast.svelte";
   import { decideShowSetupWizard, readSetupFlags } from "./lib/features/onboarding/setup";
+  import { loadAfterOrphanedDownload } from "./lib/features/transcription/runtime";
   import type { TranscriptionCatalog } from "./lib/types";
 
   const app = getAppState();
@@ -141,7 +142,7 @@
         }
       } catch {
         // First run, no settings yet — still offer the setup wizard.
-        if (decideShowSetupWizard("download_required", readSetupFlags())) {
+        if (decideShowSetupWizard("download_required", readSetupFlags(), app.machineState.state)) {
           app.showOnboarding = true;
         }
       }
@@ -177,6 +178,7 @@
     });
 
     events.stateChanged.listen((event) => {
+      const previous = app.machineState;
       // Detect a backend-initiated session abort (recording → error) so the
       // recorder controllers can reset their local state.
       const aborted = event.payload.state === "error" ? wasRecording(app.machineState) : null;
@@ -186,6 +188,9 @@
       // Lets a wake-resume that's waiting on a still-draining sleep-triggered
       // stop fire the moment the machine reports `ready`.
       notifyStateChanged(event.payload);
+      // A download that finished into a Channel the previous webview took
+      // with it still needs its model loaded (SOU-073).
+      loadAfterOrphanedDownload(app, previous, event.payload);
     }).then((fn) => {
       unlistenState = fn;
     });

--- a/src/lib/api/settings.ts
+++ b/src/lib/api/settings.ts
@@ -1,5 +1,10 @@
 import { commands, unwrap } from "./generated";
-import type { AppSettings, AudioInputDevice, ShortcutSettings } from "../types";
+import type {
+  AppSettings,
+  AudioInputDevice,
+  ShortcutSettings,
+  SystemAudioStatus,
+} from "../types";
 
 export async function getSettings(): Promise<AppSettings> {
   return unwrap(commands.getSettings());
@@ -35,6 +40,13 @@ export async function resetInputSampleRate(deviceUid: string): Promise<number> {
 
 export async function getSystemAudioSupport(): Promise<boolean> {
   return commands.getSystemAudioSupport();
+}
+
+/** Last system-audio leg status of the current meeting. The event only fires
+ * when the tap is (re)built, so a webview reloaded mid-meeting reads this
+ * snapshot instead (SOU-073). `null` outside a meeting session. */
+export async function getSystemAudioStatus(): Promise<SystemAudioStatus | null> {
+  return commands.getSystemAudioStatus();
 }
 
 export async function isLaptop(): Promise<boolean> {

--- a/src/lib/api/transcription.ts
+++ b/src/lib/api/transcription.ts
@@ -35,6 +35,13 @@ export async function loadModel(selection: TranscriptionProfileSelection): Promi
   await unwrap(commands.loadModel(selection));
 }
 
+/** Last progress report of the in-flight model download. The Channel that
+ * {@link downloadModel} streams to dies with the webview, so a reload
+ * mid-download reads this snapshot to restore the gauge (SOU-073). */
+export async function getDownloadProgress(): Promise<DownloadProgress | null> {
+  return commands.getDownloadProgress();
+}
+
 export async function deleteModel(selection: TranscriptionProfileSelection): Promise<void> {
   await unwrap(commands.deleteModel(selection));
 }

--- a/src/lib/bootstrap.test.ts
+++ b/src/lib/bootstrap.test.ts
@@ -1,26 +1,43 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { getSettings, saveSettings, getAppVersion, runStartupModelFlow } = vi.hoisted(() => ({
+const {
+  getSettings,
+  saveSettings,
+  getAppVersion,
+  runStartupModelFlow,
+  getMachineState,
+  pillRelease,
+  getDownloadProgress,
+  getSystemAudioStatus,
+} = vi.hoisted(() => ({
   getSettings: vi.fn(),
   saveSettings: vi.fn(),
   getAppVersion: vi.fn(),
   runStartupModelFlow: vi.fn(),
+  getMachineState: vi.fn<() => Promise<AppStateMachine>>(async () => ({ state: "idle" })),
+  pillRelease: vi.fn<() => Promise<void>>(async () => undefined),
+  getDownloadProgress: vi.fn<() => Promise<DownloadProgress | null>>(async () => null),
+  getSystemAudioStatus: vi.fn<() => Promise<SystemAudioStatus | null>>(async () => null),
 }));
 
 vi.mock("./api/settings", () => ({
   getSettings,
+  getSystemAudioStatus,
   saveSettings,
   selectAudioDevice: vi.fn(),
 }));
 vi.mock("./api/diagnostics", () => ({
   getAppVersion,
 }));
-vi.mock("./api/generated", () => ({ commands: { getSystemAudioStatus: vi.fn().mockResolvedValue(null) } }));
 vi.mock("./api/transcription", () => ({
-  getMachineState: vi.fn().mockResolvedValue({ state: "idle" }),
-  pillRelease: vi.fn().mockResolvedValue(null),
+  getDownloadProgress,
+  getMachineState,
+  pillRelease,
 }));
-vi.mock("./features/transcription/runtime", () => ({
+// Keep the real `applyDownloadProgress`: the resync test below checks the
+// counters it writes, not that it was called.
+vi.mock("./features/transcription/runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./features/transcription/runtime")>()),
   runStartupModelFlow,
 }));
 vi.mock("./utils/theme", () => ({
@@ -29,8 +46,9 @@ vi.mock("./utils/theme", () => ({
 
 import { LOCAL_BUILD, bootstrapAppState } from "./bootstrap";
 import { getAppState } from "./stores/app.svelte";
-import { mockSettings } from "./test-helpers/fixtures";
+import { mockRuntimeStatus, mockSettings } from "./test-helpers/fixtures";
 import { SETUP_STORAGE_KEY } from "./features/onboarding/setup";
+import type { AppStateMachine, DownloadProgress, SystemAudioStatus } from "./types";
 
 describe("bootstrapAppState what's new", () => {
   const app = getAppState();
@@ -97,5 +115,124 @@ describe("bootstrapAppState what's new", () => {
     expect(saveSettings).not.toHaveBeenCalledWith(
       expect.objectContaining({ last_seen_version: LOCAL_BUILD }),
     );
+  });
+});
+
+// A webview reload (crash of the render process, or ⌘R in dev) while the
+// backend keeps running: the machine enum is synced, and so must be the three
+// stores that used to restart from zero.
+describe("bootstrapAppState webview reload resync (SOU-073)", () => {
+  const app = getAppState();
+  const profile = mockRuntimeStatus.profile;
+  const downloading: AppStateMachine = { state: "downloading", data: { profile } };
+  const meeting: AppStateMachine = {
+    state: "recording_meeting",
+    data: { profile, session_id: 1, meeting_id: "m1" },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    app.settings = { ...mockSettings };
+    app.machineState = { state: "idle" };
+    app.systemAudioStatus = null;
+    app.downloadFile = "";
+    app.downloadCompletedFiles = 0;
+    app.downloadTotalFiles = 0;
+    app.downloadedBytes = 0;
+    app.downloadTotalBytes = null;
+    getSettings.mockResolvedValue({ ...mockSettings });
+    saveSettings.mockResolvedValue(undefined);
+    getAppVersion.mockResolvedValue("0.4.0");
+    runStartupModelFlow.mockResolvedValue(undefined);
+  });
+
+  it("releases a pill hold left over from before the reload when not recording", async () => {
+    // Dictation polish held the pill, then the page died before its
+    // pillRelease: the machine is Ready and `pill::sync` sees no rising edge.
+    getMachineState.mockResolvedValueOnce({ state: "ready", data: { profile } });
+
+    await bootstrapAppState(app);
+
+    expect(pillRelease).toHaveBeenCalledTimes(1);
+  });
+
+  it("never releases the pill while a session is recording", async () => {
+    getMachineState.mockResolvedValueOnce(meeting);
+    await bootstrapAppState(app);
+
+    getMachineState.mockResolvedValueOnce({
+      state: "recording_dictation",
+      data: { profile, session_id: 2 },
+    });
+    await bootstrapAppState(app);
+
+    expect(pillRelease).not.toHaveBeenCalled();
+  });
+
+  it("restores the download gauge from the backend snapshot while a download is in flight", async () => {
+    getMachineState.mockResolvedValueOnce(downloading);
+    getDownloadProgress.mockResolvedValueOnce({
+      file: "model.safetensors",
+      downloaded_bytes: 300,
+      total_bytes: 1000,
+      completed_files: 1,
+      total_files: 3,
+      status: "downloading",
+    });
+
+    await bootstrapAppState(app);
+
+    expect(app.downloadFile).toBe("model.safetensors");
+    expect(app.downloadedBytes).toBe(300);
+    expect(app.downloadTotalBytes).toBe(1000);
+    expect(app.downloadCompletedFiles).toBe(1);
+    expect(app.downloadTotalFiles).toBe(3);
+  });
+
+  it("does not read the download snapshot when nothing is downloading", async () => {
+    getMachineState.mockResolvedValueOnce({ state: "ready", data: { profile } });
+
+    await bootstrapAppState(app);
+
+    expect(getDownloadProgress).not.toHaveBeenCalled();
+    expect(app.downloadedBytes).toBe(0);
+  });
+
+  it("restores the system-audio badge for a meeting the previous webview started", async () => {
+    getMachineState.mockResolvedValueOnce(meeting);
+    getSystemAudioStatus.mockResolvedValueOnce({
+      active: false,
+      reason: "Screen Recording permission denied",
+    });
+
+    await bootstrapAppState(app);
+
+    expect(app.systemAudioStatus).toEqual({
+      active: false,
+      reason: "Screen Recording permission denied",
+    });
+  });
+
+  it("leaves the system-audio badge alone outside a meeting", async () => {
+    getMachineState.mockResolvedValueOnce({ state: "ready", data: { profile } });
+
+    await bootstrapAppState(app);
+
+    expect(getSystemAudioStatus).not.toHaveBeenCalled();
+    expect(app.systemAudioStatus).toBeNull();
+  });
+
+  it("keeps booting when a resync read fails", async () => {
+    getMachineState.mockResolvedValueOnce(meeting);
+    getSystemAudioStatus.mockRejectedValueOnce(new Error("backend busy"));
+
+    await expect(bootstrapAppState(app)).resolves.toEqual({ whatsNew: null });
+    expect(runStartupModelFlow).toHaveBeenCalledTimes(1);
+
+    getMachineState.mockResolvedValueOnce({ state: "ready", data: { profile } });
+    pillRelease.mockRejectedValueOnce(new Error("backend busy"));
+
+    await expect(bootstrapAppState(app)).resolves.toEqual({ whatsNew: null });
   });
 });

--- a/src/lib/bootstrap.test.ts
+++ b/src/lib/bootstrap.test.ts
@@ -15,8 +15,10 @@ vi.mock("./api/settings", () => ({
 vi.mock("./api/diagnostics", () => ({
   getAppVersion,
 }));
+vi.mock("./api/generated", () => ({ commands: { getSystemAudioStatus: vi.fn().mockResolvedValue(null) } }));
 vi.mock("./api/transcription", () => ({
   getMachineState: vi.fn().mockResolvedValue({ state: "idle" }),
+  pillRelease: vi.fn().mockResolvedValue(null),
 }));
 vi.mock("./features/transcription/runtime", () => ({
   runStartupModelFlow,

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -1,8 +1,12 @@
-import { getSettings, saveSettings, selectAudioDevice } from "./api/settings";
+import {
+  getSettings,
+  getSystemAudioStatus,
+  saveSettings,
+  selectAudioDevice,
+} from "./api/settings";
 import { getAppVersion } from "./api/diagnostics";
-import { getMachineState, pillRelease } from "./api/transcription";
-import { commands } from "./api/generated";
-import { runStartupModelFlow } from "./features/transcription/runtime";
+import { getDownloadProgress, getMachineState, pillRelease } from "./api/transcription";
+import { applyDownloadProgress, runStartupModelFlow } from "./features/transcription/runtime";
 import { readSetupFlags } from "./features/onboarding/setup";
 import { setLocale } from "./i18n";
 import { getAppState } from "./stores/app.svelte";
@@ -27,17 +31,7 @@ export async function bootstrapAppState(
     // Backend not ready yet — StateChanged events will sync us.
   }
 
-  if (app.machineState?.state !== "recording_dictation" && app.machineState?.state !== "recording_meeting") {
-    pillRelease().catch(() => {});
-  }
-  if (app.machineState?.state === "recording_meeting") {
-    commands.getSystemAudioStatus().then((res) => {
-      if (res) {
-        const [active, reason] = res;
-        app.systemAudioStatus = { active, reason };
-      }
-    });
-  }
+  await resyncAfterReload(app);
 
   const settings = await getSettings();
   app.settings = settings;
@@ -91,6 +85,43 @@ export async function bootstrapAppState(
       releaseNotes: whatsNewFallback(currentVersion),
     },
   };
+}
+
+/** The truths a webview reload loses with the page while the backend keeps
+ * running (SOU-073): the pill HOLD whose release call lived in the destroyed
+ * dictation controller, the download gauge whose Channel died, and the
+ * system-audio badge whose event already fired. Each is a read, never a
+ * rebuild, and each failure is swallowed like the machine sync above. */
+async function resyncAfterReload(app: ReturnType<typeof getAppState>): Promise<void> {
+  const state = app.machineState.state;
+
+  // A hold left by an interrupted polish has nobody left to release it, and
+  // `pill::sync` only drops it on the next idle → recording edge. Never
+  // release during a session: that would hide a live meeting's pill.
+  if (state !== "recording_dictation" && state !== "recording_meeting") {
+    try {
+      await pillRelease();
+    } catch {
+      // Nothing held, or backend not ready: the pill is not showing anyway.
+    }
+  }
+
+  if (state === "downloading") {
+    try {
+      const progress = await getDownloadProgress();
+      if (progress) applyDownloadProgress(app, progress);
+    } catch {
+      // Gauge stays at zero; the download itself is unaffected.
+    }
+  }
+
+  if (state === "recording_meeting") {
+    try {
+      app.systemAudioStatus = await getSystemAudioStatus();
+    } catch {
+      // Badge stays hidden until the next tap rebuild emits.
+    }
+  }
 }
 
 export function whatsNewFallback(version: string): string {

--- a/src/lib/bootstrap.ts
+++ b/src/lib/bootstrap.ts
@@ -1,6 +1,7 @@
 import { getSettings, saveSettings, selectAudioDevice } from "./api/settings";
 import { getAppVersion } from "./api/diagnostics";
-import { getMachineState } from "./api/transcription";
+import { getMachineState, pillRelease } from "./api/transcription";
+import { commands } from "./api/generated";
 import { runStartupModelFlow } from "./features/transcription/runtime";
 import { readSetupFlags } from "./features/onboarding/setup";
 import { setLocale } from "./i18n";
@@ -24,6 +25,18 @@ export async function bootstrapAppState(
     app.machineState = await getMachineState();
   } catch {
     // Backend not ready yet — StateChanged events will sync us.
+  }
+
+  if (app.machineState?.state !== "recording_dictation" && app.machineState?.state !== "recording_meeting") {
+    pillRelease().catch(() => {});
+  }
+  if (app.machineState?.state === "recording_meeting") {
+    commands.getSystemAudioStatus().then((res) => {
+      if (res) {
+        const [active, reason] = res;
+        app.systemAudioStatus = { active, reason };
+      }
+    });
   }
 
   const settings = await getSettings();

--- a/src/lib/features/onboarding/setup.test.ts
+++ b/src/lib/features/onboarding/setup.test.ts
@@ -61,13 +61,13 @@ describe("decideShowSetupWizard", () => {
       decideShowSetupWizard("download_required", {
         permissionsDone: false,
         setupDone: false,
-      }),
+      }, "idle"),
     ).toBe(true);
   });
 
   it("keeps showing after the model is ready until the wizard is finished", () => {
     expect(
-      decideShowSetupWizard("ready", { permissionsDone: false, setupDone: false }),
+      decideShowSetupWizard("ready", { permissionsDone: false, setupDone: false }, "ready"),
     ).toBe(true);
   });
 
@@ -76,13 +76,13 @@ describe("decideShowSetupWizard", () => {
       decideShowSetupWizard("download_required", {
         permissionsDone: true,
         setupDone: false,
-      }),
+      }, "idle"),
     ).toBe(true);
   });
 
   it("hides for migrated existing users", () => {
     expect(
-      decideShowSetupWizard("ready", { permissionsDone: true, setupDone: true }),
+      decideShowSetupWizard("ready", { permissionsDone: true, setupDone: true }, "ready"),
     ).toBe(false);
   });
 
@@ -91,7 +91,26 @@ describe("decideShowSetupWizard", () => {
       decideShowSetupWizard("download_required", {
         permissionsDone: true,
         setupDone: true,
-      }),
+      }, "idle"),
+    ).toBe(true);
+  });
+
+  it("stays closed on a webview reload while the backend is still downloading (SOU-073)", () => {
+    // Files on disk are incomplete, so the phase reads "download_required",
+    // but the machine is mid-download: reopening would stack the wizard over
+    // a download that is about to finish.
+    expect(
+      decideShowSetupWizard("download_required", {
+        permissionsDone: true,
+        setupDone: true,
+      }, "downloading"),
+    ).toBe(false);
+    // A first run is different: the wizard is what is running the download.
+    expect(
+      decideShowSetupWizard("download_required", {
+        permissionsDone: true,
+        setupDone: false,
+      }, "downloading"),
     ).toBe(true);
   });
 });

--- a/src/lib/features/onboarding/setup.ts
+++ b/src/lib/features/onboarding/setup.ts
@@ -1,3 +1,4 @@
+import { getAppState } from "../../stores/app.svelte";
 import type { TranscriptionRuntimePhase } from "../../types";
 
 export const PERMISSIONS_STORAGE_KEY = "permissionsOnboarded";
@@ -56,7 +57,10 @@ export function decideShowSetupWizard(
   phase: TranscriptionRuntimePhase,
   flags: SetupFlags,
 ): boolean {
-  if (flags.setupDone) return phase === "download_required";
+  const app = getAppState();
+  if (flags.setupDone) {
+    return phase === "download_required" && app.machineState?.state !== "downloading";
+  }
   if (flags.permissionsDone && phase !== "download_required") return false;
   return true;
 }

--- a/src/lib/features/onboarding/setup.ts
+++ b/src/lib/features/onboarding/setup.ts
@@ -1,5 +1,4 @@
-import { getAppState } from "../../stores/app.svelte";
-import type { TranscriptionRuntimePhase } from "../../types";
+import type { AppStateMachine, TranscriptionRuntimePhase } from "../../types";
 
 export const PERMISSIONS_STORAGE_KEY = "permissionsOnboarded";
 export const SETUP_STORAGE_KEY = "setupOnboarded";
@@ -56,10 +55,14 @@ export function shouldMigrateSetupComplete(
 export function decideShowSetupWizard(
   phase: TranscriptionRuntimePhase,
   flags: SetupFlags,
+  machineState: AppStateMachine["state"],
 ): boolean {
-  const app = getAppState();
   if (flags.setupDone) {
-    return phase === "download_required" && app.machineState?.state !== "downloading";
+    // Model-only recovery after the user deleted the files. Not while the
+    // backend is still downloading: a webview reload mid-download reports
+    // "download_required" too, and must not reopen the wizard over a
+    // download that is about to finish (SOU-073).
+    return phase === "download_required" && machineState !== "downloading";
   }
   if (flags.permissionsDone && phase !== "download_required") return false;
   return true;

--- a/src/lib/features/transcription/runtime.test.ts
+++ b/src/lib/features/transcription/runtime.test.ts
@@ -1,5 +1,35 @@
-import { describe, expect, it } from "vitest";
-import { decideStartupModelAction } from "./runtime";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const api = vi.hoisted(() => ({
+  getTranscriptionCatalog: vi.fn(),
+  getModelStatus: vi.fn(),
+  downloadModel: vi.fn(),
+  loadModel: vi.fn(),
+}));
+vi.mock("../../api/transcription", () => api);
+
+import {
+  decideStartupModelAction,
+  loadAfterOrphanedDownload,
+  runStartupModelFlow,
+  shouldLoadAfterOrphanedDownload,
+  startTranscriptionModelDownload,
+} from "./runtime";
+import { getAppState } from "../../stores/app.svelte";
+import { markSetupComplete } from "../onboarding/setup";
+import { mockCatalog, mockRuntimeStatus, mockSettings } from "../../test-helpers/fixtures";
+import type { AppStateMachine, DownloadProgress } from "../../types";
+
+const profile = mockRuntimeStatus.profile;
+const selection = {
+  engine_id: profile.engine_id,
+  model_id: profile.model_id,
+  backend_id: profile.backend_id,
+};
+const downloading: AppStateMachine = { state: "downloading", data: { profile } };
+const downloaded: AppStateMachine = { state: "downloaded", data: { profile } };
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 describe("decideStartupModelAction", () => {
   it("shows onboarding when no model is downloaded", () => {
@@ -18,5 +48,140 @@ describe("decideStartupModelAction", () => {
     expect(decideStartupModelAction("load_required", "recording_dictation")).toBe("none");
     expect(decideStartupModelAction("ready", "ready")).toBe("none");
     expect(decideStartupModelAction("ready", "idle")).toBe("none");
+  });
+});
+
+describe("shouldLoadAfterOrphanedDownload", () => {
+  it("fires when a download completes into a dead channel", () => {
+    expect(shouldLoadAfterOrphanedDownload("downloading", "downloaded", "load_required", false))
+      .toBe(true);
+  });
+
+  it("leaves the load to the live channel callback", () => {
+    expect(shouldLoadAfterOrphanedDownload("downloading", "downloaded", "load_required", true))
+      .toBe(false);
+  });
+
+  it("ignores the downloaded state an idle-timeout unload lands on", () => {
+    expect(shouldLoadAfterOrphanedDownload("unloading", "downloaded", "load_required", false))
+      .toBe(false);
+    expect(shouldLoadAfterOrphanedDownload("ready", "downloaded", "load_required", false))
+      .toBe(false);
+  });
+
+  it("has no edge to fire on when the event repeats", () => {
+    expect(shouldLoadAfterOrphanedDownload("downloaded", "downloaded", "load_required", false))
+      .toBe(false);
+  });
+
+  it("does not load a model the user is no longer pointing at", () => {
+    expect(shouldLoadAfterOrphanedDownload("downloading", "downloaded", "download_required", false))
+      .toBe(false);
+  });
+});
+
+describe("loadAfterOrphanedDownload", () => {
+  const app = getAppState();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    app.settings = { ...mockSettings };
+    app.machineState = { state: "idle" };
+    api.loadModel.mockResolvedValue(undefined);
+    api.getModelStatus.mockResolvedValue({ ...mockRuntimeStatus, phase: "ready" });
+  });
+
+  it("loads the model once when the DownloadComplete lands on a dead channel", async () => {
+    // The StateChanged listener has already applied the new machine state,
+    // which moved the selected profile's phase to load_required.
+    app.machineState = downloaded;
+
+    loadAfterOrphanedDownload(app, downloading, downloaded);
+    await vi.waitFor(() => expect(api.loadModel).toHaveBeenCalledTimes(1));
+    expect(api.loadModel).toHaveBeenCalledWith(selection);
+
+    // A duplicate event has no edge left to fire on.
+    loadAfterOrphanedDownload(app, downloaded, downloaded);
+    await flush();
+    expect(api.loadModel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reload a model the idle timeout just unloaded", async () => {
+    app.machineState = downloaded;
+
+    loadAfterOrphanedDownload(app, { state: "unloading", data: { profile, next_profile: null } }, downloaded);
+    await flush();
+
+    expect(api.loadModel).not.toHaveBeenCalled();
+  });
+
+  it("defers to the live channel callback while this webview owns the download", async () => {
+    // What get_model_status reports once the files are on disk.
+    api.getModelStatus.mockResolvedValue({ ...mockRuntimeStatus, phase: "load_required" });
+    let onProgress: ((progress: DownloadProgress) => void) | null = null;
+    api.downloadModel.mockImplementation(async (_selection, callback) => {
+      onProgress = callback;
+    });
+    await startTranscriptionModelDownload(app, null, () => {});
+    expect(onProgress).not.toBeNull();
+
+    app.machineState = downloaded;
+    loadAfterOrphanedDownload(app, downloading, downloaded);
+    await flush();
+    expect(api.loadModel).not.toHaveBeenCalled();
+
+    // The channel finishes (no autoLoad requested by this caller), which
+    // hands the responsibility back to the safety net for the next download.
+    onProgress!({
+      file: "all",
+      downloaded_bytes: 0,
+      total_bytes: null,
+      completed_files: 1,
+      total_files: 1,
+      status: "complete",
+    });
+    await flush();
+    expect(api.loadModel).not.toHaveBeenCalled();
+
+    loadAfterOrphanedDownload(app, downloading, downloaded);
+    await vi.waitFor(() => expect(api.loadModel).toHaveBeenCalledTimes(1));
+  });
+});
+
+describe("runStartupModelFlow", () => {
+  const app = getAppState();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    app.settings = { ...mockSettings };
+    app.machineState = { state: "idle" };
+    app.showOnboarding = false;
+    api.getTranscriptionCatalog.mockResolvedValue(mockCatalog);
+    api.loadModel.mockResolvedValue(undefined);
+  });
+
+  it("loads a model the backend finished downloading while the webview was gone", async () => {
+    markSetupComplete();
+    app.machineState = downloaded;
+    api.getModelStatus.mockResolvedValue({ ...mockRuntimeStatus, phase: "load_required" });
+
+    await runStartupModelFlow(app);
+
+    await vi.waitFor(() => expect(api.loadModel).toHaveBeenCalledTimes(1));
+    expect(api.loadModel).toHaveBeenCalledWith(selection);
+    expect(app.showOnboarding).toBe(false);
+  });
+
+  it("keeps the wizard closed on a reload mid-download once setup is done", async () => {
+    markSetupComplete();
+    app.machineState = downloading;
+    api.getModelStatus.mockResolvedValue({ ...mockRuntimeStatus, phase: "download_required" });
+
+    await runStartupModelFlow(app);
+
+    expect(app.showOnboarding).toBe(false);
+    expect(api.loadModel).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/features/transcription/runtime.ts
+++ b/src/lib/features/transcription/runtime.ts
@@ -6,6 +6,7 @@ import {
   loadModel,
 } from "../../api/transcription";
 import type {
+  AppStateMachine,
   DownloadProgress,
   TranscriptionCatalog,
   TranscriptionRuntimePhase,
@@ -60,6 +61,23 @@ export async function refreshTranscriptionRuntimeStatus(
   return status.phase;
 }
 
+/** Whether a download's progress Channel is alive in this webview. A reload
+ * drops it with the page, and the download thread then finishes into a dead
+ * callback: no autoLoad, no counter reset (SOU-073). */
+let downloadChannelLive = false;
+
+/** Mirror one progress report into the download counters. Shared by the live
+ * Channel callback and by the bootstrap resync after a webview reload. */
+export function applyDownloadProgress(app: AppState, progress: DownloadProgress): void {
+  app.downloadFile = progress.file;
+  app.downloadCompletedFiles = progress.completed_files;
+  app.downloadTotalFiles = progress.total_files;
+  app.downloadedBytes = progress.downloaded_bytes;
+  if (progress.total_bytes !== null) {
+    app.downloadTotalBytes = progress.total_bytes;
+  }
+}
+
 export async function startTranscriptionModelDownload(
   app: AppState,
   catalog: TranscriptionCatalog | null,
@@ -75,24 +93,21 @@ export async function startTranscriptionModelDownload(
   app.downloadTotalBytes = null;
   setStatusMessage("");
 
+  downloadChannelLive = true;
   try {
     await downloadModel(
       currentTranscriptionSelection(app, catalog),
       (progress: DownloadProgress) => {
-        app.downloadFile = progress.file;
-        app.downloadCompletedFiles = progress.completed_files;
-        app.downloadTotalFiles = progress.total_files;
-        app.downloadedBytes = progress.downloaded_bytes;
-        if (progress.total_bytes !== null) {
-          app.downloadTotalBytes = progress.total_bytes;
-        }
+        applyDownloadProgress(app, progress);
 
         if (typeof progress.status === "object" && "error" in progress.status) {
+          downloadChannelLive = false;
           setStatusMessage(`Download error: ${progress.status.error}`);
           return;
         }
 
         if (progress.status === "complete" && progress.file === "all") {
+          downloadChannelLive = false;
           app.downloadFile = "";
           app.downloadedBytes = 0;
           app.downloadTotalBytes = null;
@@ -114,8 +129,50 @@ export async function startTranscriptionModelDownload(
       },
     );
   } catch (error) {
+    downloadChannelLive = false;
     setStatusMessage(errorMessage(error));
   }
+}
+
+/** Whether a `StateChanged` marks a download finishing into a dead Channel.
+ * Only the downloading → downloaded edge counts: an idle-timeout unload also
+ * lands on `downloaded` (via `unloading`) and must not reload what it just
+ * freed, and a repeated event has no edge to fire on. */
+export function shouldLoadAfterOrphanedDownload(
+  previous: AppStateMachine["state"],
+  next: AppStateMachine["state"],
+  phase: TranscriptionRuntimePhase,
+  channelLive: boolean,
+): boolean {
+  return (
+    previous === "downloading"
+    && next === "downloaded"
+    && phase === "load_required"
+    && !channelLive
+  );
+}
+
+/** Safety net for the autoLoad a webview reload lost with its progress
+ * Channel (SOU-073). Called from the global StateChanged listener with the
+ * machine state before and after the event. Loads at most once per
+ * download; if `runStartupModelFlow` raced it, `load_model` reuses the
+ * engine already loaded and the silent status callback shows no error. */
+export function loadAfterOrphanedDownload(
+  app: AppState,
+  previous: AppStateMachine,
+  next: AppStateMachine,
+): void {
+  if (
+    !shouldLoadAfterOrphanedDownload(
+      previous.state,
+      next.state,
+      app.transcriptionRuntimePhase,
+      downloadChannelLive,
+    )
+  ) {
+    return;
+  }
+  void startTranscriptionModelLoad(app, null, () => {});
 }
 
 /// What to do with the selected model when the app starts.
@@ -137,7 +194,11 @@ function applySetupWizardVisibility(app: AppState): void {
   if (shouldMigrateSetupComplete(app.transcriptionRuntimePhase, flags)) {
     markSetupComplete();
   }
-  app.showOnboarding = decideShowSetupWizard(app.transcriptionRuntimePhase, readSetupFlags());
+  app.showOnboarding = decideShowSetupWizard(
+    app.transcriptionRuntimePhase,
+    readSetupFlags(),
+    app.machineState.state,
+  );
 }
 
 /** Startup flow: auto-load the last-selected model, or surface onboarding

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -39,10 +39,20 @@ async downloadModel(selection: TranscriptionProfileSelection, channel: TAURI_CHA
     else return { status: "error", error: e  as any };
 }
 },
+/**
+ * Snapshot of the in-flight model download, for a webview that reloaded
+ * while the machine was `Downloading` and lost its progress Channel.
+ * `None` until the first download of the process starts.
+ */
 async getDownloadProgress() : Promise<DownloadProgress | null> {
     return await TAURI_INVOKE("get_download_progress");
 },
-async getSystemAudioStatus() : Promise<[boolean, string | null] | null> {
+/**
+ * Last system-audio leg status of the current meeting, for a webview that
+ * reloaded after the `SystemAudioStatus` event already fired (SOU-073).
+ * `None` outside a meeting session or before the tap was first attempted.
+ */
+async getSystemAudioStatus() : Promise<SystemAudioStatus | null> {
     return await TAURI_INVOKE("get_system_audio_status");
 },
 /**

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -39,6 +39,12 @@ async downloadModel(selection: TranscriptionProfileSelection, channel: TAURI_CHA
     else return { status: "error", error: e  as any };
 }
 },
+async getDownloadProgress() : Promise<DownloadProgress | null> {
+    return await TAURI_INVOKE("get_download_progress");
+},
+async getSystemAudioStatus() : Promise<[boolean, string | null] | null> {
+    return await TAURI_INVOKE("get_system_audio_status");
+},
 /**
  * Delete a downloaded model from disk.
  */


### PR DESCRIPTION
### Fixes

* **Bootstrap State Resync:** Fetch download progress and system audio status on bootstrap if machine is in downloading or recording states.
* **Pill Zombification:** Added `pillRelease()` on bootstrap for non-recording states to clear any leftover hold.
* **Setup Wizard:** `decideShowSetupWizard` no longer returns true if the machine is downloading and setup is done.

### Test Plan

* Validated `decideShowSetupWizard` unit tests for download state checks.
* Validated `pill.rs` to ensure hold is cleared when not recording.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - System-audio capture status is now available, including failure details when capture is inactive.
  - Model download progress is retained and can be retrieved after updates or completion.

- **Bug Fixes**
  - Prevented stale recording controls from remaining visible after app startup.
  - Improved setup wizard behavior so it does not appear while model downloading is already in progress.
  - Preserved held recording controls correctly when recording has not begun.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->