### PR TITLE
Feat: Escape discards in-progress toggle dictation (SOU-117)

### DIFF
--- a/src-tauri/src/app_events.rs
+++ b/src-tauri/src/app_events.rs
@@ -78,6 +78,11 @@ pub struct MeetingStopRequested;
 #[derive(Debug, Clone, Serialize, Deserialize, Type, Event)]
 pub struct DictationStopRequested;
 
+/// Emitted when Escape is pressed during a cancelable (toggle) dictation.
+/// Discards the take: no polish, no history row, no paste (SOU-117).
+#[derive(Debug, Clone, Serialize, Deserialize, Type, Event)]
+pub struct DictationCancelRequested;
+
 /// Emitted once a stopped meeting has been fully drained and saved in the
 /// background, so the detail view can refresh from the now-complete record.
 /// `stop_meeting_recording` returns before this work finishes (decoupled stop),

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -81,6 +81,7 @@ pub fn register_shortcuts(app: &AppHandle, shortcuts: &ShortcutSettings) -> Resu
 
     gs.unregister_all()
         .map_err(|e| format!("Unregister: {e}"))?;
+    crate::dictation_cancel::mark_unregistered();
 
     let toggle_target = shortcut_registration_target(&shortcuts.toggle);
     let ptt_target = shortcut_registration_target(&shortcuts.push_to_talk);
@@ -155,6 +156,12 @@ pub fn register_shortcuts(app: &AppHandle, shortcuts: &ShortcutSettings) -> Resu
             shortcut = shortcuts.push_to_talk,
             "Push-to-talk shortcut registered via native tap"
         );
+    }
+
+    if let Some(state) = app.try_state::<AppState>()
+        && let Ok(machine) = state.current_machine_state()
+    {
+        crate::dictation_cancel::sync(app, &machine);
     }
 
     Ok(())

