### PR TITLE
Feat: SOU-038 - Entretien dictionnaire

### DIFF
--- a/add_translations.cjs
+++ b/add_translations.cjs
@@ -1,0 +1,33 @@
+const fs = require('fs');
+
+function addTranslations(file, newStrings) {
+  const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+  Object.assign(data.onboarding, newStrings);
+  fs.writeFileSync(file, JSON.stringify(data, null, 2));
+}
+
+addTranslations('src/lib/i18n/fr.json', {
+  "interview_title": "Dictionnaire",
+  "interview_subtitle": "5 questions optionnelles pour aider Souffle à reconnaître vos mots habituels.",
+  "interview_skip": "Passer",
+  "interview_next": "Suivant",
+  "interview_q_name": "Quel est votre prénom ?",
+  "interview_q_job": "Quel est votre métier ?",
+  "interview_q_people": "Quels sont les prénoms de vos proches ou collègues ?",
+  "interview_q_jargon": "Quel est le jargon que vous utilisez souvent ?",
+  "interview_q_tone": "Quel ton ou style Souffle doit-il utiliser lors du nettoyage de la dictée (ex: tutoiement, formel, concis) ?",
+  "interview_ton_polish_warning": "Le nettoyage de dictée est désactivé. Ce style sera enregistré mais ignoré tant qu'il n'est pas activé."
+});
+
+addTranslations('src/lib/i18n/en.json', {
+  "interview_title": "Dictionary",
+  "interview_subtitle": "5 optional questions to help Souffle recognize your usual words.",
+  "interview_skip": "Skip",
+  "interview_next": "Next",
+  "interview_q_name": "What is your first name?",
+  "interview_q_job": "What is your job?",
+  "interview_q_people": "What are the first names of your colleagues or relatives?",
+  "interview_q_jargon": "What jargon do you frequently use?",
+  "interview_q_tone": "What tone or style should Souffle use when polishing your dictation (e.g. casual, formal, concise)?",
+  "interview_ton_polish_warning": "Dictation polish is disabled. This style will be saved but ignored until it is re-enabled."
+});

--- a/add_translations.js
+++ b/add_translations.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+
+function addTranslations(file, newStrings) {
+  const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+  Object.assign(data.onboarding, newStrings);
+  fs.writeFileSync(file, JSON.stringify(data, null, 2));
+}
+
+addTranslations('src/lib/i18n/fr.json', {
+  "interview_title": "Personnalisation",
+  "interview_subtitle": "Aidez Souffle à reconnaître vos mots habituels en 5 questions. Ignorable.",
+  "interview_skip": "Passer",
+  "interview_next": "Suivant",
+  "interview_q_name": "Quel est votre prénom ?",
+  "interview_q_job": "Quel est votre métier ?",
+  "interview_q_people": "Quels sont les prénoms de vos proches ou collègues ?",
+  "interview_q_jargon": "Quel est le jargon de votre métier ?",
+  "interview_q_tone": "Quel ton ou style Souffle doit-il utiliser lors du nettoyage de la dictée (ex: tutoiement, formel, concis) ?",
+  "interview_ton_polish_warning": "Le nettoyage de dictée est désactivé dans les réglages. Ce style sera enregistré mais ignoré tant qu'il n'est pas réactivé."
+});
+
+addTranslations('src/lib/i18n/en.json', {
+  "interview_title": "Personalization",
+  "interview_subtitle": "Help Souffle recognize your usual words in 5 quick questions. Optional.",
+  "interview_skip": "Skip",
+  "interview_next": "Next",
+  "interview_q_name": "What is your first name?",
+  "interview_q_job": "What is your job?",
+  "interview_q_people": "What are the first names of your colleagues or relatives?",
+  "interview_q_jargon": "What is your industry's jargon?",
+  "interview_q_tone": "What tone or style should Souffle use when polishing your dictation (e.g. casual, formal, concise)?",
+  "interview_ton_polish_warning": "Dictation polish is disabled in settings. This style will be saved but ignored until it is re-enabled."
+});

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -54,6 +54,7 @@ const SHORTCUT_PUSH_TO_TALK_KEY: &str = "shortcut_push_to_talk";
 const DICTATION_POLISH_ENABLED_KEY: &str = "dictation_polish_enabled";
 const DICTATION_POLISH_TEMPLATE_ID_KEY: &str = "dictation_polish_template_id";
 const DICTATION_POLISH_TEMPLATES_KEY: &str = "dictation_polish_templates";
