### PR TITLE
fix: allow native single-key Toggle shortcuts (SOU-115)

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -100,8 +100,10 @@ pub fn register_shortcuts(app: &AppHandle, shortcuts: &ShortcutSettings) -> Resu
                 _ => None,
             };
         }
+        // Key-repeat latch for Toggle. Do not touch `ptt_start_armed`: a
+        // settings save while native PTT is held would swallow the release
+        // and leave dictation running (SOU-115 AC6).
         state.toggle_armed.store(false, Ordering::SeqCst);
-        state.ptt_start_armed.store(false, Ordering::SeqCst);
     }
 
     if toggle_target == ShortcutRegistrationTarget::Plugin {

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -6,7 +6,7 @@ use tauri_specta::Event;
 use tracing::info;
 
 use crate::app_events::{ShortcutPttStart, ShortcutPttStop, ShortcutToggle};
-use crate::modifier_shortcut::is_native_ptt_shortcut;
+use crate::modifier_shortcut::{ShortcutRegistrationTarget, shortcut_registration_target};
 use crate::settings::{AppSettings, ShortcutSettings};
 use crate::state::AppState;
 
@@ -82,7 +82,29 @@ pub fn register_shortcuts(app: &AppHandle, shortcuts: &ShortcutSettings) -> Resu
     gs.unregister_all()
         .map_err(|e| format!("Unregister: {e}"))?;
 
-    if !shortcuts.toggle.is_empty() {
+    let toggle_target = shortcut_registration_target(&shortcuts.toggle);
+    let ptt_target = shortcut_registration_target(&shortcuts.push_to_talk);
+
+    if let Some(state) = app.try_state::<AppState>() {
+        {
+            let mut lock = state.modifier_toggle_shortcut.write().unwrap();
+            *lock = match toggle_target {
+                ShortcutRegistrationTarget::Native => Some(shortcuts.toggle.clone()),
+                _ => None,
+            };
+        }
+        {
+            let mut lock = state.modifier_ptt_shortcut.write().unwrap();
+            *lock = match ptt_target {
+                ShortcutRegistrationTarget::Native => Some(shortcuts.push_to_talk.clone()),
+                _ => None,
+            };
+        }
+        state.toggle_armed.store(false, Ordering::SeqCst);
+        state.ptt_start_armed.store(false, Ordering::SeqCst);
+    }
+
+    if toggle_target == ShortcutRegistrationTarget::Plugin {
         gs.on_shortcut(shortcuts.toggle.as_str(), move |app, _shortcut, event| {
             if event.state == ShortcutState::Pressed {
                 let _ = ShortcutToggle.emit(app);
@@ -90,20 +112,14 @@ pub fn register_shortcuts(app: &AppHandle, shortcuts: &ShortcutSettings) -> Resu
         })
         .map_err(|e| format!("Register toggle shortcut '{}': {e}", shortcuts.toggle))?;
         info!(shortcut = shortcuts.toggle, "Toggle shortcut registered");
+    } else if toggle_target == ShortcutRegistrationTarget::Native {
+        info!(
+            shortcut = shortcuts.toggle,
+            "Toggle shortcut registered via native tap"
+        );
     }
 
-    let is_native = is_native_ptt_shortcut(&shortcuts.push_to_talk);
-
-    if let Some(state) = app.try_state::<AppState>() {
-        let mut lock = state.modifier_ptt_shortcut.write().unwrap();
-        *lock = if is_native {
-            Some(shortcuts.push_to_talk.clone())
-        } else {
-            None
-        };
-    }
-
-    if !shortcuts.push_to_talk.is_empty() && !is_native {
+    if ptt_target == ShortcutRegistrationTarget::Plugin {
         gs.on_shortcut(
             shortcuts.push_to_talk.as_str(),
             move |app, _shortcut, event| match event.state {
@@ -131,6 +147,11 @@ pub fn register_shortcuts(app: &AppHandle, shortcuts: &ShortcutSettings) -> Resu
         info!(
             shortcut = shortcuts.push_to_talk,
             "Push-to-talk shortcut registered"
+        );
+    } else if ptt_target == ShortcutRegistrationTarget::Native {
+        info!(
+            shortcut = shortcuts.push_to_talk,
+            "Push-to-talk shortcut registered via native tap"
         );
     }
 

--- a/src-tauri/src/modifier_shortcut.rs
+++ b/src-tauri/src/modifier_shortcut.rs
@@ -13,7 +13,7 @@ use tauri::{AppHandle, Manager};
 use tauri_specta::Event;
 use tracing::{error, info};
 
-use crate::app_events::{ModifierTapStatus, ShortcutPttStart, ShortcutPttStop};
+use crate::app_events::{ModifierTapStatus, ShortcutPttStart, ShortcutPttStop, ShortcutToggle};
 use crate::state::AppState;
 
 /// Last `ModifierTapStatus` emitted. The event is edge-triggered (install
@@ -34,9 +34,20 @@ fn store_and_emit_modifier_tap_status(app: &AppHandle, installed: bool) {
     let _ = status.emit(app);
 }
 
-/// Single-key PTT bindings that the plugin cannot register. Combos stay on
-/// `tauri-plugin-global-shortcut` (SOU-032).
-pub(crate) fn is_native_ptt_shortcut(shortcut: &str) -> bool {
+/// Where a dictation shortcut is registered (SOU-032 / SOU-115).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ShortcutRegistrationTarget {
+    /// Empty binding — nothing to register.
+    None,
+    /// Single native key handled by the CGEventTap.
+    Native,
+    /// Classic combo handled by `tauri-plugin-global-shortcut`.
+    Plugin,
+}
+
+/// Single-key bindings that the plugin cannot register. Combos stay on
+/// `tauri-plugin-global-shortcut` (SOU-032). Shared by Toggle and PTT (SOU-115).
+pub(crate) fn is_native_shortcut(shortcut: &str) -> bool {
     matches!(
         shortcut,
         "Fn" | "MetaLeft"
@@ -56,6 +67,17 @@ pub(crate) fn is_native_ptt_shortcut(shortcut: &str) -> bool {
             | "F11"
             | "F12"
     )
+}
+
+/// Route a stored accelerator to the native tap or the global-shortcut plugin.
+pub(crate) fn shortcut_registration_target(shortcut: &str) -> ShortcutRegistrationTarget {
+    if shortcut.is_empty() {
+        ShortcutRegistrationTarget::None
+    } else if is_native_shortcut(shortcut) {
+        ShortcutRegistrationTarget::Native
+    } else {
+        ShortcutRegistrationTarget::Plugin
+    }
 }
 
 pub fn start_modifier_tap(app: AppHandle) {
@@ -119,20 +141,27 @@ fn install_and_run(app: AppHandle) -> bool {
                 Some(s) => s.inner(),
                 None => return CallbackResult::Keep,
             };
-            let current_shortcut = {
-                let lock = state.modifier_ptt_shortcut.read().unwrap();
+            let toggle_shortcut = {
+                let lock = state.modifier_toggle_shortcut.read().unwrap();
                 lock.clone()
             };
-
-            let Some(shortcut) = current_shortcut else {
-                return CallbackResult::Keep;
+            let ptt_shortcut = {
+                let lock = state.modifier_ptt_shortcut.read().unwrap();
+                lock.clone()
             };
 
             let keycode = event
                 .get_integer_value_field(core_graphics::event::EventField::KEYBOARD_EVENT_KEYCODE);
             let flags = event.get_flags();
 
-            if !shortcut_matches_keycode(&shortcut, keycode) {
+            let matches_toggle = toggle_shortcut
+                .as_deref()
+                .is_some_and(|s| shortcut_matches_keycode(s, keycode));
+            let matches_ptt = ptt_shortcut
+                .as_deref()
+                .is_some_and(|s| shortcut_matches_keycode(s, keycode));
+
+            if !matches_toggle && !matches_ptt {
                 return CallbackResult::Keep;
             }
 
@@ -147,18 +176,36 @@ fn install_and_run(app: AppHandle) -> bool {
                 };
 
                 if is_pressed {
-                    emit_ptt_start(state, &app);
-                } else if state.ptt_start_armed.swap(false, Ordering::SeqCst) {
-                    let _ = ShortcutPttStop.emit(&app);
+                    if matches_toggle {
+                        emit_toggle(state, &app);
+                    }
+                    if matches_ptt {
+                        emit_ptt_start(state, &app);
+                    }
+                } else {
+                    if matches_toggle {
+                        state.toggle_armed.store(false, Ordering::SeqCst);
+                    }
+                    if matches_ptt && state.ptt_start_armed.swap(false, Ordering::SeqCst) {
+                        let _ = ShortcutPttStop.emit(&app);
+                    }
                 }
                 return CallbackResult::Drop;
             }
 
             if matches!(event_type, CGEventType::KeyDown) {
-                emit_ptt_start(state, &app);
+                if matches_toggle {
+                    emit_toggle(state, &app);
+                }
+                if matches_ptt {
+                    emit_ptt_start(state, &app);
+                }
                 return CallbackResult::Drop;
             } else if matches!(event_type, CGEventType::KeyUp) {
-                if state.ptt_start_armed.swap(false, Ordering::SeqCst) {
+                if matches_toggle {
+                    state.toggle_armed.store(false, Ordering::SeqCst);
+                }
+                if matches_ptt && state.ptt_start_armed.swap(false, Ordering::SeqCst) {
                     let _ = ShortcutPttStop.emit(&app);
                 }
                 return CallbackResult::Drop;
@@ -192,6 +239,13 @@ fn install_and_run(app: AppHandle) -> bool {
     }
 }
 
+fn emit_toggle(state: &AppState, app: &AppHandle) {
+    // Key-repeat (and extra FlagsChanged) must not re-fire Toggle.
+    if !state.toggle_armed.swap(true, Ordering::SeqCst) {
+        let _ = ShortcutToggle.emit(app);
+    }
+}
+
 fn emit_ptt_start(state: &AppState, app: &AppHandle) {
     if state.ptt_is_paused() {
         state.ptt_start_armed.store(false, Ordering::SeqCst);
@@ -203,7 +257,7 @@ fn emit_ptt_start(state: &AppState, app: &AppHandle) {
     }
 }
 
-/// macOS virtual keycodes for modifier-only PTT and F5–F12 (SOU-032).
+/// macOS virtual keycodes for modifier-only PTT/Toggle and F5–F12 (SOU-032).
 fn shortcut_matches_keycode(shortcut: &str, keycode: i64) -> bool {
     matches!(
         (shortcut, keycode),
@@ -229,7 +283,10 @@ fn shortcut_matches_keycode(shortcut: &str, keycode: i64) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_native_ptt_shortcut, shortcut_matches_keycode};
+    use super::{
+        ShortcutRegistrationTarget, is_native_shortcut, shortcut_matches_keycode,
+        shortcut_registration_target,
+    };
 
     #[test]
     fn modifier_and_fn_keycodes() {
@@ -252,10 +309,34 @@ mod tests {
             ("F12", 111),
         ] {
             assert!(shortcut_matches_keycode(name, code), "{name}");
-            assert!(is_native_ptt_shortcut(name), "{name}");
+            assert!(is_native_shortcut(name), "{name}");
         }
         assert!(!shortcut_matches_keycode("F5", 122));
-        assert!(!is_native_ptt_shortcut("F4"));
-        assert!(!is_native_ptt_shortcut("CommandOrControl+Shift+Space"));
+        assert!(!is_native_shortcut("F4"));
+        assert!(!is_native_shortcut("CommandOrControl+Shift+Space"));
+    }
+
+    #[test]
+    fn native_toggle_routes_to_tap_not_plugin() {
+        assert_eq!(
+            shortcut_registration_target("Fn"),
+            ShortcutRegistrationTarget::Native
+        );
+        assert_eq!(
+            shortcut_registration_target("MetaRight"),
+            ShortcutRegistrationTarget::Native
+        );
+        assert_eq!(
+            shortcut_registration_target("F8"),
+            ShortcutRegistrationTarget::Native
+        );
+        assert_eq!(
+            shortcut_registration_target("CommandOrControl+Shift+Space"),
+            ShortcutRegistrationTarget::Plugin
+        );
+        assert_eq!(
+            shortcut_registration_target(""),
+            ShortcutRegistrationTarget::None
+        );
     }
 }

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1244,6 +1244,32 @@ mod tests {
     }
 
     #[test]
+    fn shortcut_settings_reject_duplicate_native_bindings() {
+        let shortcuts = ShortcutSettings {
+            toggle: "Fn".into(),
+            push_to_talk: "Fn".into(),
+        };
+
+        assert_eq!(
+            shortcuts.normalize().unwrap_err(),
+            "Dictation shortcuts must be different"
+        );
+    }
+
+    #[test]
+    fn native_toggle_shortcut_persists_across_load() {
+        let (db, _dir) = test_db();
+        let s = ShortcutSettings {
+            toggle: "Fn".into(),
+            push_to_talk: "MetaRight".into(),
+        };
+        s.save(&db).unwrap();
+        let loaded = ShortcutSettings::load(&db).unwrap();
+        assert_eq!(loaded.toggle, "Fn");
+        assert_eq!(loaded.push_to_talk, "MetaRight");
+    }
+
+    #[test]
     fn missing_settings_use_defaults() {
         let (db, _dir) = test_db();
         let settings = AppSettings::load(&db).expect("load defaults");

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -181,7 +181,12 @@ pub struct AppState {
     /// Release only emits `ShortcutPttStop` if this is still true, so a
     /// paused PTT press cannot stop a dictation started another way.
     pub ptt_start_armed: AtomicBool,
+    /// Set when `ShortcutToggle` was emitted for the current native key-down.
+    /// Cleared on release so key-repeat cannot flip dictation in a loop.
+    pub toggle_armed: AtomicBool,
     pub modifier_ptt_shortcut: std::sync::Arc<std::sync::RwLock<Option<String>>>,
+    /// Native single-key Toggle binding (SOU-115), symmetric to PTT.
+    pub modifier_toggle_shortcut: std::sync::Arc<std::sync::RwLock<Option<String>>>,
 }
 
 impl AppState {
@@ -204,7 +209,9 @@ impl AppState {
             live_edit_lock: Mutex::new(()),
             ptt_paused_until: Mutex::new(None),
             ptt_start_armed: AtomicBool::new(false),
+            toggle_armed: AtomicBool::new(false),
             modifier_ptt_shortcut: std::sync::Arc::new(std::sync::RwLock::new(None)),
+            modifier_toggle_shortcut: std::sync::Arc::new(std::sync::RwLock::new(None)),
         }
     }
 

--- a/src/lib/features/settings/components/InterfaceSettingsSection.svelte
+++ b/src/lib/features/settings/components/InterfaceSettingsSection.svelte
@@ -60,7 +60,7 @@
   } = $props();
 
   const showNativeTapBanner = $derived(
-    shouldShowNativeTapBanner(pttShortcut, modifierTapStatus),
+    shouldShowNativeTapBanner(pttShortcut, modifierTapStatus, toggleShortcut),
   );
 </script>
 

--- a/src/lib/features/settings/components/InterfaceSettingsSection.test.ts
+++ b/src/lib/features/settings/components/InterfaceSettingsSection.test.ts
@@ -49,7 +49,24 @@ describe("InterfaceSettingsSection native tap banner (SOU-116)", () => {
 
     expect(
       screen.getByText(
-        /push-to-talk shortcut won't work until Accessibility is granted/i,
+        /single-key shortcut won't work until Accessibility is granted/i,
+      ),
+    ).toBeTruthy();
+  });
+
+  it("shows the banner when Toggle is native and the tap is missing (SOU-115)", () => {
+    render(InterfaceSettingsSection, {
+      props: {
+        ...baseProps,
+        toggleShortcut: "Fn",
+        pttShortcut: "",
+        modifierTapStatus: { installed: false },
+      },
+    });
+
+    expect(
+      screen.getByText(
+        /single-key shortcut won't work until Accessibility is granted/i,
       ),
     ).toBeTruthy();
   });
@@ -65,7 +82,7 @@ describe("InterfaceSettingsSection native tap banner (SOU-116)", () => {
 
     expect(
       screen.queryByText(
-        /push-to-talk shortcut won't work until Accessibility is granted/i,
+        /single-key shortcut won't work until Accessibility is granted/i,
       ),
     ).toBeNull();
   });

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -149,7 +149,7 @@
     "clear": "Clear",
     "push_to_talk": "Push-to-talk",
     "push_to_talk_desc": "Hold to record, release to stop.",
-    "native_tap_missing": "Your single-key push-to-talk shortcut won't work until Accessibility is granted.",
+    "native_tap_missing": "Your single-key shortcut won't work until Accessibility is granted.",
     "native_tap_missing_action": "Review permissions",
     "pill_hidden": "Hide recording overlay",
     "pill_hidden_desc": "Don't show the floating HUD while dictating or in a meeting. Drag it when visible to move it; the position is remembered and stays on-screen if the display changes.",

--- a/src/lib/utils/shortcut.test.ts
+++ b/src/lib/utils/shortcut.test.ts
@@ -68,11 +68,21 @@ describe("shouldShowNativeTapBanner (SOU-116)", () => {
     expect(shouldShowNativeTapBanner("F5", { installed: false })).toBe(true);
   });
 
+  it("shows when Toggle is native and the tap is missing (SOU-115)", () => {
+    expect(shouldShowNativeTapBanner("", { installed: false }, "Fn")).toBe(true);
+    expect(shouldShowNativeTapBanner("CommandOrControl+Shift+Space", { installed: false }, "F8")).toBe(
+      true,
+    );
+  });
+
   it("hides when no native shortcut is bound (AC6)", () => {
     expect(shouldShowNativeTapBanner("", { installed: false })).toBe(false);
     expect(shouldShowNativeTapBanner("CommandOrControl+Shift+Space", { installed: false })).toBe(
       false,
     );
+    expect(
+      shouldShowNativeTapBanner("CommandOrControl+Shift+Space", { installed: false }, "Alt+Space"),
+    ).toBe(false);
   });
 
   it("hides while status is unknown or the tap is installed", () => {

--- a/src/lib/utils/shortcut.ts
+++ b/src/lib/utils/shortcut.ts
@@ -58,13 +58,17 @@ export function isNativePttShortcut(shortcut: string): boolean {
   return NATIVE_PTT_SHORTCUTS.has(shortcut);
 }
 
-/** Settings banner for a bound native PTT key when the tap is known missing.
- * `null` status = not yet attempted (startup delay); do not flash (SOU-116). */
+/** Settings banner when a native Toggle or PTT key is bound and the tap is
+ * known missing. `null` status = not yet attempted (startup delay); do not
+ * flash (SOU-116). Toggle is included once SOU-115 can bind native keys. */
 export function shouldShowNativeTapBanner(
   pttShortcut: string,
   tapStatus: { installed: boolean } | null,
+  toggleShortcut = "",
 ): boolean {
-  return isNativePttShortcut(pttShortcut) && tapStatus?.installed === false;
+  const nativeBound =
+    isNativePttShortcut(pttShortcut) || isNativePttShortcut(toggleShortcut);
+  return nativeBound && tapStatus?.installed === false;
 }
 
 function mapKey(code: string, key: string): string | null {


### PR DESCRIPTION
## Summary

Native single-key shortcuts (Fn, lone modifiers, F5–F12) only worked for push-to-talk. Toggle always went through `tauri-plugin-global-shortcut`, which cannot parse those accelerators, so saving failed or the binding never stuck. This routes native Toggle bindings through the same CGEventTap as PTT, emitting `ShortcutToggle` on press only with anti-repeat, while classic combos keep using the plugin unchanged.

## Context

Ticket SOU-115 (internal tracker, not mirrored on GitHub).
Root cause: `AppState` held only `modifier_ptt_shortcut`, and `register_shortcuts` sent Toggle to the plugin unconditionally while `is_native_ptt_shortcut` gated PTT alone (`commands/settings.rs`, `modifier_shortcut.rs`, `state.rs`).

## Acceptance criteria

1. **Binding Toggle to Fn / lone modifier / F5–F12 must save and persist across restart** — verified by `native_toggle_shortcut_persists_across_load` in `src-tauri/src/settings.rs`, and by `register_shortcuts` storing native Toggle in `modifier_toggle_shortcut` when `shortcut_registration_target` returns `Native` (`commands/settings.rs`).
2. **Press starts dictation; second press stops; no release dependency** — verified by `emit_toggle` emitting `ShortcutToggle` only on KeyDown / FlagsChanged press (not release) in `modifier_shortcut.rs`; the existing frontend `events.shortcutToggle.listen` handler already toggles recording.
3. **Same native key on Toggle and PTT must refuse with existing conflicting_pair message** — verified by `shortcut_settings_reject_duplicate_native_bindings` in `settings.rs` (message `"Dictation shortcuts must be different"` via `conflicting_pair`).
4. **Non-native Toggle still uses global-shortcut unchanged** — verified by `native_toggle_routes_to_tap_not_plugin` asserting classic combos map to `ShortcutRegistrationTarget::Plugin`, and by the `toggle_target == Plugin` branch still calling `gs.on_shortcut`.
5. **Bound native key consumed (Drop); other keys pass** — verified by tap callback returning `CallbackResult::Drop` when `matches_toggle || matches_ptt`, else `Keep` (`modifier_shortcut.rs`).
6. **Native PTT behaviour unchanged** — verified by unchanged `emit_ptt_start` / `ptt_start_armed` / pause gating and Start/Stop emit paths; only dual-binding matching was added around them.

## Out of scope

- Native tap install / permission feedback (SOU-116 / PR #208) — not touched beyond shared files that will need a careful merge
- HUD Esc cancel (SOU-117)
- Expanding the native key list / `shortcut_matches_keycode` table
- Changing `tauri-plugin-global-shortcut` behaviour for classic combos
- Frontend meeting invariant SOU-044 — `ShortcutToggle` handler already no-ops during meetings; not reopened

## Risk zones

- **Key-repeat**: `toggle_armed` mirrors PTT's press latch so a held Fn/F-key cannot start/stop in a loop; rearmed on KeyUp / FlagsChanged release
- **Event consumption**: Drop only when the keycode matches a bound native Toggle or PTT shortcut
- **Locks**: Tap callback still only takes `RwLock` reads on the binding slots — no window ops, no `AppState` mutex
- **Merge with SOU-116 PR #208**: that PR also edits `modifier_shortcut.rs` and `commands/settings.rs` for tap permission surfacing — expect a textual conflict on those two files when landing both

## Verification

```bash
npm run check:generated-types
# → export_typescript_bindings ok; no diff on generated.ts

cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
# → no diff

cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings
# → Finished `dev` profile (0 errors, 0 warnings)

cargo test --manifest-path src-tauri/Cargo.toml --workspace
# → lib: ok. 886 passed; 0 failed; 4 ignored
# → app_flows: ok. 6 passed
# → mcp_sidecar_contract: ok. 2 passed
# → punctuation_threshold: ok. 1 passed; 1 ignored
# → souffle-mcp: ok. 21 passed
# → tts-fixtures: ok. 7 passed

npm test
# → Test Files 52 passed (52); Tests 539 passed (539)

npm run check
# → svelte-check found 0 errors and 0 warnings
```

## Deliberate decisions

- Renamed `is_native_ptt_shortcut` → `is_native_shortcut` and introduced `shortcut_registration_target` so Toggle and PTT share one routing predicate; keeps `register_shortcuts` free of duplicated `is_empty` / native checks
- Toggle emits the existing `ShortcutToggle` event (same as the plugin path) rather than inventing a parallel event, so SOU-044 meeting protection stays in one place in the frontend listener
- Same-key Toggle+PTT is refused at `normalize` / save time; the tap does not special-case dual match because validation already prevents it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a dedicated Toggle shortcut alongside Push-to-Talk.
  - Native keyboard shortcuts are now handled consistently for both dictation modes.
  - Toggle shortcuts respond reliably to key presses without repeated toggling while a key is held.

- **Bug Fixes**
  - Prevented duplicate native shortcuts from being saved.
  - Native shortcut settings now persist correctly after restarting or reloading the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->