### PR TITLE
fix: stop re-prompting system audio on every permissions window open (SOU-120)

### DIFF
--- a/src-tauri/src/commands/permissions.rs
+++ b/src-tauri/src/commands/permissions.rs
@@ -1,22 +1,37 @@
+use std::sync::Arc;
+
+use tauri::State;
+
 use crate::permissions::{
     self, PermState, PermissionKind, PermissionStatus, RepairAccessibilityResult,
 };
+use crate::state::AppState;
 
 /// Cheap, non-prompting snapshot for the onboarding's initial render.
 #[tauri::command]
 #[specta::specta]
-pub fn get_permission_status() -> Result<PermissionStatus, String> {
-    Ok(permissions::snapshot())
+pub fn get_permission_status(state: State<'_, AppState>) -> Result<PermissionStatus, String> {
+    Ok(permissions::snapshot(&state.db))
 }
 
 /// Trigger the native prompt (or open System Settings) for one permission.
 /// The probe opens a device, so it runs off the command thread.
 #[tauri::command]
 #[specta::specta]
-pub async fn request_permission(kind: PermissionKind) -> Result<PermState, String> {
-    tauri::async_runtime::spawn_blocking(move || permissions::request(kind))
-        .await
-        .map_err(|e| format!("Permission probe failed: {e}"))
+pub async fn request_permission(
+    state: State<'_, AppState>,
+    kind: PermissionKind,
+) -> Result<PermState, String> {
+    let db = Arc::clone(&state.db);
+    tauri::async_runtime::spawn_blocking(move || {
+        let result = permissions::request(kind);
+        if kind == PermissionKind::SystemAudio {
+            permissions::remember_system_audio(&db, result);
+        }
+        result
+    })
+    .await
+    .map_err(|e| format!("Permission probe failed: {e}"))
 }
 
 /// Clear a stale Accessibility TCC entry and re-prompt. Updating the app by

--- a/src-tauri/src/permissions.rs
+++ b/src-tauri/src/permissions.rs
@@ -13,6 +13,12 @@ use serde::{Deserialize, Serialize};
 use specta::Type;
 
 use crate::constants::APP_IDENTIFIER;
+use crate::db::Database;
+
+/// Last observed system-audio tap permission. There is no read-only TCC
+/// API for Core Audio taps, so a successful probe is remembered and the
+/// snapshot returns it without mounting a tap (SOU-120).
+const SYSTEM_AUDIO_PERMISSION_KEY: &str = "system_audio_permission";
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -61,17 +67,19 @@ pub struct RepairAccessibilityResult {
     pub prompt_shown: bool,
 }
 
-/// Cheap, non-prompting snapshot for the initial onboarding render. Microphone
-/// and system audio are left `Unknown` (probing them would prompt); the user
-/// triggers those explicitly via `request_permission`.
-pub fn snapshot() -> PermissionStatus {
+/// Cheap, non-prompting snapshot for the initial onboarding render.
+///
+/// System audio has no read-only TCC API. Probing mounts a Core Audio tap
+/// and would prompt on a first launch, so the snapshot never probes: it
+/// returns a remembered `Granted`/`Denied` after a user-initiated probe,
+/// and `Unknown` until then (SOU-120).
+pub fn snapshot(db: &Database) -> PermissionStatus {
     PermissionStatus {
         microphone: microphone_authorization_status(),
-        system_audio: if system_audio_supported() {
-            PermState::Unknown
-        } else {
-            PermState::Unsupported
-        },
+        system_audio: system_audio_snapshot_state(
+            system_audio_supported(),
+            load_remembered_system_audio(db),
+        ),
         accessibility: if accessibility_granted() {
             PermState::Granted
         } else {
@@ -85,6 +93,38 @@ pub fn snapshot() -> PermissionStatus {
         } else {
             PermState::Unknown
         },
+    }
+}
+
+/// Snapshot value for system audio given platform support and a remembered
+/// probe result. Never mounts a tap.
+pub fn system_audio_snapshot_state(supported: bool, remembered: Option<PermState>) -> PermState {
+    if !supported {
+        return PermState::Unsupported;
+    }
+    match remembered {
+        Some(PermState::Granted) => PermState::Granted,
+        Some(PermState::Denied) => PermState::Denied,
+        _ => PermState::Unknown,
+    }
+}
+
+pub fn load_remembered_system_audio(db: &Database) -> Option<PermState> {
+    let raw = db.get_setting(SYSTEM_AUDIO_PERMISSION_KEY).ok().flatten()?;
+    match serde_json::from_str::<PermState>(&raw) {
+        Ok(state @ (PermState::Granted | PermState::Denied)) => Some(state),
+        _ => None,
+    }
+}
+
+pub fn remember_system_audio(db: &Database, state: PermState) {
+    if !matches!(state, PermState::Granted | PermState::Denied) {
+        return;
+    }
+    if let Ok(raw) = serde_json::to_string(&state)
+        && let Err(e) = db.set_setting(SYSTEM_AUDIO_PERMISSION_KEY, &raw)
+    {
+        tracing::warn!(error = %e, "Failed to persist system audio permission");
     }
 }
 
@@ -554,6 +594,70 @@ mod tests {
         );
         assert_eq!(seen.as_deref(), Some(APP_IDENTIFIER));
         assert_eq!(APP_IDENTIFIER, "com.souffle.desktop");
+    }
+
+    #[test]
+    fn system_audio_snapshot_is_unknown_until_a_probe_succeeds() {
+        assert_eq!(system_audio_snapshot_state(true, None), PermState::Unknown);
+        assert_eq!(
+            system_audio_snapshot_state(true, Some(PermState::Unknown)),
+            PermState::Unknown
+        );
+    }
+
+    #[test]
+    fn system_audio_snapshot_returns_remembered_granted_without_probing() {
+        assert_eq!(
+            system_audio_snapshot_state(true, Some(PermState::Granted)),
+            PermState::Granted
+        );
+    }
+
+    #[test]
+    fn system_audio_snapshot_returns_remembered_denied() {
+        assert_eq!(
+            system_audio_snapshot_state(true, Some(PermState::Denied)),
+            PermState::Denied
+        );
+    }
+
+    #[test]
+    fn system_audio_snapshot_stays_unsupported_even_if_something_was_remembered() {
+        assert_eq!(
+            system_audio_snapshot_state(false, Some(PermState::Granted)),
+            PermState::Unsupported
+        );
+        assert_eq!(
+            system_audio_snapshot_state(false, None),
+            PermState::Unsupported
+        );
+    }
+
+    #[test]
+    fn system_audio_permission_round_trips_through_the_db() {
+        let (db, _dir) = crate::test_helpers::fixtures::test_db();
+        assert_eq!(load_remembered_system_audio(&db), None);
+
+        remember_system_audio(&db, PermState::Granted);
+        assert_eq!(load_remembered_system_audio(&db), Some(PermState::Granted));
+        assert_eq!(
+            snapshot(&db).system_audio,
+            if system_audio_supported() {
+                PermState::Granted
+            } else {
+                PermState::Unsupported
+            }
+        );
+
+        remember_system_audio(&db, PermState::Denied);
+        assert_eq!(load_remembered_system_audio(&db), Some(PermState::Denied));
+
+        remember_system_audio(&db, PermState::Unknown);
+        assert_eq!(
+            load_remembered_system_audio(&db),
+            Some(PermState::Denied),
+            "Unknown must not clobber a remembered answer"
+        );
     }
 }
 

--- a/src/lib/features/onboarding/PermissionsStep.svelte
+++ b/src/lib/features/onboarding/PermissionsStep.svelte
@@ -48,6 +48,7 @@
   let accessibilityAttempts = $state(0);
   let leftAfterAttempt = $state(false);
   let returnedStillDenied = $state(false);
+  let leftWindow = $state(false);
   const showStaleHint = $derived(returnedStillDenied || accessibilityAttempts >= 2);
 
   /** Every write to `status` goes through here so the parent (which cannot
@@ -206,10 +207,21 @@
     // Denied that `request_permission` returns) does not count as a return.
     const onBlur = () => {
       if (accessibilityAttempts > 0) leftAfterAttempt = true;
+      leftWindow = true;
     };
     const onFocus = () => {
       if (leftAfterAttempt && status.accessibility === "denied") {
         returnedStillDenied = true;
+      }
+      // Re-probe system audio only after the user left the app (typically
+      // System Settings) so a revoke is reflected without mounting a tap
+      // on every window open (SOU-120 AC4 vs AC5).
+      if (
+        leftWindow
+        && (status.system_audio === "granted" || status.system_audio === "denied")
+      ) {
+        leftWindow = false;
+        void grant("system_audio");
       }
     };
     window.addEventListener("blur", onBlur);

--- a/src/lib/features/onboarding/PermissionsStep.svelte
+++ b/src/lib/features/onboarding/PermissionsStep.svelte
@@ -175,9 +175,12 @@
       pollInFlight = true;
       void getPermissionStatus()
         .then((s) => {
-          // snapshot() intentionally returns "unknown" for un-probed capabilities
-          // like system_audio so we don't trigger unwarranted prompts. We only
-          // overwrite our state when we get a real answer.
+          // A probe in flight is newer than this snapshot. Dropping the
+          // result is what keeps a just-observed revoke from flipping back
+          // to the remembered Granted (SOU-120 AC4).
+          if (Object.values(busy).some(Boolean)) return;
+          // Snapshot never prompts. Unknown means "not remembered yet";
+          // keep the local value rather than wiping a grant in progress.
           const next = { ...status };
           if (s.accessibility !== "unknown") next.accessibility = s.accessibility;
           if (s.microphone !== "unknown") next.microphone = s.microphone;
@@ -213,12 +216,14 @@
       if (leftAfterAttempt && status.accessibility === "denied") {
         returnedStillDenied = true;
       }
-      // Re-probe system audio only after the user left the app (typically
-      // System Settings) so a revoke is reflected without mounting a tap
-      // on every window open (SOU-120 AC4 vs AC5).
+      // Re-probe a remembered grant after the user left the app (typically
+      // System Settings) so a revoke is reflected. Opening the window does
+      // not probe (AC5). Denied already has Grant; Unknown must not prompt
+      // (AC3). Skip while a probe is in flight so two taps cannot overlap.
       if (
         leftWindow
-        && (status.system_audio === "granted" || status.system_audio === "denied")
+        && status.system_audio === "granted"
+        && !busy.system_audio
       ) {
         leftWindow = false;
         void grant("system_audio");

--- a/src/lib/features/onboarding/PermissionsStep.test.ts
+++ b/src/lib/features/onboarding/PermissionsStep.test.ts
@@ -369,3 +369,80 @@ describe("PermissionsStep permission poll", () => {
     expect(permissionsApi.getPermissionStatus).toHaveBeenCalledTimes(3);
   });
 });
+
+describe("PermissionsStep system audio remembered grant (SOU-120)", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  function statusWithAudio(systemAudio: PermState): PermissionStatus {
+    return {
+      microphone: "granted",
+      system_audio: systemAudio,
+      accessibility: "granted",
+      calendar: "unknown",
+      input_monitoring: "granted",
+    };
+  }
+
+  it("shows Granted on open when the backend remembers a grant", async () => {
+    permissionsApi.getPermissionStatus.mockResolvedValue(statusWithAudio("granted"));
+    render(PermissionsStep);
+
+    await waitFor(() => {
+      expect(within(rowFor("System audio")).getByText("Granted")).toBeTruthy();
+    });
+    expect(within(rowFor("System audio")).queryByRole("button", { name: "Grant" })).toBeNull();
+    expect(permissionsApi.requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("keeps Allow when the backend has never probed", async () => {
+    permissionsApi.getPermissionStatus.mockResolvedValue(statusWithAudio("unknown"));
+    render(PermissionsStep);
+
+    await waitFor(() => expect(permissionsApi.getPermissionStatus).toHaveBeenCalled());
+    expect(within(rowFor("System audio")).getByRole("button", { name: "Grant" })).toBeTruthy();
+    expect(permissionsApi.requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("shows Unsupported without an Allow button", async () => {
+    permissionsApi.getPermissionStatus.mockResolvedValue(statusWithAudio("unsupported"));
+    render(PermissionsStep);
+
+    await waitFor(() => {
+      expect(within(rowFor("System audio")).getByText("Not supported")).toBeTruthy();
+    });
+    expect(within(rowFor("System audio")).queryByRole("button")).toBeNull();
+  });
+
+  it("re-probes system audio after the window loses and regains focus", async () => {
+    permissionsApi.getPermissionStatus.mockResolvedValue(statusWithAudio("granted"));
+    permissionsApi.requestPermission.mockResolvedValue("denied");
+    render(PermissionsStep);
+    await waitFor(() => {
+      expect(within(rowFor("System audio")).getByText("Granted")).toBeTruthy();
+    });
+
+    window.dispatchEvent(new Event("blur"));
+    window.dispatchEvent(new Event("focus"));
+
+    await waitFor(() => {
+      expect(permissionsApi.requestPermission).toHaveBeenCalledWith("system_audio");
+    });
+    await waitFor(() => {
+      expect(within(rowFor("System audio")).getByRole("button", { name: "Grant" })).toBeTruthy();
+    });
+  });
+
+  it("does not re-probe on focus if the window never lost it", async () => {
+    permissionsApi.getPermissionStatus.mockResolvedValue(statusWithAudio("granted"));
+    render(PermissionsStep);
+    await waitFor(() => {
+      expect(within(rowFor("System audio")).getByText("Granted")).toBeTruthy();
+    });
+
+    window.dispatchEvent(new Event("focus"));
+    expect(permissionsApi.requestPermission).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/features/onboarding/PermissionsStep.test.ts
+++ b/src/lib/features/onboarding/PermissionsStep.test.ts
@@ -372,6 +372,7 @@ describe("PermissionsStep permission poll", () => {
 
 describe("PermissionsStep system audio remembered grant (SOU-120)", () => {
   afterEach(() => {
+    vi.useRealTimers();
     cleanup();
     vi.clearAllMocks();
   });
@@ -444,5 +445,65 @@ describe("PermissionsStep system audio remembered grant (SOU-120)", () => {
 
     window.dispatchEvent(new Event("focus"));
     expect(permissionsApi.requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("does not re-probe a remembered deny or an unprobed row (SOU-120 AC3)", async () => {
+    permissionsApi.getPermissionStatus.mockResolvedValue(statusWithAudio("denied"));
+    render(PermissionsStep);
+    await waitFor(() => {
+      expect(within(rowFor("System audio")).getByRole("button", { name: "Grant" })).toBeTruthy();
+    });
+
+    window.dispatchEvent(new Event("blur"));
+    window.dispatchEvent(new Event("focus"));
+    expect(permissionsApi.requestPermission).not.toHaveBeenCalled();
+
+    cleanup();
+    permissionsApi.getPermissionStatus.mockResolvedValue(statusWithAudio("unknown"));
+    render(PermissionsStep);
+    await waitFor(() => expect(permissionsApi.getPermissionStatus).toHaveBeenCalled());
+
+    window.dispatchEvent(new Event("blur"));
+    window.dispatchEvent(new Event("focus"));
+    expect(permissionsApi.requestPermission).not.toHaveBeenCalled();
+  });
+
+  it("does not start a second probe while one is in flight", async () => {
+    permissionsApi.getPermissionStatus.mockResolvedValue(statusWithAudio("granted"));
+    let release: (() => void) | undefined;
+    permissionsApi.requestPermission.mockImplementationOnce(
+      () =>
+        new Promise<PermState>((resolve) => {
+          release = () => resolve("granted");
+        }),
+    );
+    render(PermissionsStep);
+    await waitFor(() => {
+      expect(within(rowFor("System audio")).getByText("Granted")).toBeTruthy();
+    });
+
+    window.dispatchEvent(new Event("blur"));
+    window.dispatchEvent(new Event("focus"));
+    await waitFor(() => {
+      expect(permissionsApi.requestPermission).toHaveBeenCalledTimes(1);
+    });
+
+    window.dispatchEvent(new Event("blur"));
+    window.dispatchEvent(new Event("focus"));
+    expect(permissionsApi.requestPermission).toHaveBeenCalledTimes(1);
+    release?.();
+  });
+
+  it("the 600 ms poll does not mount a tap on a remembered grant (SOU-120 AC5)", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval"] });
+    permissionsApi.getPermissionStatus.mockResolvedValue(statusWithAudio("granted"));
+    render(PermissionsStep);
+    await waitFor(() => {
+      expect(within(rowFor("System audio")).getByText("Granted")).toBeTruthy();
+    });
+
+    await vi.advanceTimersByTimeAsync(1800);
+    expect(permissionsApi.requestPermission).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
## Summary

The permissions repair window always offered Grant for system audio, even after the user had already allowed it. Closing and reopening the window reset the row because the snapshot hard-coded `Unknown` and the component state died with the unmount. The grant is now remembered. The window shows Granted on open, without mounting a tap.

## Context

Ticket SOU-120 (internal tracker, not mirrored on GitHub).
Root cause: `snapshot()` hard-codes `PermState::Unknown` for system audio (`permissions.rs`) because there is no read-only TCC API for Core Audio taps. `PermissionsStep.svelte` initializes `system_audio` to `"unknown"` and the 600 ms poll only overwrites on a non-unknown snapshot, so the remembered Grant from a click never survived a remount. Each click on Grant also spawned a real tap (the `Souffle Tap connected` / `disconnected` pairs in the 2026-09-10 logs).

## Acceptance criteria

1. **WHEN the user has granted system audio, the permissions window MUST show Granted on open, without a click** — verified by `system_audio_snapshot_returns_remembered_granted_without_probing` and `shows Granted on open when the backend remembers a grant`.
2. **WHEN the window is closed then reopened, the displayed state MUST match what it was at close** — verified by the DB round-trip (`system_audio_permission_round_trips_through_the_db`) plus the same component test: the snapshot reads the persisted grant, so a remount starts from Granted rather than hardcoded `"unknown"`.
3. **IF the permission has never been granted, THEN opening the window MUST NOT show a system prompt or mount a tap** — verified by `system_audio_snapshot_is_unknown_until_a_probe_succeeds` and `keeps Allow when the backend has never probed` (no `requestPermission` on mount).
4. **IF the permission is revoked in System Settings after being granted, THEN the app MUST stop presenting it as granted without a restart** — verified by `re-probes system audio after the window loses and regains focus`: a blur/focus pair (the user went to Settings and came back) calls `request_permission("system_audio")` and the row follows the new result.
5. **Opening the window on a known state MUST NOT create an aggregate device** — verified by the snapshot never calling `spawn_tap`, and `does not re-probe on focus if the window never lost it` (no `requestPermission` on mount/open).
6. **IF the platform does not support taps, THEN the row MUST stay Unsupported** — verified by `system_audio_snapshot_stays_unsupported_even_if_something_was_remembered`.

## Out of scope

- Microphone, Accessibility, Calendar, and Input Monitoring paths are unchanged.
- Native CGEvent tap permission labelling (SOU-116).
- `repair_accessibility` / stale TCC diagnosis (SOU-054, SOU-055).
- Live `SystemAudioStatus` during a meeting (SOU-119). A remembered grant is not a live capture path.
- Why some meetings fall back to mic-only.

## Risk zones

- A remembered grant can go stale if the user revokes it. AC4 is the counterpart: returning from System Settings re-probes once. The 600 ms poll does **not** probe, because a tap every tick would recreate the aggregate churn this ticket exists to stop.
- First-launch TCC: the snapshot still never probes. The first tap is still the user's Grant click.
- Persistence is a dedicated `settings` row (`system_audio_permission`), not an `AppSettings` field, so it does not add a fourth wiring site (SOU-093).

## Verification

```bash
cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
# → no diff

cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings
# → Finished (0 errors, 0 warnings)

cargo test --manifest-path src-tauri/Cargo.toml --workspace
# → test result: ok. 888 passed; 0 failed; 4 ignored (lib)
# → app_flows 6 passed; mcp_sidecar_contract 2 passed

npm test
# → Test Files 52 passed (52)
# → Tests 544 passed (544)

npm run check
# → svelte-check found 0 errors and 0 warnings
```

`get_permission_status` / `request_permission` only gained a `State<'_, AppState>` parameter. The JS invoke payload is unchanged, so generated types did not move.

## Deliberate decisions

- Snapshot never mounts a tap, even when a grant is remembered. Returning Granted from memory on open is what AC5 requires. Verification of a revoke waits for a blur/focus (the user actually went to Settings), not for the 600 ms poll.
- Denied is persisted too, so a refused prompt does not become Unknown again on the next open.
- Unknown / Unsupported are never written to the key, so a failed read cannot look like a grant.