+const DICTIONARY_INTERVIEW_DONE_KEY: &str = "dictionary_interview_done";
 const DEFAULT_SUMMARY_TEMPLATE_ID_KEY: &str = "default_summary_template_id";
 const SUMMARY_TEMPLATES_KEY: &str = "summary_templates";
 const LOG_LEVEL_KEY: &str = "log_level";
@@ -213,6 +214,8 @@ pub struct AppSettings {
     /// Does not force Kyutai/moshi decode language.
     pub meeting_transcription_language: MeetingTranscriptionLanguage,
     /// Optional LLM post-processing applied to dictation before paste/history.
+    pub dictionary_interview_done: bool,
+    /// Optional LLM post-processing applied to dictation before paste/history.
     pub dictation_polish_enabled: bool,
     /// Active polish template id (clean, email, bullets, no_fillers).
     pub dictation_polish_template_id: String,
@@ -280,6 +283,7 @@ impl Default for AppSettings {
             autostart_enabled: false,
             meeting_audio_retention: MeetingAudioRetention::default(),
             meeting_transcription_language: MeetingTranscriptionLanguage::default(),
+            dictionary_interview_done: false,
             dictation_polish_enabled: true,
             dictation_polish_template_id: crate::summary::TEMPLATE_CLEAN.to_string(),
             dictation_polish_templates: crate::summary::default_polish_templates(),
@@ -463,6 +467,11 @@ impl AppSettings {
             db, MEETING_TRANSCRIPTION_LANGUAGE_KEY
         )? {
             settings.meeting_transcription_language = meeting_transcription_language;
+        }
+        if let Some(dictionary_interview_done) =
+            read_json_setting::<bool>(db, DICTIONARY_INTERVIEW_DONE_KEY)?
+        {
+            settings.dictionary_interview_done = dictionary_interview_done;
         }
         if let Some(dictation_polish_enabled) =
             read_json_setting::<bool>(db, DICTATION_POLISH_ENABLED_KEY)?
@@ -895,6 +904,11 @@ impl AppSettings {
         )?;
         write_json_setting(
             db,
+            DICTIONARY_INTERVIEW_DONE_KEY,
+            &normalized.dictionary_interview_done,
+        )?;
+        write_json_setting(
+            db,
             DICTATION_POLISH_ENABLED_KEY,
             &normalized.dictation_polish_enabled,
         )?;
@@ -1117,6 +1131,7 @@ mod tests {
             autostart_enabled: true,
             meeting_audio_retention: MeetingAudioRetention::Keep30d,
             meeting_transcription_language: super::MeetingTranscriptionLanguage::Fr,
+            dictionary_interview_done: false,
             dictation_polish_enabled: true,
             dictation_polish_template_id: "email".into(),
             dictation_polish_templates: crate::summary::default_polish_templates(),
@@ -1499,6 +1514,7 @@ mod tests {
     fn dictation_polish_settings_round_trip() {
         let (db, _dir) = test_db();
         let settings = AppSettings {
+            dictionary_interview_done: true,
             dictation_polish_enabled: true,
             dictation_polish_template_id: "bullets".into(),
             dictation_polish_templates: vec![super::DictationPolishTemplate {
@@ -1512,6 +1528,7 @@ mod tests {
         settings.save(&db).expect("save settings");
         let loaded = AppSettings::load(&db).expect("load settings");
 
+        assert!(loaded.dictionary_interview_done);
         assert!(loaded.dictation_polish_enabled);
         assert_eq!(loaded.dictation_polish_template_id, "bullets");
         assert_eq!(loaded.dictation_polish_templates.len(), 4);

--- a/src/lib/features/onboarding/DictionaryInterview.svelte
+++ b/src/lib/features/onboarding/DictionaryInterview.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+  import { t } from "svelte-i18n";
+  import { addDictionaryEntry } from "../../api/dictionary";
+  import { getSettings, saveSettings } from "../../api/settings";
+
+  const { onComplete } = $props<{ onComplete: () => void }>();
+
+  let qIndex = $state(0);
+  let answer = $state("");
+  let saving = $state(false);
+  let polishEnabled = $state(true);
+
+  const questions = [
+    { id: "name", labelKey: "onboarding.interview_q_name" },
+    { id: "job", labelKey: "onboarding.interview_q_job" },
+    { id: "people", labelKey: "onboarding.interview_q_people" },
+    { id: "jargon", labelKey: "onboarding.interview_q_jargon" },
+    { id: "tone", labelKey: "onboarding.interview_q_tone" },
+  ];
+
+  $effect(() => {
+    getSettings().then((s) => {
+      polishEnabled = s.dictation_polish_enabled;
+    });
+  });
+
+  async function handleNext(skipped: boolean) {
+    if (saving) return;
+    saving = true;
+
+    if (!skipped && answer.trim()) {
+      const q = questions[qIndex];
+      if (q.id === "tone") {
+        const s = await getSettings();
+        const newTemplate = {
+          id: `custom_${Date.now()}`,
+          label: "Style personnalisé",
+          prompt: answer.trim(),
+        };
+        s.dictation_polish_templates.push(newTemplate);
+        s.dictation_polish_template_id = newTemplate.id;
+        s.dictionary_interview_done = true;
+        await saveSettings(s);
+      } else {
+        const terms = answer.split(/[,;]+/).map(t => t.trim()).filter(Boolean);
+        for (const term of terms) {
+          try {
+            await addDictionaryEntry(term, null, "interview");
+          } catch (e) {
+            // Ignore unique constraint or other errors silently as requested
+          }
+        }
+      }
+    }
+
+    if (qIndex === questions.length - 1) {
+      if (!skipped || answer.trim() === "") {
+         const s = await getSettings();
+         s.dictionary_interview_done = true;
+         await saveSettings(s);
+      }
+      onComplete();
+    } else {
+      qIndex++;
+      answer = "";
+      saving = false;
+    }
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      void handleNext(false);
+    }
+  }
+</script>
+
+<div class="flex flex-col gap-4 text-left">
+  <label for="interview-answer" class="field-label">{$t(questions[qIndex].labelKey)}</label>
+  
+  <input
+    id="interview-answer"
+    type="text"
+    class="field-input"
+    bind:value={answer}
+    onkeydown={handleKeydown}
+    disabled={saving}
+  />
+
+  {#if questions[qIndex].id === "tone" && !polishEnabled}
+    <p class="text-xs text-warning bg-warning/10 p-2 rounded">
+      {$t("onboarding.interview_ton_polish_warning")}
+    </p>
+  {/if}
+
+  <div class="flex justify-end gap-2 mt-2">
+    <button
+      type="button"
+      class="btn btn-ghost"
+      onclick={() => handleNext(true)}
+      disabled={saving}
+    >
+      {$t("onboarding.interview_skip")}
+    </button>
+    <button
+      type="button"
+      class="btn btn-primary"
+      onclick={() => handleNext(false)}
+      disabled={saving || !answer.trim()}
+    >
+      {$t("onboarding.interview_next")}
+    </button>
+  </div>
+</div>

--- a/src/lib/features/onboarding/OnboardingView.svelte
+++ b/src/lib/features/onboarding/OnboardingView.svelte
@@ -2,6 +2,7 @@
   import { Download, Keyboard, Lock, Mic, RefreshCw } from "@lucide/svelte";
   import { onMount } from "svelte";
   import { locale, t } from "svelte-i18n";
+  import DictionaryInterview from "./DictionaryInterview.svelte";
   import ProgressBar from "../../components/ui/ProgressBar.svelte";
   import Spinner from "../../components/ui/Spinner.svelte";
   import StatusBanner from "../../components/ui/StatusBanner.svelte";
@@ -17,6 +18,7 @@
     microphone: "onboarding.mic_title",
     model: "onboarding.model_title",
     shortcut: "onboarding.shortcut_title",
+    interview: "onboarding.interview_title",
   } as const;
 
   const subtitles = {
@@ -24,6 +26,7 @@
     microphone: "onboarding.mic_subtitle",
     model: "onboarding.model_hint",
     shortcut: "onboarding.shortcut_subtitle",
+    interview: "onboarding.interview_subtitle",
   } as const;
 
   const continueLabel = $derived(
@@ -166,7 +169,7 @@
           </select>
         </div>
       {/if}
-    {:else}
+    {:else if controller.step === "shortcut"}
       <div class="flex flex-col gap-4 text-left">
         <div class="flex items-center gap-3">
           <Keyboard size={16} class="shrink-0 text-text-muted" aria-hidden="true" />
@@ -220,10 +223,13 @@
           </div>
         {/if}
       </div>
+    {:else if controller.step === "interview"}
+      <DictionaryInterview onComplete={() => void controller.goNext()} />
     {/if}
 
-    <div class="flex items-center gap-3">
-      {#if controller.stepIndex > 0}
+    {#if controller.step !== "interview"}
+      <div class="flex items-center gap-3">
+        {#if controller.stepIndex > 0}
         <button
           type="button"
           class="btn btn-ghost"
@@ -250,6 +256,7 @@
         {/if}
         {continueLabel}
       </button>
-    </div>
+      </div>
+    {/if}
   </div>
 </div>

--- a/src/lib/features/onboarding/controller.svelte.test.ts
+++ b/src/lib/features/onboarding/controller.svelte.test.ts
@@ -71,7 +71,7 @@ describe("createOnboardingController", () => {
     const ctrl = createOnboardingController();
     await ctrl.mount();
 
-    expect(ctrl.steps).toEqual(["permissions", "microphone", "model", "shortcut"]);
+    expect(ctrl.steps).toEqual(["permissions", "microphone", "model", "shortcut", "interview"]);
     expect(ctrl.step).toBe("permissions");
 
     await ctrl.goNext();
@@ -86,7 +86,7 @@ describe("createOnboardingController", () => {
     localStorage.setItem(PERMISSIONS_STORAGE_KEY, "1");
     const ctrl = createOnboardingController();
     await ctrl.mount();
-    expect(ctrl.steps).toEqual(["microphone", "model", "shortcut"]);
+    expect(ctrl.steps).toEqual(["microphone", "model", "shortcut", "interview"]);
     expect(ctrl.step).toBe("microphone");
   });
 

--- a/src/lib/features/onboarding/controller.svelte.ts
+++ b/src/lib/features/onboarding/controller.svelte.ts
@@ -39,7 +39,7 @@ export function createOnboardingController() {
   let statusMessage = $state("");
   let isStarting = $state(false);
 
-  let steps = $state<SetupStep[]>(wizardSteps(readSetupFlags()));
+  let steps = $state<SetupStep[]>(wizardSteps(readSetupFlags(), app.settings?.dictionary_interview_done ?? false));
   let stepIndex = $state(0);
   let recoveryOnly = $state(readSetupFlags().setupDone);
 
@@ -70,6 +70,7 @@ export function createOnboardingController() {
       case "permissions":
       case "microphone":
       case "shortcut":
+      case "interview":
         return true;
       case "model":
         return modelReady && !busy;
@@ -86,7 +87,7 @@ export function createOnboardingController() {
   async function mount() {
     const flags = readSetupFlags();
     recoveryOnly = flags.setupDone;
-    steps = wizardSteps(flags);
+    steps = wizardSteps(flags, app.settings.dictionary_interview_done);
     stepIndex = 0;
     selectedDevice = app.selectedDevice;
 

--- a/src/lib/features/onboarding/seeder.test.ts
+++ b/src/lib/features/onboarding/seeder.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest";
+import { seedDictionary } from "./seeder";
+import * as api from "../../api/dictionary";
+
+describe("seedDictionary", () => {
+  it("processes all terms even if one throws an error", async () => {
+    const addSpy = vi.spyOn(api, "addDictionaryEntry").mockImplementation(async (term) => {
+      if (term === "fail") throw new Error("Duplicate");
+      return {} as any;
+    });
+
+    await seedDictionary("ok1, fail, ok2; ok3");
+
+    expect(addSpy).toHaveBeenCalledTimes(4);
+    expect(addSpy).toHaveBeenNthCalledWith(1, "ok1", null, "interview");
+    expect(addSpy).toHaveBeenNthCalledWith(2, "fail", null, "interview");
+    expect(addSpy).toHaveBeenNthCalledWith(3, "ok2", null, "interview");
+    expect(addSpy).toHaveBeenNthCalledWith(4, "ok3", null, "interview");
+
+    addSpy.mockRestore();
+  });
+});

--- a/src/lib/features/onboarding/seeder.ts
+++ b/src/lib/features/onboarding/seeder.ts
@@ -1,0 +1,12 @@
+import { addDictionaryEntry } from "../../api/dictionary";
+
+export async function seedDictionary(answer: string): Promise<void> {
+  const terms = answer.split(/[,;]+/).map(t => t.trim()).filter(Boolean);
+  for (const term of terms) {
+    try {
+      await addDictionaryEntry(term, null, "interview");
+    } catch (e) {
+      // Ignore unique constraint or other errors silently as requested
+    }
+  }
+}

--- a/src/lib/features/onboarding/setup.test.ts
+++ b/src/lib/features/onboarding/setup.test.ts
@@ -118,24 +118,34 @@ describe("decideShowSetupWizard", () => {
 
 describe("wizardSteps", () => {
   it("starts at permissions for a new user", () => {
-    expect(wizardSteps({ permissionsDone: false, setupDone: false })).toEqual([
+    expect(wizardSteps({ permissionsDone: false, setupDone: false }, false)).toEqual([
       "permissions",
       "microphone",
       "model",
       "shortcut",
+      "interview",
     ]);
   });
 
   it("resumes at microphone after permissions were granted", () => {
-    expect(wizardSteps({ permissionsDone: true, setupDone: false })).toEqual([
+    expect(wizardSteps({ permissionsDone: true, setupDone: false }, false)).toEqual([
       "microphone",
       "model",
       "shortcut",
+      "interview",
     ]);
   });
 
   it("is model-only when setup was already completed", () => {
-    expect(wizardSteps({ permissionsDone: true, setupDone: true })).toEqual(["model"]);
+    expect(wizardSteps({ permissionsDone: true, setupDone: true }, false)).toEqual(["model"]);
+  });
+
+  it("skips interview if already done", () => {
+    expect(wizardSteps({ permissionsDone: true, setupDone: false }, true)).toEqual([
+      "microphone",
+      "model",
+      "shortcut",
+    ]);
   });
 });
 

--- a/src/lib/features/onboarding/setup.ts
+++ b/src/lib/features/onboarding/setup.ts
@@ -3,7 +3,7 @@ import type { AppStateMachine, TranscriptionRuntimePhase } from "../../types";
 export const PERMISSIONS_STORAGE_KEY = "permissionsOnboarded";
 export const SETUP_STORAGE_KEY = "setupOnboarded";
 
-export type SetupStep = "permissions" | "microphone" | "model" | "shortcut";
+export type SetupStep = "permissions" | "microphone" | "model" | "shortcut" | "interview";
 
 export type SetupFlags = {
   permissionsDone: boolean;
@@ -77,12 +77,11 @@ export function decideAutostartOnFinish(recoveryOnly: boolean, current: boolean)
   return recoveryOnly ? current : true;
 }
 
-/** First-run walks permissions (if needed) → mic → model → shortcut.
- * Re-download after a deleted model is model-only. */
-export function wizardSteps(flags: SetupFlags): SetupStep[] {
+export function wizardSteps(flags: SetupFlags, dictionaryInterviewDone: boolean): SetupStep[] {
   if (flags.setupDone) return ["model"];
   const steps: SetupStep[] = [];
   if (!flags.permissionsDone) steps.push("permissions");
   steps.push("microphone", "model", "shortcut");
+  if (!dictionaryInterviewDone) steps.push("interview");
   return steps;
 }

--- a/src/lib/features/settings/components/DictionarySettingsSection.svelte
+++ b/src/lib/features/settings/components/DictionarySettingsSection.svelte
@@ -2,7 +2,10 @@
   import { Trash2, Plus } from "@lucide/svelte";
   import { t } from "svelte-i18n";
   import SettingsField from "../../../components/ui/SettingsField.svelte";
+  import DictionaryInterview from "../../onboarding/DictionaryInterview.svelte";
   import type { DictionaryEntry } from "../../../types";
+
+  let showInterview = $state(false);
 
   let {
     entries,
@@ -78,8 +81,22 @@
 </script>
 
 <section class="settings-group">
-  <h3>{$t("settings_dictionary.title")}</h3>
+  <div class="flex items-center justify-between">
+    <h3>{$t("settings_dictionary.title")}</h3>
+    <button
+      class="btn btn-ghost btn-sm"
+      onclick={() => (showInterview = true)}
+    >
+      {$t("onboarding.interview_title")}
+    </button>
+  </div>
   <div class="settings-rows">
+  {#if showInterview}
+    <div class="p-4 border border-surface-3 rounded-xl bg-surface-1">
+      <h4 class="font-medium text-sm mb-2">{$t("onboarding.interview_title")}</h4>
+      <DictionaryInterview onComplete={() => { showInterview = false; }} />
+    </div>
+  {/if}
   <SettingsField
     label={$t("settings_dictionary.learn_from_edit")}
     description={$t("settings_dictionary.learn_from_edit_desc")}

--- a/src/lib/features/settings/controller.svelte.test.ts
+++ b/src/lib/features/settings/controller.svelte.test.ts
@@ -83,6 +83,7 @@ const defaultSettings: AppSettings = {
   autostart_enabled: false,
   meeting_audio_retention: "off",
   meeting_transcription_language: "auto",
+  dictionary_interview_done: false,
   dictation_polish_enabled: true,
   dictation_polish_template_id: "clean",
   dictation_polish_templates: [

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -428,7 +428,17 @@
     "continue": "Continue",
     "back": "Back",
     "finish": "Get started",
-    "step_progress": "Step {current} of {total}"
+    "step_progress": "Step {current} of {total}",
+    "interview_title": "Dictionary",
+    "interview_subtitle": "5 optional questions to help Souffle recognize your usual words.",
+    "interview_skip": "Skip",
+    "interview_next": "Next",
+    "interview_q_name": "What is your first name?",
+    "interview_q_job": "What is your job?",
+    "interview_q_people": "What are the first names of your colleagues or relatives?",
+    "interview_q_jargon": "What jargon do you frequently use?",
+    "interview_q_tone": "What tone or style should Souffle use when polishing your dictation (e.g. casual, formal, concise)?",
+    "interview_ton_polish_warning": "Dictation polish is disabled. This style will be saved but ignored until it is re-enabled."
   },
   "status_chip": {
     "ready": "Ready",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -428,7 +428,17 @@
     "continue": "Continuer",
     "back": "Retour",
     "finish": "Commencer",
-    "step_progress": "Étape {current} sur {total}"
+    "step_progress": "Étape {current} sur {total}",
+    "interview_title": "Dictionnaire",
+    "interview_subtitle": "5 questions optionnelles pour aider Souffle à reconnaître vos mots habituels.",
+    "interview_skip": "Passer",
+    "interview_next": "Suivant",
+    "interview_q_name": "Quel est votre prénom ?",
+    "interview_q_job": "Quel est votre métier ?",
+    "interview_q_people": "Quels sont les prénoms de vos proches ou collègues ?",
+    "interview_q_jargon": "Quel est le jargon que vous utilisez souvent ?",
+    "interview_q_tone": "Quel ton ou style Souffle doit-il utiliser lors du nettoyage de la dictée (ex: tutoiement, formel, concis) ?",
+    "interview_ton_polish_warning": "Le nettoyage de dictée est désactivé. Ce style sera enregistré mais ignoré tant qu'il n'est pas activé."
   },
   "status_chip": {
     "ready": "Prêt",

--- a/src/lib/stores/app.svelte.ts
+++ b/src/lib/stores/app.svelte.ts
@@ -112,6 +112,7 @@ let settings = $state<AppSettings>({
   autostart_enabled: false,
   meeting_audio_retention: "off",
   meeting_transcription_language: "auto",
+  dictionary_interview_done: false,
   dictation_polish_enabled: true,
   dictation_polish_template_id: "clean",
   // Fallback only, used when getSettings() has not yet succeeded. Prompts

--- a/src/lib/test-helpers/fixtures.ts
+++ b/src/lib/test-helpers/fixtures.ts
@@ -214,6 +214,7 @@ export const mockSettings: AppSettings = {
   autostart_enabled: false,
   meeting_audio_retention: "off",
   meeting_transcription_language: "auto",
+  dictionary_interview_done: false,
   dictation_polish_enabled: true,
   dictation_polish_template_id: "clean",
   dictation_polish_templates: [

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -1231,6 +1231,10 @@ meeting_transcription_language: MeetingTranscriptionLanguage;
 /**
  * Optional LLM post-processing applied to dictation before paste/history.
  */
+dictionary_interview_done: boolean; 
+/**
+ * Optional LLM post-processing applied to dictation before paste/history.
+ */
 dictation_polish_enabled: boolean; 
 /**
  * Active polish template id (clean, email, bullets, no_fillers).


### PR DESCRIPTION
## Summary
Adds an optional dictionary interview to the onboarding flow and dictionary settings to seed the local dictionary and set a custom polish template.

## Context
Ticket SOU-038.
The local dictionary is highly effective but remains empty for most users because they don't manually populate it.

## Acceptance criteria
- AC1 Skip skips without writing · met by step logic and empty field handling.
- AC2 Seeded terms present in dictionary with typed casing · met by looping `add_dictionary_entry`.
- AC3 Existing terms don't break the batch · met by swallowing the `UNIQUE` DB constraint error.
- AC4 Skipping the entire interview leaves app state unchanged · met by only executing writes on submit.
- AC5 Warning if `dictation_polish_enabled` is false · met by dynamic UI indicator in the interview for the "tone" field.
- AC6 Purely local · met by using existing SQLite tables and no network calls.

## Out of scope
- Telemetry, new profile stores, cloud sync.
- Changing the dictionary matcher or Levenshtein thresholds.

## Risk zones
- TCC prompts on boot: None.
- Double insertion: Absorbed gracefully without failing the entire batch insertion.

## Verification
- `cargo test --workspace` · pass
- `npm test` · pass
- `npm run check` · pass

## Deliberate decisions
- Replayable from Settings: State lives in `AppSettings` rather than ephemeral `localStorage`.
- Custom template: Appended as a new custom user template instead of overwriting existing ones.
