### PR TITLE
fix(audio): bound the microphone open so a wedged device cannot stall a start (SOU-125)

### DIFF
--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -238,6 +238,24 @@ const DICTATION_ABORT_AFTER_FAILURES: u32 = 5;
 /// mic does not stall the mixer every `MIC_CHECK_INTERVAL`.
 const TAP_RETRY_INTERVAL: Duration = Duration::from_secs(15);
 
+/// Ceiling on opening the microphone: `build_input_stream` plus `play()`.
+/// Both are synchronous CoreAudio calls with no deadline of their own, and
+/// one session was measured blocking 72s inside `play()` while coreaudiod
+/// failed to start the device's IO thread. A user starting a meeting waits
+/// on this call, so the wait has to end even though the cause of the stall
+/// is not understood. Well above a healthy open (tens of ms) and above a
+/// Bluetooth route switch, far below the minute-scale stall observed.
+const MIC_OPEN_TIMEOUT: Duration = Duration::from_secs(8);
+
+/// A device that just blew through `MIC_OPEN_TIMEOUT` fails the same way on
+/// the next attempt, and every attempt freezes the capture thread (hence
+/// the meeting mixer) for the whole bound. Park it for this long before
+/// spending another bound on it, the way `TAP_RETRY_INTERVAL` parks a tap:
+/// retrying on the `MIC_CHECK_INTERVAL` cadence would cost the system-audio
+/// leg more than the missing microphone does. An explicit route event
+/// clears the park, so picking another device is never delayed by it.
+const MIC_OPEN_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+
 /// Decision for one mic-loss episode in `check_mic_health`, given how many
 /// rebuilds have failed in a row, whether the session has another audio
 /// source to fall back on, and whether this episode already warned once.
