### PR TITLE
Feat: three level bars on the compact meeting pill (SOU-118)

### DIFF
--- a/src-tauri/swift/pill_panel.swift
+++ b/src-tauri/swift/pill_panel.swift
@@ -11,14 +11,15 @@ import QuartzCore
 
 private let kCompactWidth: CGFloat = 280
 private let kCompactHeight: CGFloat = 64
-private let kMeetingWidth: CGFloat = 96
+private let kMeetingWidth: CGFloat = 108
 private let kMeetingHeight: CGFloat = 44
 private let kExpandedWidth: CGFloat = 440
 private let kMaxHeight: CGFloat = 200
 private let kTopMargin: CGFloat = 40
 private let kCornerRadiusFull: CGFloat = 28
 private let kCornerRadiusMeet: CGFloat = 22
-private let kWaveformBars: Int = 24
+private let kDictationWaveformBars: Int = 24
+private let kMeetingWaveformBars: Int = 3
 private let kMaxLiveLines: Int = 5
 private let kLiveFontSize: CGFloat = 13
 
@@ -67,7 +68,8 @@ private func stretchableRoundedMask(radius: CGFloat) -> NSImage {
 /// Drawn NSView bars (not CALayer): same geometry as the Svelte pill waveform.
 /// A 30 fps tick applies the per-bar sine variation; RMS arrives from Rust.
 private final class WaveformView: NSView {
-    private var bars: [CGFloat] = Array(repeating: 0.12, count: kWaveformBars)
+    private var barCount: Int = kDictationWaveformBars
+    private var bars: [CGFloat] = Array(repeating: 0.12, count: kDictationWaveformBars)
     private var rms: CGFloat = 0
     private var tick: Timer?
 
@@ -85,6 +87,14 @@ private final class WaveformView: NSView {
         }
     }
 
+    func setBarCount(_ count: Int) {
+        let n = max(1, count)
+        guard n != barCount else { return }
+        barCount = n
+        bars = Array(repeating: 0.12, count: n)
+        needsDisplay = true
+    }
+
     func setActive(_ active: Bool) {
         if active {
             if reduceMotionEnabled() {
@@ -96,7 +106,7 @@ private final class WaveformView: NSView {
         } else {
             stopTick()
             rms = 0
-            bars = Array(repeating: 0.12, count: kWaveformBars)
+            bars = Array(repeating: 0.12, count: barCount)
             needsDisplay = true
         }
     }
@@ -117,7 +127,7 @@ private final class WaveformView: NSView {
 
     private func applyRmsToBars() {
         let target = max(0.08, min(1, rms))
-        for i in 0..<kWaveformBars {
+        for i in 0..<barCount {
             bars[i] = target
         }
         needsDisplay = true
@@ -130,7 +140,7 @@ private final class WaveformView: NSView {
             return
         }
         let t = CACurrentMediaTime()
-        for i in 0..<kWaveformBars {
+        for i in 0..<barCount {
             let variation = sin(t * 5 + Double(i) * 0.5) * 0.15
             let spread = sin(Double(i) * 0.3 + t * 3.3) * 0.1
             let target = max(0.08, min(1, Double(rms) + variation + spread))
@@ -147,7 +157,7 @@ private final class WaveformView: NSView {
 
         // Compact dictation only has ~99 pt between title and Stop; 24×3pt
         // bars with 2 pt gaps need 118. Scale to bounds so they never overlap.
-        let n = CGFloat(kWaveformBars)
+        let n = CGFloat(barCount)
         let scale = min(1, w / (n * 3 + (n - 1) * 2))
         let barWidth = 3 * scale
         let barGap = 2 * scale
@@ -155,7 +165,7 @@ private final class WaveformView: NSView {
         let offsetX = (w - occupied) / 2
 
         ctx.setFillColor(kAccent.cgColor)
-        for i in 0..<kWaveformBars {
+        for i in 0..<barCount {
             let barH = max(2, bars[i] * (h - 4))
             let x = offsetX + CGFloat(i) * (barWidth + barGap)
             let y = (h - barH) / 2
@@ -313,7 +323,8 @@ private final class PillContentView: NSView {
         modeLabel.stringValue = title
         modeLabel.isHidden = compact
 
-        let showWave = (mode == .dictation)
+        let showWave = (mode == .dictation || mode == .meeting)
+        waveform.setBarCount(mode == .meeting ? kMeetingWaveformBars : kDictationWaveformBars)
         waveform.isHidden = !showWave
         waveform.setActive(showWave)
         spinner.isHidden = (mode != .polishing)
@@ -423,9 +434,20 @@ private final class PillContentView: NSView {
 
         if compact {
             modeLabel.frame = .zero
-            waveform.frame = .zero
             spinner.frame = .zero
             liveLabel.frame = .zero
+            // Between the recording dot and Stop: 6 pt inset each side so
+            // three 3 pt bars never sit on a neighbour (SOU-118 AC3).
+            let waveGap: CGFloat = 6
+            let waveX = hPad + dotSize + waveGap
+            let waveW = max(0, btnX - waveGap - waveX)
+            let waveH: CGFloat = 16
+            waveform.frame = CGRect(
+                x: waveX,
+                y: headerY + (rowH - waveH) / 2,
+                width: waveW,
+                height: waveH
+            )
         } else {
             let labelX = hPad + dotSize + 8
             let labelW: CGFloat = 96


### PR DESCRIPTION
## Summary

During a meeting the compact HUD only showed a pulsing red dot and Stop, so a dead capture looked the same as a live one. It now draws three level bars in the same style as dictation, driven by the RMS that already reached Swift.

## Context

Ticket SOU-118 (internal tracker, not mirrored on GitHub).
Root cause: RMS already flows `store_meeting_rms` → `emit_throttled_audio_level` → `pill::push_rms` → `pill_panel_push_rms`. Display was cut in Swift: `applyMode` hid the waveform unless the mode was dictation (`pill_panel.swift`, `showWave = (mode == .dictation)`), and compact `layout()` set `waveform.frame = .zero`.

## Acceptance criteria

1. **WHILE a meeting records, the compact pill MUST show three bars whose height follows captured RMS** — verified by `showWave` including `.meeting`, `setBarCount(kMeetingWaveformBars)` (3), and compact `layout()` giving the waveform a non-zero frame between the dot and Stop. RMS path is unchanged (`pill_panel_push_rms` still hops to main).
2. **WHEN input is silent, bars MUST fall to rest height and stay there, not freeze on last value** — verified by the existing `WaveformView` tick / `applyRmsToBars` floor of 0.08; meeting now calls `setActive(true)` so silence lerps down instead of leaving a stale height. Capture already emits ~0 on silence.
3. **The three bars MUST NOT overlap the recording dot or Stop, at the chosen meeting width** — verified by layout arithmetic at `kMeetingWidth = 108`: pad 10 + dot 10 + gap 6 + wave 42 + gap 6 + Stop 24 + pad 10. Wave occupies x=26…68, Stop x=74…98, dot x=10…20. Three 3 pt bars with 2 pt gaps occupy 13 pt, centered in 42 pt.
4. **Dictation MUST keep 24 bars, same width and geometry** — verified by `kDictationWaveformBars = 24`, `kCompactWidth = 280` unchanged, and the non-compact layout branch unchanged (`compact` is meeting-only).
5. **WHEN the pill changes mode or size, the window MUST stay top-anchored with no vertical drift** — verified by no change to `applyFrame` / `kTopMargin` / height (`kMeetingHeight` remains 44). Width-only resize pins the top via existing `lastAppliedSize`.
6. **IF reduce motion is on, bar animation MUST follow the same rule as the dot and spinner** — verified by reuse of `WaveformView`'s `reduceMotionEnabled()` path (no 30 fps tick; RMS applied directly in `push` / `setActive`).

## Out of scope

- Dictation visual design (24 bars, compact 280×64).
- Polishing mode still hides the waveform and shows the spinner.
- Separate me/them levels (still the mixed RMS from `store_meeting_rms`).
- Meeting live text (`liveLabel` remains dictation-expanded only).
- Pill position and hide (SOU-012, SOU-011); no `setFrame` from Rust.

## Risk zones

- Top anchor: geometry stays in Swift. This commit only changes meeting width; `applyFrame` still pins the top edge.
- Bar count is an instance property. `setBarCount` resizes the `bars` array; every loop uses `barCount`.
- `pill_panel_push_rms` still wraps `pushRMS` in `onMain`. No Cocoa from the audio thread.
- The 30 fps tick now runs in meeting, but `needsDisplay` is still on `WaveformView` only, not the whole pill.

## Verification

```bash
npm run check:generated-types
# → export_typescript_bindings ok; no diff in generated.ts

cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
# → no diff

cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings
# → Finished (0 errors, 0 warnings); Swift compiled via build.rs

cargo test --manifest-path src-tauri/Cargo.toml --workspace
# → test result: ok. 883 passed; 0 failed; 4 ignored (lib)
# → app_flows 6 passed; mcp_sidecar_contract 2 passed

npm test
# → Test Files 52 passed (52)
# → Tests 539 passed (539)

npm run check
# → svelte-check found 0 errors and 0 warnings
```

No `#[tauri::command]` change. Swift is not covered by unit tests in this repo; the compile is the cargo/clippy step above. Remaining check is manual: start a meeting, speak, confirm the three bars move, then go silent and confirm they drop.

## Deliberate decisions

- Meeting width 96 → 108 so three bars sit in a 42 pt slot with 6 pt gaps to the dot and Stop, instead of packing them into the previous 42 pt raw gap.
- Meeting always uses 3 bars, including if the pill were expanded; dictation stays 24. One `WaveformView`, bar count is a mode switch.
- The 30 fps sine variation is the same rest motion as dictation. Silence does not freeze the last loud height; it lerps to the 0.08 floor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Meeting mode now displays a compact three-bar waveform while recording.
  - The waveform is positioned between the recording indicator and Stop button in compact mode.
- **Improvements**
  - Meeting mode uses a narrower 108pt panel for a more compact presentation.
  - Dictation mode retains its 24-bar waveform for detailed audio visualization.
  - Waveform rendering adapts consistently to each mode’s configured bar count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->