### PR TITLE
In-app update download and install (SOU-098)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,9 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # Updater artifact signing (minisign). Distinct from Apple codesign.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           releaseId: ${{ needs.create-release.outputs.release_id }}
           args: --target aarch64-apple-darwin

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -192,6 +192,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,7 +727,7 @@ dependencies = [
  "safetensors 0.7.0",
  "thiserror 2.0.18",
  "yoke 0.8.1",
- "zip",
+ "zip 7.2.0",
 ]
 
 [[package]]
@@ -1451,6 +1460,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_builder"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,6 +1981,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -3784,6 +3814,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4499,6 +4535,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4726,6 +4774,20 @@ dependencies = [
  "hmac-sha256",
  "lzma-rust2",
  "ureq 3.3.0",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5683,15 +5745,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -5929,6 +5996,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5936,6 +6015,33 @@ checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -6568,6 +6674,7 @@ dependencies = [
  "tauri-plugin-log",
  "tauri-plugin-notification",
  "tauri-plugin-single-instance",
+ "tauri-plugin-updater",
  "tauri-specta",
  "tempfile",
  "thiserror 2.0.18",
@@ -6933,6 +7040,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7182,6 +7300,39 @@ dependencies = [
  "tracing",
  "windows-sys 0.60.2",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b28d8cabdeb0564f03ae261963de4bc3d98321cd3d213e76a81b7d344e5df606"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.2",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip 4.6.1",
 ]
 
 [[package]]
@@ -9234,6 +9385,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "xkbcommon"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9436,6 +9597,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.13.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -130,6 +130,7 @@ core-graphics = "0.25.0"
 core-foundation = "0.10.1"
 objc2-service-management = "0.3"
 fdaf-aec = "0.1.0"
+tauri-plugin-updater = "2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 accessibility-sys = "0.2"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -3,8 +3,7 @@
   "identifier": "default",
   "description": "Capability for the app windows",
   "windows": [
-    "main",
-    "pill"
+    "main"
   ],
   "permissions": [
     "core:default",
@@ -16,6 +15,7 @@
     "fs:default",
     "dialog:allow-save",
     "dialog:allow-open",
-    "log:default"
+    "log:default",
+    "updater:default"
   ]
 }

--- a/src-tauri/src/app_events.rs
+++ b/src-tauri/src/app_events.rs
@@ -364,6 +364,28 @@ pub struct UpdateAvailable {
     pub release_url: Option<String>,
 }
 
