### PR TITLE
fix(audio): adopt a microphone that answers late, and stop feedback cues stacking (SOU-125)

### DIFF
--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -334,28 +334,78 @@ impl std::fmt::Display for MicOpenError {
     }
 }
 
+/// An open still inside CoreAudio after the caller stopped waiting.
+///
+/// Two things can be done with it and the caller decides which: `abandon`
+/// it, so it releases whatever it builds instead of starting a device for
+/// nobody; or keep it and `try_take` the stream when it finally arrives.
+/// The thread is never killed and never joined — one stuck in the HAL would
+/// never return — so `is_running` is the only question that can be asked
+/// of it.
+struct PendingOpen<T> {
+    thread: JoinHandle<()>,
+    rx: std::sync::mpsc::Receiver<Result<T, String>>,
+    abandoned: Arc<AtomicBool>,
+    started: Instant,
+}
+
+impl<T> PendingOpen<T> {
+    fn is_running(&self) -> bool {
+        !self.thread.is_finished()
+    }
+
+    /// Tell the worker nobody is waiting any more. It checks this before
+    /// starting the device, and releases anything it has already built.
+    fn abandon(&self) {
+        self.abandoned.store(true, Ordering::Relaxed);
+    }
+
+    /// The stream, if the open has answered since the last look. `Err` is
+    /// the open's own failure; `Ok(None)` means it is still inside
+    /// CoreAudio.
+    fn try_take(&self) -> Result<Option<T>, String> {
+        match self.rx.try_recv() {
+            Ok(Ok(value)) => Ok(Some(value)),
+            Ok(Err(error)) => Err(error),
+            Err(std::sync::mpsc::TryRecvError::Empty) => Ok(None),
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => Err("Mic open thread died".into()),
+        }
+    }
+
+    fn elapsed(&self) -> Duration {
+        self.started.elapsed()
+    }
+}
+
+/// What a meeting needs to put a late microphone stream to work: the ring
+/// its callback already writes into, and the mixer parameters to hand that
+/// ring back with. Held while the open is still out, dropped with it.
+struct MicAdoption {
+    session_id: u64,
+    mic_cons: ringbuf::HeapCons<f32>,
+    sample_rate: u32,
+    channels: u16,
+    mic_gain: f32,
+}
+
 /// Run `open` on a throwaway thread and wait at most `timeout` for it.
 ///
-/// `open` is handed an "abandoned" flag and must check it before any step
-/// that has an effect outside this process: once the wait has expired the
-/// caller has moved on, and starting device IO for a stream nobody will
-/// receive leaves a device running for no one. Whatever `open` still
-/// returns after that point is handed to `discard`, which releases it the
-/// way `release_capture_stream` does — pause, then drop — so a Bluetooth
-/// headset leaves HFP instead of staying in mono. A thread still inside a
-/// CoreAudio call is never killed and never joined; its handle is returned
-/// so the caller can tell whether it is still stuck before spawning
-/// another. Moving the stream between threads is fine: cpal's CoreAudio
-/// `Stream` is `Send` (cpal 0.17).
+/// Whatever `open` returns once nobody is waiting is handed to `discard`,
+/// which releases it the way `release_capture_stream` does — pause, then
+/// drop — so a Bluetooth headset leaves HFP instead of staying in mono.
+/// Moving the stream between threads is fine: cpal's CoreAudio `Stream` is
+/// `Send` (cpal 0.17).
 ///
-/// Returns the worker's handle alongside the result — `None` only when the
-/// thread could not be spawned at all.
+/// On timeout the worker is handed back rather than cut loose, so the
+/// caller can either abandon it or wait for its stream on its own clock.
+/// The open is given the abandoned flag and must check it before any step
+/// with an effect outside this process.
 #[allow(clippy::type_complexity)]
 fn open_with_timeout<T, F, D>(
     timeout: Duration,
     open: F,
     discard: D,
-) -> (Option<JoinHandle<()>>, Result<T, MicOpenError>)
+) -> (Option<PendingOpen<T>>, Result<T, MicOpenError>)
 where
     T: Send + 'static,
     F: FnOnce(&AtomicBool) -> Result<T, String> + Send + 'static,
