### PR TITLE
docs: sync README and site facts post-v0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ System-audio capture separates **Me** from **Them** in the live transcript, with
 
 - **Live transcript** with editable notes and participants beside it.
 - **Optional audio**, kept as compact Opus files for 7 days, 30 days or until you delete them, replayable with click-to-seek from any line.
-- **Corrections that stick**: fix a misheard name by hand once and Soufflé keeps that spelling, in a custom dictionary you can also edit yourself.
+- **Corrections that stick**: fix a misheard name by hand once and Soufflé keeps that spelling, in a custom dictionary you can also edit yourself — seeded by an optional interview on first run.
 - **A summary when you want one**, written on-device by Apple Intelligence on macOS 26 or newer, or by a local [Ollama](https://ollama.com/), with the decisions, the action items and their owners, and the questions nobody answered pulled out alongside it.
 
 ## Dictation, straight into the app you are already in
@@ -50,10 +50,11 @@ Soufflé is not a window you type into. Press the shortcut and a small pill appe
   <img src="docs/demo/overlay.gif" width="820" alt="The pill floating over a chat app: shortcut, dictation, reformulation, and the tidied text landing in the composer">
 </p>
 
-- **Press once to start and stop**, or bind a push-to-talk key and hold it instead.
+- **Press once to start and stop**, or bind a push-to-talk key and hold it instead — including Fn, a lone modifier, or F5–F12.
+- **Voice snippets**: say a trigger phrase at the start of a dictation to paste a prepared block instead; that take skips the polish pass.
 - **Insertion that fits the app**: the clipboard and ⌘V, simulated typing for terminals and secure fields that reject a synthetic paste, or a direct write through Accessibility.
 - **Polish before it lands** (optional): a local LLM pass tidies the phrasing, with editable prompt templates — clean up, professional email, bullet points, remove fillers.
-- **Optional start/stop sounds**, so you know the shortcut landed.
+- **Optional start/stop sounds**, so you know the shortcut landed. The menu bar can also copy the last transcription.
 
 ## Text arrives while you are still talking
 
@@ -76,6 +77,7 @@ Meetings and dictations land on one timeline, with today's calendar above it and
 - 🔒 **Nothing is uploaded.** Transcription, summaries and audio all stay on your Mac, in one local database you can export or delete whenever you like.
 - ✈️ **Works offline.** Once the speech model is on disk, transcription keeps working with the Wi-Fi off.
 - 🙅 **No account, ever.** No sign-up, no subscription, no API key to paste in. Every outbound connection the app makes is listed [below](#what-touches-the-network).
+- 🚀 **Launch at login** (optional): open Soufflé automatically when you start your Mac. On by default after a fresh setup wizard.
 
 ## Own your data
 
@@ -121,6 +123,7 @@ Soufflé asks for these as you use the features that need them, never up front:
 | Microphone | Records your voice to transcribe it | Everything |
 | System Audio Recording | Captures what the other participants say, without a virtual audio device | Meetings (macOS 14.4+) |
 | Accessibility | Pastes into the app you were using, and reads back your corrections when "learn from edits" is on | Auto-paste, dictation polish |
+| Input Monitoring | Installs the native event tap for single-key push-to-talk (Fn, lone modifier, F5–F12) | Single-key PTT (optional) |
 | Calendar | Reads today's events to list them and offer to start recording | Calendar integration (optional) |
 
 Settings > System > Permissions shows the current state of each and links straight to the matching System Settings pane.

--- a/site/src/_data/en.json
+++ b/site/src/_data/en.json
@@ -53,7 +53,8 @@
       "body": "With the default model the text streams in while you are still talking, punctuated and capitalised. A local pass can tidy the phrasing before you use it, and that same model handles French and English without you switching anything.",
       "bullets": [
         "Text appears as you speak, not once you stop",
-        "Press once to start and stop, or hold to talk",
+        "Press once to start and stop, or hold to talk — including Fn or a lone modifier",
+        "Say a trigger phrase to paste a voice snippet instead of free dictation",
         "Fix a misheard name by hand once, and it stays fixed",
         "A local LLM pass can polish the wording, with editable prompts",
         "French and English on the same model, no switching"
@@ -593,13 +594,17 @@
                 "Inserts the text into the app you were using, and reads back your corrections when “learn from edits” is on."
               ],
               [
+                "Input Monitoring",
+                "Lets push-to-talk bind to a single key (Fn, a lone modifier, or F5–F12) through a native event tap, while other keys pass through. Optional until you set such a shortcut."
+              ],
+              [
                 "Calendar",
                 "Reads today's events to list them and offer to start recording. Optional, and off until you turn it on."
               ]
             ]
           },
           {
-            "p": "Refusing one disables only the feature that needs it. Without System Audio a meeting still records your microphone and the transcript is labelled <em>Mic only</em>. Without Accessibility the dictated text is copied to the clipboard instead of being inserted for you."
+            "p": "Refusing one disables only the feature that needs it. Without System Audio a meeting still records your microphone and the transcript is labelled <em>Mic only</em>. Without Accessibility the dictated text is copied to the clipboard instead of being inserted for you. Without Input Monitoring, classic modifier shortcuts still work; only single-key push-to-talk will not install."
           }
         ]
       },
