### PR TITLE
Derive the update install block from the contract (SOU-144)

### DIFF
--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -473,6 +473,25 @@ mod tests {
     }
 
     #[test]
+    fn install_block_reason_wire_encoding_matches_as_str() {
+        for reason in [
+            InstallBlockReason::RecordingDictation,
+            InstallBlockReason::RecordingMeeting,
+            InstallBlockReason::Stopping,
+            InstallBlockReason::Downloading,
+            InstallBlockReason::Loading,
+            InstallBlockReason::Unloading,
+        ] {
+            let json = serde_json::to_string(&reason).unwrap();
+            assert_eq!(json, format!("\"{}\"", reason.as_str()));
+            assert_eq!(
+                serde_json::from_str::<InstallBlockReason>(&json).unwrap(),
+                reason
+            );
+        }
+    }
+
+    #[test]
     fn install_is_allowed_when_idle_ready_or_error() {
         let p = profile();
         assert!(install_blocked_reason(&AppStateMachine::Idle).is_none());

--- a/src/lib/features/update/UpdateAction.svelte
+++ b/src/lib/features/update/UpdateAction.svelte
@@ -28,8 +28,19 @@
     return Math.min(100, Math.round((status.downloaded_bytes / status.total_bytes) * 100));
   });
 
+  /** One i18n key per blocking reason. Adding a variant in Rust fails
+   * `npm run check` here instead of producing a missing key at runtime. */
+  const BLOCK_LABEL_KEY: Record<InstallBlockReason, string> = {
+    recording_dictation: "update_available.blocked_recording_dictation",
+    recording_meeting: "update_available.blocked_recording_meeting",
+    stopping: "update_available.blocked_stopping",
+    downloading: "update_available.blocked_downloading",
+    loading: "update_available.blocked_loading",
+    unloading: "update_available.blocked_unloading",
+  };
+
   function blockLabel(reason: InstallBlockReason): string {
-    return $t(`update_available.blocked_${reason}`);
+    return $t(BLOCK_LABEL_KEY[reason]);
   }
 
   const btnClass = $derived(compact ? "text-xs text-accent hover:underline cursor-pointer" : "btn btn-active");

