### PR TITLE
fix(permissions): ask through the framework, read from TCC, and give the Nightly a stable identity (SOU-124)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,7 @@ Soufflé asks for these as you use the features that need them, never up front:
 | --- | --- | --- |
 | Microphone | Records your voice to transcribe it | Everything |
 | System Audio Recording | Captures what the other participants say, without a virtual audio device | Meetings (macOS 14.4+) |
-| Accessibility | Pastes into the app you were using, and reads back your corrections when "learn from edits" is on | Auto-paste, dictation polish |
-| Input Monitoring | Installs the native event tap for single-key push-to-talk (Fn, lone modifier, F5–F12) | Single-key PTT (optional) |
+| Accessibility | Pastes into the app you were using, reads back your corrections when "learn from edits" is on, and installs the native event tap for single-key shortcuts (Fn, lone modifier, F5–F12) | Auto-paste, dictation polish, single-key shortcuts |
 | Calendar | Reads today's events to list them and offer to start recording | Calendar integration (optional) |
 
 Settings > System > Permissions shows the current state of each and links straight to the matching System Settings pane.

--- a/scripts/codeql-local.sh
+++ b/scripts/codeql-local.sh
@@ -23,11 +23,20 @@ codeql database create "$out/js" \
 codeql database create "$out/actions" \
   --language=actions --source-root=.
 
-codeql database analyze "$out/rust" rust-code-scanning.qls \
+# Suites are named by pack spec, not by bare name. The bare name only
+# resolves inside the CodeQL Action's bundle, which ships the query packs; the
+# Homebrew CLI carries none, so it downloads them into ~/.codeql/packages and
+# resolves them by spec.
+codeql pack download codeql/rust-queries codeql/javascript-queries codeql/actions-queries
+
+codeql database analyze "$out/rust" \
+  'codeql/rust-queries:codeql-suites/rust-code-scanning.qls' \
   --format=sarif-latest --output="$out/rust.sarif"
-codeql database analyze "$out/js" javascript-code-scanning.qls \
+codeql database analyze "$out/js" \
+  'codeql/javascript-queries:codeql-suites/javascript-code-scanning.qls' \
   --format=sarif-latest --output="$out/js.sarif"
-codeql database analyze "$out/actions" actions-code-scanning.qls \
+codeql database analyze "$out/actions" \
+  'codeql/actions-queries:codeql-suites/actions-code-scanning.qls' \
   --format=sarif-latest --output="$out/actions.sarif"
 
 echo "CodeQL local gate green. SARIF under $out/*.sarif"

--- a/scripts/run-nightly.sh
+++ b/scripts/run-nightly.sh
@@ -47,6 +47,10 @@ fi
 # a DR of the form `identifier ... and certificate leaf[subject.OU] = X6H966RSDB`,
 # which survives a rebuild. No notarization needed: a locally built bundle
 # carries no quarantine flag, so Gatekeeper never asks.
+#
+# The first build after this fails with `errSecInternalComponent` unless the
+# keychain prompt for the signing key is answered with "Always Allow": the
+# private key's ACL does not list codesign. One click, once per machine.
 export APPLE_SIGNING_IDENTITY="Developer ID Application: Damien Goehrig (X6H966RSDB)"
 
 npm run tauri -- build --debug --bundles app

--- a/scripts/run-nightly.sh
+++ b/scripts/run-nightly.sh
@@ -36,8 +36,10 @@ if [[ "$fresh" -eq 1 ]]; then
   echo "Wiping Nightly data and TCC rows ($nightly_id)"
   rm -rf "${HOME}/Library/Application Support/${nightly_id}"
   rm -rf "${HOME}/Library/WebKit/${nightly_id}"
+  # Failures are printed, not swallowed: a service name macOS no longer
+  # accepts is exactly what makes a --fresh run lie about its starting state.
   for svc in Accessibility AudioCapture Calendar Microphone ScreenCapture; do
-    tccutil reset "$svc" "$nightly_id" >/dev/null 2>&1 || true
+    tccutil reset "$svc" "$nightly_id" >/dev/null || echo "  tccutil reset $svc failed (see above)"
   done
 fi
 
@@ -51,7 +53,15 @@ fi
 # The first build after this fails with `errSecInternalComponent` unless the
 # keychain prompt for the signing key is answered with "Always Allow": the
 # private key's ACL does not list codesign. One click, once per machine.
-export APPLE_SIGNING_IDENTITY="Developer ID Application: Damien Goehrig (X6H966RSDB)"
+export APPLE_SIGNING_IDENTITY="${APPLE_SIGNING_IDENTITY:-Developer ID Application: Damien Goehrig (X6H966RSDB)}"
+
+if ! security find-identity -v -p codesigning | grep -qF "$APPLE_SIGNING_IDENTITY"; then
+  echo "WARNING: no codesigning identity matching '$APPLE_SIGNING_IDENTITY' in the keychain."
+  echo "         Building unsigned: every rebuild will be a new TCC subject, so"
+  echo "         all permissions have to be granted again each time."
+  echo "         Set APPLE_SIGNING_IDENTITY to an identity you do have to fix this."
+  unset APPLE_SIGNING_IDENTITY
+fi
 
 npm run tauri -- build --debug --bundles app
 

--- a/scripts/run-nightly.sh
+++ b/scripts/run-nightly.sh
@@ -36,10 +36,18 @@ if [[ "$fresh" -eq 1 ]]; then
   echo "Wiping Nightly data and TCC rows ($nightly_id)"
   rm -rf "${HOME}/Library/Application Support/${nightly_id}"
   rm -rf "${HOME}/Library/WebKit/${nightly_id}"
-  for svc in Accessibility ListenEvent Microphone ScreenCapture; do
+  for svc in Accessibility AudioCapture Calendar Microphone ScreenCapture; do
     tccutil reset "$svc" "$nightly_id" >/dev/null 2>&1 || true
   done
 fi
+
+# TCC keys its records on the designated requirement, not on the bundle id. An
+# unsigned bundle's DR is its cdhash, so every rebuild is a new subject and all
+# permissions have to be granted again. Signing with a stable Developer ID gives
+# a DR of the form `identifier ... and certificate leaf[subject.OU] = X6H966RSDB`,
+# which survives a rebuild. No notarization needed: a locally built bundle
+# carries no quarantine flag, so Gatekeeper never asks.
+export APPLE_SIGNING_IDENTITY="Developer ID Application: Damien Goehrig (X6H966RSDB)"
 
 npm run tauri -- build --debug --bundles app
 

--- a/site/src/_data/en.json
+++ b/site/src/_data/en.json
@@ -591,11 +591,7 @@
               ],
               [
                 "Accessibility",
-                "Inserts the text into the app you were using, and reads back your corrections when “learn from edits” is on."
-              ],
-              [
-                "Input Monitoring",
-                "Lets push-to-talk bind to a single key (Fn, a lone modifier, or F5–F12) through a native event tap, while other keys pass through. Optional until you set such a shortcut."
+                "Inserts the text into the app you were using, reads back your corrections when “learn from edits” is on, and installs the native event tap that lets a dictation shortcut bind to a single key (Fn, a lone modifier, or F5–F12)."
               ],
               [
                 "Calendar",
@@ -604,7 +600,7 @@
             ]
           },
           {
-            "p": "Refusing one disables only the feature that needs it. Without System Audio a meeting still records your microphone and the transcript is labelled <em>Mic only</em>. Without Accessibility the dictated text is copied to the clipboard instead of being inserted for you. Without Input Monitoring, classic modifier shortcuts still work; only single-key push-to-talk will not install."
+            "p": "Refusing one disables only the feature that needs it. Without System Audio a meeting still records your microphone and the transcript is labelled <em>Mic only</em>. Without Accessibility the dictated text is copied to the clipboard instead of being inserted for you, and a single-key shortcut cannot install its event tap; classic modifier shortcuts still work."
           }
         ]
       },
@@ -646,7 +642,7 @@
         "h": "Shortcuts",
         "blocks": [
           {
-            "p": "Both dictation shortcuts are set in Settings → Interface. Toggle uses a classic combo with a modifier (default <kbd>⌘⇧Space</kbd>). Push-to-talk can use the same style, or a single key — Fn, a lone modifier, or F5–F12 — which needs the Input Monitoring permission so the native tap can install. The two bindings cannot share a combination."
+            "p": "Both dictation shortcuts are set in Settings → Interface. Toggle uses a classic combo with a modifier (default <kbd>⌘⇧Space</kbd>). Push-to-talk can use the same style, or a single key (Fn, a lone modifier, or F5–F12), which needs the Accessibility permission so the native tap can install. The two bindings cannot share a combination."
           },
           {
             "table": [
@@ -975,7 +971,7 @@
               ],
               [
                 "A single-key push-to-talk shortcut does nothing",
-                "Fn, lone modifiers and F5–F12 need Input Monitoring for the native tap. Settings → System → Permissions links there."
+                "Fn, lone modifiers and F5–F12 need the Accessibility permission for the native tap. Settings → System → Permissions links there."
               ],
               [
                 "The dictated text is not inserted",

--- a/site/src/_data/fr.json
+++ b/site/src/_data/fr.json
@@ -591,11 +591,7 @@
               ],
               [
                 "Accessibilité",
-                "Insère le texte dans l'app que vous utilisiez, et relit vos corrections quand « apprendre de mes corrections » est actif."
-              ],
-              [
-                "Surveillance de l'entrée",
-                "Permet d'assigner le push-to-talk à une seule touche (Fn, un modificateur seul, ou F5–F12) via un tap d'événements natif, les autres touches passant. Optionnel tant que vous n'avez pas choisi un tel raccourci."
+                "Insère le texte dans l'app que vous utilisiez, relit vos corrections quand « apprendre de mes corrections » est actif, et installe le tap d'événements natif qui permet d'assigner un raccourci de dictée à une seule touche (Fn, un modificateur seul, ou F5–F12)."
               ],
               [
                 "Calendrier",
@@ -604,7 +600,7 @@
             ]
           },
           {
-            "p": "Refuser une permission ne désactive que la fonction concernée. Sans Audio système, une réunion enregistre quand même votre micro et la transcription est marquée <em>Micro seul</em>. Sans Accessibilité, le texte dicté est copié dans le presse-papiers au lieu d'être inséré à votre place. Sans Surveillance de l'entrée, les raccourcis classiques avec modificateur fonctionnent encore ; seul le push-to-talk à une touche ne s'installera pas."
+            "p": "Refuser une permission ne désactive que la fonction concernée. Sans Audio système, une réunion enregistre quand même votre micro et la transcription est marquée <em>Micro seul</em>. Sans Accessibilité, le texte dicté est copié dans le presse-papiers au lieu d'être inséré à votre place et un raccourci à une seule touche ne peut pas installer son tap ; les raccourcis classiques avec modificateur fonctionnent encore."
           }
         ]
       },