@@ -608,10 +613,10 @@
         "h": "First run",
         "blocks": [
           {
-            "p": "A setup wizard covers four things: the permissions Soufflé needs, which microphone to use, the speech model to download, and the dictation shortcut. The default shortcut is <kbd>⌘⇧Space</kbd>."
+            "p": "A setup wizard covers the permissions Soufflé needs, which microphone to use, the speech model to download, the dictation shortcut, and an optional dictionary interview (names, jargon, polish tone) you can skip. The default shortcut is <kbd>⌘⇧Space</kbd>."
           },
           {
-            "p": "The last step also offers auto-paste, on by default: when you stop dictating, the text goes straight into the app you were in. Turn it off and the text is put on the clipboard instead. Everything here can be changed later in Settings."
+            "p": "The shortcut step also offers auto-paste, on by default: when you stop dictating, the text goes straight into the app you were in. Turn it off and the text is put on the clipboard instead. A fresh install finishes with Launch at login on; change that later in Settings → System. Everything here can be changed later in Settings."
           }
         ]
       },
@@ -629,6 +634,9 @@
             "p": "Two optional passes run on the way out. <strong>Dictation polish</strong> sends the raw transcript through a local LLM with an editable prompt template (clean up, professional email, bullet points, remove fillers) and needs Apple Intelligence or Ollama. <strong>Learn from edits</strong>, on by default, watches the field just after insertion: correct a misheard name by hand once and Soufflé keeps that spelling for next time, in the custom dictionary under Settings → Transcription."
           },
           {
+            "p": "<strong>Voice snippets</strong> live under Settings → Transcription: say a trigger phrase at the start of a dictation and Soufflé pastes the expansion instead, case- and accent-insensitive, with no AI polish on that take. The menu bar also offers <em>Copy Last Transcription</em> when you need the previous take back."
+          },
+          {
             "p": "Optional start and stop sounds confirm the shortcut landed."
           }
         ]
@@ -638,7 +646,7 @@
         "h": "Shortcuts",
         "blocks": [
           {
-            "p": "Both dictation shortcuts are set in Settings → Interface. Each must include a modifier key, and the two cannot share a combination."
+            "p": "Both dictation shortcuts are set in Settings → Interface. Toggle uses a classic combo with a modifier (default <kbd>⌘⇧Space</kbd>). Push-to-talk can use the same style, or a single key — Fn, a lone modifier, or F5–F12 — which needs the Input Monitoring permission so the native tap can install. The two bindings cannot share a combination."
           },
           {
             "table": [
@@ -648,7 +656,7 @@
               ],
               [
                 "Push-to-talk",
-                "Hold to record, release to stop. Not set by default; bind it if you prefer holding."
+                "Hold to record, release to stop. Not set by default; bind a classic combo or a single key (Fn, lone modifier, F5–F12) if you prefer holding."
               ]
             ]
           }
@@ -663,6 +671,9 @@
           },
           {
             "p": "When you stop, the pill switches to <em>Reformulating…</em> while the local polish pass runs, then disappears as the text lands in the field you were already using. The window is excluded from screen capture, so it does not turn up in the meeting you are in."
+          },
+          {
+            "p": "You can hide the overlay in Settings → Interface; drag it when visible to move it. Position is remembered across display changes."
           }
         ]
       },