@@ -369,10 +419,11 @@ where
         .name("mic-open".into())
         .spawn(move || {
             let outcome = open(&worker_abandoned);
-            // The caller is gone: it will never read this, and it is the
-            // only place the true cost of the stall can be reported.
+            let elapsed_ms = started.elapsed().as_millis() as u64;
+            // Nobody is waiting: this is the only place the true cost of
+            // the stall can be reported, and the only place the stream can
+            // still be released.
             if worker_abandoned.load(Ordering::Relaxed) {
-                let elapsed_ms = started.elapsed().as_millis() as u64;
                 match &outcome {
                     Ok(_) => warn!(
                         elapsed_ms,
@@ -390,9 +441,9 @@ where
             }
             match outcome {
                 Ok(value) => {
-                    // Lost the race with the caller's timeout by microseconds:
-                    // release it here rather than letting the receiver's drop
-                    // take it without a pause.
+                    // A receiver that is gone means the caller dropped the
+                    // pending open without abandoning it: release the stream
+                    // here rather than letting it drop without its pause.
                     if let Err(std::sync::mpsc::SendError(Ok(unclaimed))) = tx.send(Ok(value)) {
                         discard(unclaimed);
                     }
@@ -402,8 +453,8 @@ where
                 }
             }
         });
-    let handle = match spawned {
-        Ok(handle) => handle,
+    let thread = match spawned {
+        Ok(thread) => thread,
         Err(e) => {
             return (
                 None,
@@ -414,18 +465,23 @@ where
         }
     };
 
-    let result = match rx.recv_timeout(timeout) {
-        Ok(Ok(value)) => Ok(value),
-        Ok(Err(error)) => Err(MicOpenError::Failed(error)),
-        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-            abandoned.store(true, Ordering::Relaxed);
-            Err(MicOpenError::TimedOut(started.elapsed()))
-        }
-        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-            Err(MicOpenError::Failed("Mic open thread died".into()))
-        }
-    };
-    (Some(handle), result)
+    match rx.recv_timeout(timeout) {
+        Ok(Ok(value)) => (None, Ok(value)),
+        Ok(Err(error)) => (None, Err(MicOpenError::Failed(error))),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => (
+            Some(PendingOpen {
+                thread,
+                rx,
+                abandoned,
+                started,
+            }),
+            Err(MicOpenError::TimedOut(started.elapsed())),
+        ),
+        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => (
+            None,
+            Err(MicOpenError::Failed("Mic open thread died".into())),
+        ),
+    }
 }
 
 /// Whether `device_name` is the device that just ran past the bound, still
@@ -453,11 +509,25 @@ mod mic_open_tests {
     /// not CoreAudio.
     const OPENED: u32 = 7;
 
+    /// Wait for the kept open to answer, the way `poll_pending_mic_open`
+    /// does on the capture thread's clock, but without its 2 s cadence.
+    fn take_within(pending: &PendingOpen<u32>, bound: Duration) -> Result<Option<u32>, String> {
+        let deadline = Instant::now() + bound;
+        loop {
+            match pending.try_take() {
+                Ok(None) if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+                other => return other,
+            }
+        }
+    }
+
     #[test]
     fn a_stalled_open_gives_the_caller_back_a_timeout() {
         let (discarded_tx, discarded_rx) = std::sync::mpsc::channel();
         let waited = Instant::now();
-        let (_pending, opened) = open_with_timeout(
+        let (pending, opened) = open_with_timeout(
             Duration::from_millis(50),
             |_abandoned| {
                 std::thread::sleep(Duration::from_millis(400));
@@ -471,6 +541,10 @@ mod mic_open_tests {
         let Err(MicOpenError::TimedOut(elapsed)) = opened else {
             panic!("an open past the bound must report a timeout");
         };
+        // What every caller but a meeting does with the worker it is handed.
+        pending
+            .expect("a spawned worker must be handed back")
+            .abandon();
         assert!(
             elapsed >= Duration::from_millis(50),
             "the reported elapsed time must cover the bound, got {elapsed:?}"
@@ -494,7 +568,7 @@ mod mic_open_tests {
     #[test]
     fn an_abandoned_open_is_told_before_it_starts_the_device() {
         let (started_tx, started_rx) = std::sync::mpsc::channel();
-        let (_pending, opened) = open_with_timeout(
+        let (pending, opened) = open_with_timeout(
             Duration::from_millis(50),
             move |abandoned| {
                 std::thread::sleep(Duration::from_millis(300));
@@ -504,6 +578,9 @@ mod mic_open_tests {
             |_| {},
         );
         assert!(matches!(opened, Err(MicOpenError::TimedOut(_))));
+        pending
+            .expect("a spawned worker must be handed back")
+            .abandon();
         assert_eq!(
             started_rx.recv_timeout(Duration::from_secs(5)),
             Ok(true),
@@ -526,9 +603,59 @@ mod mic_open_tests {
         );
         assert!(matches!(opened, Err(MicOpenError::TimedOut(_))));
         let pending = pending.expect("a spawned worker must be handed back");
-        assert!(!pending.is_finished(), "the worker is still in the open");
+        assert!(pending.is_running(), "the worker is still in the open");
+        assert_eq!(pending.try_take(), Ok(None), "nothing to take yet");
         let _ = release_tx.send(());
-        pending.join().expect("the worker must end cleanly");
+        pending.thread.join().expect("the worker must end cleanly");
+    }
+
+    /// The whole point of keeping the worker: a device that answers a minute
+    /// late still hands its stream over, instead of the open being cut loose
+    /// and the session left without a microphone for good.
+    #[test]
+    fn a_late_open_still_delivers_its_stream_to_whoever_kept_it() {
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let (pending, opened) = open_with_timeout(
+            Duration::from_millis(50),
+            move |abandoned| {
+                let _ = release_rx.recv_timeout(Duration::from_secs(5));
+                assert!(
+                    !abandoned.load(Ordering::Relaxed),
+                    "an open nobody abandoned must not be told it was"
+                );
+                Ok(OPENED)
+            },
+            |_| panic!("a stream the caller kept waiting for must not be discarded"),
+        );
+        assert!(matches!(opened, Err(MicOpenError::TimedOut(_))));
+        let pending = pending.expect("a spawned worker must be handed back");
+
+        let _ = release_tx.send(());
+        assert_eq!(
+            take_within(&pending, Duration::from_secs(5)),
+            Ok(Some(OPENED)),
+            "the late stream must reach the caller that kept the open"
+        );
+    }
+
+    /// An open that fails late reports its own error rather than looking
+    /// like a stream that never came.
+    #[test]
+    fn a_late_open_that_fails_reports_its_error() {
+        let (pending, opened) = open_with_timeout(
+            Duration::from_millis(50),
+            |_abandoned| {
+                std::thread::sleep(Duration::from_millis(200));
+                Err::<u32, String>("Failed to start stream: device gone".into())
+            },
+            |_| {},
+        );
+        assert!(matches!(opened, Err(MicOpenError::TimedOut(_))));
+        let pending = pending.expect("a spawned worker must be handed back");
+        assert_eq!(
+            take_within(&pending, Duration::from_secs(5)),
+            Err("Failed to start stream: device gone".into())
+        );
     }
 
     #[test]
@@ -1523,11 +1650,16 @@ pub struct AudioCapture {
     /// resolves back to the same wedged device does not hand it a fresh
     /// bound to burn (the app's own tap churn emits those events).
     mic_open_timed_out: Option<(String, Instant)>,
-    /// The `mic-open` worker of the last attempt, kept only to ask whether
-    /// it is still inside CoreAudio. Never joined: a thread stuck in the HAL
-    /// would never return. A new open is refused while it runs, so a wedged
-    /// device cannot stack one stuck thread and one AUHAL per retry.
-    mic_open_pending: Option<JoinHandle<()>>,
+    /// The `mic-open` worker of the last attempt, once the caller stopped
+    /// waiting for it. A new open is refused while it runs, so a wedged
+    /// device cannot stack one stuck thread and one AUHAL per retry; on a
+    /// meeting it is also where the stream comes from when the device
+    /// finally answers.
+    mic_open_pending: Option<PendingOpen<Stream>>,
+    /// Everything needed to put a late stream to work, set when a meeting
+    /// gave up waiting for one. Absent on the dictation path, which has
+    /// nothing to adopt into and ends the session instead.
+    mic_open_adoption: Option<MicAdoption>,
     /// Set by the cpal error callback when the stream dies (e.g. its device
     /// disappeared); the next mic health check rebuilds the capture leg.
     stream_failed: Arc<std::sync::atomic::AtomicBool>,
@@ -1598,6 +1730,7 @@ impl AudioCapture {
                     route_attempt_uid: None,
                     mic_open_timed_out: None,
                     mic_open_pending: None,
+                    mic_open_adoption: None,
                     stream_failed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
                     last_mic_check: Instant::now(),
                     level_throttle: AudioLevelThrottle::new(),
@@ -1821,11 +1954,12 @@ impl AudioCapture {
         F: FnOnce(&AtomicBool) -> Result<Stream, String> + Send + 'static,
     {
         if let Some(pending) = &self.mic_open_pending {
-            if pending.is_finished() {
-                self.mic_open_pending = None;
-            } else {
+            if pending.is_running() {
                 return Err(MicOpenError::Busy);
             }
+            // Finished, and whatever it produced was collected (or released)
+            // by `poll_pending_mic_open`. Nothing left to keep.
+            self.drop_pending_mic_open();
         }
         if mic_open_is_parked(self.mic_open_timed_out.as_ref(), device_name) {
             return Err(MicOpenError::Parked);
@@ -1838,6 +1972,9 @@ impl AudioCapture {
                 debug!("Pause of an abandoned mic stream: {e}");
             }
         });
+        // Kept, not abandoned: the caller decides. A meeting waits for it on
+        // its own clock (`poll_pending_mic_open`); everything else abandons
+        // it right away.
         self.mic_open_pending = pending;
 
         match &opened {
@@ -1870,8 +2007,11 @@ impl AudioCapture {
         if is_new_session {
             self.clear_mic_loss_ladder();
             // A new session is a fresh user intent: give a device parked by
-            // a previous session's timeout one more chance.
+            // a previous session's timeout one more chance, and give up on
+            // an open left out by the session before it — its stream belongs
+            // to nobody now.
             self.mic_open_timed_out = None;
+            self.abandon_pending_mic_open();
         }
         // Ensure any previous callback stops emitting immediately. The
         // recorder is NOT torn down here; see `sync_recorder`, so a
@@ -2075,10 +2215,12 @@ impl AudioCapture {
         let stream = match self.open_mic_stream(&device_name, build) {
             Ok(stream) => stream,
             Err(e) => {
-                // No stream to gate, and the abandoned open may still start
-                // one minutes from now: close the gate so nothing it
-                // captures reaches this session.
+                // No stream to gate, and the open may still return one
+                // minutes from now: close the gate so nothing it captures
+                // reaches this session. Dictation has no mixer to hand a
+                // late stream to, so the open is given up rather than kept.
                 self.active_session_id.store(0, Ordering::Release);
+                self.abandon_pending_mic_open();
                 return Err(e.to_string());
             }
         };
@@ -2264,14 +2406,29 @@ impl AudioCapture {
             Err(e) => {
                 // The meeting goes on with the system-audio leg alone rather
                 // than waiting on a device that does not answer. Close the
-                // gate, and hand the mixer a ring nobody writes to: the
-                // abandoned open still owns the producer of `mic_cons` and
-                // could push frames minutes out of place, which is exactly
-                // what shifts the diarized lanes apart.
+                // gate, and hand the mixer a ring nobody writes to: the open
+                // that is still out owns the producer of `mic_cons` and
+                // would otherwise push frames minutes out of place, which is
+                // exactly what shifts the diarized lanes apart.
                 self.active_session_id.store(0, Ordering::Release);
                 let (dead_prod, dead_cons) = HeapRb::<f32>::new(1).split();
                 drop(dead_prod);
-                drop(mic_cons);
+                if matches!(e, MicOpenError::TimedOut(_)) && self.mic_open_pending.is_some() {
+                    // This attempt's open is still inside CoreAudio. Keep its
+                    // ring: `poll_pending_mic_open` hands it to the mixer if
+                    // the device ever answers, and only then is the gate
+                    // reopened. A `Busy` error belongs to an earlier attempt,
+                    // whose ring is already held, so it must not clobber it.
+                    self.mic_open_adoption = Some(MicAdoption {
+                        session_id,
+                        mic_cons,
+                        sample_rate,
+                        channels,
+                        mic_gain,
+                    });
+                } else {
+                    drop(mic_cons);
+                }
                 (dead_cons, Some(e.to_string()))
             }
         };
@@ -2386,6 +2543,11 @@ impl AudioCapture {
         let Some(params) = self.active_params.clone() else {
             return false;
         };
+
+        // A device that answered late gets its leg back here, before the
+        // rebuild decision: the session has a microphone again and there is
+        // nothing to rebuild.
+        self.poll_pending_mic_open();
 
         let failed = self
             .stream_failed
@@ -2763,6 +2925,7 @@ impl AudioCapture {
         self.mic_device_object_id = None;
         self.route_attempt_uid = None;
         self.mic_open_timed_out = None;
+        self.abandon_pending_mic_open();
         self.last_mic_callback_ms.store(0, Ordering::Relaxed);
         self.release_capture_stream();
         self.resampler.take();
@@ -2793,6 +2956,120 @@ impl AudioCapture {
     /// tearing down — see `teardown_session_state` for why exiting this
     /// thread is what lets the actor salvage and fail the session, exactly
     /// like a panic abort.
+    /// Give up on an open that is still out, and forget it. The worker
+    /// releases whatever it built, on its own thread.
+    fn abandon_pending_mic_open(&mut self) {
+        if let Some(pending) = &self.mic_open_pending {
+            pending.abandon();
+        }
+        self.drop_pending_mic_open();
+    }
+
+    /// Forget the pending open without telling the worker anything. Only
+    /// correct once the worker has finished, or right after `abandon`.
+    fn drop_pending_mic_open(&mut self) {
+        self.mic_open_pending = None;
+        self.mic_open_adoption = None;
+    }
+
+    /// Put a late microphone stream to work, if one has arrived.
+    ///
+    /// A meeting keeps running on the system-audio leg while the device is
+    /// not answering, so the open is left out rather than abandoned: when
+    /// CoreAudio finally returns a stream — a minute later, in the case that
+    /// opened SOU-125 — the mic leg comes back without the user doing
+    /// anything, and without another bound being spent to find out.
+    ///
+    /// Nothing the stream captured before this point can reach the session:
+    /// its callback is gated on `active_session_id`, which stays closed
+    /// until the ring is handed to the mixer here. That is what keeps a late
+    /// stream from pushing frames minutes out of place and shifting the
+    /// diarized lanes apart.
+    fn poll_pending_mic_open(&mut self) {
+        let Some(pending) = &self.mic_open_pending else {
+            return;
+        };
+        let elapsed_ms = pending.elapsed().as_millis() as u64;
+        match pending.try_take() {
+            Ok(None) => {
+                // Still inside CoreAudio. A thread that ended without
+                // sending anything is a dead end, not a wait.
+                if !pending.is_running() {
+                    self.drop_pending_mic_open();
+                }
+            }
+            Ok(Some(stream)) => {
+                let adopted = self.adopt_mic_stream(stream, elapsed_ms);
+                self.drop_pending_mic_open();
+                if adopted {
+                    self.mic_open_timed_out = None;
+                    self.clear_mic_loss_ladder();
+                }
+            }
+            Err(error) => {
+                warn!(elapsed_ms, error, "Late microphone open failed");
+                self.drop_pending_mic_open();
+            }
+        }
+    }
+
+    /// Install a stream the open delivered after the session stopped waiting
+    /// for it. Returns whether it was taken up; a stream belonging to a
+    /// session that has since ended, or to one that already has a
+    /// microphone, is released instead.
+    fn adopt_mic_stream(&mut self, stream: Stream, elapsed_ms: u64) -> bool {
+        let release = |stream: Stream, why: &str| {
+            debug!("Late microphone stream released: {why}");
+            if let Err(e) = stream.pause() {
+                debug!("Pause of a released late mic stream: {e}");
+            }
+        };
+
+        let Some(adoption) = self.mic_open_adoption.take() else {
+            release(stream, "nothing was waiting for it");
+            return false;
+        };
+        let Some(params) = self.active_params.as_ref() else {
+            release(stream, "the session has ended");
+            return false;
+        };
+        if params.session_id != adoption.session_id {
+            release(stream, "it belongs to a session that has ended");
+            return false;
+        }
+        let Some(meeting) = self.meeting.as_mut() else {
+            release(stream, "the meeting is gone");
+            return false;
+        };
+        if meeting.session_id != adoption.session_id {
+            release(stream, "the meeting moved on to another session");
+            return false;
+        }
+        if self.stream.is_some() {
+            release(stream, "the session already rebuilt its microphone");
+            return false;
+        }
+
+        meeting.mixer.replace_mic(
+            adoption.mic_cons,
+            adoption.sample_rate,
+            adoption.channels,
+            adoption.mic_gain,
+        );
+        self.stream = Some(stream);
+        // The callback has been discarding everything until now; start the
+        // staleness clock from the moment it is allowed to deliver.
+        self.last_mic_callback_ms
+            .store(unix_now_ms(), Ordering::Relaxed);
+        self.active_session_id
+            .store(adoption.session_id, Ordering::Release);
+        info!(
+            elapsed_ms,
+            "Microphone opened after the meeting gave up waiting; mic leg restored"
+        );
+        true
+    }
+
     /// Whether the last open ran past the bound or was refused because the
     /// previous one still has not come back. Read right after a failed
     /// `start` to tell a device that is not answering from a device that
@@ -2802,7 +3079,7 @@ impl AudioCapture {
             || self
                 .mic_open_pending
                 .as_ref()
-                .is_some_and(|pending| !pending.is_finished())
+                .is_some_and(PendingOpen::is_running)
     }
 
     /// End a session that never started, carrying the real reason. Unlike
@@ -2894,6 +3171,7 @@ impl AudioCapture {
         self.mic_device_object_id = None;
         self.route_attempt_uid = None;
         self.mic_open_timed_out = None;
+        self.abandon_pending_mic_open();
         self.last_mic_callback_ms.store(0, Ordering::Relaxed);
         self.emit_audio_level(0.0);
         self.level_throttle.reset();

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -344,7 +344,9 @@ impl std::fmt::Display for MicOpenError {
 /// of it.
 struct PendingOpen<T> {
     thread: JoinHandle<()>,
-    rx: std::sync::mpsc::Receiver<Result<T, String>>,
+    /// Gone once the open has been abandoned: the worker's `send` then fails
+    /// and it releases the value itself.
+    rx: Option<std::sync::mpsc::Receiver<Result<T, String>>>,
     abandoned: Arc<AtomicBool>,
     started: Instant,
 }
@@ -354,17 +356,30 @@ impl<T> PendingOpen<T> {
         !self.thread.is_finished()
     }
 
-    /// Tell the worker nobody is waiting any more. It checks this before
-    /// starting the device, and releases anything it has already built.
-    fn abandon(&self) {
+    /// Tell the worker nobody is waiting any more, and stop listening.
+    ///
+    /// Returns a value the worker had already delivered before the flag was
+    /// set: dropping the receiver on it would drop it without the release
+    /// its `discard` performs, so the caller has to do that itself. An
+    /// abandoned open is still worth keeping around — `is_running` is what
+    /// stops a second open being spawned on a device that has not answered
+    /// the first.
+    fn abandon(&mut self) -> Option<T> {
         self.abandoned.store(true, Ordering::Relaxed);
+        self.rx
+            .take()
+            .and_then(|rx| rx.try_recv().ok())
+            .and_then(Result::ok)
     }
 
     /// The stream, if the open has answered since the last look. `Err` is
     /// the open's own failure; `Ok(None)` means it is still inside
-    /// CoreAudio.
+    /// CoreAudio, or nobody is listening any more.
     fn try_take(&self) -> Result<Option<T>, String> {
-        match self.rx.try_recv() {
+        let Some(rx) = self.rx.as_ref() else {
+            return Ok(None);
+        };
+        match rx.try_recv() {
             Ok(Ok(value)) => Ok(Some(value)),
             Ok(Err(error)) => Err(error),
             Err(std::sync::mpsc::TryRecvError::Empty) => Ok(None),
@@ -382,19 +397,84 @@ impl<T> PendingOpen<T> {
 /// ring back with. Held while the open is still out, dropped with it.
 struct MicAdoption {
     session_id: u64,
+    /// UID of the device this open targeted. A session that has moved to
+    /// another input since must not be handed this one: `mic_device_uid`
+    /// and friends would then describe one device while the live stream
+    /// runs on another, and the health check would watch the wrong object.
+    device_uid: Option<String>,
     mic_cons: ringbuf::HeapCons<f32>,
     sample_rate: u32,
     channels: u16,
     mic_gain: f32,
 }
 
+/// Whether a late microphone stream is still the right one to install.
+#[derive(Debug, PartialEq, Eq)]
+enum AdoptionVerdict {
+    Install,
+    Release(&'static str),
+}
+
+/// Everything the decision depends on, so it can be made without a device.
+struct AdoptionContext<'a> {
+    adoption_session: u64,
+    active_session: Option<u64>,
+    meeting_session: Option<u64>,
+    adoption_device: Option<&'a str>,
+    current_device: Option<&'a str>,
+    has_stream: bool,
+}
+
+/// A stream that took a minute to arrive can easily belong to a world that
+/// no longer exists. Every reason it might is checked here.
+fn adoption_verdict(ctx: AdoptionContext<'_>) -> AdoptionVerdict {
+    let Some(active_session) = ctx.active_session else {
+        return AdoptionVerdict::Release("the session has ended");
+    };
+    if active_session != ctx.adoption_session {
+        return AdoptionVerdict::Release("it belongs to a session that has ended");
+    }
+    // The session may have been pointed at another input while this open was
+    // out — the user picking one, or a route change resolving elsewhere.
+    // Installing it then would leave `mic_device_name/uid/object_id`
+    // describing one device and the live stream running on another: the
+    // health check would watch the wrong HAL object, and no rebuild would
+    // ever correct it.
+    if ctx.current_device != ctx.adoption_device {
+        return AdoptionVerdict::Release("the session has moved to another input device");
+    }
+    match ctx.meeting_session {
+        None => return AdoptionVerdict::Release("the meeting is gone"),
+        Some(meeting_session) if meeting_session != ctx.adoption_session => {
+            return AdoptionVerdict::Release("the meeting moved on to another session");
+        }
+        Some(_) => {}
+    }
+    if ctx.has_stream {
+        return AdoptionVerdict::Release("the session already rebuilt its microphone");
+    }
+    AdoptionVerdict::Install
+}
+
+/// Release a microphone stream nobody is going to install, the way
+/// `release_capture_stream` does: pause, then drop, or a Bluetooth headset
+/// stays in HFP/mono.
+fn release_late_mic_stream(stream: Stream, why: &str) {
+    debug!("Late microphone stream released: {why}");
+    if let Err(e) = stream.pause() {
+        debug!("Pause of a released late mic stream: {e}");
+    }
+}
+
 /// Run `open` on a throwaway thread and wait at most `timeout` for it.
 ///
-/// Whatever `open` returns once nobody is waiting is handed to `discard`,
+/// A value `open` returns once nobody is waiting is handed to `discard`,
 /// which releases it the way `release_capture_stream` does — pause, then
-/// drop — so a Bluetooth headset leaves HFP instead of staying in mono.
-/// Moving the stream between threads is fine: cpal's CoreAudio `Stream` is
-/// `Send` (cpal 0.17).
+/// drop — so a Bluetooth headset leaves HFP instead of staying in mono. The
+/// one case `discard` cannot cover is a value already delivered when the
+/// caller gives up; `PendingOpen::abandon` hands that one back for the
+/// caller to release. Moving the stream between threads is fine: cpal's
+/// CoreAudio `Stream` is `Send` (cpal 0.16 added it).
 ///
 /// On timeout the worker is handed back rather than cut loose, so the
 /// caller can either abandon it or wait for its stream on its own clock.
@@ -471,7 +551,7 @@ where
         Err(std::sync::mpsc::RecvTimeoutError::Timeout) => (
             Some(PendingOpen {
                 thread,
-                rx,
+                rx: Some(rx),
                 abandoned,
                 started,
             }),
@@ -698,6 +778,88 @@ mod mic_open_tests {
                 );
             }
         }
+    }
+
+    fn adoption_of(session: u64) -> AdoptionContext<'static> {
+        AdoptionContext {
+            adoption_session: session,
+            active_session: Some(session),
+            meeting_session: Some(session),
+            adoption_device: Some("BuiltInMicrophoneDevice"),
+            current_device: Some("BuiltInMicrophoneDevice"),
+            has_stream: false,
+        }
+    }
+
+    #[test]
+    fn a_late_stream_for_the_running_meeting_is_installed() {
+        assert_eq!(adoption_verdict(adoption_of(9)), AdoptionVerdict::Install);
+    }
+
+    /// Everything a minute-late stream can outlive. Each of these installed
+    /// would be worse than no microphone: a stream nobody drains, or one the
+    /// health check is not watching.
+    #[test]
+    fn a_late_stream_is_released_when_the_world_moved_on() {
+        for (what, ctx) in [
+            (
+                "session ended",
+                AdoptionContext {
+                    active_session: None,
+                    ..adoption_of(9)
+                },
+            ),
+            (
+                "another session",
+                AdoptionContext {
+                    active_session: Some(10),
+                    ..adoption_of(9)
+                },
+            ),
+            (
+                "meeting gone",
+                AdoptionContext {
+                    meeting_session: None,
+                    ..adoption_of(9)
+                },
+            ),
+            (
+                "meeting moved on",
+                AdoptionContext {
+                    meeting_session: Some(10),
+                    ..adoption_of(9)
+                },
+            ),
+            (
+                "microphone already rebuilt",
+                AdoptionContext {
+                    has_stream: true,
+                    ..adoption_of(9)
+                },
+            ),
+        ] {
+            assert!(
+                matches!(adoption_verdict(ctx), AdoptionVerdict::Release(_)),
+                "a late stream must not be installed after {what}"
+            );
+        }
+    }
+
+    /// The wedged built-in answers a minute after the user plugged in a
+    /// headset. Installing it would leave the session recording the device
+    /// the user moved away from, with the health check watching the other
+    /// one — and no rebuild would ever notice.
+    #[test]
+    fn a_late_stream_from_a_device_the_session_left_is_released() {
+        let ctx = AdoptionContext {
+            adoption_device: Some("BuiltInMicrophoneDevice"),
+            current_device: Some("com.shure.mv7"),
+            ..adoption_of(9)
+        };
+        assert_eq!(
+            adoption_verdict(ctx),
+            AdoptionVerdict::Release("the session has moved to another input device")
+        );
     }
 
     /// The park belongs to the device that stalled. CoreAudio emits a
@@ -1959,7 +2121,8 @@ impl AudioCapture {
             }
             // Finished, and whatever it produced was collected (or released)
             // by `poll_pending_mic_open`. Nothing left to keep.
-            self.drop_pending_mic_open();
+            self.mic_open_pending = None;
+            self.mic_open_adoption = None;
         }
         if mic_open_is_parked(self.mic_open_timed_out.as_ref(), device_name) {
             return Err(MicOpenError::Parked);
@@ -2012,6 +2175,21 @@ impl AudioCapture {
             // to nobody now.
             self.mic_open_timed_out = None;
             self.abandon_pending_mic_open();
+        }
+        // Refused here rather than in `open_mic_stream`: everything between
+        // this point and the open touches the device that is not answering
+        // — two `list_input_devices_impl`, `find_device`, and a
+        // `preferred_config` that instantiates and disposes an AUHAL twice —
+        // and the meeting path reopens the capture gate before it, which a
+        // stream still out on the previous open must not slip through. None
+        // of it can change the answer while that open is still running.
+        self.reap_pending_mic_open();
+        if self
+            .mic_open_pending
+            .as_ref()
+            .is_some_and(PendingOpen::is_running)
+        {
+            return Err(MicOpenError::Busy.to_string());
         }
         // Ensure any previous callback stops emitting immediately. The
         // recorder is NOT torn down here; see `sync_recorder`, so a
@@ -2413,14 +2591,16 @@ impl AudioCapture {
                 self.active_session_id.store(0, Ordering::Release);
                 let (dead_prod, dead_cons) = HeapRb::<f32>::new(1).split();
                 drop(dead_prod);
-                if matches!(e, MicOpenError::TimedOut(_)) && self.mic_open_pending.is_some() {
+                if matches!(e, MicOpenError::TimedOut(_)) {
                     // This attempt's open is still inside CoreAudio. Keep its
                     // ring: `poll_pending_mic_open` hands it to the mixer if
                     // the device ever answers, and only then is the gate
-                    // reopened. A `Busy` error belongs to an earlier attempt,
-                    // whose ring is already held, so it must not clobber it.
+                    // reopened. Only a timeout gets here with an open of its
+                    // own; `Busy` belongs to an earlier attempt whose ring is
+                    // already held, and must not clobber it.
                     self.mic_open_adoption = Some(MicAdoption {
                         session_id,
+                        device_uid: self.mic_device_uid.clone(),
                         mic_cons,
                         sample_rate,
                         channels,
@@ -2950,26 +3130,36 @@ impl AudioCapture {
         self.teardown_session_state();
     }
 
-    /// Ends a dictation session whose microphone could not be rebuilt after
-    /// repeated attempts and has no other audio source to fall back on.
-    /// Records the reason for the engine actor's `AudioGone` handler before
-    /// tearing down — see `teardown_session_state` for why exiting this
-    /// thread is what lets the actor salvage and fail the session, exactly
-    /// like a panic abort.
-    /// Give up on an open that is still out, and forget it. The worker
-    /// releases whatever it built, on its own thread.
+    /// Stop waiting on an open that is still out. The worker is *not*
+    /// forgotten: `is_running` on it is what refuses a second open on a
+    /// device that has not answered the first, and that guard has to
+    /// outlive the session that gave up — a stop and a restart on the same
+    /// wedged device would otherwise each spend a fresh bound and leave a
+    /// fresh AUHAL behind.
     fn abandon_pending_mic_open(&mut self) {
-        if let Some(pending) = &self.mic_open_pending {
-            pending.abandon();
+        let delivered = self
+            .mic_open_pending
+            .as_mut()
+            .and_then(PendingOpen::abandon);
+        if let Some(stream) = delivered {
+            // It answered between the last look and now, so the worker will
+            // not release it.
+            release_late_mic_stream(stream, "the session stopped waiting for it");
         }
-        self.drop_pending_mic_open();
+        self.mic_open_adoption = None;
+        self.reap_pending_mic_open();
     }
 
-    /// Forget the pending open without telling the worker anything. Only
-    /// correct once the worker has finished, or right after `abandon`.
-    fn drop_pending_mic_open(&mut self) {
-        self.mic_open_pending = None;
-        self.mic_open_adoption = None;
+    /// Drop a worker that has come back. Keeping a finished one only hides
+    /// the next open behind a guard that no longer guards anything.
+    fn reap_pending_mic_open(&mut self) {
+        if self
+            .mic_open_pending
+            .as_ref()
+            .is_some_and(|pending| !pending.is_running())
+        {
+            self.mic_open_pending = None;
+        }
     }
 
     /// Put a late microphone stream to work, if one has arrived.
@@ -2990,17 +3180,21 @@ impl AudioCapture {
             return;
         };
         let elapsed_ms = pending.elapsed().as_millis() as u64;
+        // Asked first, and on purpose: a worker that sends and exits between
+        // the look and this question would otherwise be read as a dead end
+        // while its stream sits unread in the channel.
+        let was_running = pending.is_running();
         match pending.try_take() {
             Ok(None) => {
-                // Still inside CoreAudio. A thread that ended without
-                // sending anything is a dead end, not a wait.
-                if !pending.is_running() {
-                    self.drop_pending_mic_open();
+                if !was_running {
+                    self.mic_open_pending = None;
+                    self.mic_open_adoption = None;
                 }
             }
             Ok(Some(stream)) => {
                 let adopted = self.adopt_mic_stream(stream, elapsed_ms);
-                self.drop_pending_mic_open();
+                self.mic_open_pending = None;
+                self.mic_open_adoption = None;
                 if adopted {
                     self.mic_open_timed_out = None;
                     self.clear_mic_loss_ladder();
@@ -3008,7 +3202,8 @@ impl AudioCapture {
             }
             Err(error) => {
                 warn!(elapsed_ms, error, "Late microphone open failed");
-                self.drop_pending_mic_open();
+                self.mic_open_pending = None;
+                self.mic_open_adoption = None;
             }
         }
     }
@@ -3018,37 +3213,26 @@ impl AudioCapture {
     /// session that has since ended, or to one that already has a
     /// microphone, is released instead.
     fn adopt_mic_stream(&mut self, stream: Stream, elapsed_ms: u64) -> bool {
-        let release = |stream: Stream, why: &str| {
-            debug!("Late microphone stream released: {why}");
-            if let Err(e) = stream.pause() {
-                debug!("Pause of a released late mic stream: {e}");
-            }
-        };
-
         let Some(adoption) = self.mic_open_adoption.take() else {
-            release(stream, "nothing was waiting for it");
+            release_late_mic_stream(stream, "nothing was waiting for it");
             return false;
         };
-        let Some(params) = self.active_params.as_ref() else {
-            release(stream, "the session has ended");
-            return false;
-        };
-        if params.session_id != adoption.session_id {
-            release(stream, "it belongs to a session that has ended");
+        let verdict = adoption_verdict(AdoptionContext {
+            adoption_session: adoption.session_id,
+            active_session: self.active_params.as_ref().map(|p| p.session_id),
+            meeting_session: self.meeting.as_ref().map(|m| m.session_id),
+            adoption_device: adoption.device_uid.as_deref(),
+            current_device: self.mic_device_uid.as_deref(),
+            has_stream: self.stream.is_some(),
+        });
+        if let AdoptionVerdict::Release(why) = verdict {
+            release_late_mic_stream(stream, why);
             return false;
         }
         let Some(meeting) = self.meeting.as_mut() else {
-            release(stream, "the meeting is gone");
+            release_late_mic_stream(stream, "the meeting is gone");
             return false;
         };
-        if meeting.session_id != adoption.session_id {
-            release(stream, "the meeting moved on to another session");
-            return false;
-        }
-        if self.stream.is_some() {
-            release(stream, "the session already rebuilt its microphone");
-            return false;
-        }
 
         meeting.mixer.replace_mic(
             adoption.mic_cons,
@@ -3091,6 +3275,12 @@ impl AudioCapture {
         self.teardown_session_state();
     }
 
+    /// Ends a dictation session whose microphone could not be rebuilt after
+    /// repeated attempts and has no other audio source to fall back on.
+    /// Records the reason for the engine actor's `AudioGone` handler before
+    /// tearing down — see `teardown_session_state` for why exiting this
+    /// thread is what lets the actor salvage and fail the session, exactly
+    /// like a panic abort.
     fn abort_after_mic_loss(&mut self) {
         if let Ok(mut reason) = self.audio_gone_reason.lock() {
             *reason = Some(

--- a/src-tauri/src/audio/capture.rs
+++ b/src-tauri/src/audio/capture.rs
@@ -738,6 +738,38 @@ mod mic_open_tests {
         );
     }
 
+    /// Forgetting a finished worker without draining drops a delivered stream
+    /// without its `pause()` — the race inside `check_mic_health` between
+    /// poll (still running, empty) and `start`/`reap` (finished, value waiting).
+    #[test]
+    fn a_finished_open_still_hands_over_what_it_delivered() {
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let (pending, opened) = open_with_timeout(
+            Duration::from_millis(50),
+            move |_abandoned| {
+                let _ = release_rx.recv_timeout(Duration::from_secs(5));
+                Ok(OPENED)
+            },
+            |_| panic!("a kept open must not discard on its own thread"),
+        );
+        assert!(matches!(opened, Err(MicOpenError::TimedOut(_))));
+        let mut pending = pending.expect("a spawned worker must be handed back");
+        assert!(pending.is_running());
+        assert_eq!(pending.try_take(), Ok(None));
+
+        let _ = release_tx.send(());
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while pending.is_running() {
+            assert!(
+                Instant::now() < deadline,
+                "worker must finish once released"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        // What `reap_pending_mic_open` must do instead of `pending = None`.
+        assert_eq!(pending.abandon(), Some(OPENED));
+    }
+
     #[test]
     fn an_open_that_answers_in_time_returns_its_stream() {
         let (_pending, opened) = open_with_timeout(
@@ -2115,14 +2147,25 @@ impl AudioCapture {
     where
         F: FnOnce(&AtomicBool) -> Result<Stream, String> + Send + 'static,
     {
-        if let Some(pending) = &self.mic_open_pending {
-            if pending.is_running() {
-                return Err(MicOpenError::Busy);
-            }
-            // Finished, and whatever it produced was collected (or released)
-            // by `poll_pending_mic_open`. Nothing left to keep.
+        if self
+            .mic_open_pending
+            .as_ref()
+            .is_some_and(PendingOpen::is_running)
+        {
+            return Err(MicOpenError::Busy);
+        }
+        if self.mic_open_pending.is_some() {
+            // Finished between the last poll and here: drain before forget,
+            // same reason as `reap_pending_mic_open`.
+            let delivered = self
+                .mic_open_pending
+                .as_mut()
+                .and_then(PendingOpen::abandon);
             self.mic_open_pending = None;
             self.mic_open_adoption = None;
+            if let Some(stream) = delivered {
+                release_late_mic_stream(stream, "a new open is starting");
+            }
         }
         if mic_open_is_parked(self.mic_open_timed_out.as_ref(), device_name) {
             return Err(MicOpenError::Parked);
@@ -3152,13 +3195,33 @@ impl AudioCapture {
 
     /// Drop a worker that has come back. Keeping a finished one only hides
     /// the next open behind a guard that no longer guards anything.
+    ///
+    /// Drains first: a stream delivered between the last `poll_pending_mic_open`
+    /// and here (the gap inside `check_mic_health` between poll and `start`)
+    /// would otherwise be dropped with the receiver and never `pause()`d —
+    /// the cpal 0.15 `StreamInner` leak, and a missed adoption.
     fn reap_pending_mic_open(&mut self) {
-        if self
+        let finished = self
             .mic_open_pending
             .as_ref()
-            .is_some_and(|pending| !pending.is_running())
-        {
-            self.mic_open_pending = None;
+            .is_some_and(|pending| !pending.is_running());
+        if !finished {
+            return;
+        }
+        let delivered = self
+            .mic_open_pending
+            .as_mut()
+            .and_then(PendingOpen::abandon);
+        self.mic_open_pending = None;
+        // Prefer install when the meeting is still waiting on this open;
+        // release when the world moved on (route change rebuild, etc.).
+        if let Some(stream) = delivered {
+            if self.adopt_mic_stream(stream, 0) {
+                self.mic_open_timed_out = None;
+                self.clear_mic_loss_ladder();
+            }
+        } else {
+            self.mic_open_adoption = None;
         }
     }
 

--- a/src-tauri/src/audio/feedback.rs
+++ b/src-tauri/src/audio/feedback.rs
@@ -1,6 +1,7 @@
 //! Short bundled WAV cues for dictation start/stop confirmation.
 
 use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
@@ -14,6 +15,39 @@ use crate::settings::AppSettings;
 pub enum DictationFeedbackKind {
     Start,
     Stop,
+}
+
+/// Cues currently on a playback thread. Playback is short (a few hundred
+/// milliseconds), so more than a couple at once means threads are piling up
+/// rather than overlapping.
+static FEEDBACK_IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
+
+/// How many playback threads may exist at once. `play()` and
+/// `build_output_stream` are synchronous CoreAudio calls with no deadline of
+/// their own — the same property that let a wedged input device stall a
+/// meeting for 72 s (SOU-125) — and this thread is never joined, so a wedged
+/// output device would otherwise leave one stuck thread behind per dictation
+/// toggle for the life of the app. Two, so the stop cue is never dropped
+/// because the start cue is still playing.
+const MAX_FEEDBACK_THREADS: usize = 2;
+
+/// Take one of `max` slots, or report that none is free. Never blocks, and
+/// never overshoots under concurrent callers.
+fn try_reserve_slot(in_flight: &AtomicUsize, max: usize) -> bool {
+    in_flight
+        .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+            (current < max).then_some(current + 1)
+        })
+        .is_ok()
+}
+
+/// Releases its slot however the playback thread ends, panic included.
+struct FeedbackSlot;
+
+impl Drop for FeedbackSlot {
+    fn drop(&mut self) {
+        FEEDBACK_IN_FLIGHT.fetch_sub(1, Ordering::AcqRel);
+    }
 }
 
 /// Fire-and-forget playback on a background thread so capture never blocks.
@@ -30,14 +64,24 @@ pub fn play_dictation_feedback(settings: &AppSettings, kind: DictationFeedbackKi
         warn!("Feedback sound not found: {filename}");
         return;
     };
-    thread::Builder::new()
+    if !try_reserve_slot(&FEEDBACK_IN_FLIGHT, MAX_FEEDBACK_THREADS) {
+        // Earlier cues have not come back. The output device is not
+        // answering; skip this one rather than stacking another thread that
+        // may never return.
+        warn!("Feedback sound skipped: previous playback has not finished");
+        return;
+    }
+    let spawned = thread::Builder::new()
         .name("feedback-sound".into())
         .spawn(move || {
+            let _slot = FeedbackSlot;
             if let Err(e) = play_wav_blocking(&path, volume) {
                 warn!("Feedback sound playback failed: {e}");
             }
-        })
-        .ok();
+        });
+    if spawned.is_err() {
+        FEEDBACK_IN_FLIGHT.fetch_sub(1, Ordering::AcqRel);
+    }
 }
 
 fn normalized_volume(percent: u32) -> f32 {
@@ -157,6 +201,26 @@ fn resample_linear(input: &[f32], from_rate: u32, to_rate: u32) -> Vec<f32> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A wedged output device never returns from `play()`, and the playback
+    /// thread is never joined. The cap is what keeps one stuck thread per
+    /// dictation toggle from piling up for the life of the app.
+    #[test]
+    fn playback_slots_are_capped_and_returned() {
+        let in_flight = AtomicUsize::new(0);
+        assert!(try_reserve_slot(&in_flight, 2));
+        assert!(try_reserve_slot(&in_flight, 2));
+        assert!(
+            !try_reserve_slot(&in_flight, 2),
+            "a third cue must be skipped, not stacked on a device that is not answering"
+        );
+
+        in_flight.fetch_sub(1, Ordering::AcqRel);
+        assert!(
+            try_reserve_slot(&in_flight, 2),
+            "a finished playback must free its slot"
+        );
+    }
 
     #[test]
     fn normalized_volume_clamps() {

--- a/src-tauri/src/audio/feedback.rs
+++ b/src-tauri/src/audio/feedback.rs
@@ -17,9 +17,9 @@ pub enum DictationFeedbackKind {
     Stop,
 }
 
-/// Cues currently on a playback thread. Playback is short (a few hundred
-/// milliseconds), so more than a couple at once means threads are piling up
-/// rather than overlapping.
+/// Cues currently on a playback thread. Each cue is 120 ms of audio plus the
+/// time it takes to open the output, so several at once means threads are
+/// piling up rather than overlapping.
 static FEEDBACK_IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
 
 /// How many playback threads may exist at once. `play()` and
@@ -27,9 +27,16 @@ static FEEDBACK_IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
 /// their own — the same property that let a wedged input device stall a
 /// meeting for 72 s (SOU-125) — and this thread is never joined, so a wedged
 /// output device would otherwise leave one stuck thread behind per dictation
-/// toggle for the life of the app. Two, so the stop cue is never dropped
-/// because the start cue is still playing.
-const MAX_FEEDBACK_THREADS: usize = 2;
+/// toggle for the life of the app.
+///
+/// Four rather than two: a cue outlives its 120 ms by however long the
+/// device takes to open, which on a Bluetooth sink waking from idle is not
+/// negligible, and push-to-talk can fire start and stop inside that window.
+/// The cap exists to bound a wedge, not to serialise normal use. Once it is
+/// reached every further cue is skipped until a thread returns, which on a
+/// genuinely wedged output is the honest outcome — a device that cannot
+/// start cannot play a sound either.
+const MAX_FEEDBACK_THREADS: usize = 4;
 
 /// Take one of `max` slots, or report that none is free. Never blocks, and
 /// never overshoots under concurrent callers.
@@ -42,11 +49,11 @@ fn try_reserve_slot(in_flight: &AtomicUsize, max: usize) -> bool {
 }
 
 /// Releases its slot however the playback thread ends, panic included.
-struct FeedbackSlot;
+struct FeedbackSlot(&'static AtomicUsize);
 
 impl Drop for FeedbackSlot {
     fn drop(&mut self) {
-        FEEDBACK_IN_FLIGHT.fetch_sub(1, Ordering::AcqRel);
+        self.0.fetch_sub(1, Ordering::AcqRel);
     }
 }
 
@@ -74,7 +81,7 @@ pub fn play_dictation_feedback(settings: &AppSettings, kind: DictationFeedbackKi
     let spawned = thread::Builder::new()
         .name("feedback-sound".into())
         .spawn(move || {
-            let _slot = FeedbackSlot;
+            let _slot = FeedbackSlot(&FEEDBACK_IN_FLIGHT);
             if let Err(e) = play_wav_blocking(&path, volume) {
                 warn!("Feedback sound playback failed: {e}");
             }
@@ -207,19 +214,35 @@ mod tests {
     /// dictation toggle from piling up for the life of the app.
     #[test]
     fn playback_slots_are_capped_and_returned() {
-        let in_flight = AtomicUsize::new(0);
-        assert!(try_reserve_slot(&in_flight, 2));
-        assert!(try_reserve_slot(&in_flight, 2));
+        static IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
+        assert!(try_reserve_slot(&IN_FLIGHT, 2));
+        assert!(try_reserve_slot(&IN_FLIGHT, 2));
         assert!(
-            !try_reserve_slot(&in_flight, 2),
+            !try_reserve_slot(&IN_FLIGHT, 2),
             "a third cue must be skipped, not stacked on a device that is not answering"
         );
 
-        in_flight.fetch_sub(1, Ordering::AcqRel);
+        drop(FeedbackSlot(&IN_FLIGHT));
         assert!(
-            try_reserve_slot(&in_flight, 2),
+            try_reserve_slot(&IN_FLIGHT, 2),
             "a finished playback must free its slot"
         );
+    }
+
+    /// The slot is released however the playback thread ends: a panic inside
+    /// cpal would otherwise burn one permanently, and four of them would
+    /// silence the cues for the life of the app.
+    #[test]
+    fn a_panicking_playback_still_frees_its_slot() {
+        static IN_FLIGHT: AtomicUsize = AtomicUsize::new(0);
+        assert!(try_reserve_slot(&IN_FLIGHT, 1));
+        let panicked = std::panic::catch_unwind(|| {
+            let _slot = FeedbackSlot(&IN_FLIGHT);
+            panic!("cpal gave up mid-playback");
+        });
+        assert!(panicked.is_err());
+        assert_eq!(IN_FLIGHT.load(Ordering::Acquire), 0);
+        assert!(try_reserve_slot(&IN_FLIGHT, 1));
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to SOU-125 (#217) and to the review of #216, both now on `develop`. Builds directly on the pending-open work that landed with #216.

Two devices with no deadline of their own, both left to pile up.

## The microphone comes back on its own

A meeting that gave up waiting on the microphone cut the open loose: the stream CoreAudio returned a minute later — the case that opened SOU-125 measured 72 s — was paused and dropped, and the session ran to the end on system audio alone even though the device had come back. Every retry in between paid another full bound on the capture thread, which is the meeting mixer's clock, and each of those cost roughly six seconds of far-end audio (the tap ring holds two).

The open is now kept rather than abandoned when a meeting is what is waiting. `open_with_timeout` hands the worker back — its thread, its receiver, its abandoned flag — and the caller decides:

- **dictation abandons it.** There is no mixer to hand a late stream to, and the session ends immediately with the device error (#216).
- **a meeting holds on to it**, together with the ring its callback already writes into. The mic health check looks once every two seconds; when the stream arrives the ring goes back to the mixer and the gate reopens, in that order.

Nothing the late stream captured before that can reach the session: its callback is gated on `active_session_id`, which stays closed the whole time the open is out. That is what keeps frames from arriving minutes out of place and shifting the diarized lanes apart — the reason the stream used to be thrown away rather than kept. A stream whose session has ended, or whose session has rebuilt its microphone in the meantime, is released with its `pause()` instead of installed.

So the "one bound per retry" cost from the #217 review is gone for the case that matters: after the first timeout there is no second open at all while the first is still out, and no third bound spent to discover the device recovered.

## The feedback cues stop stacking

`play()` and `build_output_stream` have no deadline either, and the `feedback-sound` thread is never joined, so a wedged output device left one stuck thread behind per dictation toggle for the life of the app. Capped at two concurrent playback threads — two, so the stop cue is never dropped because the start cue is still playing — and a skipped cue says so in the log.

## Review round (e9c2617)

An independent review of the first commit found two ways it gave back what the previous round had fixed.

**The stacking guard died with the session.** Giving up on an open forgot the worker too, so a stop and a restart on the same wedged device each spent a fresh bound and left a fresh AUHAL behind — five dictation toggles, five stuck threads, which is what the busy guard was added to prevent in the first place. Abandoning now only stops the waiting; the worker is kept until it comes back, because `is_running` on it *is* the guard. A stream delivered between the last look and the abandon is handed back and released rather than dropped without its `pause()`.

**A late stream from a device the session has left is now released.** A rebuild that resolves to another input rewrites `mic_device_name/uid/object_id` before the busy refusal, so the wedged built-in answering a minute after the user plugged in a headset would have been installed: the session recording the device the user moved away from, the health check watching the other one's HAL object, and no rebuild ever noticing. The adoption carries the UID it was opened for, and the whole decision moved into a pure `adoption_verdict` with a test for each way a minute-late stream can outlive the world it was opened in.

Three smaller ones:

- The poll asked whether the worker was still running *after* looking for its value, so a worker that sent and exited in between read as a dead end and its stream was dropped unread.
- The busy refusal moved to the top of `start`, ahead of the device resolution (two device enumerations and a `preferred_config` that instantiates and disposes an AUHAL twice, all on the device that is not answering) and ahead of the capture gate the meeting path opens — so the gate really does stay closed for the whole time an open is out, which the comment already claimed.
- The feedback cap goes to four. The cues are 120 ms, not "a few hundred", and a cue outlives its audio by however long the output takes to open; push-to-talk can put start and stop inside that window. The cap bounds a wedge, it does not serialise normal use.

Not taken: surfacing the restored microphone in the UI. "Microphone lost; still recording system audio" is a dismissable error banner with nothing to clear it when the leg comes back, so the user keeps seeing "lost" while the mic is live. Real, but it is a frontend change on a different surface and belongs in its own PR.

Gate re-run on e9c2617: fmt clean, clippy `-D warnings` clean, **958** Rust tests passed / 0 failed / 4 ignored, `--no-default-features` clean, 582 vitest, `npm run check` 0 errors, generated types in sync.

## Verification

```
cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check     clean
cargo clippy --manifest-path src-tauri/Cargo.toml --workspace \
  --all-targets -- -D warnings                                      clean
cargo test --manifest-path src-tauri/Cargo.toml --workspace         958 passed, 0 failed, 4 ignored
cargo check --manifest-path src-tauri/Cargo.toml --no-default-features   clean
npm test                                                            582 passed, 0 failed, 55 files
npm run check                                                       4018 files, 0 errors, 0 warnings
npm run check:generated-types                                       in sync
```

Nine tests cover the new code: a kept open still delivers its stream, a late open that fails reports its own error rather than looking like a stream that never came, an abandoned open is told before it starts the device, the worker is still visible as running after the bound, the feedback slot cap is taken and returned and survives a panic, and every branch of the adoption verdict — session ended, another session, meeting gone, meeting moved on, microphone already rebuilt, and a device the session has left.

`./scripts/codeql-local.sh` did not run: the CodeQL CLI is not installed on this machine (`brew install --cask codeql`). The script exits 1 rather than passing quietly.

**Needs a device that actually wedges** (dock reboot, Bluetooth HFP transition) to confirm on hardware: the meeting card losing the mic within a few seconds and getting it back without the user doing anything once the device answers; the transcript showing no repeated far-end gaps while it is out; the diarized lanes staying aligned across an adoption; and no stuck `feedback-sound` threads after repeated dictation toggles on a wedged output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved microphone startup handling when devices respond slowly, allowing eligible meeting sessions to adopt the microphone once it becomes available.
  - Prevented stale or mismatched microphone connections from being attached to the wrong session.
  - Improved cleanup after microphone startup failures and delayed responses.
  - Limited simultaneous audio feedback cues to maintain reliable playback and prevent overload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->