+/// Phase of the in-app updater download pipeline (not the app state machine).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdatePhase {
+    Idle,
+    Downloading,
+    Ready,
+    Failed,
+}
+
+/// Progress / phase of an in-app update download. Source of truth is Rust;
+/// the webview mirrors this (and can re-query after reload).
+#[derive(Debug, Clone, Serialize, Deserialize, Type, Event)]
+pub struct UpdateDownloadProgress {
+    pub phase: UpdatePhase,
+    pub version: Option<String>,
+    pub downloaded_bytes: u64,
+    pub total_bytes: Option<u64>,
+    pub error: Option<String>,
+    pub manual_fallback: bool,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -13,6 +13,7 @@ mod pill;
 mod settings;
 mod snippets;
 pub(crate) mod transcription;
+pub mod updater;
 
 pub use audio::*;
 pub use calendar::*;
@@ -29,3 +30,4 @@ pub use pill::*;
 pub use settings::*;
 pub use snippets::*;
 pub use transcription::*;
+pub use updater::*;

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -1,0 +1,455 @@
+//! Download and install in-app updates via `tauri-plugin-updater`.
+//!
+//! Detection stays in [`crate::update_check`]: this module only executes.
+//! Progress and ready bytes live here so a webview reload cannot lose them.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, State};
+use tauri_plugin_updater::{Update, UpdaterExt};
+use tauri_specta::Event;
+use tracing::{info, warn};
+
+use crate::app_events::{UpdateDownloadProgress, UpdatePhase};
+use crate::state::AppState;
+use crate::state_machine::AppStateMachine;
+
+/// Why "Install and restart" must stay disabled / refuse before any side effect.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "snake_case")]
+pub enum InstallBlockReason {
+    RecordingDictation,
+    RecordingMeeting,
+    Stopping,
+    Downloading,
+    Loading,
+    Unloading,
+}
+
+impl InstallBlockReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::RecordingDictation => "recording_dictation",
+            Self::RecordingMeeting => "recording_meeting",
+            Self::Stopping => "stopping",
+            Self::Downloading => "downloading",
+            Self::Loading => "loading",
+            Self::Unloading => "unloading",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+pub struct UpdateDownloadStatus {
+    pub phase: UpdatePhase,
+    pub version: Option<String>,
+    pub downloaded_bytes: u64,
+    pub total_bytes: Option<u64>,
+    pub error: Option<String>,
+    /// Offer the GitHub release-page fallback when true.
+    pub manual_fallback: bool,
+}
+
+struct ReadyPackage {
+    update: Update,
+    bytes: Vec<u8>,
+    version: String,
+}
+
+struct DownloadState {
+    phase: UpdatePhase,
+    version: Option<String>,
+    downloaded_bytes: u64,
+    total_bytes: Option<u64>,
+    error: Option<String>,
+    manual_fallback: bool,
+    ready: Option<ReadyPackage>,
+}
+
+impl Default for DownloadState {
+    fn default() -> Self {
+        Self {
+            phase: UpdatePhase::Idle,
+            version: None,
+            downloaded_bytes: 0,
+            total_bytes: None,
+            error: None,
+            manual_fallback: false,
+            ready: None,
+        }
+    }
+}
+
+impl DownloadState {
+    fn status(&self) -> UpdateDownloadStatus {
+        UpdateDownloadStatus {
+            phase: self.phase,
+            version: self.version.clone(),
+            downloaded_bytes: self.downloaded_bytes,
+            total_bytes: self.total_bytes,
+            error: self.error.clone(),
+            manual_fallback: self.manual_fallback,
+        }
+    }
+
+    fn emit(&self, app: &AppHandle) {
+        let status = self.status();
+        let _ = (UpdateDownloadProgress {
+            phase: status.phase,
+            version: status.version,
+            downloaded_bytes: status.downloaded_bytes,
+            total_bytes: status.total_bytes,
+            error: status.error,
+            manual_fallback: status.manual_fallback,
+        })
+        .emit(app);
+    }
+}
+
+static DOWNLOAD: Mutex<DownloadState> = Mutex::new(DownloadState {
+    phase: UpdatePhase::Idle,
+    version: None,
+    downloaded_bytes: 0,
+    total_bytes: None,
+    error: None,
+    manual_fallback: false,
+    ready: None,
+});
+
+static CANCEL_DOWNLOAD: AtomicBool = AtomicBool::new(false);
+
+/// Map a machine state to an install block, if any.
+pub fn install_blocked_reason(machine: &AppStateMachine) -> Option<InstallBlockReason> {
+    match machine {
+        AppStateMachine::RecordingDictation { .. } => Some(InstallBlockReason::RecordingDictation),
+        AppStateMachine::RecordingMeeting { .. } => Some(InstallBlockReason::RecordingMeeting),
+        AppStateMachine::Stopping { .. } => Some(InstallBlockReason::Stopping),
+        AppStateMachine::Downloading { .. } => Some(InstallBlockReason::Downloading),
+        AppStateMachine::Loading { .. } => Some(InstallBlockReason::Loading),
+        AppStateMachine::Unloading { .. } => Some(InstallBlockReason::Unloading),
+        AppStateMachine::Idle
+        | AppStateMachine::Downloaded { .. }
+        | AppStateMachine::Ready { .. }
+        | AppStateMachine::Error { .. } => None,
+    }
+}
+
+fn with_state<R>(f: impl FnOnce(&mut DownloadState) -> R) -> Result<R, String> {
+    let mut guard = DOWNLOAD
+        .lock()
+        .map_err(|_| "Update download state lock poisoned".to_string())?;
+    Ok(f(&mut guard))
+}
+
+/// Snapshot of the in-flight / ready update download. Source of truth for the UI.
+#[tauri::command]
+#[specta::specta]
+pub fn get_update_download_status() -> Result<UpdateDownloadStatus, String> {
+    with_state(|s| s.status())
+}
+
+/// Why install is currently refused, if it is. Pure read — no side effects.
+#[tauri::command]
+#[specta::specta]
+pub fn get_update_install_block(
+    state: State<'_, AppState>,
+) -> Result<Option<InstallBlockReason>, String> {
+    let machine = state.current_machine_state()?;
+    Ok(install_blocked_reason(&machine))
+}
+
+/// Start downloading the updater artifact. Detection has already happened via
+/// `update_check`; this only obtains a plugin handle and fetches bytes.
+#[tauri::command]
+#[specta::specta]
+pub async fn download_update(app: AppHandle) -> Result<UpdateDownloadStatus, String> {
+    {
+        let busy =
+            with_state(|s| matches!(s.phase, UpdatePhase::Downloading | UpdatePhase::Ready))?;
+        if busy {
+            return with_state(|s| s.status());
+        }
+        with_state(|s| {
+            *s = DownloadState {
+                phase: UpdatePhase::Downloading,
+                ..DownloadState::default()
+            };
+            s.emit(&app);
+        })?;
+    }
+
+    CANCEL_DOWNLOAD.store(false, Ordering::SeqCst);
+
+    let updater = app
+        .updater()
+        .map_err(|e| format!("Updater unavailable: {e}"))?;
+
+    let update = match updater.check().await {
+        Ok(Some(update)) => update,
+        Ok(None) => {
+            // Release exists (update_check said so) but no updater artifact yet.
+            return fail(
+                &app,
+                "This release has no in-app update package yet. Download it from GitHub instead."
+                    .into(),
+                true,
+            );
+        }
+        Err(e) => {
+            let message = e.to_string();
+            return fail(
+                &app,
+                format!("Could not prepare the update: {message}"),
+                true,
+            );
+        }
+    };
+
+    if CANCEL_DOWNLOAD.load(Ordering::SeqCst) {
+        return reset_idle(&app);
+    }
+
+    let version = update.version.clone();
+    with_state(|s| {
+        s.version = Some(version.clone());
+        s.emit(&app);
+    })?;
+
+    let app_progress = app.clone();
+    let download_result = update
+        .download(
+            |chunk_len, content_length| {
+                if CANCEL_DOWNLOAD.load(Ordering::SeqCst) {
+                    return;
+                }
+                let _ = with_state(|s| {
+                    if s.phase != UpdatePhase::Downloading {
+                        return;
+                    }
+                    s.downloaded_bytes = s.downloaded_bytes.saturating_add(chunk_len as u64);
+                    if content_length.is_some() {
+                        s.total_bytes = content_length;
+                    }
+                    s.emit(&app_progress);
+                });
+            },
+            || {},
+        )
+        .await;
+
+    if CANCEL_DOWNLOAD.load(Ordering::SeqCst) {
+        return reset_idle(&app);
+    }
+
+    match download_result {
+        Ok(bytes) => {
+            if CANCEL_DOWNLOAD.load(Ordering::SeqCst) {
+                return reset_idle(&app);
+            }
+            info!(
+                version = %version,
+                bytes = bytes.len(),
+                "Update package downloaded and verified"
+            );
+            with_state(|s| {
+                if s.phase != UpdatePhase::Downloading {
+                    return s.status();
+                }
+                s.phase = UpdatePhase::Ready;
+                s.version = Some(version.clone());
+                s.downloaded_bytes = bytes.len() as u64;
+                s.total_bytes = Some(bytes.len() as u64);
+                s.error = None;
+                s.manual_fallback = false;
+                s.ready = Some(ReadyPackage {
+                    update,
+                    bytes,
+                    version,
+                });
+                s.emit(&app);
+                s.status()
+            })
+        }
+        Err(e) => {
+            let message = e.to_string();
+            fail(&app, format!("Update download failed: {message}"), true)
+        }
+    }
+}
+
+/// Abandon an in-flight download. No-op if nothing is downloading.
+#[tauri::command]
+#[specta::specta]
+pub fn cancel_update_download(app: AppHandle) -> Result<UpdateDownloadStatus, String> {
+    CANCEL_DOWNLOAD.store(true, Ordering::SeqCst);
+    with_state(|s| {
+        if matches!(s.phase, UpdatePhase::Downloading) {
+            *s = DownloadState::default();
+            s.emit(&app);
+        }
+        s.status()
+    })
+}
+
+/// Replace the on-disk bundle and restart. Refuses before any side effect when
+/// the state machine is busy.
+#[tauri::command]
+#[specta::specta]
+pub async fn install_update(app: AppHandle, state: State<'_, AppState>) -> Result<(), String> {
+    let machine = state.current_machine_state()?;
+    if let Some(reason) = install_blocked_reason(&machine) {
+        return Err(format!(
+            "Cannot install update while {}",
+            reason.as_str().replace('_', " ")
+        ));
+    }
+
+    let package = with_state(|s| {
+        if s.phase != UpdatePhase::Ready {
+            return Err("No update package is ready to install".to_string());
+        }
+        s.ready
+            .take()
+            .ok_or_else(|| "No update package is ready to install".to_string())
+    })??;
+
+    // Explicit shutdown: AppHandle::restart() on the main thread skips
+    // ExitRequested (tauri 2.11), and we must free Metal before process exit.
+    if let Err(e) = state.engine_actor.shutdown() {
+        warn!("Engine shutdown before update install: {e}");
+    }
+
+    let version = package.version.clone();
+    if let Err(e) = package.update.install(&package.bytes) {
+        let message = e.to_string();
+        let user = format!(
+            "Could not write the update (is Soufflé in /Applications writable?): {message}"
+        );
+        // Put the package back so a retry is possible after a write failure.
+        let _ = with_state(|s| {
+            s.phase = UpdatePhase::Failed;
+            s.version = Some(version.clone());
+            s.error = Some(user.clone());
+            s.manual_fallback = true;
+            s.ready = Some(package);
+            s.emit(&app);
+        });
+        return Err(user);
+    }
+
+    info!(version = %version, "Update installed; restarting");
+    app.restart();
+    #[allow(unreachable_code)]
+    Ok(())
+}
+
+fn fail(
+    app: &AppHandle,
+    error: String,
+    manual_fallback: bool,
+) -> Result<UpdateDownloadStatus, String> {
+    with_state(|s| {
+        let version = s.version.clone();
+        *s = DownloadState {
+            phase: UpdatePhase::Failed,
+            version,
+            error: Some(error),
+            manual_fallback,
+            ..DownloadState::default()
+        };
+        s.emit(app);
+        s.status()
+    })
+}
+
+fn reset_idle(app: &AppHandle) -> Result<UpdateDownloadStatus, String> {
+    with_state(|s| {
+        *s = DownloadState::default();
+        s.emit(app);
+        s.status()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::engine::TranscriptionProfile;
+    use crate::state_machine::{AppStateMachine, ErrorRecovery};
+
+    fn profile() -> TranscriptionProfile {
+        TranscriptionProfile {
+            engine_id: "test".into(),
+            engine_label: "Test".into(),
+            model_id: "m".into(),
+            model_label: "M".into(),
+            backend_id: "b".into(),
+            backend_label: "B".into(),
+        }
+    }
+
+    #[test]
+    fn install_is_blocked_in_every_busy_state() {
+        let p = profile();
+        let cases = [
+            (
+                AppStateMachine::RecordingDictation {
+                    profile: p.clone(),
+                    session_id: 1,
+                },
+                InstallBlockReason::RecordingDictation,
+            ),
+            (
+                AppStateMachine::RecordingMeeting {
+                    profile: p.clone(),
+                    session_id: 1,
+                    meeting_id: "m1".into(),
+                },
+                InstallBlockReason::RecordingMeeting,
+            ),
+            (
+                AppStateMachine::Stopping {
+                    profile: p.clone(),
+                    was_recording: crate::state_machine::RecordingKind::Dictation,
+                },
+                InstallBlockReason::Stopping,
+            ),
+            (
+                AppStateMachine::Downloading { profile: p.clone() },
+                InstallBlockReason::Downloading,
+            ),
+            (
+                AppStateMachine::Loading { profile: p.clone() },
+                InstallBlockReason::Loading,
+            ),
+            (
+                AppStateMachine::Unloading {
+                    profile: p.clone(),
+                    next_profile: None,
+                },
+                InstallBlockReason::Unloading,
+            ),
+        ];
+        for (machine, expected) in cases {
+            assert_eq!(install_blocked_reason(&machine), Some(expected));
+        }
+    }
+
+    #[test]
+    fn install_is_allowed_when_idle_ready_or_error() {
+        let p = profile();
+        assert!(install_blocked_reason(&AppStateMachine::Idle).is_none());
+        assert!(install_blocked_reason(&AppStateMachine::Ready { profile: p.clone() }).is_none());
+        assert!(
+            install_blocked_reason(&AppStateMachine::Downloaded { profile: p.clone() }).is_none()
+        );
+        assert!(
+            install_blocked_reason(&AppStateMachine::Error {
+                message: "x".into(),
+                recovery: ErrorRecovery::RetryFromIdle,
+            })
+            .is_none()
+        );
+    }
+}

--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -4,7 +4,7 @@
 //! Progress and ready bytes live here so a webview reload cannot lose them.
 
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, State};
@@ -93,19 +93,18 @@ impl DownloadState {
             manual_fallback: self.manual_fallback,
         }
     }
+}
 
