### PR TITLE
Feat: SOU-099 - Timeout and dismiss for StatusBanner

### DIFF
--- a/src/lib/components/HomeView.svelte
+++ b/src/lib/components/HomeView.svelte
@@ -115,6 +115,7 @@
         message={transcription.statusMessage}
         actionLabel={transcription.statusActionLabel}
         onAction={transcription.statusAction}
+        onDismiss={transcription.clearBanner}
         variant="warning"
       />
     {/if}
@@ -123,6 +124,7 @@
         message={meeting.statusMessage}
         actionLabel={meeting.statusActionLabel}
         onAction={meeting.statusAction}
+        onDismiss={meeting.clearBanner}
         variant="warning"
       />
     {/if}

--- a/src/lib/components/ui/StatusBanner.svelte
+++ b/src/lib/components/ui/StatusBanner.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { X } from "lucide-svelte";
+  import { X } from "@lucide/svelte";
   import { t } from "svelte-i18n";
   let {
     message,
@@ -26,15 +26,20 @@
   }`}
 >
   <p class="text-sm">{message}</p>
-  
+
   <div class="flex items-center gap-2">
     {#if actionLabel && onAction}
-      <button class="btn btn-primary btn-sm shrink-0" onclick={onAction}>
+      <button type="button" class="btn btn-primary btn-sm shrink-0" onclick={onAction}>
         {actionLabel}
       </button>
     {/if}
     {#if onDismiss}
-      <button class="flex h-6 w-6 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-surface-4 hover:text-text-primary" onclick={onDismiss} aria-label={$t("mic_toast.dismiss")}>
+      <button
+        type="button"
+        class="btn btn-icon shrink-0"
+        onclick={onDismiss}
+        aria-label={$t("mic_toast.dismiss")}
+      >
         <X size={14} aria-hidden="true" />
       </button>
     {/if}

--- a/src/lib/components/ui/StatusBanner.svelte
+++ b/src/lib/components/ui/StatusBanner.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
+  import { X } from "lucide-svelte";
+  import { t } from "svelte-i18n";
   let {
     message,
     variant = "info",
     actionLabel,
-    onAction
+    onAction,
+    onDismiss
   }: {
     message: string;
     variant?: "warning" | "danger" | "info";
     actionLabel?: string;
     onAction?: () => void;
+    onDismiss?: () => void;
   } = $props();
 </script>
 
@@ -22,9 +26,17 @@
   }`}
 >
   <p class="text-sm">{message}</p>