@@ -698,7 +709,7 @@
             "code": "brew install ollama\nollama pull qwen2.5:7b"
           },
           {
-            "p": "Then, in Settings → Meetings → Summarization, leave the server at <code>http://localhost:11434</code> and pick the model. Any general-purpose chat model works; <code>qwen2.5:7b</code> is the one Soufflé recommends. The same provider is what dictation polish uses."
+            "p": "Then, in Settings → AI, leave the server at <code>http://localhost:11434</code> and pick the model. Any general-purpose chat model works; <code>qwen2.5:7b</code> is the one Soufflé recommends. The same provider is what dictation polish uses."
           },
           {
             "p": "Nothing about a summary is sent anywhere. With Ollama the only request is to your own instance."
@@ -736,7 +747,7 @@
             "p": "The two Kyutai models are the streaming ones: text appears while you are still talking. Whisper and Parakeet transcribe the whole recording once you stop, which is fine for a meeting you read afterwards but changes how dictation feels."
           },
           {
-            "p": "A loaded model is unloaded after an hour of inactivity to give the RAM back, and reloaded on the next recording. Change or disable that in Settings → Audio."
+            "p": "A loaded model is unloaded after an hour of inactivity to give the RAM back, and reloaded on the next recording. Change or disable that in Settings → Transcription."
           }
         ]
       },
@@ -745,7 +756,7 @@
         "h": "Settings reference",
         "blocks": [
           {
-            "p": "Five tabs. The settings worth knowing about:"
+            "p": "Six tabs. The settings worth knowing about:"
           },
           {
             "table": [
@@ -762,12 +773,20 @@
                 "Start and stop cues, with a volume."
               ],
               [
-                "Dictation polish<br><span class=\"docs-tab\">Transcription</span>",
+                "Hide recording overlay<br><span class=\"docs-tab\">Interface</span>",
+                "Hide the floating HUD while dictating or in a meeting. Drag it when visible to move it; the position is remembered."
+              ],
+              [
+                "Dictation polish<br><span class=\"docs-tab\">AI</span>",
                 "The local LLM pass and its prompt templates, which you can edit. Needs Apple Intelligence or Ollama."
               ],
               [
                 "Custom dictionary<br><span class=\"docs-tab\">Transcription</span>",
-                "Proper nouns and technical terms to spell correctly, filled in by hand or learned from your corrections."
+                "Proper nouns and technical terms to spell correctly, filled in by hand, learned from your corrections, or seeded by the optional first-run interview."
+              ],
+              [
+                "Voice snippets<br><span class=\"docs-tab\">Transcription</span>",
+                "Trigger phrases that expand to a prepared block of text at the start of a dictation. Matching skips the polish pass."
               ],
               [
                 "Microphone priority<br><span class=\"docs-tab\">Audio</span>",
@@ -778,7 +797,7 @@
                 "Stop after 5, 10, 15 or 30 minutes without speech, with a hard failsafe behind it."
               ],
               [
-                "Model unload<br><span class=\"docs-tab\">Audio</span>",
+                "Model unload<br><span class=\"docs-tab\">Transcription</span>",
                 "Free the model's RAM after 5, 15 or 60 idle minutes, or never."
               ],
               [
@@ -786,8 +805,12 @@
                 "Off until you turn it on. Lists today's events and offers to start recording when one begins."
               ],
               [
-                "Summarization<br><span class=\"docs-tab\">Meetings</span>",
+                "Summarization<br><span class=\"docs-tab\">AI</span>",
                 "Provider, Ollama server and model, and the summary templates."
+              ],
+              [
+                "Launch at login<br><span class=\"docs-tab\">System</span>",
+                "Open Soufflé automatically when you start your Mac. On by default after a fresh setup wizard."
               ],
               [
                 "Meeting audio<br><span class=\"docs-tab\">System</span>",
@@ -949,6 +972,10 @@
               [
                 "The other participants are missing from the transcript",
                 "System-audio capture needs macOS 14.4 or later and the System Audio permission. When it is unavailable the transcript is labelled <em>Mic only</em> and records your microphone alone."
+              ],
+              [
+                "A single-key push-to-talk shortcut does nothing",
+                "Fn, lone modifiers and F5–F12 need Input Monitoring for the native tap. Settings → System → Permissions links there."
               ],
               [
                 "The dictated text is not inserted",

--- a/site/src/_data/fr.json
+++ b/site/src/_data/fr.json
@@ -53,7 +53,8 @@
       "body": "Avec le modèle par défaut, le texte s'affiche pendant que vous parlez encore, ponctué et avec les majuscules. Un passage local peut en polir la formulation avant que vous l'utilisiez, et ce même modèle gère le français et l'anglais sans que vous ayez à basculer.",
       "bullets": [
         "Le texte s'affiche pendant que vous parlez, pas à la fin",
-        "Un appui pour lancer et arrêter, ou maintenu tant que vous parlez",
+        "Un appui pour lancer et arrêter, ou maintenu tant que vous parlez — y compris Fn ou un modificateur seul",
+        "Dites une phrase déclencheur pour coller un extrait vocal au lieu d'une dictée libre",
         "Corrigez un nom mal entendu une fois : il reste corrigé ensuite",
         "Une IA locale peut s'occuper de polir la formulation, avec des instructions que vous pouvez changer",
         "Français et anglais sur le même modèle, sans bascule"
@@ -593,13 +594,17 @@
                 "Insère le texte dans l'app que vous utilisiez, et relit vos corrections quand « apprendre de mes corrections » est actif."
               ],
               [
+                "Surveillance de l'entrée",
+                "Permet d'assigner le push-to-talk à une seule touche (Fn, un modificateur seul, ou F5–F12) via un tap d'événements natif, les autres touches passant. Optionnel tant que vous n'avez pas choisi un tel raccourci."
+              ],
+              [
                 "Calendrier",
                 "Lit les événements du jour pour les lister et proposer de démarrer un enregistrement. Optionnel, et inactif tant que vous ne l'activez pas."
               ]
             ]
           },
           {
-            "p": "Refuser une permission ne désactive que la fonction concernée. Sans Audio système, une réunion enregistre quand même votre micro et la transcription est marquée <em>Micro seul</em>. Sans Accessibilité, le texte dicté est copié dans le presse-papiers au lieu d'être inséré à votre place."
+            "p": "Refuser une permission ne désactive que la fonction concernée. Sans Audio système, une réunion enregistre quand même votre micro et la transcription est marquée <em>Micro seul</em>. Sans Accessibilité, le texte dicté est copié dans le presse-papiers au lieu d'être inséré à votre place. Sans Surveillance de l'entrée, les raccourcis classiques avec modificateur fonctionnent encore ; seul le push-to-talk à une touche ne s'installera pas."
           }
         ]
       },