@@ -646,7 +642,7 @@
         "h": "Raccourcis",
         "blocks": [
           {
-            "p": "Les deux raccourcis de dictée se règlent dans Paramètres → Interface. La bascule utilise une combinaison classique avec modificateur (<kbd>⌘⇧Espace</kbd> par défaut). Le push-to-talk peut faire de même, ou une seule touche — Fn, un modificateur seul, ou F5–F12 — qui demande la permission Surveillance de l'entrée pour que le tap natif s'installe. Les deux ne peuvent pas partager la même combinaison."
+            "p": "Les deux raccourcis de dictée se règlent dans Paramètres → Interface. La bascule utilise une combinaison classique avec modificateur (<kbd>⌘⇧Espace</kbd> par défaut). Le push-to-talk peut faire de même, ou une seule touche (Fn, un modificateur seul, ou F5–F12), qui demande la permission Accessibilité pour que le tap natif s'installe. Les deux ne peuvent pas partager la même combinaison."
           },
           {
             "table": [
@@ -975,7 +971,7 @@
               ],
               [
                 "Un raccourci push-to-talk à une touche ne fait rien",
-                "Fn, les modificateurs seuls et F5–F12 demandent la Surveillance de l'entrée pour le tap natif. Paramètres → Système → Permissions y renvoie."
+                "Fn, les modificateurs seuls et F5–F12 demandent la permission Accessibilité pour le tap natif. Paramètres → Système → Permissions y renvoie."
               ],
               [
                 "Le texte dicté n'est pas inséré",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4238,6 +4238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-foundation 0.3.2",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -111,6 +111,7 @@ objc2-event-kit = "0.3"
 objc2-av-foundation = { version = "0.3", default-features = false, features = [
     "AVCaptureDevice",
     "AVMediaFormat",
+    "block2",
 ] }
 # Sleep/wake observers (NSWorkspace notifications)
 objc2-app-kit = "0.3"
@@ -134,6 +135,8 @@ fdaf-aec = "0.1.0"
 accessibility-sys = "0.2"
 
 [features]
+default = ["private-tcc"]
+
 # Exposes the mock transcription engine (normally `#[cfg(test)]`-only) so the
 # `tests/` integration binaries — which link the lib as a normal, non-`cfg(test)`
 # dependency — can use it too. Enabled automatically for `cargo test` via the
@@ -141,6 +144,13 @@ accessibility-sys = "0.2"
 # dev-dependency (e.g. `tempfile`): dev-dependencies aren't available when the
 # lib is built as a dependency, even via this self-reference.
 test-support = []
+
+# `TCCAccessPreflight` is an SPI: there is no public API to read the system
+# audio capture permission, and Apple can drop the symbol. On means the status
+# is read by XPC to tccd; off (or a `dlsym` miss at runtime) falls back to
+# mounting a short-lived tap, which answers the same question by doing the
+# thing.
+private-tcc = []
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -11,6 +11,6 @@
 	<key>NSCalendarsUsageDescription</key>
 	<string>Soufflé reads your calendar to show today's meetings and start transcriptions from them.</string>
 	<key>NSInputMonitoringUsageDescription</key>
-	<string>Soufflé observes keyboard and mouse events without modifying them.</string>
+	<string>Soufflé watches keyboard and mouse events to catch the single key you set as a dictation shortcut.</string>
 </dict>
 </plist>

--- a/src-tauri/entitlements.nightly.plist
+++ b/src-tauri/entitlements.nightly.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Required for Candle/Metal GPU acceleration (JIT compilation of Metal shaders) -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <!-- Required for Mimi codec and Candle inference engine -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <!-- Required for Metal framework loading -->
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <!-- Core functionality: microphone capture for speech-to-text -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <!-- Core functionality: microphone capture for speech-to-text -->
+    <key>com.apple.security.device.audio-recording</key>
+    <true/>
+    <!-- Required for HuggingFace model downloads and Ollama API communication -->
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <!-- Required for saving recordings and accessing user files -->
+    <key>com.apple.security.files.user-selected.read-write</key>
+    <true/>
+    <!-- Calendar integration: list today's meetings and start transcriptions from them -->
+    <key>com.apple.security.personal-information.calendars</key>
+    <true/>
+    <!-- Nightly only: the hardened runtime blocks the debugger, and sample /
+         lldb on a local build is how permission and audio defects get
+         diagnosed. Never in release: it is incompatible with notarization. -->
+    <key>com.apple.security.get-task-allow</key>
+    <true/>
+</dict>
+</plist>

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -1675,12 +1675,19 @@ impl AudioCapture {
                 err_fn,
                 None,
             )
-            .map_err(|e| format!("Failed to build input stream: {e}"))?;
+            .map_err(|e| {
+                // A CoreAudio open that failed slowly is the case worth a
+                // line: the elapsed time is the only evidence of a wedged
+                // device, and `?` would throw it away.
+                log_slow_mic_open(opened_at, &device_name);
+                format!("Failed to build input stream: {e}")
+            })?;
 
         self.active_session_id.store(session_id, Ordering::Release);
-        stream
-            .play()
-            .map_err(|e| format!("Failed to start stream: {e}"))?;
+        stream.play().map_err(|e| {
+            log_slow_mic_open(opened_at, &device_name);
+            format!("Failed to start stream: {e}")
+        })?;
         log_slow_mic_open(opened_at, &device_name);
         self.stream = Some(stream);
 
@@ -1818,10 +1825,20 @@ impl AudioCapture {
                 err_fn,
                 None,
             )
-            .map_err(|e| format!("Failed to build input stream: {e}"))?;
-        stream
-            .play()
-            .map_err(|e| format!("Failed to start stream: {e}"))?;
+            .map_err(|e| {
+                log_slow_mic_open(
+                    opened_at,
+                    self.mic_device_name.as_deref().unwrap_or("unknown"),
+                );
+                format!("Failed to build input stream: {e}")
+            })?;
+        stream.play().map_err(|e| {
+            log_slow_mic_open(
+                opened_at,
+                self.mic_device_name.as_deref().unwrap_or("unknown"),
+            );
+            format!("Failed to start stream: {e}")
+        })?;
         log_slow_mic_open(
             opened_at,
             self.mic_device_name.as_deref().unwrap_or("unknown"),

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -220,6 +220,26 @@ const MIC_CHECK_INTERVAL: Duration = Duration::from_secs(2);
 /// never fires cpal's error callback) and the mic leg must be rebuilt.
 const MIC_STALE_AFTER: Duration = Duration::from_secs(2);
 
+/// How long opening the microphone stream may take before it is worth a line
+/// in the log. `build_input_stream` + `play()` normally cost tens of
+/// milliseconds, but CoreAudio can fail to start the IO thread for a device
+/// and retry with a 14 s timeout each time, blocking this thread inside
+/// `play()`. Nothing else on the session says so: the UI keeps claiming to
+/// record, no callback ever arrives, and the stop this thread cannot service
+/// ends as "End-of-stream marker never arrived".
+const MIC_OPEN_SLOW_AFTER: Duration = Duration::from_secs(3);
+
+fn log_slow_mic_open(started: Instant, device_name: &str) {
+    let elapsed = started.elapsed();
+    if elapsed >= MIC_OPEN_SLOW_AFTER {
+        warn!(
+            device = device_name,
+            elapsed_ms = elapsed.as_millis() as u64,
+            "Microphone stream took a long time to open; CoreAudio is slow or failing to start it"
+        );
+    }
+}
+
 /// Ceiling on how often AudioLevel is pushed to the frontend. The meeting
 /// tick is faster than this; the dictation tick matches this interval, so both
 /// modes stream levels at ~15Hz.
@@ -1597,6 +1617,7 @@ impl AudioCapture {
         static LOGGED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
         LOGGED.store(false, std::sync::atomic::Ordering::Relaxed);
 
+        let opened_at = Instant::now();
         let stream = device
             .build_input_stream(
                 &config,
@@ -1660,6 +1681,7 @@ impl AudioCapture {
         stream
             .play()
             .map_err(|e| format!("Failed to start stream: {e}"))?;
+        log_slow_mic_open(opened_at, &device_name);
         self.stream = Some(stream);
 
         info!("Audio capture started on '{device_name}'");
@@ -1780,6 +1802,7 @@ impl AudioCapture {
             error!("Audio stream error: {err}");
             stream_failed.store(true, std::sync::atomic::Ordering::Relaxed);
         };
+        let opened_at = Instant::now();
         let stream = device
             .build_input_stream(
                 config,
@@ -1799,6 +1822,10 @@ impl AudioCapture {
         stream
             .play()
             .map_err(|e| format!("Failed to start stream: {e}"))?;
+        log_slow_mic_open(
+            opened_at,
+            self.mic_device_name.as_deref().unwrap_or("unknown"),
+        );
 
         // Accept mic samples into the ring buffer from here on, even though
         // `spawn_tap` below can block this thread for up to its 5s timeout

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -4,8 +4,9 @@ use crossbeam_channel::{Receiver, RecvTimeoutError, Sender};
 use ringbuf::HeapRb;
 use ringbuf::traits::{Producer, Split};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tracing::{debug, error, info, warn};
 
@@ -252,8 +253,10 @@ const MIC_OPEN_TIMEOUT: Duration = Duration::from_secs(8);
 /// the meeting mixer) for the whole bound. Park it for this long before
 /// spending another bound on it, the way `TAP_RETRY_INTERVAL` parks a tap:
 /// retrying on the `MIC_CHECK_INTERVAL` cadence would cost the system-audio
-/// leg more than the missing microphone does. An explicit route event
-/// clears the park, so picking another device is never delayed by it.
+/// leg more than the missing microphone does. The park is keyed by device,
+/// so picking another input is never delayed by it; a route event does not
+/// clear it, because CoreAudio emits one every time this app's own tap
+/// retry creates or destroys an aggregate.
 const MIC_OPEN_RETRY_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Decision for one mic-loss episode in `check_mic_health`, given how many
@@ -304,6 +307,10 @@ enum MicOpenError {
     /// Not attempted: the last open on this device hit the bound less than
     /// `MIC_OPEN_RETRY_INTERVAL` ago.
     Parked,
+    /// Not attempted: the previous open on this device is still inside
+    /// CoreAudio. Spawning another would stack a second stuck thread and a
+    /// second AUHAL instance on a device that is already not answering.
+    Busy,
 }
 
 impl std::fmt::Display for MicOpenError {
@@ -319,50 +326,115 @@ impl std::fmt::Display for MicOpenError {
                 f,
                 "Microphone device is not responding; not reopened yet after the last timeout"
             ),
+            Self::Busy => write!(
+                f,
+                "Microphone device is not responding; the previous open has not returned yet"
+            ),
         }
     }
 }
 
 /// Run `open` on a throwaway thread and wait at most `timeout` for it.
 ///
-/// `open` owns everything it builds. Once the wait has expired the value
-/// can no longer be handed over, so that thread `discard`s it instead: a
-/// cpal stream has to be paused and dropped by the thread holding it (cpal
-/// 0.15 leaked `StreamInner` when it was released elsewhere). A thread
-/// still inside a CoreAudio call is never killed and never joined, and its
-/// handle is dropped here, so the process can exit while it is stuck.
-fn open_with_timeout<T, F, D>(timeout: Duration, open: F, discard: D) -> Result<T, MicOpenError>
+/// `open` is handed an "abandoned" flag and must check it before any step
+/// that has an effect outside this process: once the wait has expired the
+/// caller has moved on, and starting device IO for a stream nobody will
+/// receive leaves a device running for no one. Whatever `open` still
+/// returns after that point is handed to `discard`, which releases it the
+/// way `release_capture_stream` does — pause, then drop — so a Bluetooth
+/// headset leaves HFP instead of staying in mono. A thread still inside a
+/// CoreAudio call is never killed and never joined; its handle is returned
+/// so the caller can tell whether it is still stuck before spawning
+/// another. Moving the stream between threads is fine: cpal's CoreAudio
+/// `Stream` is `Send` (cpal 0.17).
+///
+/// Returns the worker's handle alongside the result — `None` only when the
+/// thread could not be spawned at all.
+#[allow(clippy::type_complexity)]
+fn open_with_timeout<T, F, D>(
+    timeout: Duration,
+    open: F,
+    discard: D,
+) -> (Option<JoinHandle<()>>, Result<T, MicOpenError>)
 where
     T: Send + 'static,
-    F: FnOnce() -> Result<T, String> + Send + 'static,
+    F: FnOnce(&AtomicBool) -> Result<T, String> + Send + 'static,
     D: FnOnce(T) + Send + 'static,
 {
     let started = Instant::now();
+    let abandoned = Arc::new(AtomicBool::new(false));
+    let worker_abandoned = Arc::clone(&abandoned);
     let (tx, rx) = std::sync::mpsc::channel::<Result<T, String>>();
-    std::thread::Builder::new()
+    let spawned = std::thread::Builder::new()
         .name("mic-open".into())
-        .spawn(move || match open() {
-            Ok(value) => {
-                if let Err(std::sync::mpsc::SendError(Ok(abandoned))) = tx.send(Ok(value)) {
-                    discard(abandoned);
+        .spawn(move || {
+            let outcome = open(&worker_abandoned);
+            // The caller is gone: it will never read this, and it is the
+            // only place the true cost of the stall can be reported.
+            if worker_abandoned.load(Ordering::Relaxed) {
+                let elapsed_ms = started.elapsed().as_millis() as u64;
+                match &outcome {
+                    Ok(_) => warn!(
+                        elapsed_ms,
+                        "Microphone open returned after the caller gave up; releasing the stream"
+                    ),
+                    Err(error) => warn!(
+                        elapsed_ms,
+                        error, "Microphone open failed after the caller gave up"
+                    ),
+                }
+                if let Ok(value) = outcome {
+                    discard(value);
+                }
+                return;
+            }
+            match outcome {
+                Ok(value) => {
+                    // Lost the race with the caller's timeout by microseconds:
+                    // release it here rather than letting the receiver's drop
+                    // take it without a pause.
+                    if let Err(std::sync::mpsc::SendError(Ok(unclaimed))) = tx.send(Ok(value)) {
+                        discard(unclaimed);
+                    }
+                }
+                Err(error) => {
+                    let _ = tx.send(Err(error));
                 }
             }
-            Err(error) => {
-                let _ = tx.send(Err(error));
-            }
-        })
-        .map_err(|e| MicOpenError::Failed(format!("Failed to spawn mic open thread: {e}")))?;
+        });
+    let handle = match spawned {
+        Ok(handle) => handle,
+        Err(e) => {
+            return (
+                None,
+                Err(MicOpenError::Failed(format!(
+                    "Failed to spawn mic open thread: {e}"
+                ))),
+            );
+        }
+    };
 
-    match rx.recv_timeout(timeout) {
+    let result = match rx.recv_timeout(timeout) {
         Ok(Ok(value)) => Ok(value),
         Ok(Err(error)) => Err(MicOpenError::Failed(error)),
         Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            abandoned.store(true, Ordering::Relaxed);
             Err(MicOpenError::TimedOut(started.elapsed()))
         }
         Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
             Err(MicOpenError::Failed("Mic open thread died".into()))
         }
-    }
+    };
+    (Some(handle), result)
+}
+
+/// Whether `device_name` is the device that just ran past the bound, still
+/// inside `MIC_OPEN_RETRY_INTERVAL`. Keyed by device so that switching input
+/// is never delayed, and a route event resolving back to the same wedged
+/// device does not get a fresh bound to burn.
+fn mic_open_is_parked(timed_out: Option<&(String, Instant)>, device_name: &str) -> bool {
+    timed_out
+        .is_some_and(|(parked, at)| parked == device_name && at.elapsed() < MIC_OPEN_RETRY_INTERVAL)
 }
 
 fn log_mic_open_timeout(device_name: &str, elapsed: Duration) {
@@ -385,9 +457,9 @@ mod mic_open_tests {
     fn a_stalled_open_gives_the_caller_back_a_timeout() {
         let (discarded_tx, discarded_rx) = std::sync::mpsc::channel();
         let waited = Instant::now();
-        let opened = open_with_timeout(
+        let (_pending, opened) = open_with_timeout(
             Duration::from_millis(50),
-            || {
+            |_abandoned| {
                 std::thread::sleep(Duration::from_millis(400));
                 Ok(OPENED)
             },
@@ -416,11 +488,54 @@ mod mic_open_tests {
         );
     }
 
+    /// The wedge was measured inside `play()`, so the flag has to reach the
+    /// open before it starts the device: an abandoned attempt that still
+    /// starts IO runs a device for a stream nobody will ever receive.
+    #[test]
+    fn an_abandoned_open_is_told_before_it_starts_the_device() {
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (_pending, opened) = open_with_timeout(
+            Duration::from_millis(50),
+            move |abandoned| {
+                std::thread::sleep(Duration::from_millis(300));
+                let _ = started_tx.send(abandoned.load(Ordering::Relaxed));
+                Ok(OPENED)
+            },
+            |_| {},
+        );
+        assert!(matches!(opened, Err(MicOpenError::TimedOut(_))));
+        assert_eq!(
+            started_rx.recv_timeout(Duration::from_secs(5)),
+            Ok(true),
+            "the worker must see the abandoned flag once the caller gave up"
+        );
+    }
+
+    /// The handle is what lets the caller refuse a second open while the
+    /// first is still inside CoreAudio.
+    #[test]
+    fn a_stalled_open_leaves_a_worker_the_caller_can_still_see_running() {
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let (pending, opened) = open_with_timeout(
+            Duration::from_millis(50),
+            move |_abandoned| {
+                let _ = release_rx.recv_timeout(Duration::from_secs(5));
+                Ok(OPENED)
+            },
+            |_| {},
+        );
+        assert!(matches!(opened, Err(MicOpenError::TimedOut(_))));
+        let pending = pending.expect("a spawned worker must be handed back");
+        assert!(!pending.is_finished(), "the worker is still in the open");
+        let _ = release_tx.send(());
+        pending.join().expect("the worker must end cleanly");
+    }
+
     #[test]
     fn an_open_that_answers_in_time_returns_its_stream() {
-        let opened = open_with_timeout(
+        let (_pending, opened) = open_with_timeout(
             Duration::from_secs(5),
-            || Ok(OPENED),
+            |_abandoned| Ok(OPENED),
             |_| panic!("a delivered value must not be discarded"),
         );
         assert!(matches!(opened, Ok(OPENED)));
@@ -428,9 +543,9 @@ mod mic_open_tests {
 
     #[test]
     fn a_refused_open_is_a_failure_rather_than_a_timeout() {
-        let opened = open_with_timeout(
+        let (_pending, opened) = open_with_timeout(
             Duration::from_secs(5),
-            || Err::<u32, String>("Failed to build input stream: device gone".into()),
+            |_abandoned| Err::<u32, String>("Failed to build input stream: device gone".into()),
             |_| {},
         );
         let Err(MicOpenError::Failed(error)) = opened else {
@@ -443,14 +558,49 @@ mod mic_open_tests {
     /// carries into the log and the session error must not read as one.
     #[test]
     fn a_timeout_never_reads_as_a_permission_denial() {
-        let message = MicOpenError::TimedOut(Duration::from_secs(8)).to_string();
-        let lowered = message.to_lowercase();
-        for permission_word in ["permission", "denied", "access", "authoriz", "privacy"] {
-            assert!(
-                !lowered.contains(permission_word),
-                "a timeout must not be worded as a permission problem: {message}"
-            );
+        for message in [
+            MicOpenError::TimedOut(Duration::from_secs(8)).to_string(),
+            MicOpenError::Parked.to_string(),
+            MicOpenError::Busy.to_string(),
+        ] {
+            let lowered = message.to_lowercase();
+            for permission_word in ["permission", "denied", "access", "authoriz", "privacy"] {
+                assert!(
+                    !lowered.contains(permission_word),
+                    "a device stall must not be worded as a permission problem: {message}"
+                );
+            }
         }
+    }
+
+    /// The park belongs to the device that stalled. CoreAudio emits a
+    /// device-list notification every time the app's own tap retry creates
+    /// or destroys an aggregate, and those used to clear the park and hand
+    /// the same dead device another full bound.
+    #[test]
+    fn the_park_holds_for_the_stalled_device_only() {
+        let timed_out = ("MacBook Pro Microphone".to_string(), Instant::now());
+        assert!(
+            mic_open_is_parked(Some(&timed_out), "MacBook Pro Microphone"),
+            "the device that just stalled must not be reopened immediately"
+        );
+        assert!(
+            !mic_open_is_parked(Some(&timed_out), "Shure MV7"),
+            "picking another input must never be delayed by the park"
+        );
+        assert!(
+            !mic_open_is_parked(None, "MacBook Pro Microphone"),
+            "nothing has stalled yet"
+        );
+    }
+
+    #[test]
+    fn the_park_expires_with_the_retry_interval() {
+        let stale = (
+            "MacBook Pro Microphone".to_string(),
+            Instant::now() - (MIC_OPEN_RETRY_INTERVAL + Duration::from_secs(1)),
+        );
+        assert!(!mic_open_is_parked(Some(&stale), "MacBook Pro Microphone"));
     }
 }
 
@@ -1366,10 +1516,18 @@ pub struct AudioCapture {
     /// check from tearing the stream down every interval; explicit route
     /// events (`refresh_input_route`) clear it so a real change retries.
     route_attempt_uid: Option<String>,
-    /// When the last microphone open ran past `MIC_OPEN_TIMEOUT`. Parks the
-    /// next open for `MIC_OPEN_RETRY_INTERVAL`; cleared on a successful
-    /// open, on an explicit route event, and at session start.
-    mic_open_timed_out_at: Option<Instant>,
+    /// Which device last ran past `MIC_OPEN_TIMEOUT`, and when. Parks the
+    /// next open *of that device* for `MIC_OPEN_RETRY_INTERVAL`; cleared on
+    /// a successful open and at session start. Keyed by device on purpose:
+    /// picking another input is never delayed by it, and a route event that
+    /// resolves back to the same wedged device does not hand it a fresh
+    /// bound to burn (the app's own tap churn emits those events).
+    mic_open_timed_out: Option<(String, Instant)>,
+    /// The `mic-open` worker of the last attempt, kept only to ask whether
+    /// it is still inside CoreAudio. Never joined: a thread stuck in the HAL
+    /// would never return. A new open is refused while it runs, so a wedged
+    /// device cannot stack one stuck thread and one AUHAL per retry.
+    mic_open_pending: Option<JoinHandle<()>>,
     /// Set by the cpal error callback when the stream dies (e.g. its device
     /// disappeared); the next mic health check rebuilds the capture leg.
     stream_failed: Arc<std::sync::atomic::AtomicBool>,
@@ -1438,7 +1596,8 @@ impl AudioCapture {
                     mic_device_object_id: None,
                     last_mic_callback_ms: Arc::new(AtomicU64::new(0)),
                     route_attempt_uid: None,
-                    mic_open_timed_out_at: None,
+                    mic_open_timed_out: None,
+                    mic_open_pending: None,
                     stream_failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
                     last_mic_check: Instant::now(),
                     level_throttle: AudioLevelThrottle::new(),
@@ -1526,6 +1685,17 @@ impl AudioCapture {
                             ) {
                                 warn!("Failed to start audio capture: {e}");
                                 capture.report_start_failure(capture_system_audio, &e);
+                                // Dictation has no second source. With the
+                                // device not answering there is nothing to
+                                // wait for, and the rebuild ladder would
+                                // spend ten more silent seconds before
+                                // ending on "the recording so far was
+                                // saved" — which is false: nothing was
+                                // recorded, and the reason was never shown.
+                                if !capture_system_audio && capture.mic_open_stalled() {
+                                    capture.abort_after_failed_start(e);
+                                    break;
+                                }
                             }
                         }
                         AudioCommand::Stop => {
@@ -1641,36 +1811,42 @@ impl AudioCapture {
 
     /// Build and start the microphone stream under `MIC_OPEN_TIMEOUT`.
     ///
-    /// A device that just ran past the bound is not reopened for
-    /// `MIC_OPEN_RETRY_INTERVAL`: another attempt would cost this thread
-    /// (and the meeting mixer it drives) the whole bound again.
+    /// Two attempts are refused outright rather than spending the bound: a
+    /// device that just ran past it (parked for `MIC_OPEN_RETRY_INTERVAL`),
+    /// and one whose previous open has not come back from CoreAudio yet.
+    /// Either would cost this thread — and the meeting mixer it drives —
+    /// the whole bound for an answer already known.
     fn open_mic_stream<F>(&mut self, device_name: &str, build: F) -> Result<Stream, MicOpenError>
     where
-        F: FnOnce() -> Result<Stream, String> + Send + 'static,
+        F: FnOnce(&AtomicBool) -> Result<Stream, String> + Send + 'static,
     {
-        if self
-            .mic_open_timed_out_at
-            .is_some_and(|at| at.elapsed() < MIC_OPEN_RETRY_INTERVAL)
-        {
+        if let Some(pending) = &self.mic_open_pending {
+            if pending.is_finished() {
+                self.mic_open_pending = None;
+            } else {
+                return Err(MicOpenError::Busy);
+            }
+        }
+        if mic_open_is_parked(self.mic_open_timed_out.as_ref(), device_name) {
             return Err(MicOpenError::Parked);
         }
 
-        let opened = open_with_timeout(MIC_OPEN_TIMEOUT, build, |stream| {
-            // Owned end to end by the thread that built it: cpal 0.15 leaked
-            // `StreamInner` when a stream was released anywhere else, and the
-            // Bluetooth route only returns to A2DP once it is dropped.
+        let (pending, opened) = open_with_timeout(MIC_OPEN_TIMEOUT, build, |stream| {
+            // Same release as `release_capture_stream`: pause, then drop,
+            // or a Bluetooth headset stays in HFP/mono.
             if let Err(e) = stream.pause() {
                 debug!("Pause of an abandoned mic stream: {e}");
             }
         });
+        self.mic_open_pending = pending;
 
         match &opened {
-            Ok(_) => self.mic_open_timed_out_at = None,
+            Ok(_) => self.mic_open_timed_out = None,
             Err(MicOpenError::TimedOut(elapsed)) => {
                 log_mic_open_timeout(device_name, *elapsed);
-                self.mic_open_timed_out_at = Some(Instant::now());
+                self.mic_open_timed_out = Some((device_name.to_string(), Instant::now()));
             }
-            Err(MicOpenError::Failed(_) | MicOpenError::Parked) => {}
+            Err(MicOpenError::Failed(_) | MicOpenError::Parked | MicOpenError::Busy) => {}
         }
         opened
     }
@@ -1695,7 +1871,7 @@ impl AudioCapture {
             self.clear_mic_loss_ladder();
             // A new session is a fresh user intent: give a device parked by
             // a previous session's timeout one more chance.
-            self.mic_open_timed_out_at = None;
+            self.mic_open_timed_out = None;
         }
         // Ensure any previous callback stops emitting immediately. The
         // recorder is NOT torn down here; see `sync_recorder`, so a
@@ -1825,7 +2001,7 @@ impl AudioCapture {
         // is just as closed, and both calls now run on another thread.
         self.active_session_id.store(session_id, Ordering::Release);
 
-        let build = move || {
+        let build = move |abandoned: &AtomicBool| {
             let stream = device
                 .build_input_stream(
                     &config,
@@ -1884,6 +2060,12 @@ impl AudioCapture {
                     None,
                 )
                 .map_err(|e| format!("Failed to build input stream: {e}"))?;
+            // The caller has given up: starting IO now would run the
+            // device for a stream nobody will receive, and on a wedged
+            // device `play()` is exactly where the minutes go.
+            if abandoned.load(Ordering::Relaxed) {
+                return Err("Mic open abandoned before starting the device".into());
+            }
             stream
                 .play()
                 .map_err(|e| format!("Failed to start stream: {e}"))?;
@@ -2034,7 +2216,7 @@ impl AudioCapture {
 
         let device = device.clone();
         let config = config.clone();
-        let build = move || {
+        let build = move |abandoned: &AtomicBool| {
             let stream = device
                 .build_input_stream(
                     &config,
@@ -2051,6 +2233,12 @@ impl AudioCapture {
                     None,
                 )
                 .map_err(|e| format!("Failed to build input stream: {e}"))?;
+            // The caller has given up: starting IO now would run the
+            // device for a stream nobody will receive, and on a wedged
+            // device `play()` is exactly where the minutes go.
+            if abandoned.load(Ordering::Relaxed) {
+                return Err("Mic open abandoned before starting the device".into());
+            }
             stream
                 .play()
                 .map_err(|e| format!("Failed to start stream: {e}"))?;
@@ -2327,7 +2515,12 @@ impl AudioCapture {
     /// send EndOfStream (`active_params` was already cleared).
     fn refresh_input_route(&mut self) -> bool {
         self.route_attempt_uid = None;
-        self.mic_open_timed_out_at = None;
+        // The park is not cleared here. A route event is not evidence that
+        // the wedged device recovered, and CoreAudio emits one every time
+        // the app's own tap retry creates or destroys an aggregate: clearing
+        // it handed the same dead device a fresh bound every few seconds.
+        // The park is keyed by device name, so resolving to a different
+        // input is not delayed by it.
         if self.active_params.is_some() {
             self.last_mic_check = Instant::now();
             if self.check_mic_health() {
@@ -2569,7 +2762,7 @@ impl AudioCapture {
         self.mic_device_uid = None;
         self.mic_device_object_id = None;
         self.route_attempt_uid = None;
-        self.mic_open_timed_out_at = None;
+        self.mic_open_timed_out = None;
         self.last_mic_callback_ms.store(0, Ordering::Relaxed);
         self.release_capture_stream();
         self.resampler.take();
@@ -2600,6 +2793,27 @@ impl AudioCapture {
     /// tearing down — see `teardown_session_state` for why exiting this
     /// thread is what lets the actor salvage and fail the session, exactly
     /// like a panic abort.
+    /// Whether the last open ran past the bound or was refused because the
+    /// previous one still has not come back. Read right after a failed
+    /// `start` to tell a device that is not answering from a device that
+    /// refused outright (which is worth a retry).
+    fn mic_open_stalled(&self) -> bool {
+        self.mic_open_timed_out.is_some()
+            || self
+                .mic_open_pending
+                .as_ref()
+                .is_some_and(|pending| !pending.is_finished())
+    }
+
+    /// End a session that never started, carrying the real reason. Unlike
+    /// `abort_after_mic_loss` this one has nothing saved to speak of.
+    fn abort_after_failed_start(&mut self, reason: String) {
+        if let Ok(mut slot) = self.audio_gone_reason.lock() {
+            *slot = Some(reason);
+        }
+        self.teardown_session_state();
+    }
+
     fn abort_after_mic_loss(&mut self) {
         if let Ok(mut reason) = self.audio_gone_reason.lock() {
             *reason = Some(
@@ -2679,7 +2893,7 @@ impl AudioCapture {
         self.mic_device_uid = None;
         self.mic_device_object_id = None;
         self.route_attempt_uid = None;
-        self.mic_open_timed_out_at = None;
+        self.mic_open_timed_out = None;
         self.last_mic_callback_ms.store(0, Ordering::Relaxed);
         self.emit_audio_level(0.0);
         self.level_throttle.reset();

--- a/src-tauri/src/clipboard.rs
+++ b/src-tauri/src/clipboard.rs
@@ -64,9 +64,16 @@ pub fn paste_text(text: &str, delay_ms: u64, method: PasteMethod) -> Result<(), 
     match method {
         PasteMethod::Ax => {
             thread::sleep(Duration::from_millis(delay_ms));
-            if ax_set_applied(&crate::ax_text::set_selected_text(text)) {
+            let ax = crate::ax_text::set_selected_text(text);
+            if ax_set_applied(&ax) {
                 return Ok(());
             }
+            // Which of the two the target app actually saw is the first
+            // question to ask about a paste that did not land.
+            tracing::info!(
+                reason = ?ax,
+                "Accessibility insert did not apply; falling back to Cmd+V"
+            );
             paste_via_cmd_v(text, 0, &mut enigo)?;
         }
         PasteMethod::Clipboard => {

--- a/src-tauri/src/commands/permissions.rs
+++ b/src-tauri/src/commands/permissions.rs
@@ -24,9 +24,6 @@ pub async fn request_permission(
 ) -> Result<PermState, String> {
     let db = Arc::clone(&state.db);
     tauri::async_runtime::spawn_blocking(move || {
-        if kind == PermissionKind::InputMonitoring {
-            permissions::note_input_monitoring_prompt(&db);
-        }
         let result = permissions::request(kind);
         if kind == PermissionKind::SystemAudio {
             permissions::remember_system_audio(&db, result);
@@ -44,15 +41,8 @@ pub async fn request_permission(
 /// the command thread since it shells out and may block on the prompt.
 #[tauri::command]
 #[specta::specta]
-pub async fn repair_accessibility_permission(
-    state: State<'_, AppState>,
-) -> Result<RepairAccessibilityResult, String> {
-    let db = Arc::clone(&state.db);
-    tauri::async_runtime::spawn_blocking(move || {
-        let result = permissions::repair_accessibility();
-        permissions::clear_input_monitoring_memory(&db);
-        result
-    })
-    .await
-    .map_err(|e| format!("Accessibility repair failed: {e}"))?
+pub async fn repair_accessibility_permission() -> Result<RepairAccessibilityResult, String> {
+    tauri::async_runtime::spawn_blocking(permissions::repair_accessibility)
+        .await
+        .map_err(|e| format!("Accessibility repair failed: {e}"))?
 }

--- a/src-tauri/src/commands/permissions.rs
+++ b/src-tauri/src/commands/permissions.rs
@@ -2,11 +2,20 @@ use crate::permissions::{
     self, PermState, PermissionKind, PermissionStatus, RepairAccessibilityResult,
 };
 
-/// Cheap, non-prompting snapshot for the onboarding's initial render.
+/// Cheap, non-prompting snapshot for the onboarding's initial render, and
+/// the source of the panel's 600 ms poll.
+///
+/// Off the command thread even though every read is a status API: three of
+/// them (`AXIsProcessTrusted`, `TCCAccessPreflight`, EventKit) are XPC round
+/// trips to `tccd`, and a synchronous command runs on the main thread, where
+/// a stalled `tccd` would freeze the window. Nothing here needs the main
+/// thread — only *requests* do (SOU-122).
 #[tauri::command]
 #[specta::specta]
-pub fn get_permission_status() -> Result<PermissionStatus, String> {
-    Ok(permissions::snapshot())
+pub async fn get_permission_status() -> Result<PermissionStatus, String> {
+    tauri::async_runtime::spawn_blocking(permissions::snapshot)
+        .await
+        .map_err(|e| format!("Permission status read failed: {e}"))
 }
 
 /// Trigger the native prompt (or open System Settings) for one permission.

--- a/src-tauri/src/commands/permissions.rs
+++ b/src-tauri/src/commands/permissions.rs
@@ -25,8 +25,14 @@ pub async fn request_permission(
     let db = Arc::clone(&state.db);
     tauri::async_runtime::spawn_blocking(move || {
         let result = permissions::request(kind);
-        if kind == PermissionKind::SystemAudio {
-            permissions::remember_system_audio(&db, result);
+        match kind {
+            PermissionKind::SystemAudio => permissions::remember_system_audio(&db, result),
+            // `AVCaptureDevice` caches its authorization status for the life
+            // of the process, so a grant the user makes after the first read
+            // is invisible to every later snapshot. The probe's verdict is
+            // the only fresh answer this process will ever get.
+            PermissionKind::Microphone => permissions::remember_microphone(&db, result),
+            _ => {}
         }
         result
     })

--- a/src-tauri/src/commands/permissions.rs
+++ b/src-tauri/src/commands/permissions.rs
@@ -1,37 +1,23 @@
-use std::sync::Arc;
-
-use tauri::State;
-
 use crate::permissions::{
     self, PermState, PermissionKind, PermissionStatus, RepairAccessibilityResult,
 };
-use crate::state::AppState;
 
 /// Cheap, non-prompting snapshot for the onboarding's initial render.
 #[tauri::command]
 #[specta::specta]
-pub fn get_permission_status(state: State<'_, AppState>) -> Result<PermissionStatus, String> {
-    Ok(permissions::snapshot(&state.db))
+pub fn get_permission_status() -> Result<PermissionStatus, String> {
+    Ok(permissions::snapshot())
 }
 
 /// Trigger the native prompt (or open System Settings) for one permission.
-/// The probe opens a device, so it runs off the command thread.
+/// Blocks until the user answers the dialog, so it runs off the command
+/// thread.
 #[tauri::command]
 #[specta::specta]
-pub async fn request_permission(
-    state: State<'_, AppState>,
-    kind: PermissionKind,
-) -> Result<PermState, String> {
-    let db = Arc::clone(&state.db);
-    tauri::async_runtime::spawn_blocking(move || {
-        let result = permissions::request(kind);
-        if kind == PermissionKind::Microphone {
-            permissions::remember_microphone(&db, result);
-        }
-        result
-    })
-    .await
-    .map_err(|e| format!("Permission probe failed: {e}"))
+pub async fn request_permission(kind: PermissionKind) -> Result<PermState, String> {
+    tauri::async_runtime::spawn_blocking(move || permissions::request(kind))
+        .await
+        .map_err(|e| format!("Permission request failed: {e}"))
 }
 
 /// Clear a stale Accessibility TCC entry and re-prompt. Updating the app by

--- a/src-tauri/src/commands/permissions.rs
+++ b/src-tauri/src/commands/permissions.rs
@@ -25,14 +25,8 @@ pub async fn request_permission(
     let db = Arc::clone(&state.db);
     tauri::async_runtime::spawn_blocking(move || {
         let result = permissions::request(kind);
-        match kind {
-            PermissionKind::SystemAudio => permissions::remember_system_audio(&db, result),
-            // `AVCaptureDevice` caches its authorization status for the life
-            // of the process, so a grant the user makes after the first read
-            // is invisible to every later snapshot. The probe's verdict is
-            // the only fresh answer this process will ever get.
-            PermissionKind::Microphone => permissions::remember_microphone(&db, result),
-            _ => {}
+        if kind == PermissionKind::Microphone {
+            permissions::remember_microphone(&db, result);
         }
         result
     })

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -107,6 +107,13 @@ pub fn register_shortcuts(app: &AppHandle, shortcuts: &ShortcutSettings) -> Resu
         state.toggle_armed.store(false, Ordering::SeqCst);
     }
 
+    // The tap only goes in the event path for a single-key binding, and a
+    // binding is always a user action: it never installs itself at startup.
+    crate::modifier_shortcut::sync_modifier_tap(
+        app,
+        crate::modifier_shortcut::tap_is_needed(&shortcuts.toggle, &shortcuts.push_to_talk),
+    );
+
     if toggle_target == ShortcutRegistrationTarget::Plugin {
         gs.on_shortcut(shortcuts.toggle.as_str(), move |app, _shortcut, event| {
             if event.state == ShortcutState::Pressed {

--- a/src-tauri/src/commands/transcription.rs
+++ b/src-tauri/src/commands/transcription.rs
@@ -962,7 +962,23 @@ pub fn paste_text(
     delay_ms: u64,
     method: crate::settings::PasteMethod,
 ) -> Result<(), String> {
-    crate::clipboard::paste_text(&text, delay_ms, method)
+    // The insertion path left no trace at all, so afterwards a paste that
+    // was never requested, one that failed, and one the target app dropped
+    // all read the same: nothing in the log.
+    info!(
+        ?method,
+        chars = text.chars().count(),
+        delay_ms,
+        "Inserting dictation"
+    );
+    let started = std::time::Instant::now();
+    let result = crate::clipboard::paste_text(&text, delay_ms, method);
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+    match &result {
+        Ok(()) => info!(elapsed_ms, "Dictation inserted"),
+        Err(e) => warn!(elapsed_ms, error = %e, "Dictation insert failed"),
+    }
+    result
 }
 
 /// Write text to the pasteboard without pasting. Cancels a pending clipboard

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -295,10 +295,11 @@ pub fn run() {
         .invoke_handler(specta.invoke_handler())
         .setup(move |app| {
             specta.mount_events(app);
-            // ListenEvent must be requested before any AXIsProcessTrusted*
-            // call: otherwise IOHIDRequestAccess never inserts the Input
-            // Monitoring row (FB7381305 / SOU-122).
-            crate::permissions::seed_tcc_clients();
+            // Launch Services must resolve this binary before TCC looks it up,
+            // or System Settings shows the row of a previous build. Registering
+            // is not a TCC request: nothing at startup may prompt, a permission
+            // is only ever asked for on a user action.
+            crate::permissions::register_with_launch_services();
 
             // Store the AppHandle so state transitions can emit events
             let state = app.state::<AppState>();
@@ -324,10 +325,11 @@ pub fn run() {
                 }
             };
 
+            // `register_shortcuts` also installs the native tap, and only for
+            // a shortcut that needs it.
             if let Err(e) = commands::register_shortcuts(app.handle(), &shortcuts) {
                 tracing::warn!("Failed to register shortcuts on startup: {e}");
             }
-            crate::modifier_shortcut::start_modifier_tap(app.handle().clone());
 
             match settings::AppSettings::load(&state.db) {
                 Ok(app_settings) => {

--- a/src-tauri/src/modifier_shortcut.rs
+++ b/src-tauri/src/modifier_shortcut.rs
@@ -1,5 +1,5 @@
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Condvar, Mutex};
 use std::thread;
 use std::time::Duration;
 
@@ -89,8 +89,16 @@ pub(crate) fn shortcut_registration_target(shortcut: &str) -> ShortcutRegistrati
 }
 
 /// Mach port of the installed tap, for enable/disable from any thread.
-/// Zero until the tap is installed; the runloop thread never lets it go.
+/// Zero until the tap is installed, and back to zero before the tap is
+/// dropped.
 static TAP_PORT: AtomicUsize = AtomicUsize::new(0);
+
+/// Serializes `CGEventTapEnable` against the teardown that invalidates the
+/// port. `CFRunLoop::run_current` returns when the runloop has no sources
+/// left, and dropping the `CGEventTap` invalidates its `CFMachPort`; without
+/// this lock a concurrent `sync_modifier_tap` could load the port before the
+/// clear and call `CGEventTapEnable` on freed memory.
+static TAP_PORT_LOCK: Mutex<()> = Mutex::new(());
 
 /// Whether a configured shortcut currently needs the tap.
 static TAP_WANTED: AtomicBool = AtomicBool::new(false);
@@ -108,6 +116,32 @@ const TAP_STARTUP_GRACE: Duration = Duration::from_millis(500);
 /// for the grant. A read, never a request: it cannot raise a prompt.
 const TAP_PERMISSION_POLL: Duration = Duration::from_secs(2);
 
+/// Wakes the waiting thread when `TAP_WANTED` changes. Without it the thread
+/// keeps ticking every two seconds for the life of the process even after the
+/// user moves both shortcuts to combos and nothing needs the tap.
+static TAP_WANTED_CHANGED: (Mutex<bool>, Condvar) = (Mutex::new(false), Condvar::new());
+
+/// Block until the tap is wanted again. Returns immediately when it already
+/// is; a spurious wake just re-reads `TAP_WANTED`, which is the condition.
+fn wait_until_tap_wanted() {
+    let (lock, cv) = &TAP_WANTED_CHANGED;
+    let mut changed = lock.lock().unwrap_or_else(|e| e.into_inner());
+    while !TAP_WANTED.load(Ordering::SeqCst) {
+        *changed = false;
+        changed = cv
+            .wait(changed)
+            .unwrap_or_else(|e: std::sync::PoisonError<_>| e.into_inner());
+    }
+}
+
+fn signal_tap_wanted_changed() {
+    let (lock, cv) = &TAP_WANTED_CHANGED;
+    if let Ok(mut changed) = lock.lock() {
+        *changed = true;
+    }
+    cv.notify_all();
+}
+
 /// Install the native tap, or take it out of the event path, to match the
 /// shortcuts the user actually configured. Creating a `CGEventTap` is a TCC
 /// request: done with no shortcut needing it, macOS raises an Accessibility
@@ -117,6 +151,7 @@ const TAP_PERMISSION_POLL: Duration = Duration::from_secs(2);
 /// a restart.
 pub fn sync_modifier_tap(app: &AppHandle, needed: bool) {
     TAP_WANTED.store(needed, Ordering::SeqCst);
+    signal_tap_wanted_changed();
     set_tap_enabled(needed);
     if !needed || TAP_THREAD_SPAWNED.swap(true, Ordering::SeqCst) {
         return;
@@ -136,19 +171,21 @@ fn run_modifier_tap(app: AppHandle) {
     thread::sleep(TAP_STARTUP_GRACE);
     let mut warned = false;
     loop {
-        if TAP_WANTED.load(Ordering::SeqCst) {
-            // `AXIsProcessTrusted` is a snapshot read, `CGEventTap::new` is a
-            // TCC request. Reading first is what keeps the wait from raising a
-            // prompt every couple of seconds; the banner carries the news
-            // instead (SOU-116).
-            if crate::permissions::accessibility_granted() && install_and_run(app.clone()) {
-                return;
-            }
-            store_and_emit_modifier_tap_status(&app, false);
-            if !warned {
-                error!("Native shortcut tap not installed. Is Accessibility granted?");
-                warned = true;
-            }
+        // Nothing wants the tap: sleep on the condvar instead of ticking
+        // forever. `sync_modifier_tap` wakes this up when a single-key
+        // shortcut comes back.
+        wait_until_tap_wanted();
+        // `AXIsProcessTrusted` is a snapshot read, `CGEventTap::new` is a
+        // TCC request. Reading first is what keeps the wait from raising a
+        // prompt every couple of seconds; the banner carries the news
+        // instead (SOU-116).
+        if crate::permissions::accessibility_granted() && install_and_run(app.clone()) {
+            return;
+        }
+        store_and_emit_modifier_tap_status(&app, false);
+        if !warned {
+            error!("Native shortcut tap not installed. Is Accessibility granted?");
+            warned = true;
         }
         thread::sleep(TAP_PERMISSION_POLL);
     }
@@ -156,6 +193,7 @@ fn run_modifier_tap(app: AppHandle) {
 
 #[cfg(target_os = "macos")]
 fn set_tap_enabled(enabled: bool) {
+    let _guard = TAP_PORT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let ptr = TAP_PORT.load(Ordering::SeqCst);
     if ptr == 0 {
         return;
@@ -200,11 +238,20 @@ fn install_and_run(app: AppHandle) -> bool {
                 None => return CallbackResult::Keep,
             };
             let toggle_shortcut = {
-                let lock = state.modifier_toggle_shortcut.read().unwrap();
+                // A poisoned lock must not panic here: this runs inside the
+                // C callback of an active HID tap, in front of every
+                // keystroke on the machine.
+                let lock = state
+                    .modifier_toggle_shortcut
+                    .read()
+                    .unwrap_or_else(|e| e.into_inner());
                 lock.clone()
             };
             let ptt_shortcut = {
-                let lock = state.modifier_ptt_shortcut.read().unwrap();
+                let lock = state
+                    .modifier_ptt_shortcut
+                    .read()
+                    .unwrap_or_else(|e| e.into_inner());
                 lock.clone()
             };
 
@@ -282,7 +329,7 @@ fn install_and_run(app: AppHandle) -> bool {
                 Ordering::SeqCst,
             );
             let Ok(loop_source) = tap.mach_port().create_runloop_source(0) else {
-                TAP_PORT.store(0, Ordering::SeqCst);
+                clear_tap_port();
                 store_and_emit_modifier_tap_status(&app_for_status, false);
                 return false;
             };
@@ -293,10 +340,21 @@ fn install_and_run(app: AppHandle) -> bool {
             // A shortcut saved while the tap was being installed decides here.
             set_tap_enabled(TAP_WANTED.load(Ordering::SeqCst));
             core_foundation::runloop::CFRunLoop::run_current();
+            // The runloop gave up (no sources left). Retire the port before
+            // `tap` drops and invalidates it, so no enable can reach it.
+            clear_tap_port();
+            drop(tap);
             false
         }
         Err(_) => false,
     }
+}
+
+/// Zero `TAP_PORT` under the lock `set_tap_enabled` takes, so a concurrent
+/// enable either ran before the clear (on a still-valid port) or sees zero.
+fn clear_tap_port() {
+    let _guard = TAP_PORT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    TAP_PORT.store(0, Ordering::SeqCst);
 }
 
 fn emit_toggle(state: &AppState, app: &AppHandle) {

--- a/src-tauri/src/modifier_shortcut.rs
+++ b/src-tauri/src/modifier_shortcut.rs
@@ -1,6 +1,5 @@
-use std::sync::Arc;
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::thread;
 use std::time::Duration;
 
@@ -28,10 +27,19 @@ pub fn modifier_tap_status() -> Option<ModifierTapStatus> {
 
 fn store_and_emit_modifier_tap_status(app: &AppHandle, installed: bool) {
     let status = ModifierTapStatus { installed };
-    if let Ok(mut guard) = MODIFIER_TAP_STATUS.lock() {
-        *guard = Some(status);
+    let changed = match MODIFIER_TAP_STATUS.lock() {
+        Ok(mut guard) => {
+            let changed = guard.map(|s| s.installed) != Some(installed);
+            *guard = Some(status);
+            changed
+        }
+        Err(_) => true,
+    };
+    // The waiting thread re-reads the permission every couple of seconds.
+    // The banner only needs the transitions, not the polling.
+    if changed {
+        let _ = status.emit(app);
     }
-    let _ = status.emit(app);
 }
 
 /// Where a dictation shortcut is registered (SOU-032 / SOU-115).
@@ -80,32 +88,91 @@ pub(crate) fn shortcut_registration_target(shortcut: &str) -> ShortcutRegistrati
     }
 }
 
-pub fn start_modifier_tap(app: AppHandle) {
-    thread::spawn(move || {
-        // Wait a little before starting to ensure AppState is registered.
-        // Status is not emitted during this window so the settings banner
-        // cannot flash on every launch (SOU-116 risk zone).
-        thread::sleep(Duration::from_millis(500));
-        let mut warned = false;
-        loop {
-            if install_and_run(app.clone()) {
+/// Mach port of the installed tap, for enable/disable from any thread.
+/// Zero until the tap is installed; the runloop thread never lets it go.
+static TAP_PORT: AtomicUsize = AtomicUsize::new(0);
+
+/// Whether a configured shortcut currently needs the tap.
+static TAP_WANTED: AtomicBool = AtomicBool::new(false);
+
+/// Whether the runloop thread has been spawned. It cannot be unspawned, so
+/// an unwanted tap is disabled rather than torn down.
+static TAP_THREAD_SPAWNED: AtomicBool = AtomicBool::new(false);
+
+/// Give the Tauri setup hook time to finish managing `AppState` before the
+/// callback reads it. Status is not emitted during this window so the
+/// settings banner cannot flash on every launch (SOU-116 risk zone).
+const TAP_STARTUP_GRACE: Duration = Duration::from_millis(500);
+
+/// How often the thread re-reads the Accessibility snapshot while it waits
+/// for the grant. A read, never a request: it cannot raise a prompt.
+const TAP_PERMISSION_POLL: Duration = Duration::from_secs(2);
+
+/// Install the native tap, or take it out of the event path, to match the
+/// shortcuts the user actually configured. Creating a `CGEventTap` is a TCC
+/// request: done with no shortcut needing it, macOS raises an Accessibility
+/// prompt nobody asked for, and an active HID tap sits in front of every
+/// keystroke on the machine. Called from `register_shortcuts`, so a combo
+/// saved in Settings takes the tap out and a single key puts it back without
+/// a restart.
+pub fn sync_modifier_tap(app: &AppHandle, needed: bool) {
+    TAP_WANTED.store(needed, Ordering::SeqCst);
+    set_tap_enabled(needed);
+    if !needed || TAP_THREAD_SPAWNED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    let app = app.clone();
+    thread::spawn(move || run_modifier_tap(app));
+}
+
+/// True when either configured shortcut is a single native key.
+pub(crate) fn tap_is_needed(toggle: &str, push_to_talk: &str) -> bool {
+    [toggle, push_to_talk]
+        .iter()
+        .any(|s| shortcut_registration_target(s) == ShortcutRegistrationTarget::Native)
+}
+
+fn run_modifier_tap(app: AppHandle) {
+    thread::sleep(TAP_STARTUP_GRACE);
+    let mut warned = false;
+    loop {
+        if TAP_WANTED.load(Ordering::SeqCst) {
+            // `AXIsProcessTrusted` is a snapshot read, `CGEventTap::new` is a
+            // TCC request. Reading first is what keeps the wait from raising a
+            // prompt every couple of seconds; the banner carries the news
+            // instead (SOU-116).
+            if crate::permissions::accessibility_granted() && install_and_run(app.clone()) {
                 return;
             }
             store_and_emit_modifier_tap_status(&app, false);
             if !warned {
-                error!(
-                    "Failed to install modifier CGEventTap. Is Accessibility granted? Retrying."
-                );
+                error!("Native shortcut tap not installed. Is Accessibility granted?");
                 warned = true;
             }
-            thread::sleep(Duration::from_secs(2));
         }
-    });
+        thread::sleep(TAP_PERMISSION_POLL);
+    }
 }
 
+#[cfg(target_os = "macos")]
+fn set_tap_enabled(enabled: bool) {
+    let ptr = TAP_PORT.load(Ordering::SeqCst);
+    if ptr == 0 {
+        return;
+    }
+    unsafe {
+        // CGEventTapEnable takes a CFMachPortRef.
+        unsafe extern "C" {
+            fn CGEventTapEnable(tap: *const std::ffi::c_void, enable: bool);
+        }
+        CGEventTapEnable(ptr as *const _, enabled);
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn set_tap_enabled(_enabled: bool) {}
+
 fn install_and_run(app: AppHandle) -> bool {
-    let tap_port_ptr = Arc::new(AtomicUsize::new(0));
-    let tap_port_clone = tap_port_ptr.clone();
     // Callback takes ownership of `app`; keep a handle for status emits after
     // install succeeds or the runloop source fails to attach.
     let app_for_status = app.clone();
@@ -124,16 +191,7 @@ fn install_and_run(app: AppHandle) -> bool {
                 event_type,
                 CGEventType::TapDisabledByTimeout | CGEventType::TapDisabledByUserInput
             ) {
-                let ptr = tap_port_clone.load(Ordering::Relaxed);
-                if ptr != 0 {
-                    unsafe {
-                        // CGEventTapEnable takes a CFMachPortRef.
-                        unsafe extern "C" {
-                            fn CGEventTapEnable(tap: *const std::ffi::c_void, enable: bool);
-                        }
-                        CGEventTapEnable(ptr as *const _, true);
-                    }
-                }
+                set_tap_enabled(TAP_WANTED.load(Ordering::SeqCst));
                 return CallbackResult::Keep;
             }
 
@@ -219,11 +277,12 @@ fn install_and_run(app: AppHandle) -> bool {
         Ok(tap) => {
             info!("Modifier CGEventTap installed");
             store_and_emit_modifier_tap_status(&app_for_status, true);
-            tap_port_ptr.store(
+            TAP_PORT.store(
                 tap.mach_port().as_concrete_TypeRef() as usize,
-                Ordering::Relaxed,
+                Ordering::SeqCst,
             );
             let Ok(loop_source) = tap.mach_port().create_runloop_source(0) else {
+                TAP_PORT.store(0, Ordering::SeqCst);
                 store_and_emit_modifier_tap_status(&app_for_status, false);
                 return false;
             };
@@ -231,7 +290,8 @@ fn install_and_run(app: AppHandle) -> bool {
             current_loop.add_source(&loop_source, unsafe {
                 core_foundation::runloop::kCFRunLoopCommonModes
             });
-            tap.enable();
+            // A shortcut saved while the tap was being installed decides here.
+            set_tap_enabled(TAP_WANTED.load(Ordering::SeqCst));
             core_foundation::runloop::CFRunLoop::run_current();
             false
         }
@@ -285,7 +345,7 @@ fn shortcut_matches_keycode(shortcut: &str, keycode: i64) -> bool {
 mod tests {
     use super::{
         ShortcutRegistrationTarget, is_native_shortcut, shortcut_matches_keycode,
-        shortcut_registration_target,
+        shortcut_registration_target, tap_is_needed,
     };
 
     #[test]
@@ -338,5 +398,23 @@ mod tests {
             shortcut_registration_target(""),
             ShortcutRegistrationTarget::None
         );
+    }
+
+    /// The tap is an Accessibility request and sits in front of every
+    /// keystroke on the machine. Default install: a combo and an empty PTT,
+    /// so no tap and no permission prompt at startup.
+    #[test]
+    fn tap_is_only_needed_for_a_single_key_binding() {
+        assert!(!tap_is_needed(
+            "CommandOrControl+Shift+Space",
+            "CommandOrControl+Shift+D"
+        ));
+        assert!(!tap_is_needed("", ""));
+        assert!(tap_is_needed("Fn", "CommandOrControl+Shift+D"));
+        assert!(tap_is_needed(
+            "CommandOrControl+Shift+Space",
+            "ControlRight"
+        ));
+        assert!(tap_is_needed("F8", "Fn"));
     }
 }

--- a/src-tauri/src/permissions.rs
+++ b/src-tauri/src/permissions.rs
@@ -38,6 +38,14 @@ const TCC_INSERT_SETTLE: Duration = Duration::from_millis(400);
 /// claiming a permission the user has since revoked.
 static MICROPHONE_GRANT_OBSERVED: AtomicBool = AtomicBool::new(false);
 
+/// A system-audio grant reported by the tap this process mounted.
+///
+/// Same contract as `MICROPHONE_GRANT_OBSERVED`, for the one case the read
+/// path cannot answer: `TCCAccessPreflight` gone from a future macOS. Without
+/// it the row would stick on "Grant" for a permission the user has already
+/// given, which is the defect SOU-120 opened. In this process only.
+static SYSTEM_AUDIO_GRANT_OBSERVED: AtomicBool = AtomicBool::new(false);
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum PermState {
@@ -107,23 +115,28 @@ pub fn system_audio_status() -> PermState {
     system_audio_state_with(
         system_audio_supported(),
         audio_capture_preflight,
-        probe_system_audio,
+        SYSTEM_AUDIO_GRANT_OBSERVED.load(Ordering::Relaxed),
     )
 }
 
-/// `probe` only runs when the TCC SPI is unavailable (feature off, or the
-/// symbol gone from a future macOS). It answers by mounting a tap, which is
-/// what the read used to do and what the SPI exists to avoid, but it is an
-/// answer rather than a panic.
+/// A read never mounts a tap, not even when the SPI is missing. Mounting one
+/// would block the caller for two seconds and, on a fresh install, raise the
+/// AudioCapture prompt nobody asked for — on every 600 ms poll of the panel.
+/// With no SPI the honest answer is "not determined", narrowed by the one
+/// grant this process may have seen itself.
 pub fn system_audio_state_with(
     supported: bool,
     preflight: impl FnOnce() -> Option<PermState>,
-    probe: impl FnOnce() -> PermState,
+    observed_grant: bool,
 ) -> PermState {
     if !supported {
         return PermState::Unsupported;
     }
-    preflight().unwrap_or_else(probe)
+    match preflight() {
+        Some(PermState::Unknown) | None if observed_grant => PermState::Granted,
+        Some(state) => state,
+        None => PermState::Unknown,
+    }
 }
 
 /// Snapshot value for the microphone. The live status wins whenever the OS
@@ -422,10 +435,14 @@ fn open_microphone_settings() {}
 
 /// `Denied` also covers `Restricted` (parental controls, MDM): macOS never
 /// re-prompts once it has an answer, so the only move left is the pane.
+///
+/// `request_access` returns `None` when the completion block never reported:
+/// a dialog left open on screen is not a refusal, so that becomes `Unknown`
+/// and the panel's poll settles it once the user answers.
 fn request_microphone_with(
     status: impl FnOnce() -> PermState,
     open_settings: impl FnOnce(),
-    request_access: impl FnOnce() -> bool,
+    request_access: impl FnOnce() -> Option<bool>,
     has_device: impl FnOnce() -> bool,
 ) -> PermState {
     match status() {
@@ -434,13 +451,11 @@ fn request_microphone_with(
             open_settings();
             PermState::Denied
         }
-        _ => {
-            if request_access() {
-                granted_or_no_device(has_device)
-            } else {
-                PermState::Denied
-            }
-        }
+        _ => match request_access() {
+            Some(true) => granted_or_no_device(has_device),
+            Some(false) => PermState::Denied,
+            None => PermState::Unknown,
+        },
     }
 }
 
@@ -464,23 +479,25 @@ fn request_microphone() -> PermState {
         microphone_authorization_status,
         open_microphone_settings,
         || {
-            let granted = request_microphone_access();
-            if granted {
+            let answer = request_microphone_access();
+            if answer == Some(true) {
                 MICROPHONE_GRANT_OBSERVED.store(true, Ordering::Relaxed);
             }
-            granted
+            answer
         },
         has_microphone_device,
     )
 }
 
 /// The native prompt, and the only in-process event that reports its answer.
+/// `None` means no answer came back: the prompt could not be raised, or the
+/// user walked away from an open dialog.
 ///
 /// Going through the CoreAudio HAL instead (opening an input stream) raises
 /// the same dialog but leaves AVFoundation's cached status untouched, so the
 /// process keeps reading `NotDetermined` for the rest of its life.
 #[cfg(target_os = "macos")]
-fn request_microphone_access() -> bool {
+fn request_microphone_access() -> Option<bool> {
     use block2::RcBlock;
     use objc2::runtime::Bool;
     use objc2_av_foundation::{AVCaptureDevice, AVMediaTypeAudio};
@@ -501,16 +518,16 @@ fn request_microphone_access() -> bool {
         true
     });
     if !asked {
-        return false;
+        return None;
     }
-    // Generous: the user may leave the dialog on screen. The timeout only
-    // bounds a callback that never comes.
-    matches!(rx.recv_timeout(Duration::from_secs(300)), Ok(true))
+    // Generous: the user may leave the dialog on screen. A timeout is not a
+    // refusal, so it answers `None` and the panel's poll settles the row.
+    rx.recv_timeout(Duration::from_secs(300)).ok()
 }
 
 #[cfg(not(target_os = "macos"))]
-fn request_microphone_access() -> bool {
-    false
+fn request_microphone_access() -> Option<bool> {
+    None
 }
 
 // --- System audio (kTCCServiceAudioCapture) ---
@@ -570,6 +587,10 @@ fn audio_capture_preflight() -> Option<PermState> {
 /// AudioCap, Hyprnote and screenpipe all read the same three values out of
 /// this SPI. Anything else means the contract moved, and an unknown number
 /// must not be read as a verdict.
+///
+/// It does not validate the service name: an unknown service answers 1
+/// (denied), not an out-of-range value. The only signal that the SPI itself
+/// is gone is a null `dlsym`, which `tcc_preflight` handles.
 #[cfg(any(test, all(target_os = "macos", feature = "private-tcc")))]
 fn tcc_preflight_state(raw: i32) -> Option<PermState> {
     match raw {
@@ -583,9 +604,10 @@ fn tcc_preflight_state(raw: i32) -> Option<PermState> {
     }
 }
 
-/// Mounts a tap for two seconds. This is the request path (the tap is what
-/// raises the native prompt) and the read fallback when the TCC SPI is
-/// unavailable. Never call it to render a status while the SPI answers.
+/// Mounts a tap for two seconds. This is the *request* path and nothing else:
+/// the tap is what raises the native prompt. It must never run to render a
+/// status, with or without the SPI — that is what created and tore down a
+/// `Souffle Tap` aggregate on every poll (SOU-124 AC7).
 #[cfg(target_os = "macos")]
 pub fn probe_system_audio() -> PermState {
     use ringbuf::HeapRb;
@@ -607,12 +629,37 @@ pub fn probe_system_audio() -> PermState {
     PermState::Unsupported
 }
 
+/// Raise the AudioCapture prompt by mounting the tap, then let TCC say what
+/// the user answered.
+///
+/// The tap succeeding is not a grant: `AudioHardwareCreateProcessTap` and
+/// `AudioDeviceStart` return `noErr` on a refusal and deliver silence, which
+/// is why the row used to flash "Granted" right after a "Don't Allow".
+fn request_system_audio() -> PermState {
+    request_system_audio_with(probe_system_audio, audio_capture_preflight)
+}
+
+fn request_system_audio_with(
+    probe: impl FnOnce() -> PermState,
+    preflight: impl FnOnce() -> Option<PermState>,
+) -> PermState {
+    let probed = probe();
+    if probed == PermState::Unsupported {
+        return probed;
+    }
+    let state = preflight().unwrap_or(probed);
+    if state == PermState::Granted {
+        SYSTEM_AUDIO_GRANT_OBSERVED.store(true, Ordering::Relaxed);
+    }
+    state
+}
+
 /// Trigger the native prompt (or open Settings) for one permission and return
 /// the resulting state.
 pub fn request(kind: PermissionKind) -> PermState {
     match kind {
         PermissionKind::Microphone => request_microphone(),
-        PermissionKind::SystemAudio => probe_system_audio(),
+        PermissionKind::SystemAudio => request_system_audio(),
         PermissionKind::Accessibility => {
             open_accessibility_settings();
             if accessibility_granted() {
@@ -732,7 +779,7 @@ mod tests {
             || opened.set(true),
             || {
                 asked.set(true);
-                true
+                Some(true)
             },
             || true,
         );
@@ -754,7 +801,7 @@ mod tests {
             || opened.set(true),
             || {
                 asked.set(true);
-                true
+                Some(true)
             },
             || true,
         );
@@ -769,17 +816,31 @@ mod tests {
         let result = request_microphone_with(
             || PermState::Unknown,
             || panic!("the request answers, so Settings must stay shut"),
-            || false,
+            || Some(false),
             || true,
         );
         assert_eq!(result, PermState::Denied);
+    }
+
+    /// A dialog the user walked away from is not a refusal. Reporting Denied
+    /// would paint the row red and offer System Settings for a permission
+    /// that is still merely unanswered.
+    #[test]
+    fn a_request_that_never_answers_is_unknown_not_denied() {
+        let result = request_microphone_with(
+            || PermState::Unknown,
+            || panic!("an unanswered prompt must not open Settings"),
+            || None,
+            || true,
+        );
+        assert_eq!(result, PermState::Unknown);
     }
 
     /// A grant with nothing plugged in is not a permission problem, and the
     /// UI says something else about it.
     #[test]
     fn a_grant_without_an_input_device_is_no_device() {
-        let result = request_microphone_with(|| PermState::Unknown, || {}, || true, || false);
+        let result = request_microphone_with(|| PermState::Unknown, || {}, || Some(true), || false);
         assert_eq!(result, PermState::NoDevice);
     }
 
@@ -907,6 +968,7 @@ mod tests {
         );
     }
 
+    /// AC7: the SPI answers on its own, and its verdict is the row.
     #[test]
     fn system_audio_reads_the_tcc_preflight_without_mounting_a_tap() {
         for (raw, expected) in [
@@ -914,31 +976,71 @@ mod tests {
             (PermState::Denied, PermState::Denied),
             (PermState::Unknown, PermState::Unknown),
         ] {
-            let state = system_audio_state_with(
-                true,
-                || Some(raw),
-                || panic!("a status read must not mount a tap when the SPI answered"),
-            );
-            assert_eq!(state, expected);
+            assert_eq!(system_audio_state_with(true, || Some(raw), false), expected);
         }
     }
 
-    /// AC8: a missing `TCCAccessPreflight` degrades to the tap probe. The
-    /// arm is unreachable on a machine that has the symbol, so it is the
-    /// injected `None` that keeps it honest.
+    /// AC8: a missing `TCCAccessPreflight` reads as "not determined". It must
+    /// not fall back to the tap: a read that mounts a tap blocks the poll for
+    /// two seconds and raises the prompt the user never asked for.
     #[test]
-    fn system_audio_falls_back_to_the_probe_when_the_spi_is_missing() {
-        let probed = Cell::new(false);
-        let state = system_audio_state_with(
-            true,
-            || None,
-            || {
-                probed.set(true);
-                PermState::Granted
-            },
+    fn system_audio_without_the_spi_reads_unknown_and_never_probes() {
+        assert_eq!(
+            system_audio_state_with(true, || None, false),
+            PermState::Unknown,
+            "a null dlsym must degrade to Unknown, not panic and not probe"
         );
-        assert_eq!(state, PermState::Granted);
-        assert!(probed.get(), "a null dlsym must fall back, not panic");
+    }
+
+    /// The one case the read cannot answer on its own: no SPI, but this
+    /// process mounted the tap itself and saw the grant. Without this the row
+    /// would stick on "Grant" forever (SOU-120).
+    #[test]
+    fn system_audio_uses_a_grant_this_process_observed() {
+        assert_eq!(
+            system_audio_state_with(true, || None, true),
+            PermState::Granted
+        );
+        assert_eq!(
+            system_audio_state_with(true, || Some(PermState::Unknown), true),
+            PermState::Granted
+        );
+        assert_eq!(
+            system_audio_state_with(true, || Some(PermState::Denied), true),
+            PermState::Denied,
+            "a revoke read from TCC must beat a grant seen earlier"
+        );
+    }
+
+    /// CoreAudio returns noErr and silence when the user refuses, so a tap
+    /// that mounted is not a grant. TCC has the answer.
+    #[test]
+    fn a_refused_system_audio_prompt_is_denied_even_though_the_tap_mounted() {
+        assert_eq!(
+            request_system_audio_with(|| PermState::Granted, || Some(PermState::Denied)),
+            PermState::Denied
+        );
+        assert_eq!(
+            request_system_audio_with(|| PermState::Granted, || Some(PermState::Granted)),
+            PermState::Granted
+        );
+    }
+
+    /// With no SPI the probe is all there is, and an unsupported OS is not
+    /// asked at all.
+    #[test]
+    fn system_audio_request_falls_back_to_the_probe_and_skips_unsupported() {
+        assert_eq!(
+            request_system_audio_with(|| PermState::Granted, || None),
+            PermState::Granted
+        );
+        assert_eq!(
+            request_system_audio_with(
+                || PermState::Unsupported,
+                || panic!("an unsupported OS must not be preflighted"),
+            ),
+            PermState::Unsupported
+        );
     }
 
     #[test]
@@ -947,7 +1049,7 @@ mod tests {
             system_audio_state_with(
                 false,
                 || panic!("an unsupported OS must not be asked"),
-                || panic!("an unsupported OS must not be probed"),
+                true
             ),
             PermState::Unsupported
         );

--- a/src-tauri/src/permissions.rs
+++ b/src-tauri/src/permissions.rs
@@ -28,11 +28,6 @@ use crate::db::Database;
 /// list (empty, or a differently-signed Soufflé already ticked).
 const TCC_INSERT_SETTLE: Duration = Duration::from_millis(400);
 
-/// Last observed system-audio tap permission. There is no read-only TCC
-/// API for Core Audio taps, so a successful probe is remembered and the
-/// snapshot returns it without mounting a tap (SOU-120).
-const SYSTEM_AUDIO_PERMISSION_KEY: &str = "system_audio_permission";
-
 /// Last observed microphone permission. `AVCaptureDevice`'s
 /// `authorizationStatus` is answered from a per-process cache that is filled
 /// on the first call and never refreshed: a process that asks before the
@@ -87,22 +82,15 @@ pub struct RepairAccessibilityResult {
     pub prompt_shown: bool,
 }
 
-/// Cheap, non-prompting snapshot for the initial onboarding render.
-///
-/// System audio has no read-only TCC API. Probing mounts a Core Audio tap
-/// and would prompt on a first launch, so the snapshot never probes: it
-/// returns a remembered `Granted`/`Denied` after a user-initiated probe,
-/// and `Unknown` until then (SOU-120).
+/// Cheap, non-prompting snapshot for the initial onboarding render. No
+/// entry in it opens a device: every capability answers from a status API.
 pub fn snapshot(db: &Database) -> PermissionStatus {
     PermissionStatus {
         microphone: microphone_snapshot_state(
             microphone_authorization_status(),
             load_remembered_microphone(db),
         ),
-        system_audio: system_audio_snapshot_state(
-            system_audio_supported(),
-            load_remembered_system_audio(db),
-        ),
+        system_audio: system_audio_status(),
         accessibility: if accessibility_granted() {
             PermState::Granted
         } else {
@@ -114,17 +102,28 @@ pub fn snapshot(db: &Database) -> PermissionStatus {
     }
 }
 
-/// Snapshot value for system audio given platform support and a remembered
-/// probe result. Never mounts a tap.
-pub fn system_audio_snapshot_state(supported: bool, remembered: Option<PermState>) -> PermState {
+/// Live system-audio status, read without creating any audio object.
+pub fn system_audio_status() -> PermState {
+    system_audio_state_with(
+        system_audio_supported(),
+        audio_capture_preflight,
+        probe_system_audio,
+    )
+}
+
+/// `probe` only runs when the TCC SPI is unavailable (feature off, or the
+/// symbol gone from a future macOS). It answers by mounting a tap, which is
+/// what the read used to do and what the SPI exists to avoid, but it is an
+/// answer rather than a panic.
+pub fn system_audio_state_with(
+    supported: bool,
+    preflight: impl FnOnce() -> Option<PermState>,
+    probe: impl FnOnce() -> PermState,
+) -> PermState {
     if !supported {
         return PermState::Unsupported;
     }
-    match remembered {
-        Some(PermState::Granted) => PermState::Granted,
-        Some(PermState::Denied) => PermState::Denied,
-        _ => PermState::Unknown,
-    }
+    preflight().unwrap_or_else(probe)
 }
 
 /// Snapshot value for the microphone. The live status wins whenever the OS
@@ -158,25 +157,6 @@ pub fn remember_microphone(db: &Database, state: PermState) {
         && let Err(e) = db.set_setting(MICROPHONE_PERMISSION_KEY, &raw)
     {
         tracing::warn!(error = %e, "Failed to persist microphone permission");
-    }
-}
-
-pub fn load_remembered_system_audio(db: &Database) -> Option<PermState> {
-    let raw = db.get_setting(SYSTEM_AUDIO_PERMISSION_KEY).ok().flatten()?;
-    match serde_json::from_str::<PermState>(&raw) {
-        Ok(state @ (PermState::Granted | PermState::Denied)) => Some(state),
-        _ => None,
-    }
-}
-
-pub fn remember_system_audio(db: &Database, state: PermState) {
-    if !matches!(state, PermState::Granted | PermState::Denied) {
-        return;
-    }
-    if let Ok(raw) = serde_json::to_string(&state)
-        && let Err(e) = db.set_setting(SYSTEM_AUDIO_PERMISSION_KEY, &raw)
-    {
-        tracing::warn!(error = %e, "Failed to persist system audio permission");
     }
 }
 
@@ -590,8 +570,78 @@ pub fn probe_microphone() -> PermState {
     }
 }
 
-// --- System audio (probe via a short-lived Core Audio tap) ---
+// --- System audio (kTCCServiceAudioCapture) ---
 
+/// `TCCAccessPreflight(service, NULL)`, from the private TCC framework.
+/// CoreAudio ships no permission query for process taps, so this SPI is the
+/// only way to read the status without mounting one. Unlike the public
+/// preflight APIs it is an XPC round trip to tccd on every call, so it never
+/// answers from a per-process cache.
+#[cfg(all(target_os = "macos", feature = "private-tcc"))]
+fn tcc_preflight(service: &str) -> Option<PermState> {
+    use objc2_core_foundation::{CFRetained, CFString};
+    use std::ffi::c_void;
+    use std::sync::OnceLock;
+
+    type TccAccessPreflight = unsafe extern "C" fn(*const c_void, *const c_void) -> i32;
+
+    static SYMBOL: OnceLock<Option<TccAccessPreflight>> = OnceLock::new();
+    let preflight = (*SYMBOL.get_or_init(|| unsafe {
+        let handle = libc::dlopen(
+            c"/System/Library/PrivateFrameworks/TCC.framework/Versions/A/TCC".as_ptr(),
+            libc::RTLD_LAZY,
+        );
+        if handle.is_null() {
+            tracing::warn!("TCC.framework not loadable; falling back to the tap probe");
+            return None;
+        }
+        let symbol = libc::dlsym(handle, c"TCCAccessPreflight".as_ptr());
+        if symbol.is_null() {
+            tracing::warn!("TCCAccessPreflight missing; falling back to the tap probe");
+            return None;
+        }
+        Some(std::mem::transmute::<*mut c_void, TccAccessPreflight>(
+            symbol,
+        ))
+    }))?;
+
+    let service = CFString::from_str(service);
+    let raw = unsafe {
+        preflight(
+            CFRetained::as_ptr(&service).as_ptr().cast(),
+            std::ptr::null(),
+        )
+    };
+    tcc_preflight_state(raw)
+}
+
+#[cfg(not(all(target_os = "macos", feature = "private-tcc")))]
+fn tcc_preflight(_service: &str) -> Option<PermState> {
+    None
+}
+
+fn audio_capture_preflight() -> Option<PermState> {
+    tcc_preflight("kTCCServiceAudioCapture")
+}
+
+/// AudioCap, Hyprnote and screenpipe all read the same three values out of
+/// this SPI. Anything else means the contract moved, and an unknown number
+/// must not be read as a verdict.
+fn tcc_preflight_state(raw: i32) -> Option<PermState> {
+    match raw {
+        0 => Some(PermState::Granted),
+        1 => Some(PermState::Denied),
+        2 => Some(PermState::Unknown),
+        other => {
+            tracing::warn!(value = other, "Unexpected TCCAccessPreflight value");
+            None
+        }
+    }
+}
+
+/// Mounts a tap for two seconds. This is the request path (the tap is what
+/// raises the native prompt) and the read fallback when the TCC SPI is
+/// unavailable. Never call it to render a status while the SPI answers.
 #[cfg(target_os = "macos")]
 pub fn probe_system_audio() -> PermState {
     use ringbuf::HeapRb;
@@ -890,66 +940,61 @@ mod tests {
     }
 
     #[test]
-    fn system_audio_snapshot_is_unknown_until_a_probe_succeeds() {
-        assert_eq!(system_audio_snapshot_state(true, None), PermState::Unknown);
-        assert_eq!(
-            system_audio_snapshot_state(true, Some(PermState::Unknown)),
-            PermState::Unknown
-        );
+    fn system_audio_reads_the_tcc_preflight_without_mounting_a_tap() {
+        for (raw, expected) in [
+            (PermState::Granted, PermState::Granted),
+            (PermState::Denied, PermState::Denied),
+            (PermState::Unknown, PermState::Unknown),
+        ] {
+            let state = system_audio_state_with(
+                true,
+                || Some(raw),
+                || panic!("a status read must not mount a tap when the SPI answered"),
+            );
+            assert_eq!(state, expected);
+        }
     }
 
+    /// AC8: a missing `TCCAccessPreflight` degrades to the tap probe. The
+    /// arm is unreachable on a machine that has the symbol, so it is the
+    /// injected `None` that keeps it honest.
     #[test]
-    fn system_audio_snapshot_returns_remembered_granted_without_probing() {
-        assert_eq!(
-            system_audio_snapshot_state(true, Some(PermState::Granted)),
-            PermState::Granted
-        );
-    }
-
-    #[test]
-    fn system_audio_snapshot_returns_remembered_denied() {
-        assert_eq!(
-            system_audio_snapshot_state(true, Some(PermState::Denied)),
-            PermState::Denied
-        );
-    }
-
-    #[test]
-    fn system_audio_snapshot_stays_unsupported_even_if_something_was_remembered() {
-        assert_eq!(
-            system_audio_snapshot_state(false, Some(PermState::Granted)),
-            PermState::Unsupported
-        );
-        assert_eq!(
-            system_audio_snapshot_state(false, None),
-            PermState::Unsupported
-        );
-    }
-
-    #[test]
-    fn system_audio_permission_round_trips_through_the_db() {
-        let (db, _dir) = crate::test_helpers::fixtures::test_db();
-        assert_eq!(load_remembered_system_audio(&db), None);
-
-        remember_system_audio(&db, PermState::Granted);
-        assert_eq!(load_remembered_system_audio(&db), Some(PermState::Granted));
-        assert_eq!(
-            snapshot(&db).system_audio,
-            if system_audio_supported() {
+    fn system_audio_falls_back_to_the_probe_when_the_spi_is_missing() {
+        let probed = Cell::new(false);
+        let state = system_audio_state_with(
+            true,
+            || None,
+            || {
+                probed.set(true);
                 PermState::Granted
-            } else {
-                PermState::Unsupported
-            }
+            },
         );
+        assert_eq!(state, PermState::Granted);
+        assert!(probed.get(), "a null dlsym must fall back, not panic");
+    }
 
-        remember_system_audio(&db, PermState::Denied);
-        assert_eq!(load_remembered_system_audio(&db), Some(PermState::Denied));
-
-        remember_system_audio(&db, PermState::Unknown);
+    #[test]
+    fn system_audio_stays_unsupported_before_macos_14_4() {
         assert_eq!(
-            load_remembered_system_audio(&db),
-            Some(PermState::Denied),
-            "Unknown must not clobber a remembered answer"
+            system_audio_state_with(
+                false,
+                || panic!("an unsupported OS must not be asked"),
+                || panic!("an unsupported OS must not be probed"),
+            ),
+            PermState::Unsupported
+        );
+    }
+
+    /// 0/1/2 is the mapping AudioCap, Hyprnote and screenpipe agree on.
+    #[test]
+    fn tcc_preflight_values_map_to_states() {
+        assert_eq!(tcc_preflight_state(0), Some(PermState::Granted));
+        assert_eq!(tcc_preflight_state(1), Some(PermState::Denied));
+        assert_eq!(tcc_preflight_state(2), Some(PermState::Unknown));
+        assert_eq!(
+            tcc_preflight_state(-1),
+            None,
+            "an unknown value must fall back, not be read as a verdict"
         );
     }
 }

--- a/src-tauri/src/permissions.rs
+++ b/src-tauri/src/permissions.rs
@@ -1,13 +1,14 @@
 //! macOS permission detection + prompting for the startup onboarding.
 //!
-//! The microphone has a real read-only status API (`AVCaptureDevice`'s
-//! `authorizationStatus`), so `request` checks it first and only falls back
-//! to probing (briefly opening the device, which also triggers the TCC
-//! prompt) when the OS hasn't decided yet. There is no equivalent for Core
-//! Audio taps, so system audio is still probe-only. Accessibility (needed
-//! for the synthesized Cmd+V paste and for the native single-key shortcut
-//! tap) has its own cheap check (`AXIsProcessTrusted`), and is granted only
-//! via System Settings, so its "request" just opens the relevant pane.
+//! Reading a status never opens a device. The microphone answers from
+//! `AVCaptureDevice`'s `authorizationStatus` and is asked for through
+//! `requestAccessForMediaType:completionHandler:`, whose completion block is
+//! the only in-process signal that carries a fresh answer. System audio is
+//! read through TCC's `TCCAccessPreflight` SPI and asked for by mounting the
+//! tap. Accessibility (needed for the synthesized Cmd+V paste and for the
+//! native single-key shortcut tap) has its own cheap check
+//! (`AXIsProcessTrusted`), and is granted only via System Settings, so its
+//! "request" just opens the relevant pane.
 //!
 //! Input Monitoring is deliberately absent. An active `CGEventTap` is
 //! authorized by Accessibility, which subsumes the listen right, so the
@@ -16,26 +17,26 @@
 //! record, so asking could not even create the row it promised.
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
-
-use crate::db::Database;
 
 /// Pause between the TCC insert call and `open` of System Settings. The
 /// insert is asynchronous; opening the pane in the same turn shows a stale
 /// list (empty, or a differently-signed Soufflé already ticked).
 const TCC_INSERT_SETTLE: Duration = Duration::from_millis(400);
 
-/// Last observed microphone permission. `AVCaptureDevice`'s
-/// `authorizationStatus` is answered from a per-process cache that is filled
-/// on the first call and never refreshed: a process that asks before the
-/// user answers the prompt keeps being told `NotDetermined` for the rest of
-/// its life, even though TCC has recorded the grant. A probe that saw real
-/// audio is remembered here so the snapshot can still be truthful after the
-/// permissions window is closed and reopened.
-const MICROPHONE_PERMISSION_KEY: &str = "microphone_permission";
+/// A microphone grant reported by the `requestAccess` completion block.
+///
+/// `AVCaptureDevice`'s `authorizationStatus` is answered from a per-process
+/// cache filled on the first call. AVFoundation's own request path refreshes
+/// it, so this flag should never be needed; it exists because the panel must
+/// not be able to stick on "Grant" if it ever is. In this process only: a
+/// grant is not a fact the app owns, and a persisted copy could only go on
+/// claiming a permission the user has since revoked.
+static MICROPHONE_GRANT_OBSERVED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -84,11 +85,11 @@ pub struct RepairAccessibilityResult {
 
 /// Cheap, non-prompting snapshot for the initial onboarding render. No
 /// entry in it opens a device: every capability answers from a status API.
-pub fn snapshot(db: &Database) -> PermissionStatus {
+pub fn snapshot() -> PermissionStatus {
     PermissionStatus {
         microphone: microphone_snapshot_state(
             microphone_authorization_status(),
-            load_remembered_microphone(db),
+            MICROPHONE_GRANT_OBSERVED.load(Ordering::Relaxed),
         ),
         system_audio: system_audio_status(),
         accessibility: if accessibility_granted() {
@@ -127,36 +128,12 @@ pub fn system_audio_state_with(
 }
 
 /// Snapshot value for the microphone. The live status wins whenever the OS
-/// has decided; a remembered grant covers the one case it cannot answer,
-/// a cached `NotDetermined` taken before the user said yes.
-pub fn microphone_snapshot_state(live: PermState, remembered: Option<PermState>) -> PermState {
+/// has decided; a grant seen by this process covers the one case it cannot
+/// answer, a cached `NotDetermined` taken before the user said yes.
+pub fn microphone_snapshot_state(live: PermState, observed_grant: bool) -> PermState {
     match live {
-        PermState::Unknown => remembered.unwrap_or(PermState::Unknown),
-        decided => decided,
-    }
-}
-
-pub fn load_remembered_microphone(db: &Database) -> Option<PermState> {
-    let raw = db.get_setting(MICROPHONE_PERMISSION_KEY).ok().flatten()?;
-    match serde_json::from_str::<PermState>(&raw) {
-        Ok(PermState::Granted) => Some(PermState::Granted),
-        _ => None,
-    }
-}
-
-/// Only a grant is worth remembering. The probe reports `Denied` both for a
-/// real refusal and for a microphone CoreAudio failed to start, while a real
-/// refusal is already reported truthfully by `AVCaptureDevice` on the next
-/// launch, so persisting a denial could only turn a transient audio failure
-/// into a sticky one.
-pub fn remember_microphone(db: &Database, state: PermState) {
-    if state != PermState::Granted {
-        return;
-    }
-    if let Ok(raw) = serde_json::to_string(&state)
-        && let Err(e) = db.set_setting(MICROPHONE_PERMISSION_KEY, &raw)
-    {
-        tracing::warn!(error = %e, "Failed to persist microphone permission");
+        PermState::Unknown if observed_grant => PermState::Granted,
+        state => state,
     }
 }
 
@@ -444,25 +421,37 @@ fn open_microphone_settings() {
 #[cfg(not(target_os = "macos"))]
 fn open_microphone_settings() {}
 
+/// `Denied` also covers `Restricted` (parental controls, MDM): macOS never
+/// re-prompts once it has an answer, so the only move left is the pane.
 fn request_microphone_with(
     status: impl FnOnce() -> PermState,
     open_settings: impl FnOnce(),
-    probe: impl FnOnce() -> PermState,
+    request_access: impl FnOnce() -> bool,
     has_device: impl FnOnce() -> bool,
 ) -> PermState {
     match status() {
-        PermState::Granted => {
-            if has_device() {
-                PermState::Granted
-            } else {
-                PermState::NoDevice
-            }
-        }
+        PermState::Granted => granted_or_no_device(has_device),
         PermState::Denied => {
             open_settings();
             PermState::Denied
         }
-        _ => probe(),
+        _ => {
+            if request_access() {
+                granted_or_no_device(has_device)
+            } else {
+                PermState::Denied
+            }
+        }
+    }
+}
+
+/// TCC access and a usable input device are different problems with
+/// different fixes, so a grant with nothing plugged in is not `Granted`.
+fn granted_or_no_device(has_device: impl FnOnce() -> bool) -> PermState {
+    if has_device() {
+        PermState::Granted
+    } else {
+        PermState::NoDevice
     }
 }
 
@@ -475,99 +464,54 @@ fn request_microphone() -> PermState {
     request_microphone_with(
         microphone_authorization_status,
         open_microphone_settings,
-        probe_microphone,
+        || {
+            let granted = request_microphone_access();
+            if granted {
+                MICROPHONE_GRANT_OBSERVED.store(true, Ordering::Relaxed);
+            }
+            granted
+        },
         has_microphone_device,
     )
 }
 
-fn no_op_stream_error(_e: cpal::StreamError) {}
+/// The native prompt, and the only in-process event that reports its answer.
+///
+/// Going through the CoreAudio HAL instead (opening an input stream) raises
+/// the same dialog but leaves AVFoundation's cached status untouched, so the
+/// process keeps reading `NotDetermined` for the rest of its life.
+#[cfg(target_os = "macos")]
+fn request_microphone_access() -> bool {
+    use block2::RcBlock;
+    use objc2::runtime::Bool;
+    use objc2_av_foundation::{AVCaptureDevice, AVMediaTypeAudio};
 
-/// Briefly open the default input device and wait for real audio callbacks.
-/// This is what actually triggers the TCC prompt the first time; afterwards
-/// `request_microphone` skips straight to this only when the OS reports
-/// `NotDetermined`.
-pub fn probe_microphone() -> PermState {
-    use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::time::Duration;
-
-    let host = cpal::default_host();
-    let Some(device) = host.default_input_device() else {
-        return PermState::NoDevice;
-    };
-    let Ok(config) = device.default_input_config() else {
-        return PermState::NoDevice;
-    };
-
-    let got = Arc::new(AtomicBool::new(false));
-    let sample_format = config.sample_format();
-    let stream_config: cpal::StreamConfig = config.into();
-
-    let stream = match sample_format {
-        cpal::SampleFormat::F32 => {
-            let got = Arc::clone(&got);
-            device.build_input_stream(
-                &stream_config,
-                move |_d: &[f32], _: &_| got.store(true, Ordering::Relaxed),
-                no_op_stream_error,
-                None,
-            )
-        }
-        cpal::SampleFormat::I16 => {
-            let got = Arc::clone(&got);
-            device.build_input_stream(
-                &stream_config,
-                move |_d: &[i16], _: &_| got.store(true, Ordering::Relaxed),
-                no_op_stream_error,
-                None,
-            )
-        }
-        cpal::SampleFormat::U16 => {
-            let got = Arc::clone(&got);
-            device.build_input_stream(
-                &stream_config,
-                move |_d: &[u16], _: &_| got.store(true, Ordering::Relaxed),
-                no_op_stream_error,
-                None,
-            )
-        }
-        _ => return PermState::Denied,
-    };
-
-    let stream = match stream {
-        Ok(s) => s,
-        Err(cpal::BuildStreamError::DeviceNotAvailable) => return PermState::NoDevice,
-        Err(_) => return PermState::Denied,
-    };
-    if let Err(e) = stream.play() {
-        match e {
-            cpal::PlayStreamError::DeviceNotAvailable => return PermState::NoDevice,
-            _ => return PermState::Denied,
-        }
+    let (tx, rx) = std::sync::mpsc::channel::<bool>();
+    // A TCC request has to be raised from the main thread (SOU-122), and
+    // `request` runs on a blocking pool thread. Only the call hops: it
+    // returns as soon as the dialog is up, and the completion block fires
+    // later on an arbitrary queue.
+    let asked = on_main(move || unsafe {
+        let Some(media_type) = AVMediaTypeAudio else {
+            return false;
+        };
+        let block = RcBlock::new(move |granted: Bool| {
+            let _ = tx.send(granted.as_bool());
+        });
+        AVCaptureDevice::requestAccessForMediaType_completionHandler(media_type, &block);
+        true
+    });
+    if !asked {
+        return false;
     }
+    // Generous: the user may leave the dialog on screen. The timeout only
+    // bounds a callback that never comes.
+    matches!(rx.recv_timeout(Duration::from_secs(300)), Ok(true))
+}
 
-    // Wait up to 15s for a callback. On first launch the macOS TCC dialog is
-    // still on screen when this probe starts, so the window must outlast the
-    // time it takes the user to read it and click Allow/Deny. When permission
-    // was already granted the early exit as soon as data arrives keeps this fast.
-    for _ in 0..150 {
-        if got.load(Ordering::Relaxed) {
-            break;
-        }
-        std::thread::sleep(Duration::from_millis(100));
-    }
-    // Pause then drop so the probe's AudioUnit is actually disposed. cpal
-    // 0.15 leaked StreamInner on macOS, which would leave a Bluetooth
-    // headset in HFP/mono after the onboarding mic check.
-    let _ = stream.pause();
-    drop(stream);
-
-    if got.load(Ordering::Relaxed) {
-        PermState::Granted
-    } else {
-        PermState::Denied
-    }
+#[cfg(not(target_os = "macos"))]
+fn request_microphone_access() -> bool {
+    false
 }
 
 // --- System audio (kTCCServiceAudioCapture) ---
@@ -775,59 +719,78 @@ mod tests {
         assert_eq!(no_device, "\"no_device\"");
     }
 
-    /// A settled `Denied` must open Settings and must NOT re-run the probe:
-    /// macOS never re-prompts after a deny, so probing again would just
-    /// burn 15s to land on the same answer.
+    /// AC4: a settled `Denied` (or `Restricted`) opens Settings and must NOT
+    /// ask again. macOS never re-prompts after an answer, so a request would
+    /// return the same verdict without showing anything.
     #[test]
-    fn denied_opens_settings_without_probing() {
+    fn denied_opens_settings_without_asking() {
         let opened = Cell::new(false);
-        let probed = Cell::new(false);
+        let asked = Cell::new(false);
 
         let result = request_microphone_with(
             || PermState::Denied,
             || opened.set(true),
             || {
-                probed.set(true);
-                PermState::Granted
+                asked.set(true);
+                true
             },
             || true,
         );
 
         assert_eq!(result, PermState::Denied);
         assert!(opened.get(), "Denied must open System Settings");
-        assert!(!probed.get(), "Denied must not run the probe");
+        assert!(!asked.get(), "Denied must not request access");
     }
 
-    /// `NotDetermined` (modeled as `Unknown` here) still probes: that's what
-    /// shows the TCC dialog the first time.
+    /// AC3: `NotDetermined` (modeled as `Unknown` here) goes through
+    /// `requestAccess`, and the completion block's answer is the verdict.
     #[test]
-    fn not_determined_probes_without_opening_settings() {
+    fn not_determined_requests_access_without_opening_settings() {
         let opened = Cell::new(false);
-        let probed = Cell::new(false);
+        let asked = Cell::new(false);
 
         let result = request_microphone_with(
             || PermState::Unknown,
             || opened.set(true),
             || {
-                probed.set(true);
-                PermState::Granted
+                asked.set(true);
+                true
             },
             || true,
         );
 
         assert_eq!(result, PermState::Granted);
         assert!(!opened.get(), "NotDetermined must not open Settings");
-        assert!(probed.get(), "NotDetermined must run the probe");
+        assert!(asked.get(), "NotDetermined must request access");
+    }
+
+    #[test]
+    fn a_refused_request_is_denied() {
+        let result = request_microphone_with(
+            || PermState::Unknown,
+            || panic!("the request answers, so Settings must stay shut"),
+            || false,
+            || true,
+        );
+        assert_eq!(result, PermState::Denied);
+    }
+
+    /// A grant with nothing plugged in is not a permission problem, and the
+    /// UI says something else about it.
+    #[test]
+    fn a_grant_without_an_input_device_is_no_device() {
+        let result = request_microphone_with(|| PermState::Unknown, || {}, || true, || false);
+        assert_eq!(result, PermState::NoDevice);
     }
 
     /// Already-authorized short-circuits to `Granted` without touching
-    /// Settings or the probe.
+    /// Settings or raising a prompt.
     #[test]
     fn granted_short_circuits() {
         let result = request_microphone_with(
             || PermState::Granted,
             || panic!("Granted must not open Settings"),
-            || panic!("Granted must not probe"),
+            || panic!("Granted must not request access"),
             || true,
         );
         assert_eq!(result, PermState::Granted);
@@ -896,47 +859,52 @@ mod tests {
     #[test]
     fn microphone_snapshot_prefers_the_live_status_when_the_os_has_decided() {
         assert_eq!(
-            microphone_snapshot_state(PermState::Denied, Some(PermState::Granted)),
+            microphone_snapshot_state(PermState::Denied, true),
             PermState::Denied,
-            "a revoke observed on a fresh process must beat the remembered grant"
+            "a revoke read on this process must beat a grant seen earlier"
         );
         assert_eq!(
-            microphone_snapshot_state(PermState::Granted, None),
+            microphone_snapshot_state(PermState::Granted, false),
             PermState::Granted
         );
     }
 
+    /// AC5: the reported failure was a process that read NotDetermined two
+    /// seconds before the user granted the permission and kept returning it
+    /// from the AVFoundation cache, so the row showed "Grant" forever. A
+    /// grant the request callback reported wins over that stale read.
     #[test]
-    fn microphone_snapshot_falls_back_to_a_remembered_grant() {
-        // The reported failure: the process read NotDetermined two seconds
-        // before the user granted the permission and kept returning it from
-        // the AVFoundation cache, so the row showed "Grant" forever.
+    fn microphone_snapshot_uses_a_grant_this_process_observed() {
         assert_eq!(
-            microphone_snapshot_state(PermState::Unknown, Some(PermState::Granted)),
+            microphone_snapshot_state(PermState::Unknown, true),
             PermState::Granted
         );
         assert_eq!(
-            microphone_snapshot_state(PermState::Unknown, None),
+            microphone_snapshot_state(PermState::Unknown, false),
             PermState::Unknown
         );
     }
 
+    /// AC6: the two permission rows are gone from the code, and a database
+    /// still carrying them opens and reads back like any other.
     #[test]
-    fn microphone_grant_round_trips_through_the_db() {
-        let (db, _dir) = crate::test_helpers::fixtures::test_db();
-        assert_eq!(load_remembered_microphone(&db), None);
+    fn a_database_carrying_the_removed_permission_rows_still_loads() {
+        let (db, dir) = crate::test_helpers::fixtures::test_db();
+        db.set_setting("microphone_permission", "\"granted\"")
+            .unwrap();
+        db.set_setting("system_audio_permission", "\"denied\"")
+            .unwrap();
+        drop(db);
 
-        remember_microphone(&db, PermState::Granted);
-        assert_eq!(load_remembered_microphone(&db), Some(PermState::Granted));
-
-        for transient in [PermState::Denied, PermState::NoDevice, PermState::Unknown] {
-            remember_microphone(&db, transient);
-            assert_eq!(
-                load_remembered_microphone(&db),
-                Some(PermState::Granted),
-                "{transient:?} must not clobber a remembered grant"
-            );
-        }
+        let db = crate::db::Database::open(&dir.path().join("test.db"))
+            .expect("a database holding the old permission rows must still open");
+        let settings = db.get_all_settings().expect("settings must read back");
+        assert!(
+            settings
+                .iter()
+                .any(|(key, _)| key == "microphone_permission"),
+            "the rows are left in place, just unread"
+        );
     }
 
     #[test]

--- a/src-tauri/src/permissions.rs
+++ b/src-tauri/src/permissions.rs
@@ -33,6 +33,15 @@ const TCC_INSERT_SETTLE: Duration = Duration::from_millis(400);
 /// snapshot returns it without mounting a tap (SOU-120).
 const SYSTEM_AUDIO_PERMISSION_KEY: &str = "system_audio_permission";
 
+/// Last observed microphone permission. `AVCaptureDevice`'s
+/// `authorizationStatus` is answered from a per-process cache that is filled
+/// on the first call and never refreshed: a process that asks before the
+/// user answers the prompt keeps being told `NotDetermined` for the rest of
+/// its life, even though TCC has recorded the grant. A probe that saw real
+/// audio is remembered here so the snapshot can still be truthful after the
+/// permissions window is closed and reopened.
+const MICROPHONE_PERMISSION_KEY: &str = "microphone_permission";
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum PermState {
@@ -86,7 +95,10 @@ pub struct RepairAccessibilityResult {
 /// and `Unknown` until then (SOU-120).
 pub fn snapshot(db: &Database) -> PermissionStatus {
     PermissionStatus {
-        microphone: microphone_authorization_status(),
+        microphone: microphone_snapshot_state(
+            microphone_authorization_status(),
+            load_remembered_microphone(db),
+        ),
         system_audio: system_audio_snapshot_state(
             system_audio_supported(),
             load_remembered_system_audio(db),
@@ -112,6 +124,40 @@ pub fn system_audio_snapshot_state(supported: bool, remembered: Option<PermState
         Some(PermState::Granted) => PermState::Granted,
         Some(PermState::Denied) => PermState::Denied,
         _ => PermState::Unknown,
+    }
+}
+
+/// Snapshot value for the microphone. The live status wins whenever the OS
+/// has decided; a remembered grant covers the one case it cannot answer,
+/// a cached `NotDetermined` taken before the user said yes.
+pub fn microphone_snapshot_state(live: PermState, remembered: Option<PermState>) -> PermState {
+    match live {
+        PermState::Unknown => remembered.unwrap_or(PermState::Unknown),
+        decided => decided,
+    }
+}
+
+pub fn load_remembered_microphone(db: &Database) -> Option<PermState> {
+    let raw = db.get_setting(MICROPHONE_PERMISSION_KEY).ok().flatten()?;
+    match serde_json::from_str::<PermState>(&raw) {
+        Ok(PermState::Granted) => Some(PermState::Granted),
+        _ => None,
+    }
+}
+
+/// Only a grant is worth remembering. The probe reports `Denied` both for a
+/// real refusal and for a microphone CoreAudio failed to start, while a real
+/// refusal is already reported truthfully by `AVCaptureDevice` on the next
+/// launch, so persisting a denial could only turn a transient audio failure
+/// into a sticky one.
+pub fn remember_microphone(db: &Database, state: PermState) {
+    if state != PermState::Granted {
+        return;
+    }
+    if let Ok(raw) = serde_json::to_string(&state)
+        && let Err(e) = db.set_setting(MICROPHONE_PERMISSION_KEY, &raw)
+    {
+        tracing::warn!(error = %e, "Failed to persist microphone permission");
     }
 }
 
@@ -790,6 +836,52 @@ mod tests {
         );
         assert_eq!(seen.as_deref(), Some(APP_IDENTIFIER));
         assert_eq!(APP_IDENTIFIER, "com.souffle.desktop");
+    }
+
+    #[test]
+    fn microphone_snapshot_prefers_the_live_status_when_the_os_has_decided() {
+        assert_eq!(
+            microphone_snapshot_state(PermState::Denied, Some(PermState::Granted)),
+            PermState::Denied,
+            "a revoke observed on a fresh process must beat the remembered grant"
+        );
+        assert_eq!(
+            microphone_snapshot_state(PermState::Granted, None),
+            PermState::Granted
+        );
+    }
+
+    #[test]
+    fn microphone_snapshot_falls_back_to_a_remembered_grant() {
+        // The reported failure: the process read NotDetermined two seconds
+        // before the user granted the permission and kept returning it from
+        // the AVFoundation cache, so the row showed "Grant" forever.
+        assert_eq!(
+            microphone_snapshot_state(PermState::Unknown, Some(PermState::Granted)),
+            PermState::Granted
+        );
+        assert_eq!(
+            microphone_snapshot_state(PermState::Unknown, None),
+            PermState::Unknown
+        );
+    }
+
+    #[test]
+    fn microphone_grant_round_trips_through_the_db() {
+        let (db, _dir) = crate::test_helpers::fixtures::test_db();
+        assert_eq!(load_remembered_microphone(&db), None);
+
+        remember_microphone(&db, PermState::Granted);
+        assert_eq!(load_remembered_microphone(&db), Some(PermState::Granted));
+
+        for transient in [PermState::Denied, PermState::NoDevice, PermState::Unknown] {
+            remember_microphone(&db, transient);
+            assert_eq!(
+                load_remembered_microphone(&db),
+                Some(PermState::Granted),
+                "{transient:?} must not clobber a remembered grant"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/permissions.rs
+++ b/src-tauri/src/permissions.rs
@@ -206,17 +206,31 @@ fn resolve_input_monitoring(db: &Database) -> PermState {
 
 /// Accessibility already includes listen rights, so `IOHIDRequestAccess`
 /// is a no-op and the Input Monitoring list stays empty. Reset ListenEvent
-/// first so this click can insert a row for *this* binary.
+/// first so this click can insert a row for *this* binary. The same no-op
+/// applies once this process has called `AXIsProcessTrustedWithOptions`,
+/// whatever the answer was (FB7381305), which is why the Accessibility
+/// click is tracked too.
 fn prepare_listen_event_insert(
     accessibility_trusted: bool,
+    accessibility_prompted_here: bool,
     listen: HidAccess,
     reset_listen: impl FnOnce(),
     request: impl FnOnce(),
 ) {
-    if accessibility_trusted || listen == HidAccess::Granted {
+    if accessibility_trusted || accessibility_prompted_here || listen == HidAccess::Granted {
         reset_listen();
     }
     request();
+}
+
+/// Set once this process has run `AXIsProcessTrustedWithOptions`. Nothing
+/// runs it before a user action now, so the Input Monitoring insert has to
+/// know whether it is second in line.
+static ACCESSIBILITY_PROMPTED_HERE: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+fn accessibility_prompted_here() -> bool {
+    ACCESSIBILITY_PROMPTED_HERE.load(std::sync::atomic::Ordering::SeqCst)
 }
 
 /// Combine the live HID check with a remembered grant and the "Quit and
@@ -377,21 +391,6 @@ pub fn register_with_launch_services() {
     register_current_bundle_with_launch_services();
 }
 
-/// Insert this process into the Input Monitoring and Accessibility lists
-/// before the UI can poll AX. `IOHIDRequestAccess` must run first:
-/// `AXIsProcessTrustedWithOptions` beforehand makes the HID request a
-/// no-op and the Input Monitoring pane opens empty (FB7381305).
-pub fn seed_tcc_clients() {
-    #[cfg(target_os = "macos")]
-    on_main(|| {
-        register_current_bundle_with_launch_services();
-        if iohid_check_access(HID_LISTEN_EVENT) == HidAccess::Unknown {
-            request_listen_event_access_now();
-        }
-        let _ = accessibility_trusted_with_prompt_now(false);
-    });
-}
-
 #[cfg(target_os = "macos")]
 fn register_current_bundle_with_launch_services() {
     use core_foundation::base::TCFType;
@@ -488,6 +487,7 @@ fn accessibility_trusted_with_prompt_now(prompt: bool) -> bool {
     use std::ffi::c_void;
 
     register_current_bundle_with_launch_services();
+    ACCESSIBILITY_PROMPTED_HERE.store(true, std::sync::atomic::Ordering::SeqCst);
 
     #[link(name = "ApplicationServices", kind = "framework")]
     unsafe extern "C" {
@@ -958,6 +958,7 @@ mod tests {
         let requested = Cell::new(false);
         prepare_listen_event_insert(
             true,
+            false,
             HidAccess::Granted,
             || reset.set(true),
             || requested.set(true),
@@ -973,11 +974,34 @@ mod tests {
     fn listen_event_insert_does_not_reset_on_a_fresh_unknown() {
         use std::cell::Cell;
         let reset = Cell::new(false);
-        prepare_listen_event_insert(false, HidAccess::Unknown, || reset.set(true), || {});
+        prepare_listen_event_insert(false, false, HidAccess::Unknown, || reset.set(true), || {});
         assert!(
             !reset.get(),
             "first insert must not tccutil reset a service that has no row"
         );
+    }
+
+    /// Nothing seeds TCC at startup any more, so the Accessibility click can
+    /// come first. `AXIsProcessTrustedWithOptions` then makes a later
+    /// `IOHIDRequestAccess` a no-op unless ListenEvent is cleared first
+    /// (FB7381305), and the Input Monitoring pane would open with no row.
+    #[test]
+    fn listen_event_insert_resets_after_an_accessibility_prompt_in_this_process() {
+        use std::cell::Cell;
+        let reset = Cell::new(false);
+        let requested = Cell::new(false);
+        prepare_listen_event_insert(
+            false,
+            true,
+            HidAccess::Unknown,
+            || reset.set(true),
+            || requested.set(true),
+        );
+        assert!(
+            reset.get(),
+            "an AX prompt in this process must not cost the Input Monitoring row"
+        );
+        assert!(requested.get());
     }
 
     #[test]
@@ -1245,6 +1269,7 @@ fn open_input_monitoring_settings() {
     // and freezes the whole session with a cold CPU.
     prepare_listen_event_insert(
         accessibility_granted(),
+        accessibility_prompted_here(),
         iohid_check_access(HID_LISTEN_EVENT),
         || {
             let id = crate::constants::running_app_identifier();

--- a/src-tauri/src/permissions.rs
+++ b/src-tauri/src/permissions.rs
@@ -206,31 +206,17 @@ fn resolve_input_monitoring(db: &Database) -> PermState {
 
 /// Accessibility already includes listen rights, so `IOHIDRequestAccess`
 /// is a no-op and the Input Monitoring list stays empty. Reset ListenEvent
-/// first so this click can insert a row for *this* binary. The same no-op
-/// applies once this process has called `AXIsProcessTrustedWithOptions`,
-/// whatever the answer was (FB7381305), which is why the Accessibility
-/// click is tracked too.
+/// first so this click can insert a row for *this* binary.
 fn prepare_listen_event_insert(
     accessibility_trusted: bool,
-    accessibility_prompted_here: bool,
     listen: HidAccess,
     reset_listen: impl FnOnce(),
     request: impl FnOnce(),
 ) {
-    if accessibility_trusted || accessibility_prompted_here || listen == HidAccess::Granted {
+    if accessibility_trusted || listen == HidAccess::Granted {
         reset_listen();
     }
     request();
-}
-
-/// Set once this process has run `AXIsProcessTrustedWithOptions`. Nothing
-/// runs it before a user action now, so the Input Monitoring insert has to
-/// know whether it is second in line.
-static ACCESSIBILITY_PROMPTED_HERE: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
-
-fn accessibility_prompted_here() -> bool {
-    ACCESSIBILITY_PROMPTED_HERE.load(std::sync::atomic::Ordering::SeqCst)
 }
 
 /// Combine the live HID check with a remembered grant and the "Quit and
@@ -487,7 +473,6 @@ fn accessibility_trusted_with_prompt_now(prompt: bool) -> bool {
     use std::ffi::c_void;
 
     register_current_bundle_with_launch_services();
-    ACCESSIBILITY_PROMPTED_HERE.store(true, std::sync::atomic::Ordering::SeqCst);
 
     #[link(name = "ApplicationServices", kind = "framework")]
     unsafe extern "C" {
@@ -958,7 +943,6 @@ mod tests {
         let requested = Cell::new(false);
         prepare_listen_event_insert(
             true,
-            false,
             HidAccess::Granted,
             || reset.set(true),
             || requested.set(true),
@@ -974,34 +958,11 @@ mod tests {
     fn listen_event_insert_does_not_reset_on_a_fresh_unknown() {
         use std::cell::Cell;
         let reset = Cell::new(false);
-        prepare_listen_event_insert(false, false, HidAccess::Unknown, || reset.set(true), || {});
+        prepare_listen_event_insert(false, HidAccess::Unknown, || reset.set(true), || {});
         assert!(
             !reset.get(),
             "first insert must not tccutil reset a service that has no row"
         );
-    }
-
-    /// Nothing seeds TCC at startup any more, so the Accessibility click can
-    /// come first. `AXIsProcessTrustedWithOptions` then makes a later
-    /// `IOHIDRequestAccess` a no-op unless ListenEvent is cleared first
-    /// (FB7381305), and the Input Monitoring pane would open with no row.
-    #[test]
-    fn listen_event_insert_resets_after_an_accessibility_prompt_in_this_process() {
-        use std::cell::Cell;
-        let reset = Cell::new(false);
-        let requested = Cell::new(false);
-        prepare_listen_event_insert(
-            false,
-            true,
-            HidAccess::Unknown,
-            || reset.set(true),
-            || requested.set(true),
-        );
-        assert!(
-            reset.get(),
-            "an AX prompt in this process must not cost the Input Monitoring row"
-        );
-        assert!(requested.get());
     }
 
     #[test]
@@ -1269,7 +1230,6 @@ fn open_input_monitoring_settings() {
     // and freezes the whole session with a cold CPU.
     prepare_listen_event_insert(
         accessibility_granted(),
-        accessibility_prompted_here(),
         iohid_check_access(HID_LISTEN_EVENT),
         || {
             let id = crate::constants::running_app_identifier();

--- a/src-tauri/src/permissions.rs
+++ b/src-tauri/src/permissions.rs
@@ -5,9 +5,15 @@
 //! to probing (briefly opening the device, which also triggers the TCC
 //! prompt) when the OS hasn't decided yet. There is no equivalent for Core
 //! Audio taps, so system audio is still probe-only. Accessibility (needed
-//! for the synthesized Cmd+V paste) has its own cheap check
-//! (`AXIsProcessTrusted`), and is granted only via System Settings, so its
-//! "request" just opens the relevant pane.
+//! for the synthesized Cmd+V paste and for the native single-key shortcut
+//! tap) has its own cheap check (`AXIsProcessTrusted`), and is granted only
+//! via System Settings, so its "request" just opens the relevant pane.
+//!
+//! Input Monitoring is deliberately absent. An active `CGEventTap` is
+//! authorized by Accessibility, which subsumes the listen right, so the
+//! permission gated nothing; and once the app has an Accessibility TCC
+//! record, tccd answers a ListenEvent request by composing from that parent
+//! record, so asking could not even create the row it promised.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -22,34 +28,10 @@ use crate::db::Database;
 /// list (empty, or a differently-signed Soufflé already ticked).
 const TCC_INSERT_SETTLE: Duration = Duration::from_millis(400);
 
-/// `kIOHIDRequestTypeListenEvent` / `kIOHIDRequestTypePostEvent`.
-const HID_LISTEN_EVENT: u32 = 1;
-const HID_POST_EVENT: u32 = 0;
-
-/// `IOHIDCheckAccess` result. Accessibility (PostEvent) includes listen
-/// rights, so `Granted` on ListenEvent is not the same as a row in
-/// Input Monitoring.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum HidAccess {
-    Granted,
-    Denied,
-    Unknown,
-}
-
 /// Last observed system-audio tap permission. There is no read-only TCC
 /// API for Core Audio taps, so a successful probe is remembered and the
 /// snapshot returns it without mounting a tap (SOU-120).
 const SYSTEM_AUDIO_PERMISSION_KEY: &str = "system_audio_permission";
-
-/// Remembered Input Monitoring grant. `IOHIDCheckAccess(ListenEvent)` is
-/// true whenever Accessibility is trusted, so a live check cannot tell a
-/// real Input Monitoring row from AX covering listen. After the user
-/// toggles the row, macOS quits and relaunches the app: a pid change
-/// since we opened the pane is that signal.
-const INPUT_MONITORING_PERMISSION_KEY: &str = "input_monitoring_permission";
-const INPUT_MONITORING_PROMPT_PID_KEY: &str = "input_monitoring_prompt_pid";
-const INPUT_MONITORING_PROMPT_UNIX_KEY: &str = "input_monitoring_prompt_unix";
-const INPUT_MONITORING_RESTART_WINDOW_SECS: u64 = 15 * 60;
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, Type, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
@@ -74,7 +56,6 @@ pub struct PermissionStatus {
     pub system_audio: PermState,
     pub accessibility: PermState,
     pub calendar: PermState,
-    pub input_monitoring: PermState,
 }
 
 /// Which capability to probe or prompt for via `request`.
@@ -85,7 +66,6 @@ pub enum PermissionKind {
     SystemAudio,
     Accessibility,
     Calendar,
-    InputMonitoring,
 }
 
 /// Outcome of `repair_accessibility`. Distinct from `PermState` because a
@@ -119,7 +99,6 @@ pub fn snapshot(db: &Database) -> PermissionStatus {
         // EventKit has a real read-only status API, so the snapshot is truthful
         // here (no probe needed).
         calendar: crate::calendar::authorization_state(),
-        input_monitoring: resolve_input_monitoring(db),
     }
 }
 
@@ -159,168 +138,15 @@ fn system_audio_supported() -> bool {
     crate::platform::system_audio_capture_supported()
 }
 
-/// Input Monitoring snapshot. `CGPreflightListenEventAccess` and
-/// `IOHIDCheckAccess(ListenEvent)` return Granted when Accessibility is
-/// already trusted, even if System Settings has no Soufflé row (DTS,
-/// May 2026: Accessibility grants post *and* listen). That was the
-/// false "Granted" pill.
-fn input_monitoring_snapshot_state(
-    listen: HidAccess,
-    accessibility_trusted: bool,
-    post: HidAccess,
-) -> PermState {
-    match listen {
-        HidAccess::Denied => PermState::Denied,
-        HidAccess::Unknown => PermState::Unknown,
-        HidAccess::Granted => {
-            if accessibility_trusted || post == HidAccess::Granted {
-                PermState::Unknown
-            } else {
-                PermState::Granted
-            }
-        }
-    }
-}
-
-fn resolve_input_monitoring(db: &Database) -> PermState {
-    let listen = iohid_listen_access();
-    let live =
-        input_monitoring_snapshot_state(listen, accessibility_granted(), iohid_post_access());
-    let remembered = load_remembered_input_monitoring(db);
-    let prompt = load_input_monitoring_prompt(db);
-    let now_unix = unix_now();
-    let state = input_monitoring_effective_state(
-        live,
-        listen,
-        remembered,
-        prompt,
-        std::process::id(),
-        now_unix,
-    );
-    if state == PermState::Granted && remembered != Some(PermState::Granted) {
-        remember_input_monitoring(db, PermState::Granted);
-        clear_input_monitoring_prompt(db);
-    }
-    state
-}
-
-/// Accessibility already includes listen rights, so `IOHIDRequestAccess`
-/// is a no-op and the Input Monitoring list stays empty. Reset ListenEvent
-/// first so this click can insert a row for *this* binary.
-fn prepare_listen_event_insert(
-    accessibility_trusted: bool,
-    listen: HidAccess,
-    reset_listen: impl FnOnce(),
-    request: impl FnOnce(),
-) {
-    if accessibility_trusted || listen == HidAccess::Granted {
-        reset_listen();
-    }
-    request();
-}
-
-/// Combine the live HID check with a remembered grant and the "Quit and
-/// Reopen" restart macOS issues after toggling Input Monitoring.
-fn input_monitoring_effective_state(
-    live: PermState,
-    listen: HidAccess,
-    remembered: Option<PermState>,
-    prompt: Option<(u32, u64)>,
-    now_pid: u32,
-    now_unix: u64,
-) -> PermState {
-    if live == PermState::Granted || live == PermState::Denied {
-        return live;
-    }
-    if remembered == Some(PermState::Granted) {
-        return PermState::Granted;
-    }
-    if listen == HidAccess::Granted
-        && let Some((pid, unix)) = prompt
-        && pid != now_pid
-        && now_unix.saturating_sub(unix) <= INPUT_MONITORING_RESTART_WINDOW_SECS
-    {
-        return PermState::Granted;
-    }
-    PermState::Unknown
-}
-
-fn unix_now() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
-}
-
-fn load_remembered_input_monitoring(db: &Database) -> Option<PermState> {
-    let raw = db
-        .get_setting(INPUT_MONITORING_PERMISSION_KEY)
-        .ok()
-        .flatten()?;
-    match serde_json::from_str::<PermState>(&raw) {
-        Ok(PermState::Granted) => Some(PermState::Granted),
-        _ => None,
-    }
-}
-
-fn remember_input_monitoring(db: &Database, state: PermState) {
-    if state != PermState::Granted {
-        return;
-    }
-    if let Ok(raw) = serde_json::to_string(&state)
-        && let Err(e) = db.set_setting(INPUT_MONITORING_PERMISSION_KEY, &raw)
-    {
-        tracing::warn!(error = %e, "Failed to persist input monitoring permission");
-    }
-}
-
-fn load_input_monitoring_prompt(db: &Database) -> Option<(u32, u64)> {
-    let pid = db
-        .get_setting(INPUT_MONITORING_PROMPT_PID_KEY)
-        .ok()
-        .flatten()?
-        .parse()
-        .ok()?;
-    let unix = db
-        .get_setting(INPUT_MONITORING_PROMPT_UNIX_KEY)
-        .ok()
-        .flatten()?
-        .parse()
-        .ok()?;
-    Some((pid, unix))
-}
-
-fn clear_input_monitoring_prompt(db: &Database) {
-    let _ = db.set_setting(INPUT_MONITORING_PROMPT_PID_KEY, "");
-    let _ = db.set_setting(INPUT_MONITORING_PROMPT_UNIX_KEY, "");
-}
-
-/// Call when the user opens the Input Monitoring pane. After macOS quits
-/// and relaunches, `resolve_input_monitoring` treats a pid change as a grant.
-pub fn note_input_monitoring_prompt(db: &Database) {
-    let _ = db.set_setting(
-        INPUT_MONITORING_PROMPT_PID_KEY,
-        &std::process::id().to_string(),
-    );
-    let _ = db.set_setting(INPUT_MONITORING_PROMPT_UNIX_KEY, &unix_now().to_string());
-}
-
-pub fn clear_input_monitoring_memory(db: &Database) {
-    let _ = db.set_setting(INPUT_MONITORING_PERMISSION_KEY, "");
-    clear_input_monitoring_prompt(db);
-}
-
-/// TCC prompts (`AXIsProcessTrustedWithOptions`, `CGRequestListenEventAccess`,
-/// `IOHIDRequestAccess`) only insert this process into System Settings when
-/// they run on the main thread. `request_permission` is `spawn_blocking`, so
-/// hop. Reads (`AXIsProcessTrusted`, `CGPreflightListenEventAccess`) stay on
-/// the caller: `cargo test` has no main runloop, and a `dispatch_sync` there
+/// An `AXIsProcessTrustedWithOptions` prompt only registers this process
+/// with System Settings when it runs on the main thread. `request_permission`
+/// is `spawn_blocking`, so hop. Reads (`AXIsProcessTrusted`) stay on the
+/// caller: `cargo test` has no main runloop, and a `dispatch_sync` there
 /// hangs (SOU-122 AC3).
 ///
 /// Main-thread is necessary but not sufficient after an in-place rebuild:
-/// Launch Services must point at *this* binary, Input Monitoring needs
-/// `NSInputMonitoringUsageDescription`, and System Settings must not open
-/// before TCC has committed the new row.
+/// Launch Services must point at *this* binary, and System Settings must
+/// not open before TCC has committed the new row.
 #[cfg(target_os = "macos")]
 fn on_main<R: Send>(f: impl FnOnce() -> R + Send) -> R {
     on_main_with(is_main_thread(), f)
@@ -508,15 +334,6 @@ fn accessibility_trusted_with_prompt(_prompt: bool) -> bool {
 pub fn repair_accessibility() -> Result<RepairAccessibilityResult, String> {
     let bundle_id = crate::constants::running_app_identifier();
     tccutil_reset_service("Accessibility", &bundle_id)?;
-    // Input Monitoring has the same stale-identity problem. A missing row
-    // is not a failure: tccutil still succeeds for a known bundle id.
-    if let Err(e) = tccutil_reset_service("ListenEvent", &bundle_id) {
-        tracing::warn!(error = %e, "tccutil reset ListenEvent skipped");
-    }
-    // HID first: AXIsProcessTrustedWithOptions beforehand makes
-    // IOHIDRequestAccess a no-op (FB7381305).
-    #[cfg(target_os = "macos")]
-    on_main(request_listen_event_access_now);
     let _ = accessibility_trusted_with_prompt(true);
     Ok(RepairAccessibilityResult {
         reset_performed: true,
@@ -760,14 +577,6 @@ pub fn request(kind: PermissionKind) -> PermState {
             }
         }
         PermissionKind::Calendar => crate::calendar::request_access(),
-        PermissionKind::InputMonitoring => {
-            open_input_monitoring_settings();
-            input_monitoring_snapshot_state(
-                iohid_listen_access(),
-                accessibility_granted(),
-                iohid_post_access(),
-            )
-        }
     }
 }
 
@@ -836,147 +645,21 @@ mod tests {
         );
     }
 
+    /// The app never asks for Input Monitoring, but `CGEventTap::new` still
+    /// makes macOS raise a ListenEvent access request for this process (a
+    /// tap at the HID location asks for both listen and post rights). A TCC
+    /// request with no usage string is refused out of hand, so the key stays.
     #[test]
     fn info_plist_declares_input_monitoring_usage() {
         let plist = std::fs::read_to_string(format!("{}/Info.plist", env!("CARGO_MANIFEST_DIR")))
             .expect("src-tauri/Info.plist");
         assert!(
             plist.contains("<key>NSInputMonitoringUsageDescription</key>"),
-            "IOHIDRequestAccess does not insert the Input Monitoring row without this key"
+            "the native shortcut tap makes macOS ask for ListenEvent on our behalf"
         );
         assert!(
             plist.contains("keyboard and mouse events"),
-            "usage string should describe Input Monitoring, not a different permission"
-        );
-    }
-
-    #[test]
-    fn input_monitoring_is_not_granted_when_accessibility_covers_listen() {
-        assert_eq!(
-            input_monitoring_snapshot_state(HidAccess::Granted, true, HidAccess::Granted),
-            PermState::Unknown,
-            "Accessibility includes listen; that is not an Input Monitoring row"
-        );
-        assert_eq!(
-            input_monitoring_snapshot_state(HidAccess::Granted, true, HidAccess::Unknown),
-            PermState::Unknown
-        );
-        assert_eq!(
-            input_monitoring_snapshot_state(HidAccess::Granted, false, HidAccess::Granted),
-            PermState::Unknown
-        );
-    }
-
-    #[test]
-    fn input_monitoring_granted_only_when_listen_is_not_inherited_from_ax() {
-        assert_eq!(
-            input_monitoring_snapshot_state(HidAccess::Granted, false, HidAccess::Unknown),
-            PermState::Granted
-        );
-        assert_eq!(
-            input_monitoring_snapshot_state(HidAccess::Granted, false, HidAccess::Denied),
-            PermState::Granted
-        );
-        assert_eq!(
-            input_monitoring_snapshot_state(HidAccess::Unknown, false, HidAccess::Unknown),
-            PermState::Unknown
-        );
-        assert_eq!(
-            input_monitoring_snapshot_state(HidAccess::Denied, false, HidAccess::Unknown),
-            PermState::Denied
-        );
-    }
-
-    #[test]
-    fn input_monitoring_stays_open_settings_in_the_same_process_after_opening_the_pane() {
-        let live = PermState::Unknown;
-        assert_eq!(
-            input_monitoring_effective_state(
-                live,
-                HidAccess::Granted,
-                None,
-                Some((42, 1_000)),
-                42,
-                1_010,
-            ),
-            PermState::Unknown,
-            "AX covering listen plus opening the pane is not a grant"
-        );
-    }
-
-    #[test]
-    fn input_monitoring_is_granted_after_the_tcc_quit_and_reopen() {
-        let live = PermState::Unknown;
-        assert_eq!(
-            input_monitoring_effective_state(
-                live,
-                HidAccess::Granted,
-                None,
-                Some((42, 1_000)),
-                99,
-                1_030,
-            ),
-            PermState::Granted,
-        );
-    }
-
-    #[test]
-    fn input_monitoring_restart_signal_expires() {
-        let live = PermState::Unknown;
-        assert_eq!(
-            input_monitoring_effective_state(
-                live,
-                HidAccess::Granted,
-                None,
-                Some((42, 1_000)),
-                99,
-                1_000 + INPUT_MONITORING_RESTART_WINDOW_SECS + 1,
-            ),
-            PermState::Unknown,
-        );
-    }
-
-    #[test]
-    fn listen_event_insert_resets_when_accessibility_already_covers_listen() {
-        use std::cell::Cell;
-        let reset = Cell::new(false);
-        let requested = Cell::new(false);
-        prepare_listen_event_insert(
-            true,
-            HidAccess::Granted,
-            || reset.set(true),
-            || requested.set(true),
-        );
-        assert!(
-            reset.get(),
-            "must clear ListenEvent or IOHIDRequestAccess is a no-op"
-        );
-        assert!(requested.get());
-    }
-
-    #[test]
-    fn listen_event_insert_does_not_reset_on_a_fresh_unknown() {
-        use std::cell::Cell;
-        let reset = Cell::new(false);
-        prepare_listen_event_insert(false, HidAccess::Unknown, || reset.set(true), || {});
-        assert!(
-            !reset.get(),
-            "first insert must not tccutil reset a service that has no row"
-        );
-    }
-
-    #[test]
-    fn input_monitoring_remembered_grant_survives_later_launches() {
-        assert_eq!(
-            input_monitoring_effective_state(
-                PermState::Unknown,
-                HidAccess::Granted,
-                Some(PermState::Granted),
-                None,
-                7,
-                9_000,
-            ),
-            PermState::Granted,
+            "usage string should describe what the tap reads"
         );
     }
 
@@ -1173,76 +856,3 @@ mod tests {
         );
     }
 }
-
-#[cfg(target_os = "macos")]
-fn iohid_check_access(request_type: u32) -> HidAccess {
-    #[link(name = "IOKit", kind = "framework")]
-    unsafe extern "C" {
-        fn IOHIDCheckAccess(request_type: u32) -> u32;
-    }
-    match unsafe { IOHIDCheckAccess(request_type) } {
-        0 => HidAccess::Granted,
-        1 => HidAccess::Denied,
-        _ => HidAccess::Unknown,
-    }
-}
-
-#[cfg(not(target_os = "macos"))]
-fn iohid_check_access(_request_type: u32) -> HidAccess {
-    HidAccess::Granted
-}
-
-fn iohid_listen_access() -> HidAccess {
-    iohid_check_access(HID_LISTEN_EVENT)
-}
-
-fn iohid_post_access() -> HidAccess {
-    iohid_check_access(HID_POST_EVENT)
-}
-
-#[cfg(target_os = "macos")]
-fn request_listen_event_access_now() {
-    #[link(name = "CoreGraphics", kind = "framework")]
-    unsafe extern "C" {
-        fn CGRequestListenEventAccess() -> bool;
-    }
-    #[link(name = "IOKit", kind = "framework")]
-    unsafe extern "C" {
-        fn IOHIDRequestAccess(request_type: u32) -> bool;
-    }
-    register_current_bundle_with_launch_services();
-    // DTS (May 2026): IOHIDRequestAccess is the API that inserts the
-    // Input Monitoring row. CGRequestListenEventAccess is the older
-    // CoreGraphics equivalent. Do not create a listen-only tap here:
-    // with Accessibility already granted the tap succeeds and
-    // CGPreflightListenEventAccess then reports Granted with no row
-    // in the Input Monitoring list.
-    unsafe {
-        let _ = IOHIDRequestAccess(HID_LISTEN_EVENT);
-        let _ = CGRequestListenEventAccess();
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn open_input_monitoring_settings() {
-    // tccutil must not run on the main thread. A Default CGEventTap
-    // (Accessibility) sits on that runloop; blocking it stalls WindowServer
-    // and freezes the whole session with a cold CPU.
-    prepare_listen_event_insert(
-        accessibility_granted(),
-        iohid_check_access(HID_LISTEN_EVENT),
-        || {
-            let id = crate::constants::running_app_identifier();
-            let _ = tccutil_reset_service("ListenEvent", &id);
-        },
-        || {},
-    );
-    prompt_then_open_settings(
-        || on_main(request_listen_event_access_now),
-        wait_for_tcc_insert,
-        || open_privacy_pane("Privacy_ListenEvent"),
-    );
-}
-
-#[cfg(not(target_os = "macos"))]
-fn open_input_monitoring_settings() {}

--- a/src-tauri/src/permissions.rs
+++ b/src-tauri/src/permissions.rs
@@ -43,8 +43,7 @@ static MICROPHONE_GRANT_OBSERVED: AtomicBool = AtomicBool::new(false);
 pub enum PermState {
     Granted,
     Denied,
-    /// Not yet probed — the user hasn't triggered this one (probing would
-    /// prompt, so we don't do it unsolicited at startup).
+    /// TCC has no answer on record: the user has not been asked yet.
     Unknown,
     /// The OS doesn't support this capability (e.g. taps need macOS 14.4+).
     Unsupported,
@@ -571,6 +570,7 @@ fn audio_capture_preflight() -> Option<PermState> {
 /// AudioCap, Hyprnote and screenpipe all read the same three values out of
 /// this SPI. Anything else means the contract moved, and an unknown number
 /// must not be read as a verdict.
+#[cfg(any(test, all(target_os = "macos", feature = "private-tcc")))]
 fn tcc_preflight_state(raw: i32) -> Option<PermState> {
     match raw {
         0 => Some(PermState::Granted),

--- a/src-tauri/src/permissions.rs
+++ b/src-tauri/src/permissions.rs
@@ -379,7 +379,12 @@ fn accessibility_trusted_with_prompt(_prompt: bool) -> bool {
 /// repair had failed, including the ones that worked (SOU-054).
 pub fn repair_accessibility() -> Result<RepairAccessibilityResult, String> {
     let bundle_id = crate::constants::running_app_identifier();
+    // The only trace this path leaves. Without it a repair that never runs
+    // and a repair that runs and changes nothing look identical from the
+    // outside, and both are reported as "the button does nothing".
+    tracing::info!(bundle_id, "Repairing the Accessibility permission");
     tccutil_reset_service("Accessibility", &bundle_id)?;
+    tracing::info!("Accessibility TCC entry reset; asking macOS to prompt");
     let _ = accessibility_trusted_with_prompt(true);
     Ok(RepairAccessibilityResult {
         reset_performed: true,

--- a/src-tauri/tauri.nightly.conf.json
+++ b/src-tauri/tauri.nightly.conf.json
@@ -1,4 +1,9 @@
 {
   "productName": "Soufflé Nightly",
-  "identifier": "com.souffle.desktop.nightly"
+  "identifier": "com.souffle.desktop.nightly",
+  "bundle": {
+    "macOS": {
+      "entitlements": "./entitlements.nightly.plist"
+    }
+  }
 }

--- a/src/lib/features/home/LiveSessionCard.svelte
+++ b/src/lib/features/home/LiveSessionCard.svelte
@@ -16,7 +16,7 @@
     scrollTopAfterLeadingUnmount,
     windowedParagraphs,
   } from "./live-paragraph-window";
-  import { liveSystemAudioNotice } from "../meeting/system-audio";
+  import { liveSystemAudioNotice, liveSystemAudioState } from "../meeting/system-audio";
 
   let {
     mode,
@@ -76,7 +76,7 @@
     mode === "dictation" ? transcription.isStopping : meeting.isStopping,
   );
 
-  const systemAudioActive = $derived(Boolean(meeting.app.systemAudioStatus?.active));
+  const systemAudioState = $derived(liveSystemAudioState(meeting.app.systemAudioStatus));
   const liveNotice = $derived(
     mode === "meeting" ? liveSystemAudioNotice(meeting.app.systemAudioStatus) : null,
   );
@@ -280,10 +280,16 @@
       <div class="flex items-center justify-between gap-3">
         <h3 class="text-sm font-semibold text-text-primary">{$t("home.live_transcript")}</h3>
         <span class="inline-flex items-center gap-1.5 text-[11.5px] text-text-muted">
-          <span class={`h-1.5 w-1.5 rounded-full ${systemAudioActive ? "bg-accent" : "bg-surface-4"}`}></span>
-          {systemAudioActive
-            ? $t("home.system_audio_active")
-            : $t("meeting_header.system_audio_unavailable")}
+          <span
+            class={`h-1.5 w-1.5 rounded-full ${systemAudioState === "active" ? "bg-accent" : "bg-surface-4"}`}
+          ></span>
+          {#if systemAudioState === "active"}
+            {$t("home.system_audio_active")}
+          {:else if systemAudioState === "pending"}
+            {$t("home.system_audio_pending")}
+          {:else}
+            {$t("meeting_header.system_audio_unavailable")}
+          {/if}
         </span>
       </div>
       <p class="m-0 text-[11.5px] text-text-muted">{$t("home.live_edit_hint")}</p>

--- a/src/lib/features/home/LiveSessionCard.test.ts
+++ b/src/lib/features/home/LiveSessionCard.test.ts
@@ -77,4 +77,17 @@ describe("LiveSessionCard system-audio notice (SOU-119 AC5)", () => {
     expect(screen.queryByText(/System audio capture is turned off/)).toBeNull();
     expect(screen.getByText("System audio active")).toBeTruthy();
   });
+
+  it("does not call a meeting mic only before the leg has reported", () => {
+    render(LiveSessionCard, {
+      props: {
+        mode: "meeting",
+        transcription: stubTranscription() as never,
+        meeting: stubMeeting(null) as never,
+      },
+    });
+
+    expect(screen.queryByText("Mic only")).toBeNull();
+    expect(screen.getByText("Checking system audio")).toBeTruthy();
+  });
 });

--- a/src/lib/features/meeting/system-audio.test.ts
+++ b/src/lib/features/meeting/system-audio.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { MeetingSystemAudio, SystemAudioStatus } from "../../types";
 import {
   liveSystemAudioNotice,
+  liveSystemAudioState,
   pastSystemAudioNotice,
   provisionalSystemAudio,
 } from "./system-audio";
@@ -13,6 +14,19 @@ function status(over: Partial<SystemAudioStatus> = {}): SystemAudioStatus {
 function verdict(over: Partial<MeetingSystemAudio> = {}): MeetingSystemAudio {
   return { active: true, reason: null, reason_code: null, samples: 0, signal_samples: 0, ...over };
 }
+
+describe("liveSystemAudioState", () => {
+  it("is pending until the capture thread reports on the leg", () => {
+    expect(liveSystemAudioState(null)).toBe("pending");
+  });
+
+  it("separates a reported failure from a leg that has not reported yet", () => {
+    expect(liveSystemAudioState(status({ active: false, reason_code: "disabled" }))).toBe(
+      "unavailable",
+    );
+    expect(liveSystemAudioState(status())).toBe("active");
+  });
+});
 
 describe("liveSystemAudioNotice", () => {
   it("says nothing while the system-audio leg is up", () => {

--- a/src/lib/features/meeting/system-audio.ts
+++ b/src/lib/features/meeting/system-audio.ts
@@ -39,6 +39,21 @@ export function liveSystemAudioNotice(status: SystemAudioStatus | null): SystemA
   return notice(status.reason_code, status.reason);
 }
 
+/** Where the system-audio leg of a running meeting stands. */
+export type LiveSystemAudioState = "active" | "unavailable" | "pending";
+
+/**
+ * Three states, not two. The status only arrives once the capture thread has
+ * the leg up or has given up on it, and a meeting whose microphone stream is
+ * still being opened has neither. Reading the gap as "Mic only" labelled a
+ * meeting whose tap was healthy and whose microphone was the leg that
+ * failed, with no reason next to it because there was no verdict to explain.
+ */
+export function liveSystemAudioState(status: SystemAudioStatus | null): LiveSystemAudioState {
+  if (!status) return "pending";
+  return status.active ? "active" : "unavailable";
+}
+
 /**
  * What to say about a meeting reopened after the fact. Null when the tap
  * ran (both lanes were captured: AC6), and null for meetings recorded

--- a/src/lib/features/onboarding/OnboardingView.test.ts
+++ b/src/lib/features/onboarding/OnboardingView.test.ts
@@ -72,7 +72,6 @@ describe("OnboardingView shortcut step (SOU-053)", () => {
       system_audio: "granted",
       accessibility: "denied",
       calendar: "unknown",
-      input_monitoring: "unknown",
     });
 
     await goToShortcutStep();
@@ -87,7 +86,6 @@ describe("OnboardingView shortcut step (SOU-053)", () => {
       system_audio: "granted",
       accessibility: "granted",
       calendar: "unknown",
-      input_monitoring: "unknown",
     });
 
     await goToShortcutStep();

--- a/src/lib/features/onboarding/PermissionsStep.svelte
+++ b/src/lib/features/onboarding/PermissionsStep.svelte
@@ -47,7 +47,6 @@
   let accessibilityAttempts = $state(0);
   let leftAfterAttempt = $state(false);
   let returnedStillDenied = $state(false);
-  let leftWindow = $state(false);
   const showStaleHint = $derived(returnedStillDenied || accessibilityAttempts >= 2);
 
   /** Every write to `status` goes through here so the parent (which cannot
@@ -199,24 +198,15 @@
     // Denied that `request_permission` returns) does not count as a return.
     const onBlur = () => {
       if (accessibilityAttempts > 0) leftAfterAttempt = true;
-      leftWindow = true;
     };
     const onFocus = () => {
       if (leftAfterAttempt && status.accessibility === "denied") {
         returnedStillDenied = true;
       }
-      // Re-probe a remembered grant after the user left the app (typically
-      // System Settings) so a revoke is reflected. Opening the window does
-      // not probe (AC5). Denied already has Grant; Unknown must not prompt
-      // (AC3). Skip while a probe is in flight so two taps cannot overlap.
-      if (
-        leftWindow
-        && status.system_audio === "granted"
-        && !busy.system_audio
-      ) {
-        leftWindow = false;
-        void grant("system_audio");
-      }
+      // Nothing else happens here. Returning from System Settings used to
+      // re-probe system audio to catch a revoke, which mounted a real Core
+      // Audio tap every time (SOU-124 AC7). The 600 ms poll now reads the
+      // live TCC status, so a revoke shows up on its own.
     };
     window.addEventListener("blur", onBlur);
     window.addEventListener("focus", onFocus);

--- a/src/lib/features/onboarding/PermissionsStep.svelte
+++ b/src/lib/features/onboarding/PermissionsStep.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Accessibility, Check, Mic, Volume2, Keyboard } from "@lucide/svelte";
+  import { Accessibility, Check, Mic, Volume2 } from "@lucide/svelte";
   import { onMount } from "svelte";
   import { t } from "svelte-i18n";
   import Spinner from "../../components/ui/Spinner.svelte";
@@ -23,7 +23,6 @@
     system_audio: "unknown",
     accessibility: "unknown",
     calendar: "unknown",
-    input_monitoring: "unknown",
   });
   let busy = $state<Record<string, boolean>>({});
   let error = $state("");
@@ -97,13 +96,6 @@
       icon: Accessibility,
       label: $t("permissions.accessibility_label"),
       desc: $t("permissions.accessibility_desc"),
-      action: $t("permissions.open_settings"),
-    },
-    {
-      kind: "input_monitoring",
-      icon: Keyboard,
-      label: $t("permissions.input_monitoring_label"),
-      desc: $t("permissions.input_monitoring_desc"),
       action: $t("permissions.open_settings"),
     },
   ]);
@@ -186,14 +178,12 @@
           if (s.microphone !== "unknown") next.microphone = s.microphone;
           if (s.system_audio !== "unknown") next.system_audio = s.system_audio;
           if (s.calendar !== "unknown") next.calendar = s.calendar;
-          if (s.input_monitoring !== "unknown") next.input_monitoring = s.input_monitoring;
 
           if (
             next.accessibility !== status.accessibility ||
             next.microphone !== status.microphone ||
             next.system_audio !== status.system_audio ||
-            next.calendar !== status.calendar ||
-            next.input_monitoring !== status.input_monitoring
+            next.calendar !== status.calendar
           ) {
             setStatus(next);
           }

--- a/src/lib/features/onboarding/PermissionsStep.svelte
+++ b/src/lib/features/onboarding/PermissionsStep.svelte
@@ -167,12 +167,11 @@
       pollInFlight = true;
       void getPermissionStatus()
         .then((s) => {
-          // A probe in flight is newer than this snapshot. Dropping the
-          // result is what keeps a just-observed revoke from flipping back
-          // to the remembered Granted (SOU-120 AC4).
+          // A request in flight is newer than this snapshot: drop the
+          // result rather than letting it overwrite a fresher answer.
           if (Object.values(busy).some(Boolean)) return;
-          // Snapshot never prompts. Unknown means "not remembered yet";
-          // keep the local value rather than wiping a grant in progress.
+          // Snapshot never prompts. Unknown means "not determined"; keep
+          // the local value rather than wiping a grant in progress.
           const next = { ...status };
           if (s.accessibility !== "unknown") next.accessibility = s.accessibility;
           if (s.microphone !== "unknown") next.microphone = s.microphone;

--- a/src/lib/features/onboarding/PermissionsStep.test.ts
+++ b/src/lib/features/onboarding/PermissionsStep.test.ts
@@ -419,9 +419,12 @@ describe("PermissionsStep system audio remembered grant (SOU-120)", () => {
     expect(within(rowFor("System audio")).queryByRole("button")).toBeNull();
   });
 
-  it("re-probes system audio after the window loses and regains focus", async () => {
+  // SOU-124 AC7: returning from System Settings used to re-probe, which
+  // mounted a Core Audio tap on every round trip. The poll reads TCC live
+  // instead, so a revoke arrives without any device being opened.
+  it("never probes on a focus round trip, and picks a revoke up from the poll", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval"] });
     permissionsApi.getPermissionStatus.mockResolvedValue(statusWithAudio("granted"));
-    permissionsApi.requestPermission.mockResolvedValue("denied");
     render(PermissionsStep);
     await waitFor(() => {
       expect(within(rowFor("System audio")).getByText("Granted")).toBeTruthy();
@@ -429,24 +432,15 @@ describe("PermissionsStep system audio remembered grant (SOU-120)", () => {
 
     window.dispatchEvent(new Event("blur"));
     window.dispatchEvent(new Event("focus"));
+    expect(permissionsApi.requestPermission).not.toHaveBeenCalled();
 
-    await waitFor(() => {
-      expect(permissionsApi.requestPermission).toHaveBeenCalledWith("system_audio");
-    });
+    permissionsApi.getPermissionStatus.mockResolvedValue(statusWithAudio("denied"));
+    await vi.advanceTimersByTimeAsync(600);
     await waitFor(() => {
       expect(within(rowFor("System audio")).getByRole("button", { name: "Grant" })).toBeTruthy();
     });
-  });
-
-  it("does not re-probe on focus if the window never lost it", async () => {
-    permissionsApi.getPermissionStatus.mockResolvedValue(statusWithAudio("granted"));
-    render(PermissionsStep);
-    await waitFor(() => {
-      expect(within(rowFor("System audio")).getByText("Granted")).toBeTruthy();
-    });
-
-    window.dispatchEvent(new Event("focus"));
     expect(permissionsApi.requestPermission).not.toHaveBeenCalled();
+    vi.useRealTimers();
   });
 
   it("does not re-probe a remembered deny or an unprobed row (SOU-120 AC3)", async () => {
@@ -468,32 +462,6 @@ describe("PermissionsStep system audio remembered grant (SOU-120)", () => {
     window.dispatchEvent(new Event("blur"));
     window.dispatchEvent(new Event("focus"));
     expect(permissionsApi.requestPermission).not.toHaveBeenCalled();
-  });
-
-  it("does not start a second probe while one is in flight", async () => {
-    permissionsApi.getPermissionStatus.mockResolvedValue(statusWithAudio("granted"));
-    let release: (() => void) | undefined;
-    permissionsApi.requestPermission.mockImplementationOnce(
-      () =>
-        new Promise<PermState>((resolve) => {
-          release = () => resolve("granted");
-        }),
-    );
-    render(PermissionsStep);
-    await waitFor(() => {
-      expect(within(rowFor("System audio")).getByText("Granted")).toBeTruthy();
-    });
-
-    window.dispatchEvent(new Event("blur"));
-    window.dispatchEvent(new Event("focus"));
-    await waitFor(() => {
-      expect(permissionsApi.requestPermission).toHaveBeenCalledTimes(1);
-    });
-
-    window.dispatchEvent(new Event("blur"));
-    window.dispatchEvent(new Event("focus"));
-    expect(permissionsApi.requestPermission).toHaveBeenCalledTimes(1);
-    release?.();
   });
 
   it("the 600 ms poll does not mount a tap on a remembered grant (SOU-120 AC5)", async () => {

--- a/src/lib/features/onboarding/PermissionsStep.test.ts
+++ b/src/lib/features/onboarding/PermissionsStep.test.ts
@@ -19,7 +19,7 @@ function statusWith(microphone: PermState): PermissionStatus {
     microphone,
     system_audio: "unknown",
     accessibility: "granted",
-    calendar: "unknown", input_monitoring: "granted",
+    calendar: "unknown",
   };
 }
 
@@ -59,16 +59,16 @@ describe("PermissionsStep microphone denial", () => {
     expect(within(micRow).queryByRole("button", { name: "Open Settings" })).toBeTruthy();
   });
 
-  it("names Accessibility, not Input Monitoring, for single-key capture (SOU-116 AC1)", async () => {
+  // Accessibility is the permission the native tap actually needs, and the
+  // only one now listed for it. Input Monitoring gated nothing and its row
+  // could never be created from inside the app, so it is gone (SOU-116 AC1).
+  it("names Accessibility for single-key capture and lists no Input Monitoring row", async () => {
     permissionsApi.getPermissionStatus.mockResolvedValue(statusWith("granted"));
     render(PermissionsStep);
 
     await waitFor(() => expect(permissionsApi.getPermissionStatus).toHaveBeenCalled());
     expect(within(rowFor("Accessibility")).getByText(/single-key shortcut/)).toBeTruthy();
-    expect(within(rowFor("Input Monitoring")).queryByText(/single-key/)).toBeNull();
-    expect(
-      within(rowFor("Input Monitoring")).getByText(/without modifying them/),
-    ).toBeTruthy();
+    expect(screen.queryByText("Input Monitoring")).toBeNull();
   });
 
   it("does not show the denied hint for an unrelated state", async () => {
@@ -94,7 +94,7 @@ describe("PermissionsStep accessibility repair", () => {
       microphone: "granted",
       system_audio: "unknown",
       accessibility: "denied",
-      calendar: "unknown", input_monitoring: "granted",
+      calendar: "unknown",
     };
   }
 
@@ -159,7 +159,6 @@ describe("PermissionsStep accessibility on a fresh install (SOU-055)", () => {
       system_audio: "unknown",
       accessibility: "denied",
       calendar: "unknown",
-      input_monitoring: "unknown",
     };
   }
 
@@ -387,7 +386,6 @@ describe("PermissionsStep system audio remembered grant (SOU-120)", () => {
       system_audio: systemAudio,
       accessibility: "granted",
       calendar: "unknown",
-      input_monitoring: "granted",
     };
   }
 

--- a/src/lib/features/onboarding/controller.svelte.test.ts
+++ b/src/lib/features/onboarding/controller.svelte.test.ts
@@ -61,7 +61,6 @@ describe("createOnboardingController", () => {
       system_audio: "unknown",
       accessibility: "unknown",
       calendar: "unknown",
-      input_monitoring: "unknown",
     });
     permissionsApi.requestPermission.mockResolvedValue("granted");
     startDownload.mockResolvedValue(undefined);
@@ -156,7 +155,6 @@ describe("createOnboardingController", () => {
       system_audio: "granted",
       accessibility: "granted",
       calendar: "unknown",
-      input_monitoring: "granted",
     });
     const ctrl = createOnboardingController();
     await ctrl.mount();
@@ -181,7 +179,6 @@ describe("createOnboardingController", () => {
       system_audio: "granted",
       accessibility: "denied",
       calendar: "unknown",
-      input_monitoring: "unknown",
     });
     const ctrl = createOnboardingController();
     await ctrl.mount();
@@ -201,7 +198,6 @@ describe("createOnboardingController", () => {
       system_audio: "granted",
       accessibility: "granted",
       calendar: "unknown",
-      input_monitoring: "granted",
     });
     const ctrl = createOnboardingController();
     await ctrl.mount();
@@ -221,7 +217,6 @@ describe("createOnboardingController", () => {
       system_audio: "granted",
       accessibility: "denied",
       calendar: "unknown",
-      input_monitoring: "unknown",
     });
     const ctrl = createOnboardingController();
     await ctrl.mount();
@@ -232,7 +227,6 @@ describe("createOnboardingController", () => {
       system_audio: "granted",
       accessibility: "granted",
       calendar: "unknown",
-      input_monitoring: "granted",
     });
     expect(ctrl.autoPaste).toBe(true);
 
@@ -270,7 +264,6 @@ describe("createOnboardingController", () => {
       system_audio: "granted",
       accessibility: "granted",
       calendar: "unknown",
-      input_monitoring: "granted",
     });
     const ctrl = createOnboardingController();
     await ctrl.mount();

--- a/src/lib/features/transcription/controller.svelte.test.ts
+++ b/src/lib/features/transcription/controller.svelte.test.ts
@@ -355,7 +355,6 @@ describe("transcription controller", () => {
       system_audio: "unknown",
       accessibility: "granted",
       calendar: "unknown",
-      input_monitoring: "unknown",
     };
     flushSync();
 

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -554,8 +554,6 @@
     "system_desc": "Capture other participants during meetings. Only active during a meeting.",
     "accessibility_label": "Accessibility",
     "accessibility_desc": "Paste transcriptions automatically with ⌘V, and capture single-key shortcuts (e.g. fn, cmd). Soufflé doesn't read your screen.",
-    "input_monitoring_label": "Input Monitoring",
-    "input_monitoring_desc": "Observe keyboard and mouse events without modifying them.",
     "grant": "Grant",
     "open_system_settings": "Open System Settings",
     "open_settings": "Open Settings",

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -528,6 +528,7 @@
     "autopaste_hint": "Auto-pastes into your last app when you stop",
     "live_transcript": "Live transcript",
     "system_audio_active": "System audio active",
+    "system_audio_pending": "Checking system audio",
     "idle_silence_banner": "No speech detected for {minutes} min. Recording will stop soon.",
     "idle_stop_now": "Stop now",
     "idle_keep_recording": "Keep recording",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -528,6 +528,7 @@
     "autopaste_hint": "Collé automatiquement dans votre dernière app à l’arrêt",
     "live_transcript": "Transcription en direct",
     "system_audio_active": "Audio système actif",
+    "system_audio_pending": "Vérification de l’audio système",
     "idle_silence_banner": "Aucune parole détectée depuis {minutes} min. L'enregistrement va bientôt s'arrêter.",
     "idle_stop_now": "Arrêter maintenant",
     "idle_keep_recording": "Continuer l'enregistrement",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -554,8 +554,6 @@
     "system_desc": "Capturer les autres participants pendant les meetings. Actif uniquement en réunion.",
     "accessibility_label": "Accessibilité",
     "accessibility_desc": "Coller les transcriptions automatiquement avec ⌘V, et capturer le raccourci sur une seule touche (ex: fn, cmd). Soufflé ne lit pas votre écran.",
-    "input_monitoring_label": "Surveillance de l'entrée",
-    "input_monitoring_desc": "Observer les événements clavier et souris sans les modifier.",
     "grant": "Autoriser",
     "open_system_settings": "Ouvrir les Réglages Système",
     "open_settings": "Ouvrir Réglages",

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -860,7 +860,14 @@ async learnFromEdit(original: string, corrected: string) : Promise<Result<number
 }
 },
 /**
- * Cheap, non-prompting snapshot for the onboarding's initial render.
+ * Cheap, non-prompting snapshot for the onboarding's initial render, and
+ * the source of the panel's 600 ms poll.
+ * 
+ * Off the command thread even though every read is a status API: three of
+ * them (`AXIsProcessTrusted`, `TCCAccessPreflight`, EventKit) are XPC round
+ * trips to `tccd`, and a synchronous command runs on the main thread, where
+ * a stalled `tccd` would freeze the window. Nothing here needs the main
+ * thread — only *requests* do (SOU-122).
  */
 async getPermissionStatus() : Promise<Result<PermissionStatus, string>> {
     try {

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -1627,8 +1627,8 @@ export type PermState = "granted" | "denied" |
 /**
  * Which capability to probe or prompt for via `request`.
  */
-export type PermissionKind = "microphone" | "system_audio" | "accessibility" | "calendar" | "input_monitoring"
-export type PermissionStatus = { microphone: PermState; system_audio: PermState; accessibility: PermState; calendar: PermState; input_monitoring: PermState }
+export type PermissionKind = "microphone" | "system_audio" | "accessibility" | "calendar"
+export type PermissionStatus = { microphone: PermState; system_audio: PermState; accessibility: PermState; calendar: PermState }
 /**
  * Frontend-driven hold on the pill window, toggled by the `pill_hold` /
  * `pill_release` commands. The pill runs in its own webview, separate from

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -872,7 +872,8 @@ async getPermissionStatus() : Promise<Result<PermissionStatus, string>> {
 },
 /**
  * Trigger the native prompt (or open System Settings) for one permission.
- * The probe opens a device, so it runs off the command thread.
+ * Blocks until the user answers the dialog, so it runs off the command
+ * thread.
  */
 async requestPermission(kind: PermissionKind) : Promise<Result<PermState, string>> {
     try {

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -1610,8 +1610,7 @@ export type PasteMethod = "clipboard" | "type" |
 "ax"
 export type PermState = "granted" | "denied" | 
 /**
- * Not yet probed — the user hasn't triggered this one (probing would
- * prompt, so we don't do it unsolicited at startup).
+ * TCC has no answer on record: the user has not been asked yet.
  */
 "unknown" | 
 /**


### PR DESCRIPTION
Closes SOU-124. The research behind it is not committed and does not exist in this repo; what it concluded is restated below and in the code comments.

Three separate bugs had the same shape: the app was learning a permission's state by doing the thing the permission guards, on a binary whose code identity changed with every build. This branch stops both.

## What changes

**The Nightly bundle is signed.** TCC keys its records on the designated requirement, not on the bundle id. The Nightly was never signed at all (`flags=0x20002(adhoc,linker-signed)`, `Identifier=souffle-070429119c146ca5`, `Sealed Resources=none`), so its DR was its cdhash and every rebuild became a new subject: new build, every permission gone. `scripts/run-nightly.sh` now exports `APPLE_SIGNING_IDENTITY` with the Developer ID identity already in the keychain. No notarization involved: a locally built bundle carries no quarantine flag. The release path and the committed Tauri config are untouched.

**The microphone is asked for through AVFoundation.** `AVCaptureDevice.authorizationStatus` is answered from a per-process cache filled on the first call. AVFoundation's own request path refreshes it; the CoreAudio HAL path does not. The app was raising the prompt implicitly by opening a cpal input stream, which is exactly the case that leaves the status stale for the life of the process, which is why the panel kept offering "Grant" for a microphone the user had already allowed. It now calls `requestAccessForMediaType:completionHandler:` and takes the completion block as the answer. `probe_microphone` is gone: a status read must never open a device.

**System audio is read from TCC, not by mounting a tap.** Reading the status used to create and tear down an aggregate device on every call. There is no public API, so this uses `TCCAccessPreflight("kTCCServiceAudioCapture")` via `dlopen`/`dlsym`, behind the `private-tcc` cargo feature (on by default). It is an XPC round trip to tccd on every call, so it has no per-process cache. A missing symbol falls back to the old tap probe rather than panicking, and a test covers that arm.

**Both persisted permission keys are deleted.** `microphone_permission` and `system_audio_permission` cached a fact the app does not own: they could not represent a revocation and would eventually claim a permission the user had taken away. The one case they covered is now an in-process `AtomicBool`, so a fresh launch always starts from the OS.

**`--fresh` resets the right services.** The loop was `Accessibility ListenEvent Microphone ScreenCapture`. System audio is gated by `kTCCServiceAudioCapture`, not `ScreenCapture`, so `--fresh` had never cleared it. `Calendar` was missing too, and `ListenEvent` is dead since the Input Monitoring removal.

Earlier commits on this branch, kept as their own story: never asking for a permission before a user action (`7295336`), removing Input Monitoring entirely (`abaa971`, the active event tap needs Accessibility anyway, which subsumes the listen right), the meeting card no longer saying "Mic only" before the system-audio leg has reported (`cd0a663`), and two logging commits for defects still under diagnosis (`878cf8b`, `2f6e35c`).

`scripts/codeql-local.sh` was broken on a Homebrew CodeQL install (bare suite names only resolve inside the Action's bundle). Fixed in `f89119c` so the local gate actually runs.

## Audit round (74d1e41)

An independent review of the branch found two defects that survived the first
pass, both of them the same mistake in a place nobody had looked yet.

**The panel still mounted a tap on every focus round trip.** Returning from
System Settings re-probed system audio to catch a revoke, which created and
tore down a `Souffle Tap` aggregate each time — the churn this PR set out to
remove, still there because the fix had only touched the backend read path.
It is gone; the 600 ms poll reports a revoke on its own.

**The SPI fallback made a read mount a tap, on the main thread.** With the
symbol missing, `snapshot()` would open a tap for up to two seconds per poll
tick and raise the AudioCapture prompt on first render. A read with no SPI now
answers `Unknown`, narrowed by an in-process grant flag (the mirror of the
microphone one); the tap probe is the request path and nothing else.

Four more, ranked below them:

- `get_permission_status` was a synchronous Tauri command, so its three XPC
  round trips to tccd ran on the main thread every 600 ms. It is `async` now.
- The system-audio request reported `Granted` when the user clicked "Don't
  Allow": CoreAudio returns noErr on a refusal and delivers silence. It asks
  TCC for the verdict instead.
- A microphone prompt the user walked away from was reported as `Denied`. A
  timeout is not a refusal; it reports `Unknown` and the poll settles it.
- Signing the Nightly turns on the hardened runtime, which blocks lldb and
  sample from attaching. The Nightly now has its own entitlements file with
  `com.apple.security.get-task-allow`; release is untouched.

Plus, from the same pass and from CodeRabbit: `TAP_PORT` kept a stale pointer
after `CFRunLoop::run_current` returned and the tap dropped, so a concurrent
enable could touch freed memory; the tap callback read its shortcuts with
`.read().unwrap()`, panicking inside a C callback in front of every keystroke
on a poisoned lock; the waiting thread ticked every two seconds forever even
with nothing wanting the tap; and `log_slow_mic_open` only ran on success, so
a CoreAudio open that failed *slowly* — the 72 s case — lost its elapsed time
through `?`.

CodeRabbit's other two comments are not taken. Mapping `spawn_blocking` join
failures to a typed `AppError` would be a lone exception among 43 commands that
all return `Result<_, String>`; and `get_permission_status`'s `Result` is no
longer vacuous now that the command is async and the join can fail.

## Also carries the SOU-125 follow-up (20d1348)

#217 was merged ahead of this branch, so its bound on the microphone open is on
develop and this branch is merged onto it. The merge takes develop's `capture.rs`
whole: this branch's only change there was `log_slow_mic_open`, the 3 s
instrumentation written while the 72 s stall was still undiagnosed, and
`log_mic_open_timeout` now reports the same event with a verdict attached.

A review of that bound found the retry path still handing the same dead device
one full bound after another, so the fixes ride here:

- **The park is keyed by device, and a route event no longer clears it.** It was
  cleared on every `SetInputPolicy`, which `device_watch` sends for any CoreAudio
  device-list or default-input notification — including the ones this app's own
  tap retry produces whenever it creates or destroys an aggregate. A wedged
  built-in mic was un-parked within seconds and given another 8 s freeze.
- **A second open is refused while the first is still inside CoreAudio.** The
  worker's handle is kept (never joined) only to ask `is_finished`. Without it a
  permanently wedged device stacked one stuck thread and one AUHAL per retry for
  the life of the session.
- **The open is told when the caller has given up**, and checks that before
  `play()` — where the measured minutes went. Starting IO for a stream nobody
  will receive left a device running for no one. The same flag closes the
  microsecond race where a stream delivered just after the timeout was dropped
  without its `pause()`, which is how a Bluetooth headset stayed in HFP.
- **A late open says what it cost.** Only the bound (~8000 ms) was ever logged;
  the worker now logs its real elapsed time and outcome, which is the thing
  SOU-125 set out to measure.
- **Dictation stops pretending.** A start that failed on a stalled device spent
  ten more silent seconds in the rebuild ladder and ended on "the recording so
  far was saved" — false, and the real reason never reached the user.
- Two comments stated a cpal contract that does not exist (`Stream` is `Send` on
  CoreAudio since cpal 0.17; #771 was a drop-time leak, not a thread-affinity
  rule). Corrected.

Known and deliberately left: a rebuild on a newly wedged device still blocks the
capture thread for one bound, costing a meeting about six seconds of far-end
audio (the tap ring holds two). The busy guard plus the device-keyed park take
that from roughly once every ten seconds to once every hundred; making the
rebuild path adopt the stream asynchronously is a larger change and wants a
device that actually wedges to test against. Unrelated and untouched:
`feedback.rs` opens its output stream with no bound either.

## Verification

Commands run on 20d1348 (this branch merged onto develop), with their results:

```
cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check     clean
cargo clippy --manifest-path src-tauri/Cargo.toml --workspace \
  --all-targets -- -D warnings                                      clean
cargo test --manifest-path src-tauri/Cargo.toml --workspace         951 passed, 0 failed, 4 ignored
cargo check --manifest-path src-tauri/Cargo.toml --no-default-features   clean (exercises the no-SPI arm)
npm test                                                            582 passed, 0 failed, 55 files
npm run check                                                       4018 files, 0 errors, 0 warnings
npm run check:generated-types                                       in sync
./scripts/build-mcp-sidecar.sh                                      sidecar built
```

`./scripts/codeql-local.sh` did **not** run: the CodeQL CLI is not installed on
this machine (`brew install --cask codeql`). The script exits 1 rather than
passing quietly, so nothing is being skipped silently — it simply has not been
run, and should be before merge.

**AC1 and AC2 are still unverified, and the blocker moved.** A signed build is
needed for both, and there is currently **no codesigning identity in the
keychain at all** on this machine:

```
$ security find-identity -v -p codesigning
     0 valid identities found
$ security find-certificate -a -c "Developer ID"
(nothing)
```

So this is no longer the ACL/"Always Allow" click described earlier — the
Developer ID certificate and its private key have to be installed first. Until
then `scripts/run-nightly.sh` prints a warning and builds unsigned rather than
dying at `codesign`. Once the identity is in place:

```bash
make nightly            # answer the keychain prompt with "Always Allow"
codesign -dvvv "/Applications/Soufflé Nightly.app" 2>&1 | grep -E 'Identifier|TeamIdentifier|Sealed'
REQ=$(codesign -dr - "/Applications/Soufflé Nightly.app" 2>&1 | sed -n 's/^# designated => //p'); echo "$REQ"
touch src-tauri/src/lib.rs && make nightly
codesign -v -R="$REQ" "/Applications/Soufflé Nightly.app" && echo "same TCC subject"
```

`$REQ` must not contain `cdhash`, `Identifier` must be `com.souffle.desktop.nightly`, `TeamIdentifier` must be `X6H966RSDB`. The first signed build changes the TCC subject one last time, so every permission has to be granted once more after it.

Manual checks that need that signed build: the wizard showing "Accordé" for the microphone without a restart; no `device=Souffle Tap transport=aggregate` line in `coreaudiod`'s log while the permissions panel is open **and** across a System Settings round trip; a "Don't Allow" on the system-audio prompt leaving the row on Grant rather than flashing Granted; and `lldb -p` attaching to the signed Nightly.

Manual checks for the SOU-125 follow-up, which need a device that actually
wedges (dock reboot, Bluetooth HFP transition): after a timeout, no
`Input device changed, rebuilding audio capture` within 30 s without a real
route change; the meeting card degrading within a few seconds and the
transcript showing no repeated far-end gaps; and dictation against a wedged mic
surfacing the device error immediately instead of "the recording so far was
saved".

## Not in this PR

The Repair button and `tccutil reset` (SOU-054, SOU-055) and the AX paste path are instrumented only, waiting on a retest log. The 72 s block in `cpal::Stream::play()` that broke a meeting start is SOU-125. `tauri-plugin-macos-permissions` was evaluated and rejected: no system audio, no calendar, a boolean state that cannot tell "never asked" from "denied", and a `request_input_monitoring` that never calls the API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133mkpKGGxgBr75KeZ4YaUx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Permissions**
  - Simplified onboarding by removing the separate Input Monitoring permission.
  - Accessibility guidance now covers single-key shortcuts and native event handling.
  - Improved microphone and system-audio permission status detection, including pending and unavailable states.

- **Meeting Experience**
  - Added a “Checking system audio” status to distinguish verification from unavailable audio.
  - Improved live meeting indicators for active, pending, and unavailable system audio.
  - Microphone startup now fails promptly when capture cannot begin.

- **Bug Fixes**
  - Improved text insertion reliability by verifying accessibility insertion before using clipboard fallback.

- **Documentation**
  - Updated English and French permission descriptions and troubleshooting guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