-  {#if actionLabel && onAction}
-    <button class="btn btn-primary btn-sm shrink-0" onclick={onAction}>
-      {actionLabel}
-    </button>
-  {/if}
+  
+  <div class="flex items-center gap-2">
+    {#if actionLabel && onAction}
+      <button class="btn btn-primary btn-sm shrink-0" onclick={onAction}>
+        {actionLabel}
+      </button>
+    {/if}
+    {#if onDismiss}
+      <button class="flex h-6 w-6 items-center justify-center rounded-md text-text-tertiary transition-colors hover:bg-surface-4 hover:text-text-primary" onclick={onDismiss} aria-label={$t("mic_toast.dismiss")}>
+        <X size={14} aria-hidden="true" />
+      </button>
+    {/if}
+  </div>
 </div>

--- a/src/lib/components/ui/StatusBanner.test.ts
+++ b/src/lib/components/ui/StatusBanner.test.ts
@@ -46,4 +46,27 @@ describe('StatusBanner', () => {
     render(StatusBanner, { props: { message: 'Just a message', actionLabel: 'Repair' } });
     expect(screen.queryByRole('button')).toBeNull();
   });
+
+  it('renders an accessible dismiss button when onDismiss is provided', async () => {
+    const onDismiss = vi.fn();
+    render(StatusBanner, { props: { message: 'Copied', onDismiss } });
+
+    const button = screen.getByRole('button', { name: 'Dismiss' });
+    await fireEvent.click(button);
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it('keeps dismiss next to an action button', () => {
+    render(StatusBanner, {
+      props: {
+        message: 'Model required',
+        actionLabel: 'Open model',
+        onAction: vi.fn(),
+        onDismiss: vi.fn(),
+      },
+    });
+
+    expect(screen.getByRole('button', { name: 'Open model' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Dismiss' })).toBeTruthy();
+  });
 });

--- a/src/lib/features/meeting/components/MeetingDetail.svelte
+++ b/src/lib/features/meeting/components/MeetingDetail.svelte
@@ -39,6 +39,7 @@
       message={controller.statusMessage}
       actionLabel={controller.statusActionLabel}
       onAction={controller.statusAction}
+      onDismiss={controller.clearBanner}
       variant="warning"
     />
   {/if}

--- a/src/lib/features/meeting/controller.svelte.test.ts
+++ b/src/lib/features/meeting/controller.svelte.test.ts
@@ -1181,4 +1181,89 @@ describe("MeetingController", () => {
       expect(mockResumeMeetingRecording).toHaveBeenCalledOnce();
     });
   });
+
+  describe("banner lifetime (SOU-099)", () => {
+    async function mountedController() {
+      mockGetSummaryProvidersStatus.mockResolvedValue(makeSummaryProvidersStatus());
+      mockGetTranscriptionCatalog.mockResolvedValue(makeCatalog());
+      const ctrl = createMeetingController();
+      await ctrl.mount();
+      return ctrl;
+    }
+
+    it("auto-hides a banner without an action after 5s", async () => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      try {
+        const ctrl = await mountedController();
+        ctrl.handleRecordingAborted();
+        expect(ctrl.statusMessage).toMatch(/interrupted/i);
+        expect(ctrl.statusActionLabel).toBeUndefined();
+
+        await vi.advanceTimersByTimeAsync(4999);
+        expect(ctrl.statusMessage).toMatch(/interrupted/i);
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(ctrl.statusMessage).toBe("");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not auto-hide a banner that carries an action", async () => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      try {
+        mockApp.transcriptionRuntimePhase = "download_required";
+        const ctrl = await mountedController();
+        await ctrl.startRecording();
+
+        expect(ctrl.statusMessage).toContain("Load the model");
+        expect(ctrl.statusActionLabel).toBe("Open model");
+
+        await vi.advanceTimersByTimeAsync(5000);
+        expect(ctrl.statusMessage).toContain("Load the model");
+        expect(ctrl.statusActionLabel).toBe("Open model");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("clearBanner dismisses immediately and cancels the auto-hide timer", async () => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      try {
+        const ctrl = await mountedController();
+        ctrl.handleRecordingAborted();
+        expect(ctrl.statusMessage).toMatch(/interrupted/i);
+
+        ctrl.clearBanner();
+        expect(ctrl.statusMessage).toBe("");
+        expect(ctrl.statusActionLabel).toBeUndefined();
+
+        await vi.advanceTimersByTimeAsync(5000);
+        expect(ctrl.statusMessage).toBe("");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("a later banner cancels the previous auto-hide timer", async () => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      try {
+        const ctrl = await mountedController();
+        ctrl.handleRecordingAborted();
+        expect(ctrl.statusMessage).toMatch(/interrupted/i);
+
+        await vi.advanceTimersByTimeAsync(2000);
+        ctrl.handleRecordingAborted();
+        expect(ctrl.statusMessage).toMatch(/interrupted/i);
+
+        await vi.advanceTimersByTimeAsync(4000);
+        expect(ctrl.statusMessage).toMatch(/interrupted/i);
+
+        await vi.advanceTimersByTimeAsync(1000);
+        expect(ctrl.statusMessage).toBe("");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
 });

--- a/src/lib/features/meeting/controller.svelte.ts
+++ b/src/lib/features/meeting/controller.svelte.ts
@@ -290,14 +290,31 @@ function createMeetingControllerInstance() {
     }
   }
 
+  let bannerTimer: ReturnType<typeof setTimeout> | null = null;
+  const AUTO_HIDE_MS = 5000;
+
+  function clearBannerTimer() {
+    if (bannerTimer) {
+      clearTimeout(bannerTimer);
+      bannerTimer = null;
+    }
+  }
+
   function setBanner(message: string, action?: { label: string; run: () => void }) {
+    clearBannerTimer();
     statusMessage = message;
     statusActionLabel = action?.label;
     statusAction = action?.run;
+    if (message && !action) {
+      bannerTimer = setTimeout(clearBanner, AUTO_HIDE_MS);
+    }
   }
 
   function clearBanner() {
-    setBanner("");
+    clearBannerTimer();
+    statusMessage = "";
+    statusActionLabel = undefined;
+    statusAction = undefined;
   }
 
   function modelRequiredBanner(message: string) {
@@ -878,6 +895,7 @@ function createMeetingControllerInstance() {
     get idleDismissed() { return idleDismissed; },
     onNotesChange,
     flushNotes,
+    clearBanner,
     mount,
     onMeetingSelectionChange,
     refreshSummaryProviders,

--- a/src/lib/features/meeting/controller.svelte.ts
+++ b/src/lib/features/meeting/controller.svelte.ts
@@ -986,5 +986,6 @@ export function createMeetingController() {
  * Clear the controller singleton so tests can start fresh.
  */
 export function resetMeetingControllerForTest() {
+  instance?.clearBanner();
   instance = null;
 }

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -1461,6 +1461,54 @@ describe("transcription controller", () => {
     expect(mockInvoke).not.toHaveBeenCalledWith("add_dictation_entry", expect.anything());
   });
 
+  it("does not auto-hide a banner that carries an action", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === "get_model_status") {
+          return Promise.resolve({ ...fakeStatus, phase: "download_required" });
+        }
+        return defaultInvoke(cmd);
+      });
+
+      const ctrl = createTranscriptionController();
+      await ctrl.mount();
+      await ctrl.toggleRecording();
+
+      expect(ctrl.statusActionLabel).toBe("Open model");
+      const message = ctrl.statusMessage;
+      expect(message).toContain("Download and load");
+
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(ctrl.statusMessage).toBe(message);
+      expect(ctrl.statusActionLabel).toBe("Open model");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clearBanner dismisses immediately and cancels the auto-hide timer", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      const ctrl = createTranscriptionController();
+      await ctrl.mount();
+
+      await ctrl.toggleRecording(true);
+      simulateRecordingStarted(ctrl.app, 0);
+      await ctrl.toggleRecording(true);
+      expect(ctrl.statusMessage).toBe("Hold a little longer");
+
+      ctrl.clearBanner();
+      expect(ctrl.statusMessage).toBe("");
+      expect(ctrl.statusActionLabel).toBeUndefined();
+
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(ctrl.statusMessage).toBe("");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("auto-hides the banner after 5s without wiping a later banner", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     try {

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -1461,7 +1461,7 @@ describe("transcription controller", () => {
     expect(mockInvoke).not.toHaveBeenCalledWith("add_dictation_entry", expect.anything());
   });
 
-  it("auto-hides the too-short banner after 2s without wiping a later banner", async () => {
+  it("auto-hides the banner after 5s without wiping a later banner", async () => {
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     try {
       const ctrl = createTranscriptionController();
@@ -1472,8 +1472,34 @@ describe("transcription controller", () => {
       await ctrl.toggleRecording(true);
       expect(ctrl.statusMessage).toBe("Hold a little longer");
 
-      await vi.advanceTimersByTimeAsync(2000);
+      await vi.advanceTimersByTimeAsync(5000);
       expect(ctrl.statusMessage).toBe("");
+
+      // Test AC4: A later banner cancels the previous timer
+      await ctrl.toggleRecording(true);
+      simulateRecordingStarted(ctrl.app, 0);
+      await ctrl.toggleRecording(true);
+      expect(ctrl.statusMessage).toBe("Hold a little longer");
+      
+      await vi.advanceTimersByTimeAsync(2000);
+      
+      // Simulate another banner before timeout
+      ctrl.app.transcriptionRuntimePhase = "download_required";
+      await vi.advanceTimersByTimeAsync(0); // wait for reactivity
+      // In reality, download_required might trigger modelRequiredBanner via notifyDictationAborted,
+      // but let us just call setBanner directly if we could. Since we cannot access setBanner,
+      // we can trigger another short PTT.
+      await ctrl.toggleRecording(true);
+      simulateRecordingStarted(ctrl.app, 0);
+      await ctrl.toggleRecording(true);
+      
+      // We wait 4000ms. If the first timer was not cancelled, it would fire (2000+4000 > 5000)
+      // and clear the banner.
+      await vi.advanceTimersByTimeAsync(4000);
+      expect(ctrl.statusMessage).toBe("Hold a little longer"); // second banner is still here
+      
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(ctrl.statusMessage).toBe(""); // finally clears
     } finally {
       vi.useRealTimers();
     }
@@ -1489,7 +1515,7 @@ describe("transcription controller", () => {
       await ctrl.toggleRecording();
       simulateRecordingStarted(ctrl.app);
 
-      await vi.advanceTimersByTimeAsync(2000);
+      await vi.advanceTimersByTimeAsync(5000);
       await vi.waitFor(() => {
         expect(mockInvoke).toHaveBeenCalledWith("stop_transcription");
       });

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -672,5 +672,6 @@ export function createTranscriptionController() {
 
 /** Reset the singleton for testing. */
 export function resetTranscriptionControllerForTest() {
+  instance?.clearBanner();
   instance = null;
 }

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -184,20 +184,31 @@ function createTranscriptionControllerInstance() {
   let statusAction = $state<(() => void) | undefined>();
   let catalog = $state<TranscriptionCatalog | null>(null);
 
-  let tooShortBannerTimer: ReturnType<typeof setTimeout> | null = null;
+  let bannerTimer: ReturnType<typeof setTimeout> | null = null;
+  const AUTO_HIDE_MS = 5000;
+
+  function clearBannerTimer() {
+    if (bannerTimer) {
+      clearTimeout(bannerTimer);
+      bannerTimer = null;
+    }
+  }
 
   function setBanner(message: string, action?: { label: string; run: () => void }) {
-    if (tooShortBannerTimer) {
-      clearTimeout(tooShortBannerTimer);
-      tooShortBannerTimer = null;
-    }
+    clearBannerTimer();
     statusMessage = message;
     statusActionLabel = action?.label;
     statusAction = action?.run;
+    if (message && !action) {
+      bannerTimer = setTimeout(clearBanner, AUTO_HIDE_MS);
+    }
   }
 
   function clearBanner() {
-    setBanner("");
+    clearBannerTimer();
+    statusMessage = "";
+    statusActionLabel = undefined;
+    statusAction = undefined;
   }
 
   function modelRequiredBanner(message: string) {
@@ -396,10 +407,7 @@ function createTranscriptionControllerInstance() {
           console.warn("Fast stop failed:", e);
         }
         setBanner(tr("home.dictation_too_short"));
-        tooShortBannerTimer = setTimeout(() => {
-          tooShortBannerTimer = null;
-          clearBanner();
-        }, 2000);
+
         clearSessionContext();
         isStopping = false;
         return;
@@ -626,6 +634,7 @@ function createTranscriptionControllerInstance() {
     get downloadedBytes() { return app.downloadedBytes; },
     get downloadTotalBytes() { return app.downloadTotalBytes; },
     get activeProfileLabel() { return activeProfileLabel; },
+    clearBanner,
     mount,
     refreshCatalog,
     refreshRuntimeStatus,


### PR DESCRIPTION
## Summary
Adds a unified 5-second timeout and a dismiss button to StatusBanners from `setBanner` in both controllers.

## Context
Ticket SOU-099 (internal tracker).
Root cause: StatusBanners without actions didn't time out, and none were manually dismissible.

## Acceptance criteria
- AC1 banners without buttons auto-hide at 5000ms · `auto-hides the banner after 5s without wiping a later banner` in `src/lib/features/transcription/controller.svelte.test.ts`; `auto-hides a banner without an action after 5s` in `src/lib/features/meeting/controller.svelte.test.ts`. Constant is `AUTO_HIDE_MS = 5000` in both controllers, matching mic-toast.
- AC2 banners with buttons do not auto-hide · `does not auto-hide a banner that carries an action` in both controller test files (`if (message && !action)`).
- AC3 manual dismiss on all banners from `setBanner` · `X` button + `onDismiss` in `StatusBanner.svelte`; wired in `HomeView.svelte` and `MeetingDetail.svelte`; `clearBanner dismisses immediately…` in both controller tests; `renders an accessible dismiss button…` in `StatusBanner.test.ts`.
- AC4 new banner cancels old timer · second half of the transcription 5s test; `a later banner cancels the previous auto-hide timer` in meeting tests; `clearBannerTimer` at the start of `setBanner`.
- AC5 accessibility · dismiss `type="button"` with `aria-label` from `mic_toast.dismiss` (EN/FR already present).
- AC6 unified mechanism · `tooShortBannerTimer` is gone; both controllers share the same `setBanner`/`clearBanner` policy.
- AC7 Settings section banners intact · no `onDismiss` on Settings/condition `StatusBanner`s (`IntelligenceSettingsSection`, `DictationPolishSettingsSection`, `CalendarSettingsSection`).
- AC8 too short banner now 5000ms · the rewritten transcription test advances 5000ms, not 2000ms.
- AC9 error banners auto-hide · same `!action` path; meeting abort/export errors have no action.

## Out of scope
- Renaming or changing the content of the banners.
- Banners that depend on a system condition (Settings, SOU-089c).
- Mic toasts.
- Timeline/calendar `statusMessage` banners (not from `setBanner`).

## Risk zones
- Timer racing session state. Prevented by clearing the timer in `setBanner`, `clearBanner`, and test singleton reset.
- Duplication of `setBanner` across controllers (SOU-097); policy is copied, not extracted.

## Verification
- `npm run check:generated-types` · pass
- `cargo fmt --check` · pass
- `cargo clippy -D warnings` · pass
- `cargo test --workspace` · pass
- `npm test` · pass (530)
- `npm run check` · pass

## Deliberate decisions
- 5s delay aligns with mic toast delay.
- Dismiss reuses `mic_toast.dismiss` rather than adding a third copy of the same string.
- Icon import is `@lucide/svelte` (the package this repo already uses), not `lucide-svelte`.