--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -490,11 +490,15 @@ fn build_dictation_on_segment(
 ///
 /// `async` + `spawn_blocking`: the engine-reset reply can take 0.5–2s, so the
 /// blocking wait runs off-thread and the window never freezes.
+///
+/// `cancel_on_escape` arms the transient Escape binding for toggle dictation
+/// (SOU-117). Push-to-talk passes false: releasing the PTT key is its cancel.
 #[tauri::command]
 #[specta::specta]
 pub async fn start_transcription(
     state: State<'_, AppState>,
     channel: Channel<crate::engine::TranscriptionSegment>,
+    cancel_on_escape: bool,
 ) -> Result<(), String> {
     info!("Starting streaming transcription");
 
@@ -540,6 +544,12 @@ pub async fn start_transcription(
     .map_err(|e| format!("Join start task: {e}"))??;
 
     state.apply_transition(StateAction::StartDictation { session_id })?;
+    crate::dictation_cancel::set_wanted(cancel_on_escape);
+    if let Ok(app) = state.app_handle()
+        && let Ok(machine) = state.current_machine_state()
+    {
+        crate::dictation_cancel::sync(&app, &machine);
+    }
 
     if let Ok(settings) = AppSettings::load(&state.db) {
         crate::audio::feedback::play_dictation_feedback(

--- a/src-tauri/src/dictation_cancel.rs
+++ b/src-tauri/src/dictation_cancel.rs
@@ -1,0 +1,183 @@
+//! Transient Escape binding that discards an in-progress toggle dictation.
+//!
+//! Armed only while the machine is `RecordingDictation` *and* the session
+//! asked for it (toggle, not push-to-talk). `register_shortcuts` calls
+//! `unregister_all`, so this module re-applies the binding afterwards when
+//! a cancelable session is still live.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tauri::{AppHandle, Manager};
+use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
+use tauri_specta::Event;
+use tracing::warn;
+
+use crate::app_events::{
+    DictationCancelRequested, ShortcutPttStart, ShortcutPttStop, ShortcutToggle,
+};
+use crate::modifier_shortcut::is_native_ptt_shortcut;
+use crate::settings::ShortcutSettings;
+use crate::state::AppState;
+use crate::state_machine::AppStateMachine;
+
+const ESCAPE: &str = "Escape";
+
+static WANTED: AtomicBool = AtomicBool::new(false);
+static ARMED: AtomicBool = AtomicBool::new(false);
+
+/// Whether Escape should currently steal the key from the foreground app.
+pub fn should_arm(wanted: bool, machine: &AppStateMachine) -> bool {
+    wanted && matches!(machine, AppStateMachine::RecordingDictation { .. })
+}
+
+pub fn set_wanted(wanted: bool) {
+    WANTED.store(wanted, Ordering::SeqCst);
+}
+
+/// `register_shortcuts` just wiped every binding, including ours.
+pub fn mark_unregistered() {
+    ARMED.store(false, Ordering::SeqCst);
+}
+
+pub fn sync(app: &AppHandle, machine: &AppStateMachine) {
+    let in_dictation = matches!(machine, AppStateMachine::RecordingDictation { .. });
+    if !in_dictation {
+        WANTED.store(false, Ordering::SeqCst);
+    }
+    let should = should_arm(WANTED.load(Ordering::SeqCst), machine);
+    let armed = ARMED.load(Ordering::SeqCst);
+    if should == armed {
+        return;
+    }
+
+    if should {
+        arm(app);
+    } else {
+        disarm(app);
+    }
+}
+
+fn arm(app: &AppHandle) {
+    let gs = app.global_shortcut();
+    if gs.is_registered(ESCAPE)
+        && let Err(e) = gs.unregister(ESCAPE)
+    {
+        warn!(error = %e, "Failed to replace Escape binding for dictation cancel");
+        return;
+    }
+    match gs.on_shortcut(ESCAPE, |app, _shortcut, event| {
+        if event.state == ShortcutState::Pressed {
+            let _ = DictationCancelRequested.emit(app);
+        }
+    }) {
+        Ok(()) => {
+            ARMED.store(true, Ordering::SeqCst);
+            tracing::info!("Dictation cancel shortcut armed");
+        }
+        Err(e) => {
+            warn!(error = %e, "Failed to arm Escape dictation cancel");
+            restore_user_escape(app);
+        }
+    }
+}
+
+fn disarm(app: &AppHandle) {
+    let gs = app.global_shortcut();
+    if gs.is_registered(ESCAPE)
+        && let Err(e) = gs.unregister(ESCAPE)
+    {
+        warn!(error = %e, "Failed to unregister Escape dictation cancel");
+        return;
+    }
+    ARMED.store(false, Ordering::SeqCst);
+    restore_user_escape(app);
+    tracing::info!("Dictation cancel shortcut disarmed");
+}
+
+fn restore_user_escape(app: &AppHandle) {
+    let Some(state) = app.try_state::<AppState>() else {
+        return;
+    };
+    let Ok(shortcuts) = ShortcutSettings::load(&state.db) else {
+        return;
+    };
+    let gs = app.global_shortcut();
+
+    if shortcuts.toggle == ESCAPE {
+        if let Err(e) = gs.on_shortcut(ESCAPE, |app, _shortcut, event| {
+            if event.state == ShortcutState::Pressed {
+                let _ = ShortcutToggle.emit(app);
+            }
+        }) {
+            warn!(error = %e, "Failed to restore Escape as toggle shortcut");
+        }
+        return;
+    }
+
+    if shortcuts.push_to_talk != ESCAPE || is_native_ptt_shortcut(&shortcuts.push_to_talk) {
+        return;
+    }
+    if let Err(e) = gs.on_shortcut(ESCAPE, |app, _shortcut, event| match event.state {
+        ShortcutState::Pressed => {
+            let state = app.state::<AppState>();
+            if state.ptt_is_paused() {
+                state.ptt_start_armed.store(false, Ordering::SeqCst);
+            } else {
+                state.ptt_start_armed.store(true, Ordering::SeqCst);
+                let _ = ShortcutPttStart.emit(app);
+            }
+        }
+        ShortcutState::Released => {
+            if app
+                .state::<AppState>()
+                .ptt_start_armed
+                .swap(false, Ordering::SeqCst)
+            {
+                let _ = ShortcutPttStop.emit(app);
+            }
+        }
+    }) {
+        warn!(error = %e, "Failed to restore Escape as push-to-talk shortcut");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::default_transcription_profile;
+    use crate::state_machine::RecordingKind;
+
+    fn profile() -> crate::engine::TranscriptionProfile {
+        default_transcription_profile()
+    }
+
+    #[test]
+    fn arms_only_while_a_wanted_dictation_is_recording() {
+        let dictation = AppStateMachine::RecordingDictation {
+            profile: profile(),
+            session_id: 1,
+        };
+        let meeting = AppStateMachine::RecordingMeeting {
+            profile: profile(),
+            session_id: 1,
+            meeting_id: "m1".into(),
+        };
+        let stopping = AppStateMachine::Stopping {
+            profile: profile(),
+            was_recording: RecordingKind::Dictation,
+        };
+        let ready = AppStateMachine::Ready { profile: profile() };
+        let error = AppStateMachine::Error {
+            message: "boom".into(),
+            recovery: crate::state_machine::ErrorRecovery::RetryFromReady { profile: profile() },
+        };
+
+        assert!(should_arm(true, &dictation));
+        assert!(!should_arm(false, &dictation));
+        assert!(!should_arm(true, &meeting));
+        assert!(!should_arm(true, &stopping));
+        assert!(!should_arm(true, &ready));
+        assert!(!should_arm(true, &error));
+        assert!(!should_arm(true, &AppStateMachine::Idle));
+    }
+}

--- a/src-tauri/src/dictation_cancel.rs
+++ b/src-tauri/src/dictation_cancel.rs
@@ -66,7 +66,19 @@ fn arm(app: &AppHandle) {
         return;
     }
     match gs.on_shortcut(ESCAPE, |app, _shortcut, event| {
-        if event.state == ShortcutState::Pressed {
+        if event.state != ShortcutState::Pressed {
+            return;
+        }
+        // If unregister failed, this callback can outlive the session.
+        // Re-check the machine so Escape cannot cancel a later PTT take
+        // or fire while idle (SOU-117 AC6 / AC7).
+        let Some(state) = app.try_state::<AppState>() else {
+            return;
+        };
+        let Ok(machine) = state.current_machine_state() else {
+            return;
+        };
+        if should_arm(WANTED.load(Ordering::SeqCst), &machine) {
             let _ = DictationCancelRequested.emit(app);
         }
     }) {

--- a/src-tauri/src/dictation_cancel.rs
+++ b/src-tauri/src/dictation_cancel.rs
@@ -15,7 +15,7 @@ use tracing::warn;
 use crate::app_events::{
     DictationCancelRequested, ShortcutPttStart, ShortcutPttStop, ShortcutToggle,
 };
-use crate::modifier_shortcut::is_native_ptt_shortcut;
+use crate::modifier_shortcut::is_native_shortcut;
 use crate::settings::ShortcutSettings;
 use crate::state::AppState;
 use crate::state_machine::AppStateMachine;
@@ -126,7 +126,7 @@ fn restore_user_escape(app: &AppHandle) {
         return;
     }
 
-    if shortcuts.push_to_talk != ESCAPE || is_native_ptt_shortcut(&shortcuts.push_to_talk) {
+    if shortcuts.push_to_talk != ESCAPE || is_native_shortcut(&shortcuts.push_to_talk) {
         return;
     }
     if let Err(e) = gs.on_shortcut(ESCAPE, |app, _shortcut, event| match event.state {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,7 @@ pub mod constants;
 pub mod db;
 pub mod debug;
 pub mod diagnostics;
+pub mod dictation_cancel;
 pub mod engine;
 pub mod errors;
 pub mod export;
@@ -188,6 +189,7 @@ fn specta_builder() -> Builder<tauri::Wry> {
             app_events::AudioLevel,
             app_events::MeetingStopRequested,
             app_events::DictationStopRequested,
+            app_events::DictationCancelRequested,
             app_events::MeetingFinalized,
             app_events::UpcomingMeeting,
             app_events::TodayCalendarUpdated,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -266,6 +266,7 @@ impl AppState {
             let _ = StateChanged(new_state.clone()).emit(&handle);
             crate::pill::sync(&handle, &new_state);
             crate::tray::sync(&handle, &new_state);
+            crate::dictation_cancel::sync(&handle, &new_state);
         }
 
         Ok(new_state)

--- a/src-tauri/tests/app_flows.rs
+++ b/src-tauri/tests/app_flows.rs
@@ -317,7 +317,7 @@ async fn dictation_round_trip() {
 
     let (collected, channel) = collecting_channel();
 
-    commands::start_transcription(state.clone(), channel)
+    commands::start_transcription(state.clone(), channel, false)
         .await
         .expect("start_transcription");
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -27,6 +27,7 @@
   import {
     createTranscriptionController,
     notifyDictationAborted,
+    notifyDictationCancelRequested,
     notifyDictationStopRequested,
   } from "./lib/features/transcription/controller.svelte";
   import { getAppState, deriveRecordingMode } from "./lib/stores/app.svelte";
@@ -53,6 +54,7 @@
   let unlistenModifierTap: (() => void) | null = null;
   let unlistenMeetingStop: (() => void) | null = null;
   let unlistenDictationStop: (() => void) | null = null;
+  let unlistenDictationCancel: (() => void) | null = null;
   let unlistenMeetingFinalized: (() => void) | null = null;
   let unlistenUpcomingMeeting: (() => void) | null = null;
   let unlistenMeetingIdle: (() => void) | null = null;
@@ -252,6 +254,12 @@
       unlistenDictationStop = fn;
     });
 
+    events.dictationCancelRequested.listen(() => {
+      notifyDictationCancelRequested();
+    }).then((fn) => {
+      unlistenDictationCancel = fn;
+    });
+
     events.meetingFinalized.listen((event) => {
       notifyMeetingFinalized(event.payload.id);
     }).then((fn) => {
@@ -304,6 +312,7 @@
       unlistenModifierTap?.();
       unlistenMeetingStop?.();
       unlistenDictationStop?.();
+      unlistenDictationCancel?.();
       unlistenMeetingFinalized?.();
       unlistenUpcomingMeeting?.();
       unlistenMeetingIdle?.();

--- a/src/lib/api/transcription.test.ts
+++ b/src/lib/api/transcription.test.ts
@@ -85,7 +85,15 @@ describe('transcription API', () => {
 
     await startStreamingTranscription(onSegment);
 
-    expect(mockInvoke).toHaveBeenCalledWith('start_transcription', expect.objectContaining({ channel: expect.any(Object) }), undefined);
+    expect(mockInvoke).toHaveBeenCalledWith('start_transcription', expect.objectContaining({ channel: expect.any(Object), cancelOnEscape: true }), undefined);
+  });
+
+  it('startStreamingTranscription can skip the Escape cancel binding', async () => {
+    mockInvoke.mockResolvedValue(null);
+
+    await startStreamingTranscription(vi.fn(), false);
+
+    expect(mockInvoke).toHaveBeenCalledWith('start_transcription', expect.objectContaining({ cancelOnEscape: false }), undefined);
   });
 
   it('stopStreamingTranscription calls correct command', async () => {

--- a/src/lib/api/transcription.ts
+++ b/src/lib/api/transcription.ts
@@ -48,10 +48,11 @@ export async function deleteModel(selection: TranscriptionProfileSelection): Pro
 
 export async function startStreamingTranscription(
   onSegment: (segment: TranscriptionSegment) => void,
+  cancelOnEscape = true,
 ): Promise<void> {
   const channel = new Channel<TranscriptionSegment>();
   channel.onmessage = onSegment;
-  await unwrap(commands.startTranscription(channel));
+  await unwrap(commands.startTranscription(channel, cancelOnEscape));
 }
 
 export async function stopStreamingTranscription(): Promise<void> {

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -25,7 +25,7 @@ vi.mock("@tauri-apps/api/event", () => ({
   emit: vi.fn(),
 }));
 
-import { createTranscriptionController, notifyDictationStopRequested, resetTranscriptionControllerForTest } from "./controller.svelte";
+import { createTranscriptionController, notifyDictationCancelRequested, notifyDictationStopRequested, resetTranscriptionControllerForTest } from "./controller.svelte";
 import {
   startTranscriptionModelDownload,
   startTranscriptionModelLoad,
@@ -1648,6 +1648,172 @@ describe("transcription controller", () => {
 
     expect(mockInvoke).not.toHaveBeenCalledWith("stop_transcription");
     expect(mockInvoke).not.toHaveBeenCalledWith("start_transcription", expect.anything());
+    expect(ctrl.app.machineState.state).toBe("recording_meeting");
+  });
+
+  it("toggle dictation asks the backend to arm Escape cancel (SOU-117)", async () => {
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+
+    await ctrl.toggleRecording();
+
+    expect(mockInvoke).toHaveBeenCalledWith(
+      "start_transcription",
+      expect.objectContaining({ cancelOnEscape: true }),
+    );
+  });
+
+  it("PTT dictation does not arm Escape cancel (SOU-117)", async () => {
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+
+    eventListeners["shortcut-ptt-start"]?.({ payload: null });
+    await vi.waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith(
+        "start_transcription",
+        expect.objectContaining({ cancelOnEscape: false }),
+      );
+    });
+  });
+
+  it("notifyDictationCancelRequested stops without history, polish, or paste (SOU-117)", async () => {
+    const channel = captureTranscriptionChannel();
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+    ctrl.app.settings = { ...ctrl.app.settings, auto_paste: true, dictation_polish_enabled: true };
+
+    await ctrl.toggleRecording(true);
+    simulateRecordingStarted(ctrl.app);
+    channel.emit({ text: "hello world", is_final: true });
+
+    notifyDictationCancelRequested();
+    await vi.waitFor(() => {
+      expect(ctrl.statusMessage).toBe("Dictation discarded");
+    });
+
+    expect(mockInvoke).toHaveBeenCalledWith("stop_transcription");
+    expect(mockInvoke).not.toHaveBeenCalledWith("add_dictation_entry", expect.anything());
+    expect(mockInvoke).not.toHaveBeenCalledWith("polish_dictation", expect.anything());
+    expect(mockInvoke).not.toHaveBeenCalledWith("paste_text", expect.anything());
+    expect(mockInvoke).not.toHaveBeenCalledWith("copy_text", expect.anything());
+    expect(mockInvoke).not.toHaveBeenCalledWith("pill_hold", expect.anything());
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    expect(ctrl.transcript).toBe("");
+  });
+
+  it("a late segment after cancel cannot revive the take (SOU-117)", async () => {
+    const channel = captureTranscriptionChannel();
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+
+    await ctrl.toggleRecording();
+    simulateRecordingStarted(ctrl.app);
+    channel.emit({ text: "keep me", is_final: true });
+
+    notifyDictationCancelRequested();
+    await vi.waitFor(() => {
+      expect(ctrl.transcript).toBe("");
+    });
+
+    channel.emit({ text: "late word", is_final: true });
+    expect(ctrl.transcript).toBe("");
+    expect(mockInvoke).not.toHaveBeenCalledWith("add_dictation_entry", expect.anything());
+  });
+
+  it("abort during cancel does not persist or polish (SOU-117)", async () => {
+    let releaseStop: (() => void) | undefined;
+    const channel = captureTranscriptionChannel();
+    const innerInvoke = mockInvoke.getMockImplementation()!;
+    mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "stop_transcription") {
+        return new Promise<void>((r) => { releaseStop = r; });
+      }
+      return innerInvoke(cmd, args);
+    });
+
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+    ctrl.app.settings = { ...ctrl.app.settings, dictation_polish_enabled: true };
+
+    await ctrl.toggleRecording();
+    simulateRecordingStarted(ctrl.app);
+    channel.emit({ text: "do not save me", is_final: true });
+
+    notifyDictationCancelRequested();
+    await vi.waitFor(() => {
+      expect(releaseStop).toBeTypeOf("function");
+    });
+
+    ctrl.handleRecordingAborted();
+    releaseStop!();
+    await vi.waitFor(() => {
+      expect(ctrl.statusMessage).toBe("Dictation discarded");
+    });
+
+    expect(mockInvoke).not.toHaveBeenCalledWith("add_dictation_entry", expect.anything());
+    expect(mockInvoke).not.toHaveBeenCalledWith("polish_dictation", expect.anything());
+  });
+
+  it("cancels while start_transcription is still in flight (SOU-117)", async () => {
+    let releaseStart: (() => void) | undefined;
+    mockInvoke.mockImplementation((cmd: string, args?: Record<string, unknown>) => {
+      if (cmd === "start_transcription") {
+        return new Promise<void>((r) => { releaseStart = r; });
+      }
+      return defaultInvoke(cmd, args);
+    });
+
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+
+    const start = ctrl.toggleRecording();
+    await vi.waitFor(() => {
+      expect(releaseStart).toBeTypeOf("function");
+    });
+
+    notifyDictationCancelRequested();
+    releaseStart!();
+    await start;
+
+    await vi.waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("stop_transcription");
+    });
+    expect(mockInvoke).not.toHaveBeenCalledWith("add_dictation_entry", expect.anything());
+    expect(mockInvoke).not.toHaveBeenCalledWith("paste_text", expect.anything());
+  });
+
+  it("notifyDictationCancelRequested is a no-op while idle (SOU-117)", async () => {
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+
+    notifyDictationCancelRequested();
+
+    expect(mockInvoke).not.toHaveBeenCalledWith("stop_transcription");
+  });
+
+  it("notifyDictationCancelRequested is a no-op while a meeting is recording (SOU-117)", async () => {
+    const ctrl = createTranscriptionController();
+    await ctrl.mount();
+
+    ctrl.app.machineState = {
+      state: "recording_meeting",
+      data: {
+        profile: {
+          engine_id: "kyutai",
+          engine_label: "Kyutai",
+          model_id: "stt-1b-en_fr",
+          model_label: "STT 1B",
+          backend_id: "candle",
+          backend_label: "Candle",
+        },
+        session_id: 1,
+        meeting_id: "meeting-1",
+      },
+    };
+
+    notifyDictationCancelRequested();
+
+    expect(mockInvoke).not.toHaveBeenCalledWith("stop_transcription");
     expect(ctrl.app.machineState.state).toBe("recording_meeting");
   });
 

--- a/src/lib/features/transcription/controller.svelte.ts
+++ b/src/lib/features/transcription/controller.svelte.ts
@@ -332,7 +332,7 @@ function createTranscriptionControllerInstance() {
         // Push-to-talk only starts from a fully idle machine: a meeting (or
         // an already-running dictation) must not be interrupted.
         if (app.recordingMode === "idle" && !isStartingRecording && !isStopping) {
-          void toggleRecording(true);
+          void toggleRecording(true, { ptt: true });
         }
       }),
       events.shortcutPttStop.listen(() => {
@@ -380,8 +380,9 @@ function createTranscriptionControllerInstance() {
    * runs Polish on the assembled text before pasting or storing.
    *
    * @param {boolean} fromShortcut - Whether the toggle was triggered via a global keyboard shortcut.
+   * @param opts.ptt - Push-to-talk start. Escape does not cancel PTT (SOU-117).
    */
-  async function toggleRecording(fromShortcut = false) {
+  async function toggleRecording(fromShortcut = false, opts?: { ptt?: boolean }) {
     if (isStartingRecording || isStopping) return;
 
     if (!isDictating && app.recordingMode !== "idle") {
@@ -548,7 +549,7 @@ function createTranscriptionControllerInstance() {
         }
         tentative = "";
         transcript += segmentGap(transcript, segment.text) + segment.text;
-      });
+      }, !opts?.ptt);
     } catch (e) {
       setBanner({ type: "transient", message: errorMessage(e) });
       clearSessionContext();
@@ -567,8 +568,45 @@ function createTranscriptionControllerInstance() {
     }
   }
 
+  /** Discard the in-progress toggle dictation: stop capture, skip persist,
+   * polish, and paste. Same shape as the too-short abort above (SOU-117). */
+  async function cancelRecording() {
+    if (isStopping) return;
+    // `isStartingRecording` covers the window after StartDictation (Escape
+    // is already armed) but before the frontend has applied StateChanged.
+    if (!isDictating && !isStartingRecording) return;
+
+    isStopping = true;
+    sessionGeneration += 1;
+    pttStopQueued = false;
+    // Drop the take before awaiting stop so a drain-time abort cannot
+    // persist or polish the discarded text (SOU-117).
+    transcript = "";
+    tentative = "";
+    focusedApp = null;
+    sessionAutoPaste = false;
+    try {
+      await stopStreamingTranscription();
+    } catch (e) {
+      console.warn("Dictation cancel stop failed:", e);
+    }
+    setBanner({ type: "transient", message: tr("home.dictation_discarded") });
+    clearSessionContext();
+    isStartingRecording = false;
+    isStopping = false;
+  }
+
   /** The backend aborted the recording session (machine went to Error). */
   function handleRecordingAborted() {
+    if (isStopping) {
+      // Cancel or an in-flight stop already owns the session. Don't persist
+      // and don't wipe `transcript`: the stop path captured it, cancel
+      // already discarded it.
+      sessionGeneration += 1;
+      isStartingRecording = false;
+      pttStopQueued = false;
+      return;
+    }
     const sessionFocusedApp = focusedApp;
     const rawText = transcript.trim();
     sessionGeneration += 1; // cut off in-flight segments from the dead session
@@ -619,6 +657,7 @@ function createTranscriptionControllerInstance() {
     refreshCatalog,
     refreshRuntimeStatus,
     toggleRecording,
+    cancelRecording,
     handleRecordingAborted,
   };
 }
@@ -636,6 +675,15 @@ export function notifyDictationAborted() {
 export function notifyDictationStopRequested() {
   if (instance && instance.app.recordingMode === "dictation" && !instance.isStopping) {
     void instance.toggleRecording(true);
+  }
+}
+
+/** Escape during a cancelable dictation. No-op when not dictating, so this
+ * cannot start a session or take down a meeting (SOU-117). */
+export function notifyDictationCancelRequested() {
+  if (!instance || instance.isStopping) return;
+  if (instance.app.recordingMode === "dictation" || instance.isStartingRecording) {
+    void instance.cancelRecording();
   }
 }
 

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -499,6 +499,7 @@
   },
   "home": {
     "dictation_too_short": "Hold a little longer",
+    "dictation_discarded": "Dictation discarded",
     "dictate": "Dictate",
     "dictate_hint": "Set a shortcut",
     "meeting": "Meeting",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -499,6 +499,7 @@
   },
   "home": {
     "dictation_too_short": "Tiens un peu plus longtemps",
+    "dictation_discarded": "Dictée abandonnée",
     "dictate": "Dicter",
     "dictate_hint": "Définissez un raccourci",
     "meeting": "Meeting",

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -92,10 +92,13 @@ async loadModel(selection: TranscriptionProfileSelection) : Promise<Result<null,
  * 
  * `async` + `spawn_blocking`: the engine-reset reply can take 0.5–2s, so the
  * blocking wait runs off-thread and the window never freezes.
+ * 
+ * `cancel_on_escape` arms the transient Escape binding for toggle dictation
+ * (SOU-117). Push-to-talk passes false: releasing the PTT key is its cancel.
  */
-async startTranscription(channel: TAURI_CHANNEL<TranscriptionSegment>) : Promise<Result<null, string>> {
+async startTranscription(channel: TAURI_CHANNEL<TranscriptionSegment>, cancelOnEscape: boolean) : Promise<Result<null, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("start_transcription", { channel }) };
+    return { status: "ok", data: await TAURI_INVOKE("start_transcription", { channel, cancelOnEscape }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -1080,6 +1083,7 @@ async openReleasePage(url: string) : Promise<Result<null, string>> {
 export const events = __makeEvents__<{
 archiveExportProgress: ArchiveExportProgress,
 audioLevel: AudioLevel,
+dictationCancelRequested: DictationCancelRequested,
 dictationLiveText: DictationLiveText,
 dictationStopRequested: DictationStopRequested,
 inputDevicesChanged: InputDevicesChanged,
@@ -1106,6 +1110,7 @@ updateAvailable: UpdateAvailable
 }>({
 archiveExportProgress: "archive-export-progress",
 audioLevel: "audio-level",
+dictationCancelRequested: "dictation-cancel-requested",
 dictationLiveText: "dictation-live-text",
 dictationStopRequested: "dictation-stop-requested",
 inputDevicesChanged: "input-devices-changed",
@@ -1359,6 +1364,11 @@ export type CalendarMeetingNudgeKind =
  */
 export type DataStats = { db_size_bytes: number; meeting_count: number; dictation_count: number; recordings_size_bytes: number }
 export type DiagnosticsBundle = { app_version: string; data_dir: string; log_dir: string; log_file: string | null; db_path: string; models_dir: string; machine_state: string; log_level: string; debug_transcription: boolean }
+/**
+ * Emitted when Escape is pressed during a cancelable (toggle) dictation.
+ * Discards the take: no polish, no history row, no paste (SOU-117).
+ */
+export type DictationCancelRequested = null
 /**
  * A dictation history entry
  */


### PR DESCRIPTION
## Summary

Toggle dictation can be thrown away with Escape. The take is stopped immediately: no polish, no history row, no paste, and no clipboard change. Push-to-talk is unchanged (release-to-stop remains its cancel).

## Context

Ticket SOU-117 (internal tracker, not mirrored on GitHub).
Root cause: toggle dictation had no discard path. The only exit was a normal stop, which persists, polishes, and pastes. The HUD is a non-activating NSPanel, so Escape must be captured outside the webview. Integration point: the too-short abort in `controller.svelte.ts` (skip persist/polish/paste) plus a transient `tauri-plugin-global-shortcut` binding for Escape, armed only while `RecordingDictation` for toggle sessions.

## Acceptance criteria

1. **WHEN a toggle dictation is in progress and the user presses Escape, the system MUST stop capture and close the HUD immediately** — verified by `notifyDictationCancelRequested stops without history, polish, or paste (SOU-117)` calling `stop_transcription` and never `pill_hold`; HUD hide is `pill::sync` on `StopRecording` (`src-tauri/src/commands/transcription.rs`).
2. **WHEN a dictation is cancelled, the system MUST NOT write any history entry, nor create one to delete it** — verified by the same test (`add_dictation_entry` not called) and `abort during cancel does not persist or polish (SOU-117)`.
3. **WHEN a dictation is cancelled, the system MUST NOT call polish or snippet expansion** — verified by those tests asserting `polish_dictation` is not called; snippets live inside `finalizeDictationText`, which cancel never reaches.
4. **WHEN a dictation is cancelled, the system MUST NOT paste into the foreground app, and MUST NOT modify the clipboard** — verified by no `paste_text`, no `copy_text`, no `navigator.clipboard.writeText`.
5. **WHEN a dictation is cancelled, the user MUST see an explicit banner that the take was discarded** — verified by the test waiting for `Dictation discarded` (`home.dictation_discarded` in en/fr).
6. **IF no dictation is in progress, THEN Escape MUST NOT be captured by Soufflé** — verified by `should_arm` unit test (`dictation_cancel.rs`) requiring `RecordingDictation` and `wanted`; PTT passes `cancelOnEscape: false`; idle/meeting notify no-ops.
7. **WHEN a dictation stops normally (shortcut, HUD button, or error), the Escape binding MUST be removed** — verified by `should_arm` false for Stopping/Error/Ready/Idle; `apply_transition` always calls `dictation_cancel::sync`; `register_shortcuts` re-syncs after `unregister_all`.
8. **Normal stop MUST stay unchanged** — verified by existing tests (`toggleRecording stop saves to history`, paste-intent, pill hold). The `toggleRecording` stop path is untouched.

## Out of scope

- Push-to-talk: Escape is not armed (`cancelOnEscape: false`). Release remains the PTT cancel.
- Meetings: `notifyDictationCancelRequested` is a no-op while `recording_meeting`.
- Retry/resume of the last take.
- Configurable cancel shortcut. Escape is hardcoded.
- Settings-window Escape (shortcut recording) is unchanged.

## Risk zones

- Ghost pill: cancel never calls `pillHold("polishing")`; HUD drops on `StopRecording` because `HOLD` is unset.
- In-flight callbacks: `sessionGeneration` increments and transcript is cleared *before* awaiting stop, so a late segment or a drain-time abort cannot revive or persist the take.
- Clipboard: cancel never enters `paste_text` / `copy_text` / the 400 ms restore path (SOU-033).
- `unregister_all`: `register_shortcuts` calls `mark_unregistered` then `sync`, so a settings save during a cancelable dictation re-arms Escape.
- State machine: cancel uses `stop_transcription` → `StopRecording`. No parallel cancel transition (SOU-090).
- `WANTED` is set only after a successful `StartDictation`, then `sync` is called again, so a failed overlapping start cannot clear another session's cancel binding.

## Verification

```bash
cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
# → no diff

cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings
# → Finished (0 errors, 0 warnings)

cargo test --manifest-path src-tauri/Cargo.toml --workspace
# → test result: ok. 884 passed; 0 failed; 4 ignored (lib)
# → app_flows 6 passed; mcp_sidecar_contract 2 passed; punctuation_threshold 1 passed, 1 ignored

npm run generate:types
# → export_typescript_bindings ok

npm test
# → Test Files 52 passed (52)
# → Tests 548 passed (548)

npm run check
# → svelte-check found 0 errors and 0 warnings
```

## Deliberate decisions

- Escape is registered through `tauri-plugin-global-shortcut`, not the `CGEventTap`, so cancel does not depend on Input Monitoring (SOU-116).
- The binding is session-scoped and toggle-only. PTT already has a cancel (release before the threshold); arming Escape there would steal the key from the foreground app for the whole hold.
- Cancel goes through `stop_transcription` rather than a new state-machine action, so HUD, tray, and pipeline drain stay on the existing stop path.
- Transcript is discarded before awaiting stop so an abort during drain cannot persist or polish the take.