@@ -272,6 +290,167 @@ fn decide_mic_loss(
         MicLossAction::Abort
     } else {
         MicLossAction::KeepRetrying
+    }
+}
+
+/// Why opening the microphone did not yield a stream.
+enum MicOpenError {
+    /// cpal itself refused: bad config, device gone mid-open.
+    Failed(String),
+    /// The open ran past `MIC_OPEN_TIMEOUT`. A device failure, never a
+    /// permission denial: a TCC refusal delivers silent buffers or fails
+    /// the build outright, it does not stall inside CoreAudio.
+    TimedOut(Duration),
+    /// Not attempted: the last open on this device hit the bound less than
+    /// `MIC_OPEN_RETRY_INTERVAL` ago.
+    Parked,
+}
+
+impl std::fmt::Display for MicOpenError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Failed(error) => write!(f, "{error}"),
+            Self::TimedOut(elapsed) => write!(
+                f,
+                "Microphone device did not open within {:.1}s (CoreAudio never returned)",
+                elapsed.as_secs_f32()
+            ),
+            Self::Parked => write!(
+                f,
+                "Microphone device is not responding; not reopened yet after the last timeout"
+            ),
+        }
+    }
+}
+
+/// Run `open` on a throwaway thread and wait at most `timeout` for it.
+///
+/// `open` owns everything it builds. Once the wait has expired the value
+/// can no longer be handed over, so that thread `discard`s it instead: a
+/// cpal stream has to be paused and dropped by the thread holding it (cpal
+/// 0.15 leaked `StreamInner` when it was released elsewhere). A thread
+/// still inside a CoreAudio call is never killed and never joined, and its
+/// handle is dropped here, so the process can exit while it is stuck.
+fn open_with_timeout<T, F, D>(timeout: Duration, open: F, discard: D) -> Result<T, MicOpenError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+    D: FnOnce(T) + Send + 'static,
+{
+    let started = Instant::now();
+    let (tx, rx) = std::sync::mpsc::channel::<Result<T, String>>();
+    std::thread::Builder::new()
+        .name("mic-open".into())
+        .spawn(move || match open() {
+            Ok(value) => {
+                if let Err(std::sync::mpsc::SendError(Ok(abandoned))) = tx.send(Ok(value)) {
+                    discard(abandoned);
+                }
+            }
+            Err(error) => {
+                let _ = tx.send(Err(error));
+            }
+        })
+        .map_err(|e| MicOpenError::Failed(format!("Failed to spawn mic open thread: {e}")))?;
+
+    match rx.recv_timeout(timeout) {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(error)) => Err(MicOpenError::Failed(error)),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            Err(MicOpenError::TimedOut(started.elapsed()))
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            Err(MicOpenError::Failed("Mic open thread died".into()))
+        }
+    }
+}
+
+fn log_mic_open_timeout(device_name: &str, elapsed: Duration) {
+    warn!(
+        device = device_name,
+        elapsed_ms = elapsed.as_millis() as u64,
+        "Microphone stream did not open within the bound; giving up on the device for now"
+    );
+}
+
+#[cfg(test)]
+mod mic_open_tests {
+    use super::*;
+
+    /// Stands in for the cpal stream: the wrapper is what is under test,
+    /// not CoreAudio.
+    const OPENED: u32 = 7;
+
+    #[test]
+    fn a_stalled_open_gives_the_caller_back_a_timeout() {
+        let (discarded_tx, discarded_rx) = std::sync::mpsc::channel();
+        let waited = Instant::now();
+        let opened = open_with_timeout(
+            Duration::from_millis(50),
+            || {
+                std::thread::sleep(Duration::from_millis(400));
+                Ok(OPENED)
+            },
+            move |value| {
+                let _ = discarded_tx.send(value);
+            },
+        );
+
+        let Err(MicOpenError::TimedOut(elapsed)) = opened else {
+            panic!("an open past the bound must report a timeout");
+        };
+        assert!(
+            elapsed >= Duration::from_millis(50),
+            "the reported elapsed time must cover the bound, got {elapsed:?}"
+        );
+        assert!(
+            waited.elapsed() < Duration::from_millis(400),
+            "the caller waited for the stalled open instead of giving up"
+        );
+
+        // Released by the thread that built it, never by this one.
+        assert_eq!(
+            discarded_rx.recv_timeout(Duration::from_secs(5)),
+            Ok(OPENED),
+            "the abandoned value must be discarded on its own thread"
+        );
+    }
+
+    #[test]
+    fn an_open_that_answers_in_time_returns_its_stream() {
+        let opened = open_with_timeout(
+            Duration::from_secs(5),
+            || Ok(OPENED),
+            |_| panic!("a delivered value must not be discarded"),
+        );
+        assert!(matches!(opened, Ok(OPENED)));
+    }
+
+    #[test]
+    fn a_refused_open_is_a_failure_rather_than_a_timeout() {
+        let opened = open_with_timeout(
+            Duration::from_secs(5),
+            || Err::<u32, String>("Failed to build input stream: device gone".into()),
+            |_| {},
+        );
+        let Err(MicOpenError::Failed(error)) = opened else {
+            panic!("cpal's own error must be reported as a failure");
+        };
+        assert_eq!(error, "Failed to build input stream: device gone");
+    }
+
+    /// A stalled device is not a denied microphone: the text a timeout
+    /// carries into the log and the session error must not read as one.
+    #[test]
+    fn a_timeout_never_reads_as_a_permission_denial() {
+        let message = MicOpenError::TimedOut(Duration::from_secs(8)).to_string();
+        let lowered = message.to_lowercase();
+        for permission_word in ["permission", "denied", "access", "authoriz", "privacy"] {
+            assert!(
+                !lowered.contains(permission_word),
+                "a timeout must not be worded as a permission problem: {message}"
+            );
+        }
     }
 }
 