@@ -608,10 +613,10 @@
         "h": "Premier lancement",
         "blocks": [
           {
-            "p": "Un assistant couvre quatre choses : les permissions dont Soufflé a besoin, le micro à utiliser, le modèle de transcription à télécharger, et le raccourci de dictée. Le raccourci par défaut est <kbd>⌘⇧Espace</kbd>."
+            "p": "Un assistant couvre les permissions dont Soufflé a besoin, le micro à utiliser, le modèle de transcription à télécharger, le raccourci de dictée, et un entretien dictionnaire optionnel (prénoms, jargon, ton du polish) que vous pouvez passer. Le raccourci par défaut est <kbd>⌘⇧Espace</kbd>."
           },
           {
-            "p": "La dernière étape propose aussi le collage automatique, actif par défaut : quand vous arrêtez de dicter, le texte part directement dans l'app où vous étiez. Désactivez-le et le texte atterrit dans le presse-papiers. Tout cela se change plus tard dans les Paramètres."
+            "p": "L'étape du raccourci propose aussi le collage automatique, actif par défaut : quand vous arrêtez de dicter, le texte part directement dans l'app où vous étiez. Désactivez-le et le texte atterrit dans le presse-papiers. Une installation neuve termine avec Lancer à la connexion activé ; changez-le plus tard dans Paramètres → Système. Tout cela se change plus tard dans les Paramètres."
           }
         ]
       },