-    fn emit(&self, app: &AppHandle) {
-        let status = self.status();
-        let _ = (UpdateDownloadProgress {
-            phase: status.phase,
-            version: status.version,
-            downloaded_bytes: status.downloaded_bytes,
-            total_bytes: status.total_bytes,
-            error: status.error,
-            manual_fallback: status.manual_fallback,
-        })
-        .emit(app);
-    }
+fn emit_status(app: &AppHandle, status: UpdateDownloadStatus) {
+    let _ = (UpdateDownloadProgress {
+        phase: status.phase,
+        version: status.version,
+        downloaded_bytes: status.downloaded_bytes,
+        total_bytes: status.total_bytes,
+        error: status.error,
+        manual_fallback: status.manual_fallback,
+    })
+    .emit(app);
 }
 
 static DOWNLOAD: Mutex<DownloadState> = Mutex::new(DownloadState {
@@ -119,6 +118,9 @@ static DOWNLOAD: Mutex<DownloadState> = Mutex::new(DownloadState {
 });
 
 static CANCEL_DOWNLOAD: AtomicBool = AtomicBool::new(false);
+/// Bumped on each new download attempt and on cancel so a stale callback/result
+/// cannot mutate the shared state of a later attempt.
+static DOWNLOAD_ATTEMPT: AtomicU64 = AtomicU64::new(0);
 
 /// Map a machine state to an install block, if any.
 pub fn install_blocked_reason(machine: &AppStateMachine) -> Option<InstallBlockReason> {
@@ -143,6 +145,19 @@ fn with_state<R>(f: impl FnOnce(&mut DownloadState) -> R) -> Result<R, String> {
     Ok(f(&mut guard))
 }
 
+fn mutate_and_emit(app: &AppHandle, f: impl FnOnce(&mut DownloadState)) -> Result<(), String> {
+    let status = with_state(|s| {
+        f(s);
+        s.status()
+    })?;
+    emit_status(app, status);
+    Ok(())
+}
+
+fn attempt_is_current(attempt: u64) -> bool {
+    DOWNLOAD_ATTEMPT.load(Ordering::SeqCst) == attempt
+}
+
 /// Snapshot of the in-flight / ready update download. Source of truth for the UI.
 #[tauri::command]
 #[specta::specta]
@@ -165,30 +180,39 @@ pub fn get_update_install_block(
 #[tauri::command]
 #[specta::specta]
 pub async fn download_update(app: AppHandle) -> Result<UpdateDownloadStatus, String> {
-    {
+    let attempt = {
         let busy =
             with_state(|s| matches!(s.phase, UpdatePhase::Downloading | UpdatePhase::Ready))?;
         if busy {
             return with_state(|s| s.status());
         }
-        with_state(|s| {
+        CANCEL_DOWNLOAD.store(false, Ordering::SeqCst);
+        let attempt = DOWNLOAD_ATTEMPT.fetch_add(1, Ordering::SeqCst) + 1;
+        mutate_and_emit(&app, |s| {
             *s = DownloadState {
                 phase: UpdatePhase::Downloading,
                 ..DownloadState::default()
             };
-            s.emit(&app);
         })?;
-    }
+        attempt
+    };
 
-    CANCEL_DOWNLOAD.store(false, Ordering::SeqCst);
-
-    let updater = app
-        .updater()
-        .map_err(|e| format!("Updater unavailable: {e}"))?;
+    let updater = match app.updater() {
+        Ok(updater) => updater,
+        Err(e) => {
+            if !attempt_is_current(attempt) {
+                return with_state(|s| s.status());
+            }
+            return fail(&app, format!("Updater unavailable: {e}"), true);
+        }
+    };
 
     let update = match updater.check().await {
         Ok(Some(update)) => update,
         Ok(None) => {
+            if !attempt_is_current(attempt) {
+                return with_state(|s| s.status());
+            }
             // Release exists (update_check said so) but no updater artifact yet.
             return fail(
                 &app,
@@ -198,6 +222,9 @@ pub async fn download_update(app: AppHandle) -> Result<UpdateDownloadStatus, Str
             );
         }
         Err(e) => {
+            if !attempt_is_current(attempt) {
+                return with_state(|s| s.status());
+            }
             let message = e.to_string();
             return fail(
                 &app,
@@ -207,54 +234,60 @@ pub async fn download_update(app: AppHandle) -> Result<UpdateDownloadStatus, Str
         }
     };
 
-    if CANCEL_DOWNLOAD.load(Ordering::SeqCst) {
-        return reset_idle(&app);
+    if CANCEL_DOWNLOAD.load(Ordering::SeqCst) || !attempt_is_current(attempt) {
+        return with_state(|s| s.status());
     }
 
     let version = update.version.clone();
-    with_state(|s| {
-        s.version = Some(version.clone());
-        s.emit(&app);
+    mutate_and_emit(&app, |s| {
+        if attempt_is_current(attempt) && s.phase == UpdatePhase::Downloading {
+            s.version = Some(version.clone());
+        }
     })?;
 
     let app_progress = app.clone();
     let download_result = update
         .download(
             |chunk_len, content_length| {
-                if CANCEL_DOWNLOAD.load(Ordering::SeqCst) {
+                if CANCEL_DOWNLOAD.load(Ordering::SeqCst) || !attempt_is_current(attempt) {
                     return;
                 }
-                let _ = with_state(|s| {
-                    if s.phase != UpdatePhase::Downloading {
-                        return;
+                let status = with_state(|s| {
+                    if !attempt_is_current(attempt) || s.phase != UpdatePhase::Downloading {
+                        return None;
                     }
                     s.downloaded_bytes = s.downloaded_bytes.saturating_add(chunk_len as u64);
                     if content_length.is_some() {
                         s.total_bytes = content_length;
                     }
-                    s.emit(&app_progress);
-                });
+                    Some(s.status())
+                })
+                .ok()
+                .flatten();
+                if let Some(status) = status {
+                    emit_status(&app_progress, status);
+                }
             },
             || {},
         )
         .await;
 
-    if CANCEL_DOWNLOAD.load(Ordering::SeqCst) {
-        return reset_idle(&app);
+    if CANCEL_DOWNLOAD.load(Ordering::SeqCst) || !attempt_is_current(attempt) {
+        return with_state(|s| s.status());
     }
 
     match download_result {
         Ok(bytes) => {
-            if CANCEL_DOWNLOAD.load(Ordering::SeqCst) {
-                return reset_idle(&app);
+            if CANCEL_DOWNLOAD.load(Ordering::SeqCst) || !attempt_is_current(attempt) {
+                return with_state(|s| s.status());
             }
             info!(
                 version = %version,
                 bytes = bytes.len(),
                 "Update package downloaded and verified"
             );
-            with_state(|s| {
-                if s.phase != UpdatePhase::Downloading {
+            let status = with_state(|s| {
+                if !attempt_is_current(attempt) || s.phase != UpdatePhase::Downloading {
                     return s.status();
                 }
                 s.phase = UpdatePhase::Ready;
@@ -268,11 +301,15 @@ pub async fn download_update(app: AppHandle) -> Result<UpdateDownloadStatus, Str
                     bytes,
                     version,
                 });
-                s.emit(&app);
                 s.status()
-            })
+            })?;
+            emit_status(&app, status.clone());
+            Ok(status)
         }
         Err(e) => {
+            if !attempt_is_current(attempt) {
+                return with_state(|s| s.status());
+            }
             let message = e.to_string();
             fail(&app, format!("Update download failed: {message}"), true)
         }
@@ -284,13 +321,15 @@ pub async fn download_update(app: AppHandle) -> Result<UpdateDownloadStatus, Str
 #[specta::specta]
 pub fn cancel_update_download(app: AppHandle) -> Result<UpdateDownloadStatus, String> {
     CANCEL_DOWNLOAD.store(true, Ordering::SeqCst);
-    with_state(|s| {
+    DOWNLOAD_ATTEMPT.fetch_add(1, Ordering::SeqCst);
+    let status = with_state(|s| {
         if matches!(s.phase, UpdatePhase::Downloading) {
             *s = DownloadState::default();
-            s.emit(&app);
         }
         s.status()
-    })
+    })?;
+    emit_status(&app, status.clone());
+    Ok(status)
 }
 
 /// Replace the on-disk bundle and restart. Refuses before any side effect when
@@ -315,28 +354,32 @@ pub async fn install_update(app: AppHandle, state: State<'_, AppState>) -> Resul
             .ok_or_else(|| "No update package is ready to install".to_string())
     })??;
 
-    // Explicit shutdown: AppHandle::restart() on the main thread skips
-    // ExitRequested (tauri 2.11), and we must free Metal before process exit.
-    if let Err(e) = state.engine_actor.shutdown() {
-        warn!("Engine shutdown before update install: {e}");
-    }
-
     let version = package.version.clone();
+    // Install first: the running process keeps its in-memory engine until we
+    // restart. Shutting down before a fallible install would leave transcription
+    // dead if the write fails.
     if let Err(e) = package.update.install(&package.bytes) {
         let message = e.to_string();
         let user = format!(
             "Could not write the update (is Soufflé in /Applications writable?): {message}"
         );
         // Put the package back so a retry is possible after a write failure.
-        let _ = with_state(|s| {
+        let status = with_state(|s| {
             s.phase = UpdatePhase::Failed;
             s.version = Some(version.clone());
             s.error = Some(user.clone());
             s.manual_fallback = true;
             s.ready = Some(package);
-            s.emit(&app);
-        });
+            s.status()
+        })?;
+        emit_status(&app, status);
         return Err(user);
+    }
+
+    // Explicit shutdown: AppHandle::restart() on the main thread skips
+    // ExitRequested (tauri 2.11), and we must free Metal before process exit.
+    if let Err(e) = state.engine_actor.shutdown() {
+        warn!("Engine shutdown before update restart: {e}");
     }
 
     info!(version = %version, "Update installed; restarting");
@@ -350,7 +393,7 @@ fn fail(
     error: String,
     manual_fallback: bool,
 ) -> Result<UpdateDownloadStatus, String> {
-    with_state(|s| {
+    let status = with_state(|s| {
         let version = s.version.clone();
         *s = DownloadState {
             phase: UpdatePhase::Failed,
@@ -359,17 +402,10 @@ fn fail(
             manual_fallback,
             ..DownloadState::default()
         };
-        s.emit(app);
         s.status()
-    })
-}
-
-fn reset_idle(app: &AppHandle) -> Result<UpdateDownloadStatus, String> {
-    with_state(|s| {
-        *s = DownloadState::default();
-        s.emit(app);
-        s.status()
-    })
+    })?;
+    emit_status(app, status.clone());
+    Ok(status)
 }
 
 #[cfg(test)]
@@ -451,5 +487,30 @@ mod tests {
             })
             .is_none()
         );
+    }
+
+    #[test]
+    fn cancel_invalidates_prior_download_attempt() {
+        let before = DOWNLOAD_ATTEMPT.load(Ordering::SeqCst);
+        CANCEL_DOWNLOAD.store(false, Ordering::SeqCst);
+        let _ = with_state(|s| {
+            *s = DownloadState {
+                phase: UpdatePhase::Downloading,
+                ..DownloadState::default()
+            };
+        });
+        // Mimic cancel_update_download without needing an AppHandle emit.
+        CANCEL_DOWNLOAD.store(true, Ordering::SeqCst);
+        DOWNLOAD_ATTEMPT.fetch_add(1, Ordering::SeqCst);
+        let _ = with_state(|s| {
+            if matches!(s.phase, UpdatePhase::Downloading) {
+                *s = DownloadState::default();
+            }
+        });
+        assert!(CANCEL_DOWNLOAD.load(Ordering::SeqCst));
+        assert_eq!(DOWNLOAD_ATTEMPT.load(Ordering::SeqCst), before + 1);
+        assert!(!attempt_is_current(before));
+        let phase = with_state(|s| s.phase).unwrap();
+        assert_eq!(phase, UpdatePhase::Idle);
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -175,6 +175,11 @@ fn specta_builder() -> Builder<tauri::Wry> {
             commands::get_release_notes_for_version,
             commands::get_app_version,
             commands::open_release_page,
+            commands::get_update_download_status,
+            commands::get_update_install_block,
+            commands::download_update,
+            commands::cancel_update_download,
+            commands::install_update,
         ])
         .events(collect_events![
             app_events::Navigate,
@@ -203,6 +208,7 @@ fn specta_builder() -> Builder<tauri::Wry> {
             app_events::InputPinUnavailable,
             app_events::InputRouteNotice,
             app_events::UpdateAvailable,
+            app_events::UpdateDownloadProgress,
         ])
 }
 
@@ -291,6 +297,7 @@ pub fn run() {
         .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
             tray::show_main_window(app);
         }))
+        .plugin(tauri_plugin_updater::Builder::new().build())
         .manage(AppState::new(cmd_tx, engine_actor, database, audio_rms))
         .invoke_handler(specta.invoke_handler())
         .setup(move |app| {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -62,6 +62,7 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
+    "createUpdaterArtifacts": true,
     "macOS": {
       "entitlements": "./entitlements.plist",
       "minimumSystemVersion": "13.0",
@@ -71,5 +72,12 @@
       ]
     }
   },
-  "plugins": {}
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDRCNEIzOEFGNTQwMUM1RkIKUldUN3hRRlVyemhMUzBqLzZuSWpCY2RtYnM0djNQUHZvdkFGNWxNVFA1d1hUZllDUjFJK3NPZzMK",
+      "endpoints": [
+        "https://github.com/damione1/souffle/releases/latest/download/latest.json"
+      ]
+    }
+  }
 }

--- a/src/lib/api/updater.ts
+++ b/src/lib/api/updater.ts
@@ -1,0 +1,36 @@
+import { commands, events, unwrap } from "./generated";
+import type {
+  InstallBlockReason,
+  UpdateDownloadStatus,
+  UpdatePhase,
+} from "../types";
+
+export type { InstallBlockReason, UpdateDownloadStatus, UpdatePhase };
+
+export async function getUpdateDownloadStatus(): Promise<UpdateDownloadStatus> {
+  return unwrap(commands.getUpdateDownloadStatus());
+}
+
+export async function getUpdateInstallBlock(): Promise<InstallBlockReason | null> {
+  return unwrap(commands.getUpdateInstallBlock());
+}
+
+export async function downloadUpdate(): Promise<UpdateDownloadStatus> {
+  return unwrap(commands.downloadUpdate());
+}
+
+export async function cancelUpdateDownload(): Promise<UpdateDownloadStatus> {
+  return unwrap(commands.cancelUpdateDownload());
+}
+
+export async function installUpdate(): Promise<void> {
+  await unwrap(commands.installUpdate());
+}
+
+export function listenUpdateDownloadProgress(
+  handler: (status: UpdateDownloadStatus) => void,
+): Promise<() => void> {
+  return events.updateDownloadProgress.listen((event) => {
+    handler(event.payload);
+  });
+}

--- a/src/lib/features/onboarding/UpdateAvailableDialog.svelte
+++ b/src/lib/features/onboarding/UpdateAvailableDialog.svelte
@@ -2,6 +2,8 @@
   import { t } from "svelte-i18n";
   import { openReleasePage } from "../../api/diagnostics";
   import { renderReleaseNotesMarkdown } from "../../utils";
+  import UpdateAction from "../update/UpdateAction.svelte";
+  import { useUpdateController } from "../update/controller.svelte";
 
   let {
     version,
@@ -14,6 +16,8 @@
     releaseUrl: string | null;
     onDismiss: () => void;
   } = $props();
+
+  useUpdateController();
 
   // renderReleaseNotesMarkdown escapes all input text and emits only a fixed
   // set of tags, so this HTML is safe to inject (see its module docs).
@@ -29,8 +33,8 @@
     void openReleasePage(anchor.href);
   }
 
-  function download() {
-    if (releaseUrl) void openReleasePage(releaseUrl);
+  // Dismiss is always safe: download continues in Rust if in flight.
+  function dismiss() {
     onDismiss();
   }
 </script>
@@ -59,15 +63,11 @@
       </div>
     {/if}
 
-    <div class="flex justify-end gap-2">
-      <button onclick={onDismiss} class="btn">
+    <div class="flex justify-end gap-2 items-start">
+      <button onclick={dismiss} class="btn">
         {$t("update_available.later")}
       </button>
-      {#if releaseUrl}
-        <button onclick={download} class="btn btn-active">
-          {$t("update_available.download")}
-        </button>
-      {/if}
+      <UpdateAction {releaseUrl} />
     </div>
   </div>
 </div>

--- a/src/lib/features/settings/components/AboutSettingsSection.svelte
+++ b/src/lib/features/settings/components/AboutSettingsSection.svelte
@@ -2,9 +2,11 @@
   import { onMount } from "svelte";
   import { t } from "svelte-i18n";
   import SettingsField from "../../../components/ui/SettingsField.svelte";
-  import { checkForUpdates, getAppVersion, openReleasePage } from "../../../api/diagnostics";
+  import { checkForUpdates, getAppVersion } from "../../../api/diagnostics";
   import type { UpdateCheckResult } from "../../../types";
   import { errorMessage } from "../../../utils";
+  import UpdateAction from "../../update/UpdateAction.svelte";
+  import { updateController, useUpdateController } from "../../update/controller.svelte";
 
   let {
     selectedTranscriptionLabel,
@@ -18,11 +20,20 @@
     onAutoUpdateCheckChange: (event: Event) => void;
   } = $props();
 
+  useUpdateController();
+
   let appVersion = $state("");
   let checking = $state(false);
   let updateResult = $state<UpdateCheckResult | null>(null);
   let statusMessage = $state("");
   let statusIsError = $state(false);
+
+  const showUpdateAction = $derived(
+    Boolean(updateResult?.update_available) ||
+      updateController.phase === "downloading" ||
+      updateController.phase === "ready" ||
+      updateController.phase === "failed",
+  );
 
   onMount(() => {
     void getAppVersion().then((v) => {
@@ -84,13 +95,8 @@
         >
           {checking ? $t("settings_about.checking") : $t("settings_about.check_updates")}
         </button>
-        {#if updateResult?.update_available && updateResult.release_url}
-          <button
-            onclick={() => void openReleasePage(updateResult!.release_url!)}
-            class="text-xs text-accent hover:underline cursor-pointer"
-          >
-            {$t("settings_about.download_update")}
-          </button>
+        {#if showUpdateAction}
+          <UpdateAction releaseUrl={updateResult?.release_url ?? null} compact />
         {/if}
       </div>
     </div>

--- a/src/lib/features/update/UpdateAction.svelte
+++ b/src/lib/features/update/UpdateAction.svelte
@@ -101,7 +101,7 @@
         <button
           type="button"
           class={ghostClass}
-          onclick={() => updateController.openFallback(releaseUrl)}
+          onclick={() => void updateController.openFallback(releaseUrl)}
         >
           {$t("update_available.open_release_page")}
         </button>
@@ -109,11 +109,15 @@
     </div>
   {/if}
 
+  {#if phase !== "failed" && actionError}
+    <p class="text-xs text-danger-soft {compact ? 'text-right' : ''}">{actionError}</p>
+  {/if}
+
   {#if phase !== "failed" && status.manual_fallback && releaseUrl}
     <button
       type="button"
       class={ghostClass}
-      onclick={() => updateController.openFallback(releaseUrl)}
+      onclick={() => void updateController.openFallback(releaseUrl)}
     >
       {$t("update_available.open_release_page")}
     </button>

--- a/src/lib/features/update/UpdateAction.svelte
+++ b/src/lib/features/update/UpdateAction.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+  import { t } from "svelte-i18n";
+  import {
+    updateController,
+    useUpdateController,
+  } from "./controller.svelte";
+  import type { InstallBlockReason } from "../../api/updater";
+
+  let {
+    releaseUrl = null,
+    compact = false,
+  }: {
+    releaseUrl?: string | null;
+    /** Compact link-style for Settings; full buttons for the dialog. */
+    compact?: boolean;
+  } = $props();
+
+  useUpdateController();
+
+  const status = $derived(updateController.status);
+  const phase = $derived(status.phase);
+  const busy = $derived(updateController.busy);
+  const installBlock = $derived(updateController.installBlock);
+  const actionError = $derived(updateController.actionError ?? status.error);
+
+  const progressPct = $derived.by(() => {
+    if (!status.total_bytes || status.total_bytes <= 0) return null;
+    return Math.min(100, Math.round((status.downloaded_bytes / status.total_bytes) * 100));
+  });
+
+  function blockLabel(reason: InstallBlockReason): string {
+    return $t(`update_available.blocked_${reason}`);
+  }
+
+  const btnClass = $derived(compact ? "text-xs text-accent hover:underline cursor-pointer" : "btn btn-active");
+  const ghostClass = $derived(compact ? "text-xs text-text-muted hover:underline cursor-pointer" : "btn");
+</script>
+
+<div class="flex flex-col {compact ? 'items-end gap-1' : 'gap-2'}">
+  {#if phase === "idle" || (phase === "failed" && !status.manual_fallback)}
+    <button
+      type="button"
+      class={btnClass}
+      disabled={busy}
+      onclick={() => void updateController.download()}
+    >
+      {$t("update_available.download_update")}
+    </button>
+  {:else if phase === "downloading"}
+    <div class="flex {compact ? 'flex-col items-end' : 'items-center'} gap-2 w-full">
+      {#if progressPct !== null}
+        <div
+          class="h-1.5 flex-1 min-w-[8rem] overflow-hidden rounded-full bg-ghost-border"
+          role="progressbar"
+          aria-valuenow={progressPct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <div class="h-full bg-accent transition-[width]" style="width: {progressPct}%"></div>
+        </div>
+        <span class="text-xs text-text-muted tabular-nums">{progressPct}%</span>
+      {:else}
+        <span class="text-xs text-text-muted">{$t("update_available.downloading")}</span>
+      {/if}
+      <button
+        type="button"
+        class={ghostClass}
+        disabled={busy}
+        onclick={() => void updateController.cancel()}
+      >
+        {$t("update_available.cancel")}
+      </button>
+    </div>
+  {:else if phase === "ready"}
+    <button
+      type="button"
+      class={btnClass}
+      disabled={busy || installBlock !== null}
+      title={installBlock ? blockLabel(installBlock) : undefined}
+      onclick={() => void updateController.install()}
+    >
+      {$t("update_available.install_restart")}
+    </button>
+    {#if installBlock}
+      <p class="text-xs text-text-muted">{blockLabel(installBlock)}</p>
+    {/if}
+  {:else if phase === "failed"}
+    {#if actionError}
+      <p class="text-xs text-danger-soft {compact ? 'text-right' : ''}">{actionError}</p>
+    {/if}
+    <div class="flex {compact ? 'flex-col items-end' : 'justify-end'} gap-2">
+      <button
+        type="button"
+        class={btnClass}
+        disabled={busy}
+        onclick={() => void updateController.download()}
+      >
+        {$t("update_available.retry")}
+      </button>
+      {#if releaseUrl}
+        <button
+          type="button"
+          class={ghostClass}
+          onclick={() => updateController.openFallback(releaseUrl)}
+        >
+          {$t("update_available.open_release_page")}
+        </button>
+      {/if}
+    </div>
+  {/if}
+
+  {#if phase !== "failed" && status.manual_fallback && releaseUrl}
+    <button
+      type="button"
+      class={ghostClass}
+      onclick={() => updateController.openFallback(releaseUrl)}
+    >
+      {$t("update_available.open_release_page")}
+    </button>
+  {/if}
+</div>

--- a/src/lib/features/update/controller.svelte.ts
+++ b/src/lib/features/update/controller.svelte.ts
@@ -40,14 +40,28 @@ function idleStatus(): UpdateDownloadStatus {
   };
 }
 
+function statusLoadFailed(): UpdateDownloadStatus {
+  return {
+    phase: "failed",
+    version: null,
+    downloaded_bytes: 0,
+    total_bytes: null,
+    error: "Could not restore update progress. Retry the download.",
+    manual_fallback: true,
+  };
+}
+
 /** Shared mirror of the Rust updater download state. Survives dialog close. */
 class UpdateController {
   status = $state<UpdateDownloadStatus>(idleStatus());
+  /** True only for short acknowledgements (cancel/install), never for the transfer itself. */
   busy = $state(false);
   actionError = $state<string | null>(null);
   installBlock = $state<InstallBlockReason | null>(null);
   #started = false;
   #unlisten: (() => void) | null = null;
+  /** True while `downloadUpdate()` is awaiting the long transfer. */
+  #downloadInFlight = false;
 
   get phase(): UpdatePhase {
     return this.status.phase;
@@ -70,15 +84,18 @@ class UpdateController {
   async start() {
     if (this.#started) return;
     this.#started = true;
-    try {
-      this.status = await getUpdateDownloadStatus();
-    } catch {
-      this.status = idleStatus();
-    }
-    this.syncInstallBlock();
+    // Register the listener before the snapshot so a completing download cannot
+    // land between the two and leave the UI on a stale progress event.
     this.#unlisten = await listenUpdateDownloadProgress((status) => {
       this.status = status;
     });
+    try {
+      this.status = await getUpdateDownloadStatus();
+    } catch {
+      this.status = statusLoadFailed();
+      this.actionError = this.status.error;
+    }
+    this.syncInstallBlock();
   }
 
   stop() {
@@ -88,7 +105,8 @@ class UpdateController {
   }
 
   async download() {
-    this.busy = true;
+    if (this.#downloadInFlight || this.status.phase === "downloading") return;
+    this.#downloadInFlight = true;
     this.actionError = null;
     try {
       this.status = await downloadUpdate();
@@ -101,7 +119,7 @@ class UpdateController {
         manual_fallback: true,
       };
     } finally {
-      this.busy = false;
+      this.#downloadInFlight = false;
     }
   }
 
@@ -137,8 +155,13 @@ class UpdateController {
     }
   }
 
-  openFallback(releaseUrl: string | null) {
-    if (releaseUrl) void openReleasePage(releaseUrl);
+  async openFallback(releaseUrl: string | null) {
+    if (!releaseUrl) return;
+    try {
+      await openReleasePage(releaseUrl);
+    } catch (e) {
+      this.actionError = errorMessage(e);
+    }
   }
 }
 

--- a/src/lib/features/update/controller.svelte.ts
+++ b/src/lib/features/update/controller.svelte.ts
@@ -1,0 +1,160 @@
+import { onMount } from "svelte";
+import {
+  cancelUpdateDownload,
+  downloadUpdate,
+  getUpdateDownloadStatus,
+  getUpdateInstallBlock,
+  installUpdate,
+  listenUpdateDownloadProgress,
+  type InstallBlockReason,
+  type UpdateDownloadStatus,
+  type UpdatePhase,
+} from "../../api/updater";
+import { openReleasePage } from "../../api/diagnostics";
+import { errorMessage } from "../../utils";
+import { getAppState } from "../../stores/app.svelte";
+
+/** Machine states that must disable Install (mirrors Rust `install_blocked_reason`). */
+const BLOCKING_STATES = new Set([
+  "recording_dictation",
+  "recording_meeting",
+  "stopping",
+  "downloading",
+  "loading",
+  "unloading",
+]);
+
+function blockFromMachine(state: string): InstallBlockReason | null {
+  if (!BLOCKING_STATES.has(state)) return null;
+  return state as InstallBlockReason;
+}
+
+function idleStatus(): UpdateDownloadStatus {
+  return {
+    phase: "idle",
+    version: null,
+    downloaded_bytes: 0,
+    total_bytes: null,
+    error: null,
+    manual_fallback: false,
+  };
+}
+
+/** Shared mirror of the Rust updater download state. Survives dialog close. */
+class UpdateController {
+  status = $state<UpdateDownloadStatus>(idleStatus());
+  busy = $state(false);
+  actionError = $state<string | null>(null);
+  installBlock = $state<InstallBlockReason | null>(null);
+  #started = false;
+  #unlisten: (() => void) | null = null;
+
+  get phase(): UpdatePhase {
+    return this.status.phase;
+  }
+
+  /** Keep installBlock in sync with the live machine (and a backend query). */
+  syncInstallBlock() {
+    const app = getAppState();
+    const fromMachine = blockFromMachine(app.machineState.state);
+    this.installBlock = fromMachine;
+    void getUpdateInstallBlock()
+      .then((block) => {
+        this.installBlock = block ?? blockFromMachine(getAppState().machineState.state);
+      })
+      .catch(() => {
+        this.installBlock = blockFromMachine(getAppState().machineState.state);
+      });
+  }
+
+  async start() {
+    if (this.#started) return;
+    this.#started = true;
+    try {
+      this.status = await getUpdateDownloadStatus();
+    } catch {
+      this.status = idleStatus();
+    }
+    this.syncInstallBlock();
+    this.#unlisten = await listenUpdateDownloadProgress((status) => {
+      this.status = status;
+    });
+  }
+
+  stop() {
+    this.#unlisten?.();
+    this.#unlisten = null;
+    this.#started = false;
+  }
+
+  async download() {
+    this.busy = true;
+    this.actionError = null;
+    try {
+      this.status = await downloadUpdate();
+    } catch (e) {
+      this.actionError = errorMessage(e);
+      this.status = {
+        ...this.status,
+        phase: "failed",
+        error: this.actionError,
+        manual_fallback: true,
+      };
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  async cancel() {
+    this.busy = true;
+    this.actionError = null;
+    try {
+      this.status = await cancelUpdateDownload();
+    } catch (e) {
+      this.actionError = errorMessage(e);
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  async install() {
+    this.syncInstallBlock();
+    if (this.installBlock) return;
+    this.busy = true;
+    this.actionError = null;
+    try {
+      await installUpdate();
+    } catch (e) {
+      this.actionError = errorMessage(e);
+      this.status = {
+        ...this.status,
+        phase: "failed",
+        error: this.actionError,
+        manual_fallback: true,
+      };
+    } finally {
+      this.busy = false;
+    }
+  }
+
+  openFallback(releaseUrl: string | null) {
+    if (releaseUrl) void openReleasePage(releaseUrl);
+  }
+}
+
+export const updateController = new UpdateController();
+
+/** Ensure the controller is listening for the lifetime of a UI that needs it. */
+export function useUpdateController() {
+  onMount(() => {
+    void updateController.start();
+  });
+}
+
+// Re-sync install block whenever the machine changes (recording start/stop).
+$effect.root(() => {
+  $effect(() => {
+    void getAppState().machineState.state;
+    updateController.syncInstallBlock();
+  });
+});

--- a/src/lib/features/update/install-guard.test.ts
+++ b/src/lib/features/update/install-guard.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+/** Mirrors `install_blocked_reason` / UpdateAction blocking set. */
+const BLOCKING_STATES = new Set([
+  "recording_dictation",
+  "recording_meeting",
+  "stopping",
+  "downloading",
+  "loading",
+  "unloading",
+]);
+
+function isInstallBlocked(machineState: string): boolean {
+  return BLOCKING_STATES.has(machineState);
+}
+
+describe("update install guard (UI)", () => {
+  it.each([
+    "recording_dictation",
+    "recording_meeting",
+    "stopping",
+    "downloading",
+    "loading",
+    "unloading",
+  ])("disables install while %s", (state) => {
+    expect(isInstallBlocked(state)).toBe(true);
+  });
+
+  it.each(["idle", "ready", "downloaded", "error"])(
+    "allows install while %s",
+    (state) => {
+      expect(isInstallBlocked(state)).toBe(false);
+    },
+  );
+});

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -276,9 +276,9 @@
     "checking": "Checking…",
     "up_to_date": "You're on the latest release.",
     "update_available": "Version {version} is available.",
-    "download_update": "Download on GitHub",
+    "download_update": "Download update",
     "auto_check": "Check daily for updates",
-    "auto_check_desc": "Ask GitHub once a day whether a newer version exists, and show a dialog when there is one. Nothing is downloaded or installed."
+    "auto_check_desc": "Ask GitHub once a day whether a newer version exists, and show a dialog when there is one. Download and install stay under your control."
   },
   "whats_new": {
     "title": "What's New",
@@ -592,6 +592,18 @@
     "title": "Update available",
     "subtitle": "Soufflé v{version} is out.",
     "later": "Later",
-    "download": "Download"
+    "download": "Download",
+    "download_update": "Download update",
+    "downloading": "Downloading…",
+    "cancel": "Cancel",
+    "install_restart": "Install and restart",
+    "retry": "Try again",
+    "open_release_page": "Open release page",
+    "blocked_recording_dictation": "Finish dictation before installing.",
+    "blocked_recording_meeting": "Stop the meeting before installing.",
+    "blocked_stopping": "Wait for recording to finish stopping.",
+    "blocked_downloading": "Wait for the model download to finish.",
+    "blocked_loading": "Wait for the model to finish loading.",
+    "blocked_unloading": "Wait for the model to finish unloading."
   }
 }

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -276,9 +276,9 @@
     "checking": "Vérification…",
     "up_to_date": "Vous utilisez la dernière version.",
     "update_available": "La version {version} est disponible.",
-    "download_update": "Télécharger sur GitHub",
+    "download_update": "Télécharger la mise à jour",
     "auto_check": "Vérifier les mises à jour chaque jour",
-    "auto_check_desc": "Demande à GitHub une fois par jour si une version plus récente existe, et affiche une fenêtre le cas échéant. Rien n'est téléchargé ni installé."
+    "auto_check_desc": "Demande à GitHub une fois par jour si une version plus récente existe, et affiche une fenêtre le cas échéant. Téléchargement et installation restent sous votre contrôle."
   },
   "whats_new": {
     "title": "Nouveautés",
@@ -592,6 +592,18 @@
     "title": "Mise à jour disponible",
     "subtitle": "Soufflé v{version} est disponible.",
     "later": "Plus tard",
-    "download": "Télécharger"
+    "download": "Télécharger",
+    "download_update": "Télécharger la mise à jour",
+    "downloading": "Téléchargement…",
+    "cancel": "Annuler",
+    "install_restart": "Installer et redémarrer",
+    "retry": "Réessayer",
+    "open_release_page": "Ouvrir la page de release",
+    "blocked_recording_dictation": "Terminez la dictée avant d'installer.",
+    "blocked_recording_meeting": "Arrêtez la réunion avant d'installer.",
+    "blocked_stopping": "Attendez la fin de l'arrêt de l'enregistrement.",
+    "blocked_downloading": "Attendez la fin du téléchargement du modèle.",
+    "blocked_loading": "Attendez la fin du chargement du modèle.",
+    "blocked_unloading": "Attendez la fin du déchargement du modèle."
   }
 }

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -1082,6 +1082,63 @@ async openReleasePage(url: string) : Promise<Result<null, string>> {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+/**
+ * Snapshot of the in-flight / ready update download. Source of truth for the UI.
+ */
+async getUpdateDownloadStatus() : Promise<Result<UpdateDownloadStatus, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_update_download_status") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Why install is currently refused, if it is. Pure read — no side effects.
+ */
+async getUpdateInstallBlock() : Promise<Result<InstallBlockReason | null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("get_update_install_block") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Start downloading the updater artifact. Detection has already happened via
+ * `update_check`; this only obtains a plugin handle and fetches bytes.
+ */
+async downloadUpdate() : Promise<Result<UpdateDownloadStatus, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("download_update") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Abandon an in-flight download. No-op if nothing is downloading.
+ */
+async cancelUpdateDownload() : Promise<Result<UpdateDownloadStatus, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("cancel_update_download") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+/**
+ * Replace the on-disk bundle and restart. Refuses before any side effect when
+ * the state machine is busy.
+ */
+async installUpdate() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("install_update") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 
@@ -1114,7 +1171,8 @@ systemWokeUp: SystemWokeUp,
 todayCalendarUpdated: TodayCalendarUpdated,
 transcriptionHealth: TranscriptionHealth,
 upcomingMeeting: UpcomingMeeting,
-updateAvailable: UpdateAvailable
+updateAvailable: UpdateAvailable,
+updateDownloadProgress: UpdateDownloadProgress
 }>({
 archiveExportProgress: "archive-export-progress",
 audioLevel: "audio-level",
@@ -1141,7 +1199,8 @@ systemWokeUp: "system-woke-up",
 todayCalendarUpdated: "today-calendar-updated",
 transcriptionHealth: "transcription-health",
 upcomingMeeting: "upcoming-meeting",
-updateAvailable: "update-available"
+updateAvailable: "update-available",
+updateDownloadProgress: "update-download-progress"
 })
 
 /** user-defined constants **/
@@ -1476,6 +1535,10 @@ export type InputRouteReason =
  * Capture device gone (and maybe no replacement yet).
  */
 "lost"
+/**
+ * Why "Install and restart" must stay disabled / refuse before any side effect.
+ */
+export type InstallBlockReason = "recording_dictation" | "recording_meeting" | "stopping" | "downloading" | "loading" | "unloading"
 /**
  * A device remembered across disconnects for display and preference ordering.
  */
@@ -1887,6 +1950,20 @@ export type UpcomingMeeting = { event: CalendarEvent; starts_in_seconds: number;
  */
 export type UpdateAvailable = { latest_version: string; release_notes: string | null; release_url: string | null }
 export type UpdateCheckResult = { current_version: string; latest_version: string | null; update_available: boolean; release_notes: string | null; release_url: string | null; check_error: string | null }
+/**
+ * Progress / phase of an in-app update download. Source of truth is Rust;
+ * the webview mirrors this (and can re-query after reload).
+ */
+export type UpdateDownloadProgress = { phase: UpdatePhase; version: string | null; downloaded_bytes: number; total_bytes: number | null; error: string | null; manual_fallback: boolean }
+export type UpdateDownloadStatus = { phase: UpdatePhase; version: string | null; downloaded_bytes: number; total_bytes: number | null; error: string | null; 
+/**
+ * Offer the GitHub release-page fallback when true.
+ */
+manual_fallback: boolean }
+/**
+ * Phase of the in-app updater download pipeline (not the app state machine).
+ */
+export type UpdatePhase = "idle" | "downloading" | "ready" | "failed"
 
 /** tauri-specta globals **/
 

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -75,6 +75,10 @@ export type {
   TranscriptionSegment,
   SearchResult,
   UpdateCheckResult,
+  UpdateDownloadStatus,
+  UpdatePhase,
+  InstallBlockReason,
+  UpdateDownloadProgress,
 } from "./generated";
 
 /** Who produced a transcript segment: "me" (microphone) or "them"


### PR DESCRIPTION
## Summary

Soufflé can now download a signed update in-app, then install and restart from a second click — no more detour through the GitHub `.dmg`. Detection stays in `update_check`; `tauri-plugin-updater` only executes download/install against `latest.json`.

## Context

Ticket SOU-098 (internal tracker, not mirrored on GitHub).
Root cause: update detection existed (`update_check.rs`) but both UI buttons only opened the release page; no updater plugin, no signed artifacts, no install path.

## Acceptance criteria

1. **AC1 Release artifacts** — verified by config: `bundle.createUpdaterArtifacts: true` + `TAURI_SIGNING_*` wired in `.github/workflows/release.yml`. Confirm on the next tagged release that `.app.tar.gz`, `.sig`, and `latest.json` appear.
2. **AC2 Notarized archive** — deferred to first updater-enabled release QA (`codesign` / `spctl` on extracted `.app`).
3. **AC3 Download in-app** — `download_update` in `src-tauri/src/commands/updater.rs`; UI `UpdateAction.svelte` never opens a browser on the primary path.
4. **AC4 Progress survives dialog close / webview reload** — Rust `DOWNLOAD` mutex + `get_update_download_status` + `UpdateDownloadProgress` event.
5. **AC5 Install blocked in busy states** — `install_blocked_reason` + tests `install_is_blocked_in_every_busy_state`; UI disables with reason; command refuses before side effects.
6. **AC6 Download allowed during meeting** — no state-machine guard on `download_update`; only `install_update` is gated.
7. **AC7 Engine shutdown before restart** — `engine_actor.shutdown()` then `app.restart()` in `install_update` (async command).
8. **AC8 New binary after restart** — manual QA after first signed release.
9. **AC9 Missing updater artifact → manual fallback** — `updater.check()` returning `None` sets `manual_fallback` and a clear message.
10. **AC10 Network failure** — download `Err` → Failed + fallback; no install of partial bytes.
11. **AC11 Bad signature** — plugin verifies in `Update::download` before returning bytes; failure surfaces as Failed.
12. **AC12 Write permission failure** — install error message names `/Applications` writability + fallback; package retained for retry.
13. **AC13 Homebrew `auto_updates true`** — shipped in [damione1/homebrew-tap#1](https://github.com/damione1/homebrew-tap/pull/1) (merged).
14. **AC14 i18n parity** — `src/lib/i18n/parity.test.ts` green via `npm test`.
15. **AC15 Manual release page path** — `open_release_page` unchanged; still offered as fallback.
16. **AC16 CSP unchanged** — no CSP edit in `tauri.conf.json`.
17. **AC17 Existing update_check tests** — unchanged assertions; workspace tests green.

## Out of scope

- No rewrite of `update_check` detection / scheduler / `is_local_build`
- No CSP widening
- No removal of `.dmg` / cask fresh-install path
- No silent/auto install
- Homebrew cask lives in `damione1/homebrew-tap` (AC13 merged there as #1)
- Rollback to older versions

## Risk zones

- **Metal / engine shutdown:** explicit `shutdown()` before `restart()` because main-thread restart skips `ExitRequested`
- **Single-instance:** restart path must be validated manually on first release
- **Two version sources:** GitHub API (detect) vs `latest.json` (execute); AC9 covers divergence
- **IPC:** new commands + regenerated types committed
- **Capabilities:** removed obsolete `pill` window; added `updater:default`

## Verification

```bash
./scripts/build-mcp-sidecar.test.sh && ./scripts/build-mcp-sidecar.sh
# → souffle-mcp sidecar ready

npm run check:generated-types
# → no diff

cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
# → no diff

cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings
# → Finished (0 errors, 0 warnings)

cargo test --manifest-path src-tauri/Cargo.toml --workspace
# → souffle_lib 966 passed (+ updater cancel generation test); workspace green

npm test
# → Test Files 55 passed; Tests 593 passed

npm run check
# → svelte-check found 0 errors and 0 warnings

./scripts/codeql-local.sh
# → CodeQL local gate green
```

Review follow-up `b8dbae5` re-ran the same gate after Cancel/install-order/race fixes.

## Deliberate decisions

- **Rust-owned download, not JS plugin API:** progress must survive webview reload; frontend only mirrors Rust state via commands/events. `@tauri-apps/plugin-updater` JS package intentionally not added.
- **`update_check` remains the detector:** plugin `check()` runs only on download click to obtain the `Update` handle.
- **Passphrase-backed signing key:** pubkey embedded in `tauri.conf.json`; private key + password already in repo secrets (`TAURI_SIGNING_*`).
- **AC13 deferred:** cask change belongs in `homebrew-tap`, not this repo.

## Follow-up before first updater release

1. Confirm secrets `TAURI_SIGNING_PRIVATE_KEY` / `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` (already set).
2. Keep offline backup of `~/.tauri/souffle.key`.
3. Tag a release and verify artifacts + notarization (AC1/AC2).
4. Manual QA checklist from SOU-098 (SIGABRT Metal, single-instance, brew upgrade). AC13 cask stanza already merged via homebrew-tap#1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-app update management from Settings and update notifications.
  * Users can download, monitor progress, cancel, retry, and install updates directly in the app.
  * Installation is safely paused while recording, processing, or loading models.
  * Added release-page fallback when automatic updates are unavailable.
  * Added localized update messages in English and French.

* **Bug Fixes**
  * Update progress and status now persist across webview reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