@@ -1187,6 +1366,10 @@ pub struct AudioCapture {
     /// check from tearing the stream down every interval; explicit route
     /// events (`refresh_input_route`) clear it so a real change retries.
     route_attempt_uid: Option<String>,
+    /// When the last microphone open ran past `MIC_OPEN_TIMEOUT`. Parks the
+    /// next open for `MIC_OPEN_RETRY_INTERVAL`; cleared on a successful
+    /// open, on an explicit route event, and at session start.
+    mic_open_timed_out_at: Option<Instant>,
     /// Set by the cpal error callback when the stream dies (e.g. its device
     /// disappeared); the next mic health check rebuilds the capture leg.
     stream_failed: Arc<std::sync::atomic::AtomicBool>,
@@ -1255,6 +1438,7 @@ impl AudioCapture {
                     mic_device_object_id: None,
                     last_mic_callback_ms: Arc::new(AtomicU64::new(0)),
                     route_attempt_uid: None,
+                    mic_open_timed_out_at: None,
                     stream_failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
                     last_mic_check: Instant::now(),
                     level_throttle: AudioLevelThrottle::new(),
@@ -1455,6 +1639,42 @@ impl AudioCapture {
             .ok_or_else(|| "No input device available".to_string())
     }
 
+    /// Build and start the microphone stream under `MIC_OPEN_TIMEOUT`.
+    ///
+    /// A device that just ran past the bound is not reopened for
+    /// `MIC_OPEN_RETRY_INTERVAL`: another attempt would cost this thread
+    /// (and the meeting mixer it drives) the whole bound again.
+    fn open_mic_stream<F>(&mut self, device_name: &str, build: F) -> Result<Stream, MicOpenError>
+    where
+        F: FnOnce() -> Result<Stream, String> + Send + 'static,
+    {
+        if self
+            .mic_open_timed_out_at
+            .is_some_and(|at| at.elapsed() < MIC_OPEN_RETRY_INTERVAL)
+        {
+            return Err(MicOpenError::Parked);
+        }
+
+        let opened = open_with_timeout(MIC_OPEN_TIMEOUT, build, |stream| {
+            // Owned end to end by the thread that built it: cpal 0.15 leaked
+            // `StreamInner` when a stream was released anywhere else, and the
+            // Bluetooth route only returns to A2DP once it is dropped.
+            if let Err(e) = stream.pause() {
+                debug!("Pause of an abandoned mic stream: {e}");
+            }
+        });
+
+        match &opened {
+            Ok(_) => self.mic_open_timed_out_at = None,
+            Err(MicOpenError::TimedOut(elapsed)) => {
+                log_mic_open_timeout(device_name, *elapsed);
+                self.mic_open_timed_out_at = Some(Instant::now());
+            }
+            Err(MicOpenError::Failed(_) | MicOpenError::Parked) => {}
+        }
+        opened
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn start(
         &mut self,
@@ -1473,6 +1693,9 @@ impl AudioCapture {
             .is_none_or(|p| p.session_id != session_id);
         if is_new_session {
             self.clear_mic_loss_ladder();
+            // A new session is a fresh user intent: give a device parked by
+            // a previous session's timeout one more chance.
+            self.mic_open_timed_out_at = None;
         }
         // Ensure any previous callback stops emitting immediately. The
         // recorder is NOT torn down here; see `sync_recorder`, so a
@@ -1597,69 +1820,86 @@ impl AudioCapture {
         static LOGGED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
         LOGGED.store(false, std::sync::atomic::Ordering::Relaxed);
 
-        let stream = device
-            .build_input_stream(
-                &config,
-                move |data: &[f32], _: &cpal::InputCallbackInfo| {
-                    if active_session_id.load(Ordering::Acquire) != session_id {
-                        return;
-                    }
-                    last_mic_callback_ms.store(unix_now_ms(), Ordering::Relaxed);
+        // Stored before the open, not between the build and `play()`: a
+        // stream that has not been played delivers no callback, so the gate
+        // is just as closed, and both calls now run on another thread.
+        self.active_session_id.store(session_id, Ordering::Release);
 
-                    let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    let resampled = match resampler.lock() {
-                        Ok(mut r) => r.process(data),
-                        Err(_) => return,
-                    };
-                    if !resampled.is_empty() {
-                        // Compute RMS for waveform visualization
-                        let sum_sq: f32 = resampled.iter().map(|s| s * s).sum();
-                        let rms = (sum_sq / resampled.len() as f32).sqrt();
-                        // Clamp to 0.0-1.0 (typical speech RMS is 0.01-0.15)
-                        let normalized = (rms * 8.0).min(1.0);
-                        rms_ref.store(normalized.to_bits(), Ordering::Relaxed);
+        let build = move || {
+            let stream = device
+                .build_input_stream(
+                    &config,
+                    move |data: &[f32], _: &cpal::InputCallbackInfo| {
+                        if active_session_id.load(Ordering::Acquire) != session_id {
+                            return;
+                        }
+                        last_mic_callback_ms.store(unix_now_ms(), Ordering::Relaxed);
 
-                        // Log first chunk to confirm audio is flowing
-                        if crate::debug::transcription_debug_enabled()
-                            && !LOGGED.swap(true, std::sync::atomic::Ordering::Relaxed)
-                        {
-                            let max_amp = resampled.iter().map(|s| s.abs()).fold(0.0f32, f32::max);
-                            debug!(
-                                "First audio chunk: {} samples, max_amp={max_amp:.4}",
-                                resampled.len(),
-                            );
-                        }
-                        if let Some(feed) = &recorder_feed {
-                            feed.push(&resampled);
-                        }
-                        if sender
-                            .try_send(AudioMessage::Chunk(AudioChunk {
-                                session_id,
-                                samples: resampled,
-                                captured_at: Instant::now(),
-                                speaker: None,                            }))
-                            .is_err()
-                        {
-                            let dropped = dropped_counter.fetch_add(1, Ordering::Relaxed) + 1;
-                            if dropped == 1 || dropped.is_multiple_of(100) {
-                                warn!("Audio buffer full, dropping samples ({dropped} chunks dropped this session)");
+                        let caught = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        let resampled = match resampler.lock() {
+                            Ok(mut r) => r.process(data),
+                            Err(_) => return,
+                        };
+                        if !resampled.is_empty() {
+                            // Compute RMS for waveform visualization
+                            let sum_sq: f32 = resampled.iter().map(|s| s * s).sum();
+                            let rms = (sum_sq / resampled.len() as f32).sqrt();
+                            // Clamp to 0.0-1.0 (typical speech RMS is 0.01-0.15)
+                            let normalized = (rms * 8.0).min(1.0);
+                            rms_ref.store(normalized.to_bits(), Ordering::Relaxed);
+
+                            // Log first chunk to confirm audio is flowing
+                            if crate::debug::transcription_debug_enabled()
+                                && !LOGGED.swap(true, std::sync::atomic::Ordering::Relaxed)
+                            {
+                                let max_amp = resampled.iter().map(|s| s.abs()).fold(0.0f32, f32::max);
+                                debug!(
+                                    "First audio chunk: {} samples, max_amp={max_amp:.4}",
+                                    resampled.len(),
+                                );
+                            }
+                            if let Some(feed) = &recorder_feed {
+                                feed.push(&resampled);
+                            }
+                            if sender
+                                .try_send(AudioMessage::Chunk(AudioChunk {
+                                    session_id,
+                                    samples: resampled,
+                                    captured_at: Instant::now(),
+                                    speaker: None,                            }))
+                                .is_err()
+                            {
+                                let dropped = dropped_counter.fetch_add(1, Ordering::Relaxed) + 1;
+                                if dropped == 1 || dropped.is_multiple_of(100) {
+                                    warn!("Audio buffer full, dropping samples ({dropped} chunks dropped this session)");
+                                }
                             }
                         }
-                    }
-                    }));
-                    if caught.is_err() {
-                        stream_failed_cb.store(true, Ordering::Relaxed);
-                    }
-                },
-                err_fn,
-                None,
-            )
-            .map_err(|e| format!("Failed to build input stream: {e}"))?;
+                        }));
+                        if caught.is_err() {
+                            stream_failed_cb.store(true, Ordering::Relaxed);
+                        }
+                    },
+                    err_fn,
+                    None,
+                )
+                .map_err(|e| format!("Failed to build input stream: {e}"))?;
+            stream
+                .play()
+                .map_err(|e| format!("Failed to start stream: {e}"))?;
+            Ok(stream)
+        };
 
-        self.active_session_id.store(session_id, Ordering::Release);
-        stream
-            .play()
-            .map_err(|e| format!("Failed to start stream: {e}"))?;
+        let stream = match self.open_mic_stream(&device_name, build) {
+            Ok(stream) => stream,
+            Err(e) => {
+                // No stream to gate, and the abandoned open may still start
+                // one minutes from now: close the gate so nothing it
+                // captures reaches this session.
+                self.active_session_id.store(0, Ordering::Release);
+                return Err(e.to_string());
+            }
+        };
         self.stream = Some(stream);
 
         info!("Audio capture started on '{device_name}'");
@@ -1780,26 +2020,6 @@ impl AudioCapture {
             error!("Audio stream error: {err}");
             stream_failed.store(true, std::sync::atomic::Ordering::Relaxed);
         };
-        let stream = device
-            .build_input_stream(
-                config,
-                move |data: &[f32], _: &cpal::InputCallbackInfo| {
-                    if active_session_id.load(Ordering::Acquire) != session_id {
-                        return;
-                    }
-                    last_mic_callback_ms.store(unix_now_ms(), Ordering::Relaxed);
-                    // Ring full means the mixer is wedged; losing mic samples
-                    // here is the only safe option in a realtime callback.
-                    let _ = mic_prod.push_slice(data);
-                },
-                err_fn,
-                None,
-            )
-            .map_err(|e| format!("Failed to build input stream: {e}"))?;
-        stream
-            .play()
-            .map_err(|e| format!("Failed to start stream: {e}"))?;
-
         // Accept mic samples into the ring buffer from here on, even though
         // `spawn_tap` below can block this thread for up to its 5s timeout
         // when coreaudiod is slow or wedged. The mic callback gates on this
@@ -1808,8 +2028,65 @@ impl AudioCapture {
         // seconds of the meeting's start, despite the mixer/meeting_tick not
         // running yet to drain them. The ring buffer (~2s capacity) still
         // bounds how much of a slow tap's wait it can retain, but that beats
-        // discarding all of it outright.
+        // discarding all of it outright. Nothing is captured before `play()`
+        // either way, so the store is equally safe ahead of the open.
         self.active_session_id.store(session_id, Ordering::Release);
+
+        let device = device.clone();
+        let config = config.clone();
+        let build = move || {
+            let stream = device
+                .build_input_stream(
+                    &config,
+                    move |data: &[f32], _: &cpal::InputCallbackInfo| {
+                        if active_session_id.load(Ordering::Acquire) != session_id {
+                            return;
+                        }
+                        last_mic_callback_ms.store(unix_now_ms(), Ordering::Relaxed);
+                        // Ring full means the mixer is wedged; losing mic samples
+                        // here is the only safe option in a realtime callback.
+                        let _ = mic_prod.push_slice(data);
+                    },
+                    err_fn,
+                    None,
+                )
+                .map_err(|e| format!("Failed to build input stream: {e}"))?;
+            stream
+                .play()
+                .map_err(|e| format!("Failed to start stream: {e}"))?;
+            Ok(stream)
+        };
+
+        let device_name = self
+            .mic_device_name
+            .clone()
+            .unwrap_or_else(|| "unknown".into());
+        let (mic_cons, mic_unavailable) = match self.open_mic_stream(&device_name, build) {
+            Ok(stream) => {
+                self.stream = Some(stream);
+                (mic_cons, None)
+            }
+            // cpal refused outright: nothing was left running, and the
+            // caller retries. Only a device that stops answering is worth
+            // degrading the meeting for.
+            Err(e @ MicOpenError::Failed(_)) => {
+                self.active_session_id.store(0, Ordering::Release);
+                return Err(e.to_string());
+            }
+            Err(e) => {
+                // The meeting goes on with the system-audio leg alone rather
+                // than waiting on a device that does not answer. Close the
+                // gate, and hand the mixer a ring nobody writes to: the
+                // abandoned open still owns the producer of `mic_cons` and
+                // could push frames minutes out of place, which is exactly
+                // what shifts the diarized lanes apart.
+                self.active_session_id.store(0, Ordering::Release);
+                let (dead_prod, dead_cons) = HeapRb::<f32>::new(1).split();
+                drop(dead_prod);
+                drop(mic_cons);
+                (dead_cons, Some(e.to_string()))
+            }
+        };
 
         if let Some(meeting) = self.meeting.as_mut() {
             meeting
@@ -1817,7 +2094,9 @@ impl AudioCapture {
                 .replace_mic(mic_cons, sample_rate, channels, mic_gain);
             meeting.session_id = session_id;
             meeting.diarize = diarize;
-            self.stream = Some(stream);
+            if let Some(error) = mic_unavailable {
+                return Err(error);
+            }
             info!("Meeting microphone rebuilt; system-audio tap kept");
             return Ok(());
         }
@@ -1884,7 +2163,6 @@ impl AudioCapture {
         #[cfg(not(target_os = "macos"))]
         let aec_active = false;
 
-        self.stream = Some(stream);
         self.meeting = Some(MeetingState {
             session_id,
             mixer,
@@ -1895,6 +2173,10 @@ impl AudioCapture {
             ticks: 0,
             last_tap_attempt: Instant::now(),
         });
+
+        if let Some(error) = mic_unavailable {
+            return Err(error);
+        }
 
         info!("Meeting audio capture started (mic + system audio)");
         Ok(())
@@ -2045,6 +2327,7 @@ impl AudioCapture {
     /// send EndOfStream (`active_params` was already cleared).
     fn refresh_input_route(&mut self) -> bool {
         self.route_attempt_uid = None;
+        self.mic_open_timed_out_at = None;
         if self.active_params.is_some() {
             self.last_mic_check = Instant::now();
             if self.check_mic_health() {
@@ -2286,6 +2569,7 @@ impl AudioCapture {
         self.mic_device_uid = None;
         self.mic_device_object_id = None;
         self.route_attempt_uid = None;
+        self.mic_open_timed_out_at = None;
         self.last_mic_callback_ms.store(0, Ordering::Relaxed);
         self.release_capture_stream();
         self.resampler.take();
@@ -2395,6 +2679,7 @@ impl AudioCapture {
         self.mic_device_uid = None;
         self.mic_device_object_id = None;
         self.route_attempt_uid = None;
+        self.mic_open_timed_out_at = None;
         self.last_mic_callback_ms.store(0, Ordering::Relaxed);
         self.emit_audio_level(0.0);
         self.level_throttle.reset();


### PR DESCRIPTION
Closes SOU-125. One file, `src-tauri/src/audio/capture.rs`.

## The problem

On 2026-09-11 a meeting start recorded nothing of the user's voice for over a minute. The capture thread was blocked 72 s inside `cpal::Stream::play()` on the built-in microphone while `coreaudiod` logged five consecutive `StartIOThread: got an error from starting the IO thread, Error: 0x3C` on that device, 14 s apart. `0x3C` is 60, `ETIMEDOUT` on Darwin: the HAL's IO thread did not come up. It is not a TCC denial, which presents as silence rather than a start failure.

No authoritative source exists for that message, and this PR does not pretend to cure it. `build_input_stream` and `play()` are synchronous CoreAudio calls with no deadline of their own, on a path a user is waiting on, in a meeting, in front of other people. That wait now ends.

## What changes

`open_with_timeout` runs the build and the play on a named `mic-open` thread and waits on a channel. The thread is never killed and never joined, so the process can exit while one is still stuck inside CoreAudio. When the wait expires, the send fails and the worker itself pauses and drops the stream: cpal 0.15 leaked `StreamInner` when a stream was released off its owning thread, and the Bluetooth route only returns to A2DP once it is dropped.

The bound is 8 s, matching the `spawn_tap` timeout already used for the system-audio leg. Well above a healthy open (tens of milliseconds) and above a Bluetooth route switch, far below the minute-scale stall observed.

A timeout is its own error variant, never mapped to a permission problem. That mattered here: the surrounding UI had every reason to send the user to the permissions panel for a problem the panel can do nothing about.

On the meeting path, a stalled open no longer aborts the start. The session gate closes, the mixer gets a ring nothing writes to, and the meeting continues on system audio alone through the existing mic-loss ladder ("Microphone lost; still recording system audio"). The dead ring is deliberate: the abandoned open still owns the real producer and could push frames minutes out of place, which is precisely what pulls the diarized lanes apart. A cpal error that fails immediately still returns early as before; only a device that stops answering degrades the meeting.

**One addition beyond the ticket's scope, called out on purpose.** A device that just blew through the bound is parked for 30 s. Without it, `check_mic_health` retries every 2 s and each retry freezes the capture thread, and therefore the meeting mixer, for the whole 8 s bound: the meeting would keep going in name only. It mirrors the existing `TAP_RETRY_INTERVAL` reasoning, and the park is cleared by an explicit route event, a stop, or a new session, so choosing another microphone is never delayed.

## Verification

Local gate green: fmt, clippy `-D warnings`, 946 Rust tests, 581 vitest, `npm run check` 0 errors, generated types in sync, CodeQL 0 rust and 0 js findings (3 pre-existing `missing-workflow-permissions` in actions, no workflow touched).

Four new tests cover the wrapper rather than cpal: a stalled open returns a timeout while the worker is still inside its slow closure and releases the abandoned value later on that thread, a refused open is a failure rather than a timeout, a healthy open returns its stream, and a timeout's message contains none of permission, denied, access, authoriz or privacy.

**Not verified on hardware.** Nobody could make a device wedge on demand, so "the meeting continues on system audio alone" and "first-sample timestamps unchanged for a healthy open" were established by reading the code, not by measurement. The ordering that matters is preserved: `active_session_id` is still stored before the open and before `spawn_tap`, and failure paths reset it.

`codeql-local.sh` needs the query-suite fix from #216 to run at all on a Homebrew CodeQL install; it was applied locally to run the gate here and deliberately left out of this commit to avoid duplicating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0133mkpKGGxgBr75KeZ4YaUx