@@ -629,6 +634,9 @@
             "p": "Deux passages optionnels tournent à la sortie. Le <strong>polish de la dictée</strong> fait passer la transcription brute dans un LLM local, avec un modèle de prompt que vous pouvez modifier (nettoyage, courriel professionnel, liste à puces, retrait des hésitations) ; il demande Apple Intelligence ou Ollama. L'<strong>apprentissage des corrections</strong>, actif par défaut, surveille le champ juste après l'insertion : corrigez un nom mal entendu une fois à la main, et Soufflé garde cette orthographe pour la suite, dans le dictionnaire personnalisé sous Paramètres → Transcription."
           },
           {
+            "p": "Les <strong>extraits vocaux</strong> vivent sous Paramètres → Transcription : dites une phrase déclencheur en début de dictée et Soufflé colle l'expansion à la place, sans tenir compte de la casse ni des accents, et sans polish IA sur cette prise. Le menu de la barre des menus propose aussi <em>Copier la dernière transcription</em> quand vous en avez besoin."
+          },
+          {
             "p": "Des sons de départ et d'arrêt, optionnels, confirment que le raccourci a été capté."
           }
         ]
@@ -638,7 +646,7 @@
         "h": "Raccourcis",
         "blocks": [
           {
-            "p": "Les deux raccourcis de dictée se règlent dans Paramètres → Interface. Chacun doit contenir une touche de modification, et les deux ne peuvent pas partager la même combinaison."
+            "p": "Les deux raccourcis de dictée se règlent dans Paramètres → Interface. La bascule utilise une combinaison classique avec modificateur (<kbd>⌘⇧Espace</kbd> par défaut). Le push-to-talk peut faire de même, ou une seule touche — Fn, un modificateur seul, ou F5–F12 — qui demande la permission Surveillance de l'entrée pour que le tap natif s'installe. Les deux ne peuvent pas partager la même combinaison."
           },
           {
             "table": [
@@ -648,7 +656,7 @@
               ],
               [
                 "Maintenir pour parler",
-                "Maintenez pour enregistrer, relâchez pour arrêter. Non défini par défaut ; à assigner si vous préférez ce geste."
+                "Maintenir pour enregistrer, relâcher pour arrêter. Non assigné par défaut ; liez une combinaison classique ou une seule touche (Fn, modificateur seul, F5–F12) si vous préférez maintenir."
               ]
             ]
           }
@@ -663,6 +671,9 @@
           },
           {
             "p": "À l'arrêt, la pastille passe en <em>Reformulation…</em> le temps du passage de polish local, puis disparaît au moment où le texte atterrit dans le champ que vous utilisiez déjà. Sa fenêtre est exclue de la capture d'écran : elle n'apparaît pas dans la réunion où vous êtes."
+          },
+          {
+            "p": "Vous pouvez masquer la pastille dans Paramètres → Interface ; faites-la glisser quand elle est visible pour la déplacer. La position est mémorisée d'un écran à l'autre."
           }
         ]
       },
@@ -698,7 +709,7 @@
             "code": "brew install ollama\nollama pull qwen2.5:7b"
           },
           {
-            "p": "Ensuite, dans Paramètres → Réunions → Résumés, laissez le serveur sur <code>http://localhost:11434</code> et choisissez le modèle. N'importe quel modèle de conversation généraliste fait l'affaire ; <code>qwen2.5:7b</code> est celui que Soufflé recommande. C'est le même fournisseur qui sert au polish de la dictée."
+            "p": "Ensuite, dans Paramètres → IA, laissez le serveur sur <code>http://localhost:11434</code> et choisissez le modèle. N'importe quel modèle de conversation généraliste fait l'affaire ; <code>qwen2.5:7b</code> est celui que Soufflé recommande. C'est le même fournisseur qui sert au polish de la dictée."
           },
           {
             "p": "Rien de ce qui touche à un résumé ne sort de la machine. Avec Ollama, la seule requête part vers votre propre instance."
@@ -736,7 +747,7 @@
             "p": "Les deux Kyutai sont les modèles en flux continu : le texte apparaît pendant que vous parlez encore. Whisper et Parakeet transcrivent tout l'enregistrement une fois que vous avez arrêté, ce qui convient à une réunion qu'on lit après coup mais change la sensation en dictée."
           },
           {
-            "p": "Un modèle chargé est déchargé après une heure d'inactivité pour rendre la RAM, puis rechargé au prochain enregistrement. Ce délai se change, ou se désactive, dans Paramètres → Audio."
+            "p": "Un modèle chargé est déchargé après une heure d'inactivité pour rendre la RAM, puis rechargé au prochain enregistrement. Ce délai se change, ou se désactive, dans Paramètres → Transcription."
           }
         ]
       },
