### PR TITLE
ci: cap contracts and e2e jobs so a hung test cannot burn six hours of macOS minutes

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -16,6 +16,10 @@ concurrency:
 jobs:
   generated-contracts:
     runs-on: macos-latest
+    # The job normally finishes in ~13 min. Without a cap, a hung step runs to
+    # GitHub's 6 h default, and macOS minutes bill at 10x: one stuck run costs
+    # more than a month of green ones.
+    timeout-minutes: 30
 
     steps:
       - uses: actions/checkout@v6.0.1
@@ -51,6 +55,11 @@ jobs:
       # tree catches that, so run the suites here as well as locally.
       - run: cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
       - run: cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings
+      # Silero's two ort tests have hung here indefinitely: whichever thread
+      # wins the `Once` in `ensure_ort_initialized` can stall inside
+      # `ort::init_from`, and every other thread then blocks on that `Once`
+      # with no timeout. Fail the step instead of holding the runner.
       - run: cargo test --manifest-path src-tauri/Cargo.toml --workspace
+        timeout-minutes: 15
       - run: npm test
       - run: npm run check

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,6 +17,7 @@ jobs:
     # Frontend-only smoke suite (IPC is stubbed, see tests/e2e/tauri-stub.ts):
     # no Rust build needed, so a Linux runner is fine and cheaper than macOS.
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v6.0.1


### PR DESCRIPTION
## Summary

Adds `timeout-minutes` to the two CI workflows. A run stuck on `cargo test` currently holds a `macos-latest` runner until GitHub's 6 h default, and macOS minutes bill at 10x.

## What happened

The contracts run on `fix/SOU-013-rewrite-selection` (run `34382453297`) sat on the `cargo test` step for **2 h 23 min** before being cancelled by hand. The log ends on exactly two lines:

```
test filter::tests::silero_mixed_block_feeds_when_speech_is_not_last_frame has been running for over 60 seconds
test filter::tests::silero_vad_runs_against_bundled_ort_dylib has been running for over 60 seconds
```

Both ort tests stalled together and nothing else did.

## Why they can stall forever

`ort_runtime::ensure_ort_initialized` guards `ort::init_from` with a `std::sync::Once`. When the thread that wins `call_once` stalls inside it, every other ort caller blocks on that `Once` with no timeout. Nothing below it has a deadline either, and neither workflow set `timeout-minutes`.

This is intermittent, not a regression: the same two tests pass in about a second on the runs immediately before and after (`34380711520`, `34380725470`).

## Changes

- `contracts`: job capped at 30 min (normally ~13), and the `cargo test` step capped at 15 so a repeat fails on the step that hung instead of holding the runner.
- `e2e`: job capped at 20 min (normally under 1).

## Out of scope

The stall itself. This PR bounds the cost only; the ort init deadlock needs its own ticket.

## Verification

YAML-only change, exercised by this PR's own run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bc6HHHoQ9uHLEj9WNuTCSe

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added time limits to contract-generation and end-to-end test workflows.
  - Long-running test jobs now stop automatically instead of running indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->