--- a/src/lib/features/update/controller.svelte.ts
+++ b/src/lib/features/update/controller.svelte.ts
@@ -13,21 +13,7 @@ import {
 import { openReleasePage } from "../../api/diagnostics";
 import { errorMessage } from "../../utils";
 import { getAppState } from "../../stores/app.svelte";
-
-/** Machine states that must disable Install (mirrors Rust `install_blocked_reason`). */
-const BLOCKING_STATES = new Set([
-  "recording_dictation",
-  "recording_meeting",
-  "stopping",
-  "downloading",
-  "loading",
-  "unloading",
-]);
-
-function blockFromMachine(state: string): InstallBlockReason | null {
-  if (!BLOCKING_STATES.has(state)) return null;
-  return state as InstallBlockReason;
-}
+import { blockFromMachine } from "./install-block";
 
 function idleStatus(): UpdateDownloadStatus {
   return {

--- a/src/lib/features/update/install-block.ts
+++ b/src/lib/features/update/install-block.ts
@@ -1,0 +1,32 @@
+import type { InstallBlockReason } from "../../api/updater";
+import type { AppStateMachine } from "../../types";
+
+/** Install block for every machine state, keyed by the contract's own state
+ * union. Adding a state to `AppStateMachine` in Rust fails `npm run check`
+ * here, the same way it fails `cargo build` in `install_blocked_reason`.
+ *
+ * The backend stays authoritative: `getUpdateInstallBlock()` overwrites this
+ * verdict as soon as it answers, and `install_update` refuses again before any
+ * side effect. This table is what keeps the button from being active during
+ * the round trip, or when the command fails. */
+const INSTALL_BLOCK_BY_STATE: Record<
+  AppStateMachine["state"],
+  InstallBlockReason | null
+> = {
+  idle: null,
+  downloading: "downloading",
+  downloaded: null,
+  loading: "loading",
+  ready: null,
+  recording_dictation: "recording_dictation",
+  recording_meeting: "recording_meeting",
+  stopping: "stopping",
+  unloading: "unloading",
+  error: null,
+};
+
+export function blockFromMachine(
+  state: AppStateMachine["state"],
+): InstallBlockReason | null {
+  return INSTALL_BLOCK_BY_STATE[state];
+}

--- a/src/lib/features/update/install-guard.test.ts
+++ b/src/lib/features/update/install-guard.test.ts
@@ -1,35 +1,34 @@
 import { describe, expect, it } from "vitest";
+import { blockFromMachine } from "./install-block";
+import type { AppStateMachine } from "../../types";
+import type { InstallBlockReason } from "../../api/updater";
 
-/** Mirrors `install_blocked_reason` / UpdateAction blocking set. */
-const BLOCKING_STATES = new Set([
-  "recording_dictation",
-  "recording_meeting",
-  "stopping",
-  "downloading",
-  "loading",
-  "unloading",
-]);
-
-function isInstallBlocked(machineState: string): boolean {
-  return BLOCKING_STATES.has(machineState);
-}
-
+/** Exercises the production table the controller uses, not a copy of it.
+ * Mirrors `install_blocked_reason` in `src-tauri/src/commands/updater.rs`,
+ * which is tested against the same ten states on the Rust side. */
 describe("update install guard (UI)", () => {
-  it.each([
-    "recording_dictation",
-    "recording_meeting",
-    "stopping",
-    "downloading",
-    "loading",
-    "unloading",
-  ])("disables install while %s", (state) => {
-    expect(isInstallBlocked(state)).toBe(true);
+  const blocked: [AppStateMachine["state"], InstallBlockReason][] = [
+    ["recording_dictation", "recording_dictation"],
+    ["recording_meeting", "recording_meeting"],
+    ["stopping", "stopping"],
+    ["downloading", "downloading"],
+    ["loading", "loading"],
+    ["unloading", "unloading"],
+  ];
+
+  it.each(blocked)("disables install while %s", (state, reason) => {
+    expect(blockFromMachine(state)).toBe(reason);
   });
 
-  it.each(["idle", "ready", "downloaded", "error"])(
+  it.each<AppStateMachine["state"]>(["idle", "ready", "downloaded", "error"])(
     "allows install while %s",
     (state) => {
-      expect(isInstallBlocked(state)).toBe(false);
+      expect(blockFromMachine(state)).toBeNull();
     },
   );
+
+  it("covers every state of the machine", () => {
+    const covered = [...blocked.map(([state]) => state), "idle", "ready", "downloaded", "error"];
+    expect(new Set(covered).size).toBe(10);
+  });
 });


### PR DESCRIPTION
## Summary

Six of the ten `AppStateMachine` tags forbid installing an update. That set was written six times, and nothing checked the copies against each other. The frontend held two of them by hand, widened the machine state to `string` to query them, and then asserted the result back into the typed union with `as`. The one test covering the guard re-implemented the function instead of importing it, so it stayed green no matter what the production code said.

This replaces both copies with a single table keyed by the contract's own state union. No behaviour change: the same six states block, the same four allow, and the backend still has the last word.

## Context

Ticket SOU-144 (internal tracker, not mirrored on GitHub). The code came in with SOU-098 (PR #224) and is otherwise careful, which is the point of the case: the rule was lost without anyone making a visible mistake. This is the ticket that triggered a wider backend/frontend contract audit.

Root cause: `install_blocked_reason` at `src-tauri/src/commands/updater.rs:126` is exhaustive over all ten states and is correct. The frontend needs the same verdict before that command answers, so that the "Install and restart" button is never briefly active during a recording. Having no way to derive it from the contract, it copied the set at `src/lib/features/update/controller.svelte.ts:18-25`, and the test copied it again at `src/lib/features/update/install-guard.test.ts:4-11`.

Three separate mechanisms disarmed the compiler:

- `blockFromMachine(state: string)` widened a correct union, then narrowed it back with `return state as InstallBlockReason`.
- `install-guard.test.ts` declared its own `BLOCKING_STATES` and its own `isInstallBlocked`, so removing a state from the production set left the suite green.
- `blockLabel` built the i18n key by interpolation (`` $t(`update_available.blocked_${reason}`) ``), so a seventh variant would produce a missing key at runtime rather than a compile error.

## Acceptance criteria

1. **The blocking set must be declared in one place, on the Rust side** — partially met, and deliberately so. Both frontend string sets are gone, and `install_blocked_reason` remains the only place a *state* is classified in Rust. What remains on the frontend is one total `Record<AppStateMachine["state"], InstallBlockReason | null>` in `src/lib/features/update/install-block.ts`: not a set of loose strings, but a total function over the contract's own union, which cannot drift in membership without failing the build. Fully removing it would mean fetching the table from the backend, which leaves the button un-blocked during the round trip. See *Deliberate decisions*.
2. **Adding a state to `AppStateMachine` must fail the build on both sides** — verified by experiment. Adding `Paused` in Rust: `cargo check` reports `non-exhaustive patterns: &AppStateMachine::Paused not covered` at `src/commands/updater.rs:127` (plus three sites in `state_machine.rs`). Simulating the same variant in the generated union: `npm run check` reports `Property 'paused' is missing ... in type 'Record<..., InstallBlockReason | null>'` at `src/lib/features/update/install-block.ts:12`. Both reverted.
3. **Adding a block reason must fail `npm run check` on the label table** — verified by experiment: adding a variant to the generated `InstallBlockReason` makes `svelte-check` report `Property 'paused' is missing in type ... Record<InstallBlockReason, string>` at `src/lib/features/update/UpdateAction.svelte:33`. Reverted.
4. **Breaking the production table must fail `npm test`** — verified: setting `stopping: null` in `install-block.ts` makes `install-guard.test.ts` fail with `disables install while stopping` (1 failed, 10 passed). The test imports `blockFromMachine` from the production module; it no longer has a copy of anything.
5. **Install stays disabled during a dictation or a meeting, with the same message** — verified by `install-guard.test.ts` for the six blocking states, by the unchanged `install_is_blocked_while_busy` in `src-tauri/src/commands/updater.rs`, and by the i18n values being untouched (`blocked_*` keys in `en.json` / `fr.json` are byte-identical). Manual check is noted below as not performed in this environment.
6. **Install stays possible in `idle`, `downloaded`, `ready`, `error`** — verified by the four "allows install while %s" cases in `install-guard.test.ts` and by the unchanged `install_is_allowed_when_idle_ready_or_error` on the Rust side.
7. **A failing or slow `getUpdateInstallBlock()` must still refuse in a blocking state** — verified by reading: `syncInstallBlock` in `src/lib/features/update/controller.svelte.ts` keeps its three paths unchanged (local verdict first, backend verdict second, local verdict again on rejection). Only the function it calls changed; the ordering and the fallbacks did not.

## Out of scope

- **The blocking logic.** The same six states block, the same four allow. No state gained or lost a block.
- **Download and install themselves.** `downloadUpdate`, `installUpdate`, webview-reload recovery, the GitHub release-page fallback: untouched.
- **`UpdatePhase` and the `{#if}` chain in `UpdateAction.svelte`.** A neighbouring instance of the same defect class, but a different union and a different fix; it belongs to the exhaustiveness ticket.
- **The block message texts.** The six strings in `en.json` and `fr.json` are unchanged, word for word.
- **The state machine.** No state, transition or internal guard in `src-tauri/src/state_machine.rs` was touched.
- **`InstallBlockReason` itself.** Kept, not removed: see *Deliberate decisions*.
- **Other UI authorization guards.** Separate ticket.

## Risk zones

- **Losing a live session.** This guard is what stops the app from restarting mid-recording. A relaxation, even transient, costs the user their session. The three-path `syncInstallBlock` is preserved exactly, and `install_update` still refuses on the Rust side before any side effect, so the guard survives even if the UI were wrong.
- **The window before the backend answers.** Unchanged: the local table is applied synchronously first, exactly as `BLOCKING_STATES` was. That is precisely why the table was not replaced by a fetched one.
- **State that only lives in the webview.** The update controller is module state that survives dialog close but not a reload. This change does not touch that and does not claim to fix it.
- **IPC surface.** No `#[tauri::command]` signature changed, so `src/lib/types/generated.ts` and `src/lib/api/generated.ts` are untouched. `npm run check:generated-types` is green.
- **`as_str` vs the serde encoding.** `InstallBlockReason::as_str` is used to build the Rust-side refusal message and duplicates the `#[serde(rename_all = "snake_case")]` spelling. A new test asserts they agree in both directions for all six variants.

## Verification

```bash
npm run check:generated-types
# → exit 0, no diff (no command signature changed)

cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
# → no diff

cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings
# → Finished, 0 errors, 0 warnings

cargo test --manifest-path src-tauri/Cargo.toml --workspace
# → test result: ok. 967 passed; 0 failed; 4 ignored  (souffle lib, +1 new test)
# → all other targets ok, 0 failed

npm test
# → Test Files 55 passed (55), Tests 594 passed (594)

npm run check
# → 4020 FILES 0 ERRORS 0 WARNINGS

./scripts/codeql-local.sh
# → CodeQL local gate green
```

AC4, the important one, run explicitly:

```bash
# set `stopping: null` in src/lib/features/update/install-block.ts
npx vitest run src/lib/features/update/install-guard.test.ts
# → FAIL  update install guard (UI) > disables install while stopping
# → Tests 1 failed | 10 passed (11)
# reverted
```

AC2 and AC3 experiments (run locally, reverted before commit):

```bash
# add `Paused` to AppStateMachine
cargo check --manifest-path src-tauri/Cargo.toml --lib
# → error[E0004]: non-exhaustive patterns: `&AppStateMachine::Paused` not covered
#     --> src/commands/updater.rs:127:11

# simulate the same variant in the generated union, then:
npm run check
# → ERROR src/lib/features/update/install-block.ts 12:7 Property 'paused' is missing

# simulate an extra InstallBlockReason variant, then:
npm run check
# → ERROR src/lib/features/update/UpdateAction.svelte 33:9 Property 'paused' is missing
```

Not performed in this environment, and worth doing before merge: the manual pass from the ticket. Start a dictation, open Settings then About while it runs, confirm the install button is disabled and carries the same message; repeat with a meeting; confirm it is active at rest.

## Deliberate decisions

- **`InstallBlockReason` is kept, not collapsed into the state tags.** Its six variants currently repeat six state tags word for word and add no information, which is an argument for deleting it. It is kept because the two vocabularies will diverge (a state may one day block for a reason that is not its own name), and a dedicated enum allows that without a contract break. The condition for keeping it is that its derivation from the machine stays single, which `install_blocked_reason` already satisfies.
- **The frontend keeps a local table rather than fetching one.** Question 2 of the ticket asked whether the backend could ship the mapping. It can, but the frontend would then have no verdict until that call returns, and the install button is exactly the thing that must never be active by default. A compile-checked local table that cannot drift in membership is a better trade than an async one that can be briefly empty. This is the reason AC1 is reported as partially met rather than met.
- **`blockFromMachine` moved to its own module.** `controller.svelte.ts` runs `$effect.root` and touches the app store at import time, so a test importing it would pull the whole update controller. `install-block.ts` holds the table and the function the controller calls, which is what the test now exercises.
- **`install-guard.test.ts` asserts the returned reason, not just a boolean.** The old test checked blocked-or-not. Checking the reason as well is what makes a mis-mapped state (blocked, but reported as the wrong reason, hence the wrong message) a failure.