@@ -745,7 +756,7 @@
         "h": "Les paramètres",
         "blocks": [
           {
-            "p": "Cinq onglets. Les réglages qui méritent d'être connus :"
+            "p": "Six onglets. Les réglages qui méritent d'être connus :"
           },
           {
             "table": [
@@ -762,12 +773,20 @@
                 "Signaux sonores de départ et d'arrêt, avec un volume."
               ],
               [
-                "Polish de la dictée<br><span class=\"docs-tab\">Transcription</span>",
+                "Masquer la pastille<br><span class=\"docs-tab\">Interface</span>",
+                "Cache le HUD flottant pendant la dictée ou une réunion. Faites-le glisser quand il est visible pour le déplacer ; la position est mémorisée."
+              ],
+              [
+                "Polish de la dictée<br><span class=\"docs-tab\">IA</span>",
                 "Le passage LLM local et ses modèles de prompt, modifiables. Demande Apple Intelligence ou Ollama."
               ],
               [
                 "Dictionnaire personnalisé<br><span class=\"docs-tab\">Transcription</span>",
-                "Noms propres et termes techniques à orthographier correctement, saisis à la main ou appris de vos corrections."
+                "Noms propres et termes techniques à orthographier correctement, saisis à la main, appris de vos corrections, ou amorcés par l'entretien optionnel du premier lancement."
+              ],
+              [
+                "Extraits vocaux<br><span class=\"docs-tab\">Transcription</span>",
+                "Phrases déclencheurs qui se développent en un bloc de texte préparé en début de dictée. Une correspondance saute le polish."
               ],
               [
                 "Priorité des micros<br><span class=\"docs-tab\">Audio</span>",
@@ -778,7 +797,7 @@
                 "Arrêt après 5, 10, 15 ou 30 minutes sans parole, avec un garde-fou de durée maximale derrière."
               ],
               [
-                "Déchargement du modèle<br><span class=\"docs-tab\">Audio</span>",
+                "Déchargement du modèle<br><span class=\"docs-tab\">Transcription</span>",
                 "Libère la RAM du modèle après 5, 15 ou 60 minutes d'inactivité, ou jamais."
               ],
               [
@@ -786,8 +805,12 @@
                 "Inactif tant que vous ne l'activez pas. Liste les événements du jour et propose de démarrer quand l'un commence."
               ],
               [
-                "Résumés<br><span class=\"docs-tab\">Réunions</span>",
+                "Résumés<br><span class=\"docs-tab\">IA</span>",
                 "Fournisseur, serveur et modèle Ollama, et les modèles de résumé."
+              ],
+              [
+                "Lancer à la connexion<br><span class=\"docs-tab\">Système</span>",
+                "Ouvre Soufflé automatiquement au démarrage du Mac. Actif par défaut après l'assistant d'une installation neuve."
               ],
               [
                 "Audio des réunions<br><span class=\"docs-tab\">Système</span>",
@@ -949,6 +972,10 @@
               [
                 "Les autres participants n'apparaissent pas dans la transcription",
                 "La capture de l'audio système demande macOS 14.4 ou plus récent et la permission Audio système. Quand elle n'est pas disponible, la transcription est marquée <em>Micro seul</em> et n'enregistre que votre micro."
+              ],
+              [
+                "Un raccourci push-to-talk à une touche ne fait rien",
+                "Fn, les modificateurs seuls et F5–F12 demandent la Surveillance de l'entrée pour le tap natif. Paramètres → Système → Permissions y renvoie."
               ],
               [
                 "Le texte dicté n'est pas inséré",


### PR DESCRIPTION
## Summary
- Sync README marketing bullets with post-v0.12.0 develop: voice snippets, single-key PTT (Fn/modifier/F5–F12), Input Monitoring, launch-at-login, dictionary interview, menu-bar copy-last.
- Update `site/src/_data/en.json` and `fr.json` docs/landing copy to match (permissions, first-run wizard, shortcuts, Settings → AI path, overlay hide/drag).
- Docs-only; no app code or site build artifacts.

## Test plan
- [ ] Skim README diff for accuracy vs current Settings / permissions UX
- [ ] `cd site && npm run dev` — check EN + FR landing and docs pages for the new bullets (PTT, snippets, Input Monitoring, launch at login)
- [ ] Confirm no `_site/` or unrelated files in the PR
- [ ] Spot-check FR strings read naturally (not raw EN leftovers)