### PR TITLE
fix: Replace WebRTC AEC with linear FDAF (SOU-063)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -183,6 +183,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1154,15 +1163,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1513,7 +1513,6 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.117",
- "unicode-xid",
 ]
 
 [[package]]
@@ -1923,6 +1922,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "fdaf-aec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71894e687a65938dde60f3a943eedd11d22f484a1184612799d1251536fac28a"
+dependencies = [
+ "nalgebra",
+ "num-complex",
+ "rustfft",
 ]
 
 [[package]]
@@ -3859,6 +3869,33 @@ dependencies = [
  "serde",
  "thiserror 2.0.18",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nalgebra"
+version = "0.32.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5c17de023a86f59ed79891b2e5d5a94c705dbe904a5b5c9c952ea6221b03e4"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5923,6 +5960,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "safetensors"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6337,7 +6383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 
@@ -6364,6 +6410,19 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "simba"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
 ]
 
 [[package]]
@@ -6446,72 +6505,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sonora"
-version = "0.1.0"
-source = "git+https://github.com/dignifiedquire/sonora?rev=70c673606e1db8442a8ba20659b2bc7355555274#70c673606e1db8442a8ba20659b2bc7355555274"
-dependencies = [
- "sonora-aec3",
- "sonora-agc2",
- "sonora-common-audio",
- "sonora-ns",
- "sonora-simd",
- "tracing",
-]
-
-[[package]]
-name = "sonora-aec3"
-version = "0.1.0"
-source = "git+https://github.com/dignifiedquire/sonora?rev=70c673606e1db8442a8ba20659b2bc7355555274#70c673606e1db8442a8ba20659b2bc7355555274"
-dependencies = [
- "sonora-common-audio",
- "sonora-fft",
- "sonora-simd",
-]
-
-[[package]]
-name = "sonora-agc2"
-version = "0.1.0"
-source = "git+https://github.com/dignifiedquire/sonora?rev=70c673606e1db8442a8ba20659b2bc7355555274#70c673606e1db8442a8ba20659b2bc7355555274"
-dependencies = [
- "bytemuck",
- "derive_more 2.1.1",
- "sonora-common-audio",
- "sonora-fft",
- "sonora-simd",
- "tracing",
-]
-
-[[package]]
-name = "sonora-common-audio"
-version = "0.1.0"
-source = "git+https://github.com/dignifiedquire/sonora?rev=70c673606e1db8442a8ba20659b2bc7355555274#70c673606e1db8442a8ba20659b2bc7355555274"
-dependencies = [
- "derive_more 2.1.1",
- "sonora-simd",
-]
-
-[[package]]
-name = "sonora-fft"
-version = "0.1.0"
-source = "git+https://github.com/dignifiedquire/sonora?rev=70c673606e1db8442a8ba20659b2bc7355555274#70c673606e1db8442a8ba20659b2bc7355555274"
-
-[[package]]
-name = "sonora-ns"
-version = "0.1.0"
-source = "git+https://github.com/dignifiedquire/sonora?rev=70c673606e1db8442a8ba20659b2bc7355555274#70c673606e1db8442a8ba20659b2bc7355555274"
-dependencies = [
- "sonora-fft",
-]
-
-[[package]]
-name = "sonora-simd"
-version = "0.1.0"
-source = "git+https://github.com/dignifiedquire/sonora?rev=70c673606e1db8442a8ba20659b2bc7355555274#70c673606e1db8442a8ba20659b2bc7355555274"
-dependencies = [
- "cpufeatures 0.3.0",
-]
-
-[[package]]
 name = "souffle"
 version = "0.0.0"
 dependencies = [
@@ -6530,6 +6523,7 @@ dependencies = [
  "dirs-next",
  "dispatch2",
  "enigo",
+ "fdaf-aec",
  "futures-util",
  "hf-hub",
  "hound",
@@ -6560,7 +6554,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "sonora",
  "souffle",
  "souffle-mcp",
  "specta",
@@ -8509,6 +8502,16 @@ dependencies = [
  "cmake",
  "fs_extra",
  "semver",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -115,7 +115,6 @@ objc2-av-foundation = { version = "0.3", default-features = false, features = [
 # Sleep/wake observers (NSWorkspace notifications)
 objc2-app-kit = "0.3"
 ringbuf = "0.5"
-sonora = "0.1"
 block2 = "0.6"
 dispatch2 = "0.3"
 
@@ -129,6 +128,7 @@ ogg = "0.9"
 core-graphics = "0.25.0"
 core-foundation = "0.10.1"
 objc2-service-management = "0.3"
+fdaf-aec = "0.1.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 accessibility-sys = "0.2"
@@ -149,27 +149,6 @@ souffle = { path = ".", features = ["test-support"] }
 # MockRuntime + mock_builder for driving Tauri commands in integration tests
 # without a real webview.
 tauri = { version = "2", features = ["test"] }
-
-# sonora-aec3 0.1.0 (the only version published to crates.io) panics in
-# `AdaptiveFirFilter::set_size_partitions` when the filter shrinks immediately
-# (e.g. on an echo-path-change event after the filter grew past its initial
-# size): `zero_filter(old_size, new_size, ..)` slices `old_size..new_size`,
-# which is an invalid range once old_size > new_size. Fixed upstream in
-# dec6a074 ("prevent panic when shrinking adaptive FIR filter", #15) but not
-# yet released as a new crates.io version. Pinned to a specific commit
-# (rather than a branch) so the fix is reproducible via Cargo.lock; bump this
-# rev, or drop the patch entirely, once 0.1.1+ ships. Every sonora-* crate is
-# patched to the same rev (not just sonora-aec3) so the whole dependency
-# graph resolves to one source instead of building duplicate copies of the
-# shared DSP crates (sonora-common-audio, sonora-fft, sonora-simd).
-[patch.crates-io]
-sonora = { git = "https://github.com/dignifiedquire/sonora", rev = "70c673606e1db8442a8ba20659b2bc7355555274" }
-sonora-aec3 = { git = "https://github.com/dignifiedquire/sonora", rev = "70c673606e1db8442a8ba20659b2bc7355555274" }
-sonora-agc2 = { git = "https://github.com/dignifiedquire/sonora", rev = "70c673606e1db8442a8ba20659b2bc7355555274" }
-sonora-common-audio = { git = "https://github.com/dignifiedquire/sonora", rev = "70c673606e1db8442a8ba20659b2bc7355555274" }
-sonora-fft = { git = "https://github.com/dignifiedquire/sonora", rev = "70c673606e1db8442a8ba20659b2bc7355555274" }
-sonora-ns = { git = "https://github.com/dignifiedquire/sonora", rev = "70c673606e1db8442a8ba20659b2bc7355555274" }
-sonora-simd = { git = "https://github.com/dignifiedquire/sonora", rev = "70c673606e1db8442a8ba20659b2bc7355555274" }
 
 [profile.release]
 strip = true

--- a/src-tauri/src/audio/aec.rs
+++ b/src-tauri/src/audio/aec.rs
@@ -1,46 +1,87 @@
 //! Acoustic echo cancellation for meeting mode.
 //!
-//! Replaces the non-linear WebRTC AEC (which heavily distorted local voice)
-//! with a linear Frequency Domain Adaptive Filter (FDAF).
+//! When the user plays meeting audio through the built-in speakers the other
+//! participants' voices re-enter the microphone and would be transcribed twice
+//! (once on the "Them" lane captured from the tap, once on the "Me" lane
+//! captured from the mic). The system-audio tap gives us the exact far-end
+//! (render) signal, so an adaptive filter can subtract it from the mic.
+//!
+//! ## Why not WebRTC AEC (sonora)?
+//!
+//! The original implementation used `sonora`, a Rust port of the WebRTC audio
+//! processing module. Its non-linear post-filter (NLP) is tuned for telephony,
+//! where swallowing a word is preferred over letting an echo through. For an
+//! ASR pipeline the trade-off is reversed: a residual echo produces a duplicate
+//! that a text filter can handle, but a suppressed word is unrecoverable.
+//! Measurement showed the NLP stage left the output **-10 dB** worse than raw
+//! mic in double-talk (SOU-063 bench, 2026-07-18).
+//!
+//! ## Current approach: linear FDAF
+//!
+//! We use `fdaf-aec`, a pure-Rust Frequency Domain Adaptive Filter (FDAF) with
+//! the Overlap-Save method. It performs only linear echo subtraction — no
+//! non-linear suppression, no AGC, no noise reduction. The far-end signal is
+//! pre-delayed by [`EXPECTED_ACOUSTIC_DELAY_MS`] before being fed to the
+//! filter, aligning it with the echo that the mic will hear. Bench result:
+//! double-talk ERLE **+19.7 dB**, echo-only ERLE **+30.8 dB**.
 
 use fdaf_aec::FdafAec;
 use ringbuf::HeapRb;
-use ringbuf::traits::{Consumer, Producer, Split, Observer};
+use ringbuf::traits::{Consumer, Observer, Producer, Split};
 
+/// Coarse estimate of the delay between a render frame leaving the speakers
+/// and the corresponding echo arriving at the microphone. Used to pre-delay
+/// the render buffer fed to the FDAF filter so both signals are aligned before
+/// the filter tries to subtract one from the other. An unaligned reference is
+/// the single most common cause of FDAF divergence.
 pub const EXPECTED_ACOUSTIC_DELAY_MS: i32 = 50;
 
-// fdaf-aec requires fft_size to be a power of two.
-// A 4096 filter length at 48kHz covers ~85.3ms of acoustic delay.
+// fdaf-aec requires fft_size to be a power of two; frame_size is fft_size / 2.
+// At 48 kHz, FFT_SIZE = 4096 covers 85 ms of filter length, more than enough
+// to cancel the 50 ms acoustic delay plus typical room reverb tail.
 const FFT_SIZE: usize = 4096;
-const FRAME_SIZE: usize = FFT_SIZE / 2; // 2048
+const FRAME_SIZE: usize = FFT_SIZE / 2; // 2048 samples ≈ 42.7 ms at 48 kHz
 
+/// Acoustic echo canceller backed by a linear FDAF filter.
+///
+/// Call [`process_render`](Aec::process_render) with each far-end frame first,
+/// then [`process_capture`](Aec::process_capture) with the mic frame. Both
+/// methods accept frames of any size — the internal ring-buffers decouple the
+/// mixer's 10 ms tick from the FDAF's 42 ms processing block.
 pub struct Aec {
     fdaf: FdafAec,
+    /// Far-end (render) samples waiting to be processed.
     render_prod: <HeapRb<f32> as Split>::Prod,
     render_cons: <HeapRb<f32> as Split>::Cons,
+    /// Near-end (mic) samples waiting to be processed.
     capture_prod: <HeapRb<f32> as Split>::Prod,
     capture_cons: <HeapRb<f32> as Split>::Cons,
+    /// Echo-cancelled output samples ready for the mixer.
     output_prod: <HeapRb<f32> as Split>::Prod,
     output_cons: <HeapRb<f32> as Split>::Cons,
+    /// Set after a panic in the FDAF; mic passes through uncancelled.
     disabled: bool,
+    /// Pre-delay in samples applied once to the render buffer on first call.
     expected_delay_samples: usize,
     sample_rate: u32,
+    /// Whether the pre-delay silence has already been pushed.
     initialized_delay: bool,
 }
 
 impl Aec {
+    /// Creates a new `Aec` at the given sample rate without a delay hint.
+    /// Real callers should use [`new_with_default_delay_hint`](Self::new_with_default_delay_hint)
+    /// instead; `new` exists so tests can compare with and without the hint.
     pub fn new(sample_rate: u32) -> Self {
-        // Buffers need to be large enough to hold at least a few FDAF frames
-        // plus the potential delay hint pre-padding.
-        let render_rb = HeapRb::<f32>::new(32768);
-        let (render_prod, render_cons) = render_rb.split();
+        // Buffers must hold several FDAF frames plus the full delay hint.
+        // At 48 kHz, 50 ms = 2400 samples; 32768 gives plenty of headroom.
+        let (render_prod, render_cons) = HeapRb::<f32>::new(32768).split();
+        let (capture_prod, capture_cons) = HeapRb::<f32>::new(32768).split();
+        let (output_prod, output_cons) = HeapRb::<f32>::new(32768).split();
 
-        let capture_rb = HeapRb::<f32>::new(32768);
-        let (capture_prod, capture_cons) = capture_rb.split();
-
-        let output_rb = HeapRb::<f32>::new(32768);
-        let (output_prod, output_cons) = output_rb.split();
-
+        // step_size of 0.01 gives stable, convergent adaptation without
+        // diverging on the 50 ms render/capture misalignment that a faster
+        // rate (e.g. 0.5) would see before the delay hint takes effect.
         let fdaf = FdafAec::new(FFT_SIZE, 0.01);
 
         Self {
@@ -58,40 +99,64 @@ impl Aec {
         }
     }
 
+    /// Creates an `Aec` with [`EXPECTED_ACOUSTIC_DELAY_MS`] pre-applied.
+    /// This is what every real caller should use.
     pub fn new_with_default_delay_hint(sample_rate: u32) -> Self {
         let mut aec = Self::new(sample_rate);
         aec.set_expected_delay_ms(EXPECTED_ACOUSTIC_DELAY_MS);
         aec
     }
 
+    /// Sets the expected acoustic delay between render and capture in ms.
+    /// This is used to pre-delay the render buffer so the filter sees aligned
+    /// signals. Safe to call multiple times; only the last value is used.
     pub fn set_expected_delay_ms(&mut self, delay_ms: i32) {
         if delay_ms > 0 {
             self.expected_delay_samples = (delay_ms as u32 * self.sample_rate / 1000) as usize;
         }
     }
 
+    /// Feeds a far-end (render) frame to the canceller.
+    ///
+    /// Must be called before the capture frame of the same tick.
+    /// Silently drops frames once the internal buffer overflows (which should
+    /// never happen under normal operation).
     pub fn process_render(&mut self, frame: &[f32]) {
-        if self.disabled { return; }
-        if !self.initialized_delay && self.expected_delay_samples > 0 {
-            // Push delay samples of silence into the render buffer so that render is delayed
-            // to match capture. This perfectly aligns the signals if the hint is correct,
-            // allowing the filter to easily cancel it.
-            let delay_zeros = vec![0.0; self.expected_delay_samples];
-            let _ = self.render_prod.push_slice(&delay_zeros);
+        if self.disabled {
+            return;
+        }
+        // On the very first render frame, pre-fill the render buffer with
+        // `expected_delay_samples` of silence so that render and capture are
+        // temporally aligned when the FDAF first processes them.
+        if !self.initialized_delay {
+            if self.expected_delay_samples > 0 {
+                let zeros = vec![0.0f32; self.expected_delay_samples];
+                let _ = self.render_prod.push_slice(&zeros);
+            }
             self.initialized_delay = true;
         }
         let _ = self.render_prod.push_slice(frame);
     }
 
+    /// Removes the echo of previously-rendered audio from a mic frame, in place.
+    ///
+    /// Processes as many FDAF blocks as both render and capture buffers allow,
+    /// then writes the echo-cancelled result back into `frame`. If fewer
+    /// processed samples are available than `frame.len()` (only during the
+    /// initial fill period), outputs silence for those samples.
     pub fn process_capture(&mut self, frame: &mut [f32]) {
-        if self.disabled { return; }
-        
+        if self.disabled {
+            return;
+        }
+
         let _ = self.capture_prod.push_slice(frame);
 
-        while self.render_cons.occupied_len() >= FRAME_SIZE && self.capture_cons.occupied_len() >= FRAME_SIZE {
-            let mut render_chunk = vec![0.0; FRAME_SIZE];
-            let mut capture_chunk = vec![0.0; FRAME_SIZE];
-            
+        while self.render_cons.occupied_len() >= FRAME_SIZE
+            && self.capture_cons.occupied_len() >= FRAME_SIZE
+        {
+            let mut render_chunk = vec![0.0f32; FRAME_SIZE];
+            let mut capture_chunk = vec![0.0f32; FRAME_SIZE];
+
             self.render_cons.pop_slice(&mut render_chunk);
             self.capture_cons.pop_slice(&mut capture_chunk);
 
@@ -105,7 +170,10 @@ impl Aec {
                 }
                 Err(_) => {
                     self.disabled = true;
-                    tracing::error!("FDAF AEC panicked. Disabling.");
+                    tracing::error!(
+                        "FDAF AEC panicked; disabling echo cancellation for the session \
+                         (mic will pass through uncancelled)"
+                    );
                     break;
                 }
             }
@@ -114,15 +182,137 @@ impl Aec {
         if self.output_cons.occupied_len() >= frame.len() {
             self.output_cons.pop_slice(frame);
         } else {
-            // Before output buffer fills up, just pass the mic frame unmodified (with some
-            // latency zero padding if we wanted exact delay match, but passing raw mic is fine
-            // for the first few ms). Actually, wait. The output signal will be delayed by
-            // FRAME_SIZE samples relative to the input if we do this. But since it's just audio
-            // for ASR, a 42ms stutter at the very beginning of the meeting is invisible.
-            // Let's just output silence until the filter produces data.
-            for s in frame.iter_mut() {
-                *s = 0.0;
+            // Output buffer has not yet accumulated a full frame (only during
+            // the initial FRAME_SIZE fill period). Output silence rather than
+            // passing raw mic, which would skip the render-side pre-delay and
+            // corrupt the filter's alignment.
+            frame.fill(0.0);
+        }
+    }
+
+    /// Drains every sample still owed to the mic timeline.
+    ///
+    /// Order is oldest-first: already-processed output, then raw capture that
+    /// had entered the delay line but not yet produced output. Render-side
+    /// leftovers are discarded (no mic content). Called when `Aec` is replaced
+    /// so the mixer can prepend these samples and avoid a speech gap.
+    pub fn drain_pending(&mut self) -> Vec<f32> {
+        let out_n = self.output_cons.occupied_len();
+        let cap_n = self.capture_cons.occupied_len();
+        let mut buf = vec![0.0f32; out_n + cap_n];
+        if out_n > 0 {
+            self.output_cons.pop_slice(&mut buf[..out_n]);
+        }
+        if cap_n > 0 {
+            self.capture_cons.pop_slice(&mut buf[out_n..]);
+        }
+        // Drop render leftovers — they carry no near-end speech.
+        let render_n = self.render_cons.occupied_len();
+        if render_n > 0 {
+            let mut discard = vec![0.0f32; render_n];
+            self.render_cons.pop_slice(&mut discard);
+        }
+        buf
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The far-end signal leaking into the mic with a small delay must come
+    /// out attenuated once the canceller has converged.
+    #[test]
+    fn attenuates_far_end_leakage() {
+        let rate = 48_000u32;
+        let frame = rate as usize / 100; // 10 ms
+        let mut aec = Aec::new(rate);
+
+        // 3s of a 440 Hz tone as far-end; mic hears it scaled and delayed.
+        let tone: Vec<f32> = (0..rate as usize * 3)
+            .map(|i| (i as f32 * 440.0 * std::f32::consts::TAU / rate as f32).sin() * 0.5)
+            .collect();
+        let delay = rate as usize * 20 / 1000; // 20 ms simulated echo delay
+
+        let mut leaked_energy_early = 0.0f32;
+        let mut leaked_energy_late = 0.0f32;
+        let total_frames = tone.len() / frame;
+
+        for f in 0..total_frames {
+            let start = f * frame;
+            aec.process_render(&tone[start..start + frame]);
+
+            let mut mic: Vec<f32> = (0..frame)
+                .map(|i| {
+                    let idx = start + i;
+                    if idx >= delay {
+                        tone[idx - delay] * 0.3
+                    } else {
+                        0.0
+                    }
+                })
+                .collect();
+            aec.process_capture(&mut mic);
+
+            let energy: f32 = mic.iter().map(|s| s * s).sum();
+            if f < total_frames / 4 {
+                leaked_energy_early += energy;
+            } else if f >= total_frames * 3 / 4 {
+                leaked_energy_late += energy;
             }
         }
+
+        assert!(
+            leaked_energy_late < leaked_energy_early * 0.2,
+            "echo should converge: early={leaked_energy_early:.4}, late={leaked_energy_late:.4}"
+        );
+    }
+
+    /// `drain_pending` must hand back buffered output (and any unprocessed
+    /// capture) so a replacement does not drop mic speech mid-session.
+    #[test]
+    fn drain_pending_transfers_samples_on_replacement() {
+        let rate = 48_000u32;
+        let frame_len = rate as usize / 100;
+        let mut aec = Aec::new(rate);
+
+        // Feed enough frames to fill the output buffer past one FDAF block.
+        let far = vec![0.1f32; frame_len];
+        let mut mic = vec![0.05f32; frame_len];
+        for _ in 0..30 {
+            aec.process_render(&far);
+            aec.process_capture(&mut mic);
+        }
+
+        let drained = aec.drain_pending();
+        assert!(
+            !drained.is_empty(),
+            "drain_pending should return pending samples"
+        );
+        assert_eq!(aec.output_cons.occupied_len(), 0);
+        assert_eq!(aec.capture_cons.occupied_len(), 0);
+        assert_eq!(aec.render_cons.occupied_len(), 0);
+    }
+
+    /// Once disabled (e.g. after a panic), process_render and process_capture
+    /// must leave the mic frame completely untouched.
+    #[test]
+    fn process_calls_are_no_ops_once_disabled() {
+        let rate = 48_000u32;
+        let frame_len = rate as usize / 100;
+        let mut aec = Aec::new(rate);
+        aec.disabled = true;
+
+        let far = vec![0.5f32; frame_len];
+        let expected = vec![0.42f32; frame_len];
+        let mut mic = expected.clone();
+
+        aec.process_render(&far);
+        aec.process_capture(&mut mic);
+
+        assert_eq!(
+            mic, expected,
+            "a disabled Aec must leave the mic frame untouched"
+        );
     }
 }

--- a/src-tauri/src/audio/aec.rs
+++ b/src-tauri/src/audio/aec.rs
@@ -1,318 +1,128 @@
 //! Acoustic echo cancellation for meeting mode.
 //!
-//! When the user plays meeting audio through the built-in speakers, the
-//! other participants' voices re-enter the microphone and would be
-//! transcribed twice. The system-audio tap gives us the exact far-end
-//! (render) signal, so a WebRTC-style AEC can subtract it from the mic.
-//!
-//! Thin wrapper around `sonora` (pure-Rust port of the WebRTC audio
-//! processing module) so the backend can be swapped without touching the
-//! mixer. Works on 10ms mono frames at the mixer rate.
+//! Replaces the non-linear WebRTC AEC (which heavily distorted local voice)
+//! with a linear Frequency Domain Adaptive Filter (FDAF).
 
-use sonora::config::{EchoCanceller, TransparentModeType};
-use sonora::{AudioProcessing, Config, StreamConfig};
+use fdaf_aec::FdafAec;
+use ringbuf::HeapRb;
+use ringbuf::traits::{Consumer, Producer, Split, Observer};
 
-/// Coarse estimate of the delay between a render frame reaching sonora and
-/// the corresponding echo showing up in a capture frame, passed to
-/// `Aec::set_expected_delay_ms` by every real caller. This is not a measured
-/// value (macOS doesn't expose one cheaply from the mixer's position, and the
-/// combined output+input CoreAudio buffering plus acoustic propagation for
-/// built-in speakers/mic commonly falls in the tens of ms), just a mid-range
-/// heuristic for AEC3's own delay estimator to start searching from; see
-/// `set_expected_delay_ms`'s docs for why an approximate hint still helps.
 pub const EXPECTED_ACOUSTIC_DELAY_MS: i32 = 50;
 
-/// How many times a panicking sonora call may recreate a fresh instance
-/// before echo cancellation gives up for the rest of the session. Each
-/// rearm loses whatever echo-path convergence sonora had built up, so this
-/// trades a few seconds of reduced cancellation while it reconverges for
-/// not falling back to raw mic for the rest of a (possibly hour-long)
-/// meeting. Three gives real transient bugs (the kind seen in production:
-/// one panic on an unusual signal transition) room to recover without
-/// letting a pathological, repeatedly-panicking input spin forever.
-const MAX_REARM_ATTEMPTS: u32 = 3;
-
-/// What a panic during a sonora call should do next, given how many times
-/// this session has already rearmed. Pure decision function, kept free of
-/// `Aec`'s state so it can be unit-tested directly (mirrors `decide_mic_loss`
-/// in `capture.rs`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RearmDecision {
-    /// Recreate the sonora instance from scratch and keep going.
-    Rearm,
-    /// Give up for the rest of the session.
-    GiveUp,
-}
-
-fn decide_rearm(attempts_so_far: u32) -> RearmDecision {
-    if attempts_so_far < MAX_REARM_ATTEMPTS {
-        RearmDecision::Rearm
-    } else {
-        RearmDecision::GiveUp
-    }
-}
-
-fn build_apm(sample_rate: u32) -> AudioProcessing {
-    let stream = StreamConfig::new(sample_rate, 1);
-    // SOU-063: NS and AGC2 stay off (`Config` defaults). `EchoCanceller`
-    // has no NLP-level knob — `transparent_mode: Hmm` is a no-echo
-    // classifier swap vs Legacy, not NLP-off. Residual NLP still runs.
-    AudioProcessing::builder()
-        .config(Config {
-            echo_canceller: Some(EchoCanceller {
-                transparent_mode: TransparentModeType::Hmm,
-                ..EchoCanceller::default()
-            }),
-            noise_suppression: None,
-            gain_controller2: None,
-            ..Config::default()
-        })
-        .capture_config(stream)
-        .render_config(stream)
-        .build()
-}
+// fdaf-aec requires fft_size to be a power of two.
+// A 4096 filter length at 48kHz covers ~85.3ms of acoustic delay.
+const FFT_SIZE: usize = 4096;
+const FRAME_SIZE: usize = FFT_SIZE / 2; // 2048
 
 pub struct Aec {
-    apm: AudioProcessing,
-    sample_rate: u32,
-    /// 10ms at the configured sample rate.
-    frame_len: usize,
-    render_out: Vec<f32>,
-    /// Hint passed to sonora's `set_stream_delay_ms` (the expected delay
-    /// between a render frame being handed to sonora and the corresponding
-    /// echo showing up in a capture frame). Reapplied on every rearm since a
-    /// fresh sonora instance starts with no delay set. `None` until
-    /// `set_expected_delay_ms` is called, matching sonora's own default.
-    expected_delay_ms: Option<i32>,
-    /// Panics recovered so far this session by recreating sonora fresh (see
-    /// `MAX_REARM_ATTEMPTS`).
-    rearm_count: u32,
-    /// Set once rearming is exhausted. Echo cancellation is a non-essential
-    /// enhancement, so once it can't recover we stop calling it and let the
-    /// mic pass through uncancelled rather than risk taking down the session.
+    fdaf: FdafAec,
+    render_prod: <HeapRb<f32> as Split>::Prod,
+    render_cons: <HeapRb<f32> as Split>::Cons,
+    capture_prod: <HeapRb<f32> as Split>::Prod,
+    capture_cons: <HeapRb<f32> as Split>::Cons,
+    output_prod: <HeapRb<f32> as Split>::Prod,
+    output_cons: <HeapRb<f32> as Split>::Cons,
     disabled: bool,
+    expected_delay_samples: usize,
+    sample_rate: u32,
+    initialized_delay: bool,
 }
 
 impl Aec {
     pub fn new(sample_rate: u32) -> Self {
-        let frame_len = sample_rate as usize / 100;
+        // Buffers need to be large enough to hold at least a few FDAF frames
+        // plus the potential delay hint pre-padding.
+        let render_rb = HeapRb::<f32>::new(32768);
+        let (render_prod, render_cons) = render_rb.split();
+
+        let capture_rb = HeapRb::<f32>::new(32768);
+        let (capture_prod, capture_cons) = capture_rb.split();
+
+        let output_rb = HeapRb::<f32>::new(32768);
+        let (output_prod, output_cons) = output_rb.split();
+
+        let fdaf = FdafAec::new(FFT_SIZE, 0.01);
+
         Self {
-            apm: build_apm(sample_rate),
-            sample_rate,
-            frame_len,
-            render_out: vec![0.0; frame_len],
-            expected_delay_ms: None,
-            rearm_count: 0,
+            fdaf,
+            render_prod,
+            render_cons,
+            capture_prod,
+            capture_cons,
+            output_prod,
+            output_cons,
             disabled: false,
+            expected_delay_samples: 0,
+            sample_rate,
+            initialized_delay: false,
         }
     }
 
-    /// Builds an `Aec` with `EXPECTED_ACOUSTIC_DELAY_MS` applied. What every
-    /// real caller wants; `new` stays hint-free so tests (and the mixer
-    /// bench) can compare with and without it.
     pub fn new_with_default_delay_hint(sample_rate: u32) -> Self {
         let mut aec = Self::new(sample_rate);
         aec.set_expected_delay_ms(EXPECTED_ACOUSTIC_DELAY_MS);
         aec
     }
 
-    /// Hints the expected delay between render and capture (see sonora's
-    /// `set_stream_delay_ms` docs). AEC3's own delay estimator does not
-    /// strictly require this (unlike the legacy AEC2 the doc comment is
-    /// inherited from), but an external estimate narrows its search and
-    /// speeds up convergence. Applied immediately and reapplied on every
-    /// rearm, since a freshly built sonora instance starts with no hint.
     pub fn set_expected_delay_ms(&mut self, delay_ms: i32) {
-        self.expected_delay_ms = Some(delay_ms);
-        self.apply_delay_hint();
-    }
-
-    fn apply_delay_hint(&mut self) {
-        if let Some(delay_ms) = self.expected_delay_ms {
-            let _ = self.apm.set_stream_delay_ms(delay_ms);
+        if delay_ms > 0 {
+            self.expected_delay_samples = (delay_ms as u32 * self.sample_rate / 1000) as usize;
         }
     }
 
-    /// Feed a 10ms far-end frame (the system audio about to leave the
-    /// speakers). Must be called before the capture frame of the same tick.
     pub fn process_render(&mut self, frame: &[f32]) {
-        debug_assert_eq!(frame.len(), self.frame_len);
-        if self.disabled {
-            return;
+        if self.disabled { return; }
+        if !self.initialized_delay && self.expected_delay_samples > 0 {
+            // Push delay samples of silence into the render buffer so that render is delayed
+            // to match capture. This perfectly aligns the signals if the hint is correct,
+            // allowing the filter to easily cancel it.
+            let delay_zeros = vec![0.0; self.expected_delay_samples];
+            let _ = self.render_prod.push_slice(&delay_zeros);
+            self.initialized_delay = true;
         }
-        let apm = &mut self.apm;
-        let render_out = &mut self.render_out;
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            let _ = apm.process_render_f32(&[frame], &mut [&mut render_out[..]]);
-        }));
-        if result.is_err() {
-            self.handle_panic();
-        }
+        let _ = self.render_prod.push_slice(frame);
     }
 
-    /// Remove the echo of previously-rendered audio from a 10ms mic frame,
-    /// in place.
     pub fn process_capture(&mut self, frame: &mut [f32]) {
-        debug_assert_eq!(frame.len(), self.frame_len);
-        if self.disabled {
-            return;
-        }
-        let mut out = vec![0.0; self.frame_len];
-        let apm = &mut self.apm;
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            apm.process_capture_f32(&[&frame[..]], &mut [&mut out[..]])
-                .is_ok()
-        }));
-        match result {
-            Ok(true) => frame.copy_from_slice(&out),
-            Ok(false) => {}
-            Err(_) => self.handle_panic(),
-        }
-    }
+        if self.disabled { return; }
+        
+        let _ = self.capture_prod.push_slice(frame);
 
-    /// Recreate sonora from scratch (losing convergence state, which is
-    /// inherent and acceptable) up to `MAX_REARM_ATTEMPTS` times, then fall
-    /// back to disabled for the rest of the session.
-    fn handle_panic(&mut self) {
-        match decide_rearm(self.rearm_count) {
-            RearmDecision::Rearm => {
-                self.rearm_count += 1;
-                tracing::warn!(
-                    "Echo cancellation panicked; recreating it fresh (attempt {}/{MAX_REARM_ATTEMPTS}). \
-                     Convergence is lost and will take a few seconds to rebuild.",
-                    self.rearm_count
-                );
-                self.apm = build_apm(self.sample_rate);
-                self.apply_delay_hint();
-            }
-            RearmDecision::GiveUp => {
-                self.disabled = true;
-                tracing::error!(
-                    "Echo cancellation panicked again after {MAX_REARM_ATTEMPTS} rearms this \
-                     session; disabling it for the rest of the session (mic passes through \
-                     uncancelled)"
-                );
-            }
-        }
-    }
-}
+        while self.render_cons.occupied_len() >= FRAME_SIZE && self.capture_cons.occupied_len() >= FRAME_SIZE {
+            let mut render_chunk = vec![0.0; FRAME_SIZE];
+            let mut capture_chunk = vec![0.0; FRAME_SIZE];
+            
+            self.render_cons.pop_slice(&mut render_chunk);
+            self.capture_cons.pop_slice(&mut capture_chunk);
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                self.fdaf.process(&render_chunk, &capture_chunk)
+            }));
 
-    /// The far-end signal leaking into the mic with a small delay must come
-    /// out attenuated once the canceller has converged.
-    #[test]
-    fn attenuates_far_end_leakage() {
-        let rate = 48_000u32;
-        let frame = rate as usize / 100;
-        let mut aec = Aec::new(rate);
-
-        // 2s of a 440Hz tone as far-end; mic hears it scaled, delayed 30ms.
-        let tone: Vec<f32> = (0..rate as usize * 2)
-            .map(|i| (i as f32 * 440.0 * std::f32::consts::TAU / rate as f32).sin() * 0.5)
-            .collect();
-        let delay = rate as usize * 30 / 1000;
-
-        let mut leaked_energy_early = 0.0f32;
-        let mut leaked_energy_late = 0.0f32;
-        let total_frames = tone.len() / frame;
-        for f in 0..total_frames {
-            let start = f * frame;
-            aec.process_render(&tone[start..start + frame]);
-
-            let mut mic: Vec<f32> = (0..frame)
-                .map(|i| {
-                    let idx = start + i;
-                    if idx >= delay {
-                        tone[idx - delay] * 0.3
-                    } else {
-                        0.0
-                    }
-                })
-                .collect();
-            aec.process_capture(&mut mic);
-
-            let energy: f32 = mic.iter().map(|s| s * s).sum();
-            if f < total_frames / 4 {
-                leaked_energy_early += energy;
-            } else if f >= total_frames * 3 / 4 {
-                leaked_energy_late += energy;
+            match result {
+                Ok(out_chunk) => {
+                    let _ = self.output_prod.push_slice(&out_chunk);
+                }
+                Err(_) => {
+                    self.disabled = true;
+                    tracing::error!("FDAF AEC panicked. Disabling.");
+                    break;
+                }
             }
         }
 
-        assert!(
-            leaked_energy_late < leaked_energy_early * 0.2,
-            "echo should converge: early={leaked_energy_early}, late={leaked_energy_late}"
-        );
-    }
-
-    #[test]
-    fn decide_rearm_allows_up_to_the_cap_then_gives_up() {
-        for n in 0..MAX_REARM_ATTEMPTS {
-            assert_eq!(
-                decide_rearm(n),
-                RearmDecision::Rearm,
-                "attempt {n} should rearm"
-            );
+        if self.output_cons.occupied_len() >= frame.len() {
+            self.output_cons.pop_slice(frame);
+        } else {
+            // Before output buffer fills up, just pass the mic frame unmodified (with some
+            // latency zero padding if we wanted exact delay match, but passing raw mic is fine
+            // for the first few ms). Actually, wait. The output signal will be delayed by
+            // FRAME_SIZE samples relative to the input if we do this. But since it's just audio
+            // for ASR, a 42ms stutter at the very beginning of the meeting is invisible.
+            // Let's just output silence until the filter produces data.
+            for s in frame.iter_mut() {
+                *s = 0.0;
+            }
         }
-        assert_eq!(decide_rearm(MAX_REARM_ATTEMPTS), RearmDecision::GiveUp);
-        assert_eq!(decide_rearm(MAX_REARM_ATTEMPTS + 5), RearmDecision::GiveUp);
-    }
-
-    /// Repeated panics recreate sonora up to the cap, then disable it. This
-    /// drives the same `handle_panic` path a real sonora panic would, without
-    /// needing to reproduce the underlying crate bug.
-    #[test]
-    fn rearms_up_to_the_cap_then_disables() {
-        let mut aec = Aec::new(48_000);
-
-        for expected_attempt in 1..=MAX_REARM_ATTEMPTS {
-            aec.handle_panic();
-            assert_eq!(aec.rearm_count, expected_attempt);
-            assert!(
-                !aec.disabled,
-                "should still be rearming at attempt {expected_attempt}"
-            );
-        }
-
-        // One panic more than the cap allows: gives up for the session.
-        aec.handle_panic();
-        assert!(aec.disabled);
-    }
-
-    #[test]
-    fn process_calls_are_no_ops_once_disabled() {
-        let mut aec = Aec::new(48_000);
-        aec.disabled = true;
-
-        let frame = vec![0.5; aec.frame_len];
-        let mut mic = frame.clone();
-        aec.process_render(&frame);
-        aec.process_capture(&mut mic);
-
-        assert_eq!(
-            mic, frame,
-            "a disabled Aec must leave the mic frame untouched"
-        );
-    }
-
-    /// A fresh sonora instance starts with no delay hint, so a rearm must
-    /// reapply it or convergence speed regresses back to baseline on every
-    /// recovered panic.
-    #[test]
-    fn delay_hint_survives_a_rearm() {
-        let mut aec = Aec::new(48_000);
-        aec.set_expected_delay_ms(42);
-        assert_eq!(aec.apm.stream_delay_ms(), 42);
-
-        aec.handle_panic();
-
-        assert_eq!(
-            aec.apm.stream_delay_ms(),
-            42,
-            "the delay hint must be reapplied to the rearmed instance"
-        );
     }
 }

--- a/src-tauri/src/audio/mixer.rs
+++ b/src-tauri/src/audio/mixer.rs
@@ -878,10 +878,9 @@ mod aec_bench {
     // writeup). These asserts are regression floors against the measured
     // baseline, not aspirational targets — tighten them if cancellation
     // quality is improved later.
-    const DOUBLE_TALK_ERLE_FLOOR_DB: f32 = -14.0;
+    const DOUBLE_TALK_ERLE_FLOOR_DB: f32 = 0.0;
 
     #[test]
-    #[ignore = "multi-second synthetic bench, run explicitly with -- --ignored --nocapture"]
     fn wideband_echo_attenuation_baseline() {
         let (erle_db, converge_frame) = run_echo_bench(None, 1.0, 50);
         println!(
@@ -898,7 +897,6 @@ mod aec_bench {
     }
 
     #[test]
-    #[ignore = "multi-second synthetic bench, run explicitly with -- --ignored --nocapture"]
     fn wideband_echo_attenuation_with_delay_hint() {
         let (erle_db, converge_frame) = run_echo_bench(Some(50), 1.0, 50);
         println!(
@@ -919,7 +917,6 @@ mod aec_bench {
     /// whether a poor double-talk result comes from echo cancellation itself
     /// or from the double-talk/voice interaction. Measured baseline: +3.6dB.
     #[test]
-    #[ignore = "multi-second synthetic bench, run explicitly with -- --ignored --nocapture"]
     fn wideband_echo_attenuation_no_voice_diagnostic() {
         let (erle_db, converge_frame) = run_echo_bench(Some(50), 0.0, 50);
         println!(

--- a/src-tauri/src/audio/mixer.rs
+++ b/src-tauri/src/audio/mixer.rs
@@ -51,6 +51,10 @@ pub struct MeetingMixer {
     /// Recent far-end level. Gates *applying* AEC output, not whether
     /// the instance lives (SOU-063). A pause must not `set_aec(None)`.
     tap_rms_ema: f32,
+    /// Blend toward cancelled (1.0) or raw mic (0.0). Ramps over one
+    /// frame when the apply decision flips so the boundary stays continuous
+    /// (SOU-063 AC3).
+    aec_apply_mix: f32,
 }
 
 impl MeetingMixer {
@@ -79,6 +83,7 @@ impl MeetingMixer {
             aec: None,
             tap_discarded: 0,
             tap_rms_ema: 0.0,
+            aec_apply_mix: 0.0,
         }
     }
 
@@ -101,9 +106,30 @@ impl MeetingMixer {
 
     /// Enable/disable echo cancellation (e.g. when the output route changes
     /// between speakers and headphones mid-session). Passing a fresh `Aec`
-    /// also resets convergence state.
+    /// also resets convergence state. Pending mic-timeline samples from the
+    /// outgoing instance are prepended to the fifos so a mute/route flip does
+    /// not drop speech still sitting in the FDAF delay line.
     pub fn set_aec(&mut self, aec: Option<Aec>) {
+        if let Some(old) = self.aec.as_mut() {
+            let pending = old.drain_pending();
+            if !pending.is_empty() {
+                let n = pending.len();
+                let mut mic = pending;
+                mic.append(&mut self.mic_fifo);
+                self.mic_fifo = mic;
+                // Keep legs aligned: pending is mic-only content, so the tap
+                // side gets matching silence at the front.
+                let mut tap = vec![0.0f32; n];
+                tap.append(&mut self.tap_fifo);
+                self.tap_fifo = tap;
+            }
+        }
         self.aec = aec;
+        // Fresh instance (or none) starts from raw; the crossfade handles
+        // the next apply transition.
+        if self.aec.is_none() {
+            self.aec_apply_mix = 0.0;
+        }
     }
 
     /// Swap the microphone ring after a mid-session rebuild. The tap ring,
@@ -329,16 +355,28 @@ impl MeetingMixer {
         // Always feed the canceller while it exists so a far-end pause
         // does not dump convergence. Apply the output only when the tap
         // is actually playing — otherwise emit raw mic (SOU-063 lever 2).
-        let apply_aec = self.tap_has_energy();
+        // A one-frame linear crossfade covers apply↔bypass flips (AC3).
+        let target = if self.tap_has_energy() { 1.0f32 } else { 0.0 };
         if n == FRAME_SAMPLES
             && let Some(aec) = self.aec.as_mut()
         {
             aec.process_render(&tap);
-            if apply_aec {
-                aec.process_capture(&mut mic);
+            let raw = mic.clone();
+            let mut cancelled = mic;
+            aec.process_capture(&mut cancelled);
+
+            if (self.aec_apply_mix - target).abs() < f32::EPSILON {
+                mic = if target > 0.5 { cancelled } else { raw };
             } else {
-                let mut discarded = mic.clone();
-                aec.process_capture(&mut discarded);
+                let start = self.aec_apply_mix;
+                let delta = target - start;
+                mic = (0..n)
+                    .map(|i| {
+                        let t = start + delta * (i as f32 + 1.0) / n as f32;
+                        cancelled[i] * t + raw[i] * (1.0 - t)
+                    })
+                    .collect();
+                self.aec_apply_mix = target;
             }
         }
 
@@ -445,6 +483,68 @@ mod tests {
         assert!(
             (mid - 0.5).abs() < 0.05,
             "below the energy floor the mic must pass through raw, got {mid}"
+        );
+    }
+
+    /// Replacing a live Aec must not drop samples still sitting in its delay
+    /// line — they are prepended onto the mic fifo (SOU-063 / route flips).
+    #[test]
+    fn set_aec_none_preserves_pending_mic_timeline() {
+        let (mut mic, mut tap, mut mixer) = make_mixer(48_000, 48_000, MIX_RATE);
+        mixer.set_aec(Some(Aec::new(MIX_RATE)));
+
+        // Drive enough frames for the FDAF block to produce leftover output.
+        let far = vec![0.2f32; FRAME_SAMPLES];
+        let near = vec![0.4f32; FRAME_SAMPLES];
+        for _ in 0..30 {
+            mic.push_slice(&near);
+            tap.push_slice(&far);
+            let _ = mixer.tick_split();
+        }
+
+        let fifo_before = mixer.mic_fifo.len();
+        mixer.set_aec(None);
+        assert!(
+            mixer.mic_fifo.len() > fifo_before,
+            "disengaging AEC must prepend pending delay-line samples \
+             (fifo before={fifo_before}, after={})",
+            mixer.mic_fifo.len()
+        );
+        assert!(mixer.aec.is_none());
+    }
+
+    /// Apply↔bypass flips crossfade over one frame: adjacent-sample jump at
+    /// the boundary stays well under a hard switch (SOU-063 AC3).
+    #[test]
+    fn aec_apply_toggle_crossfade_bounds_discontinuity() {
+        let (mut mic, _tap, mut mixer) = make_mixer(48_000, 48_000, MIX_RATE);
+        // Live Aec during its silence-fill window: cancelled ≈ 0 while raw
+        // mic is 0.8 — a hard switch would jump by ~0.8; the one-frame fade
+        // must keep the per-step jump under ~0.8/480.
+        mixer.set_aec(Some(Aec::new(MIX_RATE)));
+        mixer.aec_apply_mix = 1.0;
+        mixer.tap_rms_ema = 0.0; // target = 0 → crossfade 1→0 this frame
+
+        mic.push_slice(&vec![0.8f32; FRAME_SAMPLES]);
+        let (me, _) = mixer.tick_split();
+
+        assert!(
+            (mixer.aec_apply_mix - 0.0).abs() < f32::EPSILON,
+            "apply mix must finish the frame at the raw target"
+        );
+        let max_jump = me
+            .windows(2)
+            .map(|w| (w[1] - w[0]).abs())
+            .fold(0.0f32, f32::max);
+        assert!(
+            max_jump < 0.01,
+            "crossfade frame adjacent jump too large: {max_jump} (hard switch would be ~0.8)"
+        );
+        // Endpoint should land on raw mic.
+        assert!(
+            (me[me.len() - 1] - 0.8).abs() < 0.05,
+            "fade must end on raw mic, got {}",
+            me[me.len() - 1]
         );
     }
 
@@ -867,17 +967,10 @@ mod aec_bench {
         (erle_db, converge_frame)
     }
 
-    // Measured baselines (release build, this bench, 2026-07-18): double-talk
-    // (voice + echo together) comes out around -10dB, i.e. sonora's NLP stage
-    // leaves the output *further* from clean voice than the raw uncancelled
-    // echo would have been, both with and without the `stream_delay_ms` hint.
-    // Echo-only (no voice, see the diagnostic below) attenuates by a modest
-    // +3.6dB. That's weak for AEC3 and corroborates the production incident's
-    // report of echo passing through even before the crate panicked; it is
-    // not something this fix attempts to solve (see the investigation
-    // writeup). These asserts are regression floors against the measured
-    // baseline, not aspirational targets — tighten them if cancellation
-    // quality is improved later.
+    // Measured baselines (release build, SOU-063 fix, 2026-09-09): fdaf-aec
+    // (linear FDAF, no NLP suppression) achieves +19.7 dB ERLE in double-talk
+    // and +30.8 dB echo-only. This floor is the regression gate — if ERLE
+    // falls back negative someone re-introduced a non-linear suppressor.
     const DOUBLE_TALK_ERLE_FLOOR_DB: f32 = 0.0;
 
     #[test]


### PR DESCRIPTION
## Summary

Replaces the non-linear WebRTC AEC (`sonora`) with a pure-linear FDAF filter (`fdaf-aec`) to fix SOU-063: the NLP stage of `sonora` was destroying the local voice during double-talk (-10 dB ERLE), causing poor ASR accuracy for the "Me" lane (missing words, spurious commas, broken paragraphs).

**Root cause:** WebRTC's non-linear post-filter is tuned for telephony — it prefers swallowing words over letting an echo through. For an ASR pipeline the trade-off is inverted: a residual echo produces a duplicate a text filter can resolve, but a suppressed word is unrecoverable.

**Fix:** Swap to a linear FDAF that performs only echo subtraction, with no suppression of double-talk or near-end speech. The render buffer is pre-delayed by 50 ms to align with the acoustic echo before the filter operates. Route flips drain the FDAF delay line into the mixer fifos; apply↔bypass ramps over one 10 ms frame.

## Acceptance Criteria

1. **Double-talk ERLE must be positive** — Verified by `wideband_echo_attenuation_baseline` and `wideband_echo_attenuation_with_delay_hint` in `mixer.rs` (floor: 0.0 dB, both active in CI). Release bench: **+18.5 / +19.7 dB**.
2. **No non-linear suppressor remains** — `aec.rs` uses only `fdaf-aec`; no `sonora` in `Cargo.toml`.
3. **Apply↔bypass discontinuity bounded** — one-frame linear crossfade in `split_frame`; `aec_apply_toggle_crossfade_bounds_discontinuity`.
4. **Buffer drain on Aec replacement** — `Aec::drain_pending()` + `MeetingMixer::set_aec` prepends pending output/capture to the mic fifo (tap padded). Tests: `drain_pending_transfers_samples_on_replacement`, `set_aec_none_preserves_pending_mic_timeline`.
5. **No regression on existing gating** — `output_can_leak_into_mic()` unchanged in `capture.rs`; `tap_has_energy` still gates apply while the instance stays fed.
6. **CI clean** — full local gate green (fmt, clippy `-D warnings`, workspace tests, vitest, svelte-check).

## Out of Scope

- Levier 5 (pre-AEC archive / second Opus encoder) — deferred per decision 2026-09-08.
- Any changes to `capture.rs` route-check logic, SOU-064, or the dictation path.
- Sonora-style panic rearm (≤3 then give up): fdaf-aec is pure Rust; `catch_unwind` permanently disables for the session on panic.
- Compensating the ~43 ms FDAF hop so Me/Them stay sample-aligned when apply=1 (follow-up if field QA hears it).

## Verification

```
npm run check:generated-types
cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings
cargo test --manifest-path src-tauri/Cargo.toml --workspace
# → souffle_lib: 886 passed; 4 ignored
npm test   # → 530 passed
npm run check

cargo test --release --manifest-path src-tauri/Cargo.toml --lib audio::mixer::aec_bench -- --nocapture
# AEC bench (no hint, 50ms delay):   ERLE = +18.5 dB
# AEC bench (50ms hint, 50ms delay): ERLE = +19.7 dB
# AEC bench (echo only, no voice):   ERLE = +30.8 dB
```