### PR TITLE
Generate Speaker as a union instead of a plain string (SOU-134)

### DIFF
--- a/src-tauri/souffle-mcp/src/db.rs
+++ b/src-tauri/souffle-mcp/src/db.rs
@@ -642,23 +642,53 @@ fn cluster_into_turns(segments: &[SegmentRow]) -> Vec<&SegmentRow> {
     turns.into_iter().flat_map(|t| t.segments).collect()
 }
 
-/// Keep Me/Them; leftover `spk:<id>` labels (and anything else) become
-/// unlabeled, matching the app's `Speaker::parse`.
-fn normalize_speaker(raw: Option<String>) -> Option<String> {
-    match raw.as_deref() {
-        Some("me") | Some("them") => raw,
-        _ => None,
+/// Mirror of the app's `engine::Speaker`. The sidecar is a standalone binary
+/// that depends on neither `souffle` nor `tauri`, so the enum is restated
+/// here rather than imported. Restating it as an enum is what matters: both
+/// helpers below branch on it exhaustively, so a third speaker cannot be
+/// silently folded into an existing one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Speaker {
+    Me,
+    Them,
+}
+
+impl Speaker {
+    /// DB encoding, identical to `Speaker::as_str` in the app.
+    fn as_str(self) -> &'static str {
+        match self {
+            Speaker::Me => "me",
+            Speaker::Them => "them",
+        }
+    }
+
+    /// Display prefix, identical to `Speaker::display_name` in the app.
+    fn display_name(self) -> &'static str {
+        match self {
+            Speaker::Me => "Me",
+            Speaker::Them => "Them",
+        }
+    }
+
+    /// Leftover `spk:<id>` labels (and anything else) become `None`,
+    /// matching the app's `Speaker::parse`.
+    fn parse(raw: &str) -> Option<Speaker> {
+        match raw {
+            "me" => Some(Speaker::Me),
+            "them" => Some(Speaker::Them),
+            _ => None,
+        }
     }
 }
 
-/// Display prefix for a raw `segments.speaker` value: "me" -> "Me", "them" ->
-/// "Them". Unlabeled / leftover values get no prefix.
+fn normalize_speaker(raw: Option<String>) -> Option<String> {
+    raw.as_deref()
+        .and_then(Speaker::parse)
+        .map(|speaker| speaker.as_str().to_string())
+}
+
 fn speaker_label(raw: &str) -> Option<&'static str> {
-    match raw {
-        "me" => Some("Me"),
-        "them" => Some("Them"),
-        _ => None,
-    }
+    Speaker::parse(raw).map(Speaker::display_name)
 }
 
 /// Simplified stand-in for the frontend's paragraph engine

--- a/src-tauri/src/engine/mod.rs
+++ b/src-tauri/src/engine/mod.rs
@@ -296,22 +296,39 @@ pub trait TranscriptionEngine {
 /// (`Me`), system audio is everyone else (`Them`). `None` = single-stream
 /// session (dictation, or a meeting recorded without system-audio capture).
 ///
-/// Wire/DB encoding is a plain string: "me" or "them". Unknown values
-/// (including leftover `spk:<id>` labels from the dropped persistent-speaker
-/// feature) parse as `None` so old meetings still load.
-/// Serialize/Deserialize/specta::Type are implemented by hand so the
-/// generated TypeScript type is a plain `string` rather than a tagged union.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// Wire and DB encoding is the snake_case variant name, "me" or "them", and
+/// specta emits the union `"me" | "them"` so the frontend branches on the
+/// contract instead of re-declaring the two values.
+///
+/// The DB column is free `TEXT` and still holds `spk:<id>` labels from the
+/// dropped persistent-speaker feature. `Speaker::parse` and
+/// `deserialize_optional_speaker` absorb those into `None` so old meetings
+/// keep loading; that tolerance lives there, not in `Deserialize`.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize, specta::Type,
+)]
+#[serde(rename_all = "snake_case")]
 pub enum Speaker {
     Me,
     Them,
 }
 
 impl Speaker {
-    pub fn as_str(self) -> String {
+    /// Wire and DB encoding. Must stay in step with `#[serde(rename_all)]`
+    /// above; `speaker_wire_encoding_matches_as_str` proves it does.
+    pub fn as_str(self) -> &'static str {
         match self {
-            Speaker::Me => "me".to_string(),
-            Speaker::Them => "them".to_string(),
+            Speaker::Me => "me",
+            Speaker::Them => "them",
+        }
+    }
+
+    /// Plain, non-localized label used by every exporter. The frontend
+    /// mirrors it in `speakerPlainLabel`.
+    pub fn display_name(self) -> &'static str {
+        match self {
+            Speaker::Me => "Me",
+            Speaker::Them => "Them",
         }
     }
 
@@ -321,38 +338,6 @@ impl Speaker {
             "them" => Some(Speaker::Them),
             _ => None,
         }
-    }
-}
-
-impl serde::Serialize for Speaker {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(&self.as_str())
-    }
-}
-
-impl<'de> serde::Deserialize<'de> for Speaker {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        Speaker::parse(&s)
-            .ok_or_else(|| serde::de::Error::custom(format!("invalid speaker: {s:?}")))
-    }
-}
-
-/// Manual impl (rather than `#[derive(specta::Type)]`) so the generated
-/// TypeScript type is a plain `string` ("me" | "them"), matching
-/// the hand-written `Serialize`/`Deserialize` above.
-impl specta::Type for Speaker {
-    fn inline(
-        type_map: &mut specta::TypeCollection,
-        generics: specta::Generics,
-    ) -> specta::DataType {
-        <String as specta::Type>::inline(type_map, generics)
     }
 }
 
@@ -809,6 +794,35 @@ fn slug_id(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn speaker_wire_encoding_matches_as_str() {
+        for speaker in [Speaker::Me, Speaker::Them] {
+            let json = serde_json::to_string(&speaker).unwrap();
+            assert_eq!(json, format!("\"{}\"", speaker.as_str()));
+            assert_eq!(serde_json::from_str::<Speaker>(&json).unwrap(), speaker);
+            assert_eq!(Speaker::parse(speaker.as_str()), Some(speaker));
+        }
+    }
+
+    #[test]
+    fn legacy_speaker_labels_deserialize_to_none() {
+        for raw in ["spk:1", "spk:abc", "garbage", ""] {
+            let json = format!(
+                r#"{{"text":"x","start_time":0.0,"end_time":1.0,"is_final":true,"speaker":"{raw}"}}"#
+            );
+            let segment: TranscriptionSegment = serde_json::from_str(&json).unwrap();
+            assert_eq!(segment.speaker, None, "{raw} should not parse");
+        }
+    }
+
+    #[test]
+    fn missing_speaker_field_deserializes_to_none() {
+        let segment: TranscriptionSegment =
+            serde_json::from_str(r#"{"text":"x","start_time":0.0,"end_time":1.0,"is_final":true}"#)
+                .unwrap();
+        assert_eq!(segment.speaker, None);
+    }
 
     #[test]
     fn default_profile_uses_kyutai_1b_candle() {

--- a/src-tauri/src/export.rs
+++ b/src-tauri/src/export.rs
@@ -305,19 +305,11 @@ fn render_structured_markdown(out: &mut String, structured: &StructuredSummary) 
     }
 }
 
-/// Display name for a speaker label: Me -> "Me", Them -> "Them".
-fn speaker_display_name(speaker: Speaker) -> &'static str {
-    match speaker {
-        Speaker::Me => "Me",
-        Speaker::Them => "Them",
-    }
-}
-
 fn render_paragraph_markdown(p: &paragraphs::Paragraph) -> String {
     match p.speaker {
         Some(speaker) => format!(
             "**{}** [{}] {}",
-            speaker_display_name(speaker),
+            speaker.display_name(),
             p.timestamp,
             p.text
         ),
@@ -351,7 +343,7 @@ fn time_ordered_segments(segments: &[TranscriptionSegment]) -> Vec<&Transcriptio
 
 fn speaker_prefix(speaker: Option<Speaker>, text: &str) -> String {
     match speaker {
-        Some(speaker) => format!("{}: {text}", speaker_display_name(speaker)),
+        Some(speaker) => format!("{}: {text}", speaker.display_name()),
         None => text.to_string(),
     }
 }

--- a/src-tauri/src/summary/turns.rs
+++ b/src-tauri/src/summary/turns.rs
@@ -1,11 +1,15 @@
-use crate::engine::{Speaker, TranscriptionSegment};
+use crate::engine::TranscriptionSegment;
 use crate::export::{PARAGRAPH_PAUSE_THRESHOLD_SECONDS, paragraphs};
 
 /// Format one grouped paragraph as a labeled turn for the summary LLM.
 fn format_turn(paragraph: &paragraphs::Paragraph) -> String {
     match paragraph.speaker {
-        Some(Speaker::Me) => format!("[{}] Me: {}", paragraph.timestamp, paragraph.text),
-        Some(Speaker::Them) => format!("[{}] Them: {}", paragraph.timestamp, paragraph.text),
+        Some(speaker) => format!(
+            "[{}] {}: {}",
+            paragraph.timestamp,
+            speaker.display_name(),
+            paragraph.text
+        ),
         None => format!("[{}] {}", paragraph.timestamp, paragraph.text),
     }
 }

--- a/src/lib/features/home/LiveSessionCard.svelte
+++ b/src/lib/features/home/LiveSessionCard.svelte
@@ -9,7 +9,14 @@
   import type { LiveParagraph } from "../meeting/live-transcript.svelte";
   import type { createMeetingController } from "../meeting/controller.svelte";
   import type { createTranscriptionController } from "../transcription/controller.svelte";
-  import { elapsedSecondsSince, formatDuration, resolveSpeakerLabel, segmentGap } from "../../utils";
+  import {
+    elapsedSecondsSince,
+    formatDuration,
+    resolveSpeaker,
+    segmentGap,
+    speakerI18nKey,
+    speakerTextClass,
+  } from "../../utils";
   import {
     leadingRemovedCount,
     measureLeadingHeight,
@@ -302,17 +309,14 @@
           <span class="text-sm text-text-muted">{$t("home.listening")}</span>
         {:else}
           {#each liveParagraphs as paragraph, i (paragraph.id)}
-            {@const label = resolveSpeakerLabel(paragraph.speaker)}
+            {@const speaker = resolveSpeaker(paragraph.speaker)}
             {@const isLastForSpeaker = lastIndexBySpeaker.get(paragraph.speaker ?? null) === i}
             {@const speakerTentative = isLastForSpeaker ? liveTentativeMeeting.find(t => t.speaker === (paragraph.speaker ?? null))?.text : null}
             <div class="flex flex-col gap-[3px]" style="animation: rise-in 240ms ease;">
               <div class="flex items-center gap-2">
-                {#if label}
-                  <span
-                    class="text-[11.5px] font-semibold"
-                    class:text-accent={label.kind === "me"}
-                    class:text-secondary={label.kind === "them"}
-                  >{label.kind === "me" ? $t("transcript.me") : $t("transcript.them")}</span>
+                {#if speaker}
+                  <span class="text-[11.5px] font-semibold {speakerTextClass(speaker)}"
+                  >{$t(speakerI18nKey(speaker))}</span>
                 {/if}
                 <span class="font-mono text-[10.5px] text-text-faint">{paragraph.timestamp}</span>
               </div>
@@ -364,15 +368,12 @@
           {/each}
           {#each liveTentativeMeeting as tentative (tentative.speaker)}
             {#if !lastIndexBySpeaker.has(tentative.speaker)}
-              {@const label = resolveSpeakerLabel(tentative.speaker)}
+              {@const speaker = resolveSpeaker(tentative.speaker)}
               <div class="flex flex-col gap-[3px]" style="animation: rise-in 240ms ease;">
                 <div class="flex items-center gap-2">
-                  {#if label}
-                    <span
-                      class="text-[11.5px] font-semibold"
-                      class:text-accent={label.kind === "me"}
-                      class:text-secondary={label.kind === "them"}
-                    >{label.kind === "me" ? $t("transcript.me") : $t("transcript.them")}</span>
+                  {#if speaker}
+                    <span class="text-[11.5px] font-semibold {speakerTextClass(speaker)}"
+                    >{$t(speakerI18nKey(speaker))}</span>
                   {/if}
                 </div>
                 <p class="m-0 text-[15px] leading-[1.75] text-text-secondary opacity-50">{tentative.text}</p>

--- a/src/lib/features/meeting/components/MeetingTranscriptSection.svelte
+++ b/src/lib/features/meeting/components/MeetingTranscriptSection.svelte
@@ -5,8 +5,10 @@
   import type { MeetingRecordingSession, Speaker, TranscriptionSegment } from "../../../types";
   import {
     buildMeetingTranscriptBlocks,
-    resolveSpeakerLabel,
+    resolveSpeaker,
+    speakerI18nKey,
     speakerPlainLabel,
+    speakerTextClass,
   } from "../../../utils";
   import TranscriptWordLine from "./TranscriptWordLine.svelte";
 
@@ -61,12 +63,6 @@
   function copyLinePrefix(speaker: Speaker | null | undefined): string {
     const label = speakerPlainLabel(speaker);
     return label ? `${label} ` : "";
-  }
-
-  function speakerDisplayText(
-    label: NonNullable<ReturnType<typeof resolveSpeakerLabel>>,
-  ): string {
-    return label.kind === "me" ? $t("transcript.me") : $t("transcript.them");
   }
 
   let copyText = $derived(
@@ -143,15 +139,12 @@
       {#if phase === "has_content"}
         {#each transcriptBlocks as block}
           {#if block.type === "paragraph"}
-            {@const label = resolveSpeakerLabel(block.speaker)}
+            {@const speaker = resolveSpeaker(block.speaker)}
             <div class="flex flex-col gap-[3px]">
               <div class="flex items-center gap-2">
-                {#if label}
-                  <span
-                    class="text-[11.5px] font-semibold"
-                    class:text-accent={label.kind === "me"}
-                    class:text-secondary={label.kind === "them"}
-                  >{speakerDisplayText(label)}</span>
+                {#if speaker}
+                  <span class="text-[11.5px] font-semibold {speakerTextClass(speaker)}"
+                  >{$t(speakerI18nKey(speaker))}</span>
                 {/if}
                 {#if onParagraphClick}
                   <button

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -1740,6 +1740,21 @@ export type ShortcutPttStop = null
 export type ShortcutSettings = { toggle: string; push_to_talk: string }
 export type ShortcutToggle = null
 export type SnippetEntry = { id: number; trigger: string; expansion: string; created_at: string }
+/**
+ * Who produced a segment in a meeting: the microphone is the local user
+ * (`Me`), system audio is everyone else (`Them`). `None` = single-stream
+ * session (dictation, or a meeting recorded without system-audio capture).
+ * 
+ * Wire and DB encoding is the snake_case variant name, "me" or "them", and
+ * specta emits the union `"me" | "them"` so the frontend branches on the
+ * contract instead of re-declaring the two values.
+ * 
+ * The DB column is free `TEXT` and still holds `spk:<id>` labels from the
+ * dropped persistent-speaker feature. `Speaker::parse` and
+ * `deserialize_optional_speaker` absorb those into `None` so old meetings
+ * keep loading; that tolerance lives there, not in `Deserialize`.
+ */
+export type Speaker = "me" | "them"
 export type StateChanged = AppStateMachine
 /**
  * A single action item extracted from a meeting summary pass.
@@ -1932,7 +1947,7 @@ export type TranscriptionSegment = { text: string; start_time: number; end_time:
 /**
  * Set by the pipeline for meetings with Me/Them lanes; `None` otherwise.
  */
-speaker?: string | null }
+speaker?: Speaker | null }
 /**
  * Human-facing transport label for an input device.
  */

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -38,6 +38,7 @@ export type {
   SummaryProvidersStatus,
   SummaryTemplate,
   SnippetEntry,
+  Speaker,
   PermState,
   PermissionKind,
   PermissionStatus,
@@ -80,9 +81,4 @@ export type {
   InstallBlockReason,
   UpdateDownloadProgress,
 } from "./generated";
-
-/** Who produced a transcript segment: "me" (microphone) or "them"
- * (system audio). Backend wire format (see `engine::Speaker` in Rust);
- * specta emits it as a plain `string`. Compare with `===`. */
-export type Speaker = string;
 export type { StatusReason } from './status';

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -11,7 +11,11 @@ export { segmentGap } from "./segment-join";
 export { renderReleaseNotesMarkdown } from "./markdown";
 export { createDebouncedSearch, filterResultsByType, findSnippet, matchedIdsForType } from "./search.svelte";
 export type { DebouncedSearch } from "./search.svelte";
-export { resolveSpeakerLabel, speakerPlainLabel } from "./speaker-label";
-export type { SpeakerLabel } from "./speaker-label";
+export {
+  resolveSpeaker,
+  speakerI18nKey,
+  speakerPlainLabel,
+  speakerTextClass,
+} from "./speaker-label";
 export { portal, fixedPopoverStyle } from "./portal";
 export type { AnchorRect } from "./portal";

--- a/src/lib/utils/speaker-label.test.ts
+++ b/src/lib/utils/speaker-label.test.ts
@@ -1,21 +1,40 @@
 import { describe, it, expect } from "vitest";
-import { resolveSpeakerLabel, speakerPlainLabel } from "./speaker-label";
+import {
+  SPEAKERS,
+  isSpeaker,
+  resolveSpeaker,
+  speakerI18nKey,
+  speakerPlainLabel,
+  speakerTextClass,
+} from "./speaker-label";
 
-describe("resolveSpeakerLabel", () => {
+describe("SPEAKERS", () => {
+  it("enumerates the generated union", () => {
+    expect([...SPEAKERS].sort()).toEqual(["me", "them"]);
+  });
+});
+
+describe("resolveSpeaker", () => {
   it("returns null for no speaker", () => {
-    expect(resolveSpeakerLabel(null)).toBeNull();
-    expect(resolveSpeakerLabel(undefined)).toBeNull();
+    expect(resolveSpeaker(null)).toBeNull();
+    expect(resolveSpeaker(undefined)).toBeNull();
   });
 
   it("resolves me and them", () => {
-    expect(resolveSpeakerLabel("me")).toEqual({ kind: "me" });
-    expect(resolveSpeakerLabel("them")).toEqual({ kind: "them" });
+    expect(resolveSpeaker("me")).toBe("me");
+    expect(resolveSpeaker("them")).toBe("them");
   });
 
   it("returns null for leftover persistent labels and garbage", () => {
-    expect(resolveSpeakerLabel("spk:1")).toBeNull();
-    expect(resolveSpeakerLabel("spk:abc")).toBeNull();
-    expect(resolveSpeakerLabel("garbage")).toBeNull();
+    expect(resolveSpeaker("spk:1")).toBeNull();
+    expect(resolveSpeaker("spk:abc")).toBeNull();
+    expect(resolveSpeaker("garbage")).toBeNull();
+    expect(resolveSpeaker("")).toBeNull();
+  });
+
+  it("does not resolve inherited object properties", () => {
+    expect(isSpeaker("toString")).toBe(false);
+    expect(isSpeaker("constructor")).toBe(false);
   });
 });
 
@@ -25,5 +44,14 @@ describe("speakerPlainLabel", () => {
     expect(speakerPlainLabel("them")).toBe("Them");
     expect(speakerPlainLabel("spk:1")).toBeNull();
     expect(speakerPlainLabel(null)).toBeNull();
+  });
+});
+
+describe("badge lookups", () => {
+  it("cover every variant of the union", () => {
+    for (const speaker of SPEAKERS) {
+      expect(speakerI18nKey(speaker)).toMatch(/^transcript\./);
+      expect(speakerTextClass(speaker)).not.toBe("");
+    }
   });
 });

--- a/src/lib/utils/speaker-label.ts
+++ b/src/lib/utils/speaker-label.ts
@@ -1,27 +1,58 @@
 import type { Speaker } from "../types";
 
-/** Parsed result of a speaker label: Me (microphone) or Them (system audio). */
-export type SpeakerLabel = { kind: "me" } | { kind: "them" };
+/** Plain, non-localized label. Mirrors `Speaker::display_name` in Rust, which
+ * is what every exporter writes, so copied transcript text matches an exported
+ * one. */
+const SPEAKER_PLAIN_LABEL: Record<Speaker, string> = {
+  me: "Me",
+  them: "Them",
+};
 
-/** Resolve a segment/paragraph's `speaker` value. `null`/`undefined` and
- * anything other than "me"/"them" (including leftover `spk:<id>` labels)
- * resolve to `null` — callers should just not render a badge. */
-export function resolveSpeakerLabel(
-  speaker: Speaker | null | undefined,
-): SpeakerLabel | null {
-  if (speaker === "me") return { kind: "me" };
-  if (speaker === "them") return { kind: "them" };
-  return null;
+/** i18n key for the speaker badge. */
+const SPEAKER_I18N_KEY: Record<Speaker, string> = {
+  me: "transcript.me",
+  them: "transcript.them",
+};
+
+/** Text colour class for the speaker badge. */
+const SPEAKER_TEXT_CLASS: Record<Speaker, string> = {
+  me: "text-accent",
+  them: "text-secondary",
+};
+
+/** The contract's variants as runtime values. specta generates types, not
+ * values, so this is the one place the union is enumerated at runtime. */
+export const SPEAKERS = Object.keys(SPEAKER_PLAIN_LABEL) as readonly Speaker[];
+
+/** Narrowing guard. `segments.speaker` is free `TEXT` in SQLite and still
+ * holds `spk:<id>` labels from the dropped persistent-speaker feature; the
+ * backend already turns those into `null` (`Speaker::parse`), this is the
+ * second line of defence for anything read outside that path. */
+export function isSpeaker(value: unknown): value is Speaker {
+  return typeof value === "string" && Object.hasOwn(SPEAKER_PLAIN_LABEL, value);
 }
 
-/** Plain (non-localized) display label, matching the Rust exporters' "Me"/
- * "Them" convention. For UI text that goes through i18n (svelte-i18n's `$t`),
- * branch on `resolveSpeakerLabel`'s `kind` instead so "me"/"them" get
- * translated. */
+/** `null`, `undefined` and anything outside the contract resolve to `null`:
+ * callers just do not render a badge. */
+export function resolveSpeaker(
+  value: Speaker | string | null | undefined,
+): Speaker | null {
+  return isSpeaker(value) ? value : null;
+}
+
+export function speakerI18nKey(speaker: Speaker): string {
+  return SPEAKER_I18N_KEY[speaker];
+}
+
+export function speakerTextClass(speaker: Speaker): string {
+  return SPEAKER_TEXT_CLASS[speaker];
+}
+
+/** Plain (non-localized) display label. For UI text that goes through i18n,
+ * use `speakerI18nKey` instead so "me"/"them" get translated. */
 export function speakerPlainLabel(
-  speaker: Speaker | null | undefined,
+  speaker: Speaker | string | null | undefined,
 ): string | null {
-  const label = resolveSpeakerLabel(speaker);
-  if (!label) return null;
-  return label.kind === "me" ? "Me" : "Them";
+  const resolved = resolveSpeaker(speaker);
+  return resolved === null ? null : SPEAKER_PLAIN_LABEL[resolved];
 }


### PR DESCRIPTION
## Summary

`Speaker` is a two-variant Rust enum, but a hand-written `impl specta::Type` flattened it to `String` in the generated contract, so the frontend received `speaker?: string | null` and had no value to import. The two possible values were therefore restated in four files across two languages, and the badge renderers branched on them with binary ternaries that would silently fold a third speaker into "Them".

This derives the three traits instead, so the contract now carries `"me" | "them"`, and rebuilds the frontend helpers around exhaustive `Record<Speaker, string>` lookups. No user-visible change: the same labels, the same colours, the same exported Markdown.

## Context

Ticket SOU-134 (internal tracker, not mirrored on GitHub). First of nine lots from a backend/frontend contract audit run on `3eb8ba0`.

Root cause: `impl specta::Type for Speaker` delegated to `<String as specta::Type>::inline`, at `src-tauri/src/engine/mod.rs:350-357` before this change. While it was there, `npm run generate:types` could not emit the union whatever the frontend did.

The three hand-written impls existed for a reason that had to survive: `segments.speaker` is free `TEXT` in SQLite and still holds `spk:<id>` labels from the dropped persistent-speaker feature. That tolerance lives in `Speaker::parse` and `deserialize_optional_speaker`, not in `Deserialize`, and both are untouched.

## Acceptance criteria

1. **The generated `Speaker` must be `"me" | "them"`, not `string`** — verified at `src/lib/types/generated.ts:1757`, and `TranscriptionSegment.speaker` is now `Speaker | null` at `:1947`.
2. **Adding a variant in Rust must fail `npm run check`** — verified by experiment: a temporary `Speaker::System` variant made `svelte-check` report 3 errors, one per `Record<Speaker, string>` in `src/lib/utils/speaker-label.ts` (lines 6, 12, 18), and also failed `cargo build` in `src-tauri/src/summary/turns.rs` before that function was routed through `display_name`. The variant was removed afterwards; the experiment is reproducible from the commands below.
3. **A meeting whose `speaker` column holds a legacy `spk:<id>` label must still load, with no badge and no error** — verified by `legacy_speaker_labels_deserialize_to_none` in `src-tauri/src/engine/mod.rs` (covers `spk:1`, `spk:abc`, `garbage`, `""`), by `missing_speaker_field_deserializes_to_none`, and on the frontend by the "returns null for leftover persistent labels and garbage" case in `src/lib/utils/speaker-label.test.ts`.
4. **Rust exporters must keep writing "Me" and "Them", byte for byte** — verified by the existing export tests in `src-tauri/src/export.rs` (969 tests pass unchanged), and by `speaker_wire_encoding_matches_as_str` proving the wire encoding still matches `as_str`.
5. **The MCP sidecar must keep returning `None` for anything but `me`/`them`** — verified by the 23 unchanged `souffle-mcp` tests; `normalize_speaker` and `speaker_label` now both route through one local `Speaker::parse`.
6. **No `"me"`/`"them"` literal outside the declaration points and tests** — verified by grep (command below): the only remaining non-test hits are the two enum declarations (app and sidecar) and doc comments.

## Out of scope

- **No schema migration.** `segments.speaker` stays free `TEXT`, stored values are untouched, `SCHEMA_VERSION` stays at 16.
- **No third speaker.** This makes adding one safe; it does not add one.
- **No type sharing between the main crate and the sidecar.** `souffle-mcp` depends on neither `souffle` nor `tauri` and that stays true: it restates `Speaker` locally as an enum rather than importing it. Sharing the declaration is a separate ticket.
- **No change to `src-tauri/src/pipeline/actor.rs`.** `buf_for`'s `_ =>` arm belongs to the next lot.
- **No change to paragraph grouping.** `export.rs` and `MeetingTranscriptSection.svelte` are touched only on the speaker lines.
- **No i18n change.** `transcript.me` / `transcript.them` keep their existing values ("Me"/"Them" in English, "Moi"/"Eux" in French).

## Risk zones

- **Existing data.** The only real risk. A bare `#[derive(Deserialize)]` replacing the tolerant read path would have made every meeting carrying a `spk:<id>` fail to load. `Speaker::parse` and `deserialize_optional_speaker` are unchanged and now have direct test coverage that did not exist before.
- **Wire encoding drift.** `as_str` (used for DB writes) and `#[serde(rename_all = "snake_case")]` (used for IPC) are two separate declarations of the same strings. `speaker_wire_encoding_matches_as_str` asserts they agree in both directions.
- **IPC surface.** `src/lib/types/generated.ts` and `src/lib/api/generated.ts` are regenerated and committed; `npm run check:generated-types` is green.
- **Diarized mode.** No frame is held or reordered. No `start_time` moves; the export tests would have caught it.
- **Badge rendering.** `class:text-accent` / `class:text-secondary` toggles became a single interpolated class from a `Record<Speaker, string>`. Same two classes, same two cases.

## Verification

```bash
npm run check:generated-types
# → exit 0, no diff

cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
# → no diff

cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings
# → Finished, 0 errors, 0 warnings

cargo test --manifest-path src-tauri/Cargo.toml --workspace
# → test result: ok. 969 passed; 0 failed; 4 ignored   (souffle lib)
# → test result: ok. 23 passed; 0 failed               (souffle-mcp)
# → all other targets ok, 0 failed

npm test
# → Test Files 55 passed (55), Tests 596 passed (596)

npm run check
# → 4019 FILES 0 ERRORS 0 WARNINGS

./scripts/codeql-local.sh
# → CodeQL local gate green (rust, javascript-typescript, actions)
```

AC6 grep:

```bash
grep -rn -e '"me"' -e '"them"' src src-tauri/src src-tauri/souffle-mcp/src \
  | grep -v -e '\.test\.' -e 'test-helpers' -e 'i18n/'
# → only the two enum declarations and doc comments
```

AC2 experiment (run locally, reverted before commit):

```bash
# add `System` to Speaker, plus its as_str/display_name arms
npm run generate:types   # → export type Speaker = "me" | "them" | "system"
npm run check            # → 3 ERRORS, all in src/lib/utils/speaker-label.ts
```

## Deliberate decisions

- **`Deserialize` is derived, not tolerant.** Unknown values still error at that layer, exactly as the hand-written impl did. The tolerance is deliberately kept one level up, in `deserialize_optional_speaker` and `Speaker::parse`, so the strict path stays available and the lenient one stays explicit at its call sites.
- **`as_str` returns `&'static str` instead of `String`.** Two call sites in `src-tauri/src/db/meetings.rs` pass it straight to rusqlite, which accepts `Option<&str>`; the allocation was pointless.
- **The sidecar restates the enum rather than importing it.** Making `souffle-mcp` depend on `souffle` would pull `tauri` into a standalone read-only binary. Restating it as an enum still buys the property that matters here: both helpers branch exhaustively, so a third speaker cannot be folded into an existing one. Sharing the declaration properly is its own ticket.
- **`speaker_display_name` moved onto the enum as `Speaker::display_name`.** It was a free function in `export.rs`, while `summary/turns.rs` had its own copy of the same two strings. There is now one.
- **`SPEAKERS` and `isSpeaker` are exported from `speaker-label.ts` but not from the `utils` barrel.** Components do not need them; the test does. specta generates types and not values, so `SPEAKERS` is the one place the union exists at runtime, which is what lets the test assert the lookups cover every variant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Standardized speaker handling across live sessions, transcripts, summaries, and exports.
  * Speaker names now consistently display as “Me” or “Them,” with matching colors and translations.
  * Invalid, missing, or unsupported speaker labels remain unlabeled instead of displaying incorrect attribution.
  * Speaker data is now represented consistently between the application interface and backend services, improving reliability for transcript rendering and exported content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->