### PR TITLE
Give the search index source type an enum (SOU-136)

### DIFF
--- a/src-tauri/souffle-mcp/src/db.rs
+++ b/src-tauri/souffle-mcp/src/db.rs
@@ -242,6 +242,30 @@ pub struct McpDb {
     conn: Mutex<Connection>,
 }
 
+/// Mirror of the app's `db::search::SearchSource`. The sidecar is a standalone
+/// binary that depends on neither `souffle` nor `tauri`, so the enum is
+/// restated here rather than imported. Only `Meeting` is needed: the sidecar
+/// never reads dictation rows out of the full-text index. The string is the
+/// on-disk encoding of `text_search.source_type` and must match the app's.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SearchSource {
+    Meeting,
+}
+
+impl SearchSource {
+    const fn as_str(self) -> &'static str {
+        match self {
+            SearchSource::Meeting => "meeting",
+        }
+    }
+}
+
+impl rusqlite::ToSql for SearchSource {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+        Ok(rusqlite::types::ToSqlOutput::from(self.as_str()))
+    }
+}
+
 impl McpDb {
     /// Open the database read-only. WAL mode lets this coexist with the app
     /// writing concurrently; `busy_timeout` covers the rare case where a
@@ -283,7 +307,7 @@ impl McpDb {
                      FROM meetings m
                      WHERE m.id IN (
                          SELECT source_id FROM text_search
-                         WHERE source_type = 'meeting' AND text_search MATCH ?1
+                         WHERE source_type = ?5 AND text_search MATCH ?1
                      )
                      AND (?2 IS NULL OR julianday(m.started_at) >= julianday(?2))
                      AND (?3 IS NULL OR julianday(m.started_at) <= julianday(?3))
@@ -291,7 +315,10 @@ impl McpDb {
                      LIMIT ?4",
                 )
                 .map_err(McpDbError::Query)?;
-            query_meeting_rows(&mut stmt, params![q, from, to, limit])?
+            query_meeting_rows(
+                &mut stmt,
+                params![q, from, to, limit, SearchSource::Meeting],
+            )?
         } else {
             let mut stmt = conn
                 .prepare(
@@ -461,13 +488,13 @@ impl McpDb {
                         snippet(text_search, 0, '**', '**', '...', 32)
                  FROM text_search ts
                  JOIN meetings m ON m.id = ts.source_id
-                 WHERE ts.source_type = 'meeting' AND text_search MATCH ?1
+                 WHERE ts.source_type = ?3 AND text_search MATCH ?1
                  ORDER BY rank
                  LIMIT ?2",
             )
             .map_err(McpDbError::Query)?;
 
-        stmt.query_map(params![query, limit], |row| {
+        stmt.query_map(params![query, limit, SearchSource::Meeting], |row| {
             Ok(MeetingSearchHit {
                 id: row.get(0)?,
                 title: row.get(1)?,

--- a/src-tauri/src/db/dictation.rs
+++ b/src-tauri/src/db/dictation.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::lock_ext::MutexExt;
 
 use super::Database;
+use super::search::SearchSource;
 
 /// A dictation history entry
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, specta::Type)]
@@ -52,14 +53,14 @@ impl Database {
         .map_err(|e| format!("Insert/Update dictation: {e}"))?;
 
         tx.execute(
-            "DELETE FROM text_search WHERE source_type = 'dictation' AND source_id = ?1",
-            params![id],
+            "DELETE FROM text_search WHERE source_type = ?1 AND source_id = ?2",
+            params![SearchSource::Dictation, id],
         )
         .map_err(|e| format!("Delete FTS: {e}"))?;
 
         tx.execute(
             "INSERT INTO text_search (content, source_type, source_id) VALUES (?1, ?2, ?3)",
-            params![text, "dictation", id],
+            params![text, SearchSource::Dictation, id],
         )
         .map_err(|e| format!("FTS insert: {e}"))?;
 
@@ -89,14 +90,14 @@ impl Database {
         }
 
         tx.execute(
-            "DELETE FROM text_search WHERE source_type = 'dictation' AND source_id = ?1",
-            params![id],
+            "DELETE FROM text_search WHERE source_type = ?1 AND source_id = ?2",
+            params![SearchSource::Dictation, id],
         )
         .map_err(|e| format!("Delete FTS: {e}"))?;
 
         tx.execute(
             "INSERT INTO text_search (content, source_type, source_id) VALUES (?1, ?2, ?3)",
-            params![text, "dictation", id],
+            params![text, SearchSource::Dictation, id],
         )
         .map_err(|e| format!("FTS insert: {e}"))?;
 
@@ -110,8 +111,8 @@ impl Database {
         let conn = self.conn.acquire()?;
 
         conn.execute(
-            "DELETE FROM text_search WHERE source_type = 'dictation' AND source_id = ?1",
-            params![id],
+            "DELETE FROM text_search WHERE source_type = ?1 AND source_id = ?2",
+            params![SearchSource::Dictation, id],
         )
         .map_err(|e| format!("Delete FTS: {e}"))?;
 
@@ -137,8 +138,8 @@ impl Database {
         let conn = self.conn.acquire()?;
 
         conn.execute(
-            "DELETE FROM text_search WHERE source_type = 'dictation'",
-            [],
+            "DELETE FROM text_search WHERE source_type = ?1",
+            params![SearchSource::Dictation],
         )
         .map_err(|e| format!("Delete FTS: {e}"))?;
 
@@ -151,6 +152,7 @@ impl Database {
 
 #[cfg(test)]
 mod tests {
+    use super::SearchSource;
     use crate::test_helpers::fixtures::test_db;
 
     #[test]
@@ -253,7 +255,7 @@ mod tests {
         assert!(db.search_text("raw", 20).unwrap().is_empty());
         let results = db.search_text("kubernetes", 20).unwrap();
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].source_type, "dictation");
+        assert_eq!(results[0].source_type, SearchSource::Dictation);
         assert_eq!(results[0].source_id, "d1");
     }
 

--- a/src-tauri/src/db/meetings.rs
+++ b/src-tauri/src/db/meetings.rs
@@ -4,6 +4,8 @@ use rusqlite::params;
 use crate::app_events::MeetingSystemAudio;
 use crate::engine::{Speaker, TranscriptionProfile, TranscriptionSegment};
 use crate::lock_ext::MutexExt;
+
+use super::search::SearchSource;
 use crate::transcript::{
     MeetingListItem, MeetingParticipant, MeetingRecordingSession, MeetingTranscript,
     StructuredSummary,
@@ -20,14 +22,14 @@ fn meeting_fts_text(edited_transcript: Option<&str>, segment_text: String) -> St
 
 fn reindex_meeting_fts(tx: &rusqlite::Transaction<'_>, id: &str, text: &str) -> Result<(), String> {
     tx.execute(
-        "DELETE FROM text_search WHERE source_type = 'meeting' AND source_id = ?1",
-        params![id],
+        "DELETE FROM text_search WHERE source_type = ?1 AND source_id = ?2",
+        params![SearchSource::Meeting, id],
     )
     .map_err(|e| format!("Delete FTS: {e}"))?;
     if !text.is_empty() {
         tx.execute(
             "INSERT INTO text_search (content, source_type, source_id) VALUES (?1, ?2, ?3)",
-            params![text, "meeting", id],
+            params![text, SearchSource::Meeting, id],
         )
         .map_err(|e| format!("Insert FTS: {e}"))?;
     }
@@ -574,8 +576,8 @@ impl Database {
         let conn = self.conn.acquire()?;
 
         conn.execute(
-            "DELETE FROM text_search WHERE source_type = 'meeting' AND source_id = ?1",
-            params![id],
+            "DELETE FROM text_search WHERE source_type = ?1 AND source_id = ?2",
+            params![SearchSource::Meeting, id],
         )
         .map_err(|e| format!("Delete FTS: {e}"))?;
 

--- a/src-tauri/src/db/schema.rs
+++ b/src-tauri/src/db/schema.rs
@@ -374,6 +374,9 @@ pub fn migrate_text_search_to_v4(conn: &mut Connection) -> Result<(), String> {
     tx.execute_batch(CREATE_TEXT_SEARCH)
         .map_err(|e| format!("Create content-storing text_search: {e}"))?;
 
+    // The two source_type literals below stay literals on purpose: a past
+    // migration writes what it wrote at the time, and must not follow a later
+    // rename of `db::search::SearchSource`.
     // Re-index all meetings: concatenate segment texts per meeting
     tx.execute_batch(
         "INSERT INTO text_search (content, source_type, source_id)

--- a/src-tauri/src/db/search.rs
+++ b/src-tauri/src/db/search.rs
@@ -5,10 +5,48 @@ use crate::lock_ext::MutexExt;
 
 use super::Database;
 
+/// Which table a full-text hit came from.
+///
+/// The strings are the on-disk encoding of the `text_search.source_type`
+/// column, written by every version of the app, so they cannot change without
+/// a migration. Declaring them here is what stops the thirteen SQL sites from
+/// spelling them themselves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, specta::Type)]
+#[serde(rename_all = "snake_case")]
+pub enum SearchSource {
+    Meeting,
+    Dictation,
+}
+
+impl SearchSource {
+    /// Column encoding. Must stay in step with `#[serde(rename_all)]` above;
+    /// `search_source_wire_encoding_matches_as_str` proves it does.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            SearchSource::Meeting => "meeting",
+            SearchSource::Dictation => "dictation",
+        }
+    }
+
+    pub fn parse(raw: &str) -> Option<SearchSource> {
+        match raw {
+            "meeting" => Some(SearchSource::Meeting),
+            "dictation" => Some(SearchSource::Dictation),
+            _ => None,
+        }
+    }
+}
+
+impl rusqlite::ToSql for SearchSource {
+    fn to_sql(&self) -> rusqlite::Result<rusqlite::types::ToSqlOutput<'_>> {
+        Ok(rusqlite::types::ToSqlOutput::from(self.as_str()))
+    }
+}
+
 /// Search result from FTS5 full-text search
 #[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
 pub struct SearchResult {
-    pub source_type: String,
+    pub source_type: SearchSource,
     pub source_id: String,
     pub snippet: String,
     pub rank: f64,
@@ -39,24 +77,78 @@ impl Database {
 
         let results = stmt
             .query_map(params![query, limit], |row| {
-                Ok(SearchResult {
-                    snippet: row.get(0)?,
-                    source_type: row.get(1)?,
-                    source_id: row.get(2)?,
-                    rank: row.get(3)?,
-                })
+                let snippet: String = row.get(0)?;
+                let source: String = row.get(1)?;
+                let source_id: String = row.get(2)?;
+                let rank: f64 = row.get(3)?;
+                // A row whose source_type is neither known value is dropped
+                // rather than surfaced: the UI already filters hits into the
+                // meeting and dictation buckets and shows nothing else.
+                Ok(
+                    SearchSource::parse(&source).map(|source_type| SearchResult {
+                        snippet,
+                        source_type,
+                        source_id,
+                        rank,
+                    }),
+                )
             })
             .map_err(|e| format!("Search query: {e}"))?
             .collect::<Result<Vec<_>, _>>()
             .map_err(|e| format!("Collect results: {e}"))?;
 
-        Ok(results)
+        Ok(results.into_iter().flatten().collect())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::SearchSource;
     use crate::test_helpers::fixtures::{sample_meeting, test_db};
+
+    #[test]
+    fn search_source_wire_encoding_matches_as_str() {
+        for source in [SearchSource::Meeting, SearchSource::Dictation] {
+            let json = serde_json::to_string(&source).unwrap();
+            assert_eq!(json, format!("\"{}\"", source.as_str()));
+            assert_eq!(SearchSource::parse(source.as_str()), Some(source));
+        }
+    }
+
+    /// AC3: the column encoding is what every past version of the app wrote.
+    /// Renaming a variant must not silently reindex the user's history.
+    #[test]
+    fn search_source_strings_are_the_on_disk_encoding() {
+        assert_eq!(SearchSource::Meeting.as_str(), "meeting");
+        assert_eq!(SearchSource::Dictation.as_str(), "dictation");
+    }
+
+    #[test]
+    fn indexed_rows_carry_the_legacy_source_type_text() {
+        use crate::lock_ext::MutexExt;
+
+        let (db, _dir) = test_db();
+        db.save_meeting(&sample_meeting("m1")).unwrap();
+        db.add_dictation_entry("d1", "Important notes", "2024-01-01T00:00:00Z")
+            .unwrap();
+
+        let conn = db.conn.acquire().unwrap();
+        let mut stmt = conn
+            .prepare("SELECT source_type, source_id FROM text_search ORDER BY source_id")
+            .unwrap();
+        let rows: Vec<(String, String)> = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .unwrap()
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                ("dictation".to_string(), "d1".to_string()),
+                ("meeting".to_string(), "m1".to_string()),
+            ]
+        );
+    }
 
     #[test]
     fn search_finds_meeting_text() {
@@ -65,7 +157,7 @@ mod tests {
 
         let results = db.search_text("Hello", 20).unwrap();
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].source_type, "meeting");
+        assert_eq!(results[0].source_type, SearchSource::Meeting);
         assert_eq!(results[0].source_id, "m1");
         assert!(results[0].snippet.contains("<mark>"));
     }
@@ -78,7 +170,7 @@ mod tests {
 
         let results = db.search_text("Important", 20).unwrap();
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].source_type, "dictation");
+        assert_eq!(results[0].source_type, SearchSource::Dictation);
     }
 
     #[test]

--- a/src/lib/features/timeline/controller.svelte.ts
+++ b/src/lib/features/timeline/controller.svelte.ts
@@ -4,7 +4,12 @@ import {
   listDictationEntries,
 } from "../../api/transcription";
 import { getAppState } from "../../stores/app.svelte";
-import type { AppStateMachine, DictationEntry, MeetingListItem } from "../../types";
+import type {
+  AppStateMachine,
+  DictationEntry,
+  MeetingListItem,
+  SearchSource,
+} from "../../types";
 import {
   createDebouncedSearch,
   errorMessage,
@@ -12,7 +17,9 @@ import {
 } from "../../utils";
 
 export interface TimelineItem {
-  kind: "dictation" | "meeting";
+  /** Which store the row came from, typed on the contract's own search
+   * source so a third one cannot appear here unannounced. */
+  kind: SearchSource;
   id: string;
   /** Meeting title, or the dictation text (also used as the excerpt). */
   title: string;
@@ -86,7 +93,10 @@ export function groupByDay(items: TimelineItem[]): TimelineGroup[] {
   return groups;
 }
 
-export type TimelineKindFilter = "all" | "meeting" | "dictation";
+/** UI filter: the contract's sources plus an "all" pseudo-value that only
+ * exists in the timeline. Composed on `SearchSource` so a new source in Rust
+ * shows up here instead of being silently unreachable. */
+export type TimelineKindFilter = "all" | SearchSource;
 
 function createTimelineControllerInstance() {
   const app = getAppState();
@@ -113,13 +123,11 @@ function createTimelineControllerInstance() {
     if (!query) return byKind;
 
     if (search.results.length > 0) {
-      const matchedDictations = matchedIdsForType(search.results, "dictation");
-      const matchedMeetings = matchedIdsForType(search.results, "meeting");
-      return byKind.filter((item) =>
-        item.kind === "dictation"
-          ? matchedDictations.has(item.id)
-          : matchedMeetings.has(item.id),
-      );
+      const matchedIds: Record<SearchSource, Set<string>> = {
+        dictation: matchedIdsForType(search.results, "dictation"),
+        meeting: matchedIdsForType(search.results, "meeting"),
+      };
+      return byKind.filter((item) => matchedIds[item.kind].has(item.id));
     }
 
     return byKind.filter((item) => item.title.toLowerCase().includes(query));

--- a/src/lib/types/generated.ts
+++ b/src/lib/types/generated.ts
@@ -1734,7 +1734,16 @@ export type RepairAccessibilityResult = { reset_performed: boolean; prompt_shown
 /**
  * Search result from FTS5 full-text search
  */
-export type SearchResult = { source_type: string; source_id: string; snippet: string; rank: number }
+export type SearchResult = { source_type: SearchSource; source_id: string; snippet: string; rank: number }
+/**
+ * Which table a full-text hit came from.
+ * 
+ * The strings are the on-disk encoding of the `text_search.source_type`
+ * column, written by every version of the app, so they cannot change without
+ * a migration. Declaring them here is what stops the thirteen SQL sites from
+ * spelling them themselves.
+ */
+export type SearchSource = "meeting" | "dictation"
 export type ShortcutPttStart = null
 export type ShortcutPttStop = null
 export type ShortcutSettings = { toggle: string; push_to_talk: string }

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -74,6 +74,7 @@ export type {
   TranscriptionRuntimeStatus,
   TranscriptionSegment,
   SearchResult,
+  SearchSource,
   UpdateCheckResult,
   UpdateDownloadStatus,
   UpdatePhase,

--- a/src/lib/utils/search.svelte.ts
+++ b/src/lib/utils/search.svelte.ts
@@ -1,5 +1,5 @@
 import { searchText } from "../api/meetings";
-import type { SearchResult } from "../types";
+import type { SearchResult, SearchSource } from "../types";
 
 export interface DebouncedSearch {
   readonly results: SearchResult[];
@@ -46,14 +46,14 @@ export function createDebouncedSearch(debounceMs = 250, limit = 20): DebouncedSe
 }
 
 /** Filter search results by source type. */
-export function filterResultsByType(results: SearchResult[], sourceType: string): SearchResult[] {
+export function filterResultsByType(results: SearchResult[], sourceType: SearchSource): SearchResult[] {
   return results.filter((r) => r.source_type === sourceType);
 }
 
 /** Find the FTS5 snippet for a given source in search results. */
 export function findSnippet(
   searchResults: SearchResult[],
-  sourceType: string,
+  sourceType: SearchSource,
   sourceId: string,
 ): string | null {
   const result = searchResults.find(
@@ -63,7 +63,7 @@ export function findSnippet(
 }
 
 /** Get the set of matched IDs for a given source type from search results. */
-export function matchedIdsForType(results: SearchResult[], sourceType: string): Set<string> {
+export function matchedIdsForType(results: SearchResult[], sourceType: SearchSource): Set<string> {
   return new Set(
     results
       .filter((r) => r.source_type === sourceType)


### PR DESCRIPTION
## Summary

The `text_search.source_type` column can hold only `meeting` or `dictation`, and that set had no declaration anywhere. Thirteen SQL sites across two crates spelled the strings themselves, the contract exposed the column as a bare `String`, and the frontend restated the set a third time as `TimelineKindFilter`.

This declares `SearchSource` once in Rust, binds it as a query parameter instead of inlining the literal, and types the contract and the frontend on it. Nothing about the stored data or the search behaviour changes.

## Context

Ticket SOU-136 (internal tracker, not mirrored on GitHub). Third lot of a backend/frontend contract audit run on `3eb8ba0`.

Root cause: there is no faulty mechanism, only an absence. The column was introduced as free text and no enum was ever written for it. `src-tauri/src/db/search.rs:11` is where that absence became contractual, since that struct is what specta exposes.

The cost is not today's bug (all thirteen sites were correct) but the failure mode: a typo in one of them produces a silently incomplete index. A meeting indexed as `meetng` never comes back from search, with no error on write and none on read. Adding a third indexable source means finding all thirteen sites by hand, plus the frontend type, with no compiler helping.

## Acceptance criteria

1. **The generated `SearchResult.source_type` must be `"meeting" | "dictation"`, not `string`** — verified in `src/lib/types/generated.ts`: `SearchResult` now references `SearchSource`, and `export type SearchSource = "meeting" | "dictation"` is generated from the Rust enum.
2. **Adding a variant must fail both builds** — verified by experiment. Adding `SearchSource::Note` in Rust: `cargo check` reports `non-exhaustive patterns: SearchSource::Note not covered` at `src/db/search.rs:26`. Simulating the same variant in the generated union: `npm run check` reports `Property 'note' is missing ... in type 'Record<SearchSource, Set<string>>'` at `src/lib/features/timeline/controller.svelte.ts:126`. Both reverted.
3. **The values written to the column must stay exactly `meeting` and `dictation`** — verified by two new tests in `src-tauri/src/db/search.rs`: `search_source_strings_are_the_on_disk_encoding` pins `as_str` to the two literals, and `indexed_rows_carry_the_legacy_source_type_text` saves a meeting and a dictation through the production write paths, then reads the raw `text_search` rows back and asserts the column text. No migration is written; `SCHEMA_VERSION` stays at 16.
4. **Full-text search must return the same results in the same order** — verified by the unchanged search tests in `src-tauri/src/db/search.rs` (`search_finds_meeting_text`, `search_finds_dictation_text`, `search_respects_limit`, `search_prefers_edited_transcript_over_segments`, and the two empty-result cases). No FTS5 query changed shape, no ranking changed, no `snippet()` call changed.
5. **The MCP sidecar must return the same meetings for the same `search_meetings` query** — verified by the unchanged `souffle-mcp` tests. Its two queries keep their exact text apart from the literal becoming a bound parameter; the added index is appended at the end (`?5`, `?3`) so no existing placeholder was renumbered.
6. **No `'meeting'` / `'dictation'` literal left outside the declaration point and tests** — verified by grep. Two hits remain and are deliberate: the v3 to v4 migration in `src-tauri/src/db/schema.rs:380,391`. See *Deliberate decisions*.

## Out of scope

- **The SQLite schema.** The column stays `TEXT`, the stored values stay `meeting` and `dictation` word for word, no migration, `SCHEMA_VERSION` stays 16. Switching to an integer would reindex the whole database for nothing.
- **A third source.** This makes adding one safe; it does not add one.
- **The search engine.** No FTS5 query was rewritten, no ranking or snippet call changed. This is a literal-to-parameter substitution.
- **`TimelineKindFilter` as a UI concept.** The `"all"` value is frontend-only and has no business in the contract. The type stays where it is and merely composes on the generated union instead of restating its two values.
- **Sharing code with the MCP sidecar.** Its literals are aligned here; sharing the declaration across crates is a separate ticket.
- **`TimelineItem.svelte:35`'s binary ternary on `item.kind`.** Same file area, but it belongs to the exhaustiveness ticket.

## Risk zones

- **Persistence.** The only real risk. The column holds values written by every past version of the app. Any serialization producing something other than `meeting` and `dictation` would make the user's entire history invisible to search, with no error anywhere. AC3 has two tests for exactly this, one of which reads the raw column.
- **FTS5 silence.** `text_search` is a virtual table: an unexpected value there raises nothing, it just returns zero rows. The failure mode is silent by construction, which is the argument for the ticket.
- **The sidecar reads the same database in parallel with the app.** Its two sites move in the same commit as the app's eleven, so the write and read sides cannot diverge across a release.
- **Placeholder renumbering.** The sidecar's two queries already bound `?1..?4` and `?1..?2`. The source type was appended as `?5` and `?3` rather than inserted, so no existing binding shifted. The full `souffle-mcp` suite covers both queries.
- **Unknown source values.** `search_text` now drops a row whose `source_type` parses to neither variant, instead of returning it with a free string. This matches what the UI already did: `filterResultsByType` and `matchedIdsForType` only ever matched the two known values, so such a row was already invisible.
- **IPC surface.** `src/lib/types/generated.ts` and `src/lib/api/generated.ts` are regenerated and committed; `npm run check:generated-types` is green.

## Verification

```bash
npm run check:generated-types
# → exit 0, no diff

cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check
# → no diff

cargo clippy --manifest-path src-tauri/Cargo.toml --workspace --all-targets -- -D warnings
# → Finished, 0 errors, 0 warnings

cargo test --manifest-path src-tauri/Cargo.toml --workspace
# → test result: ok. 967 passed; 0 failed; 4 ignored  (souffle lib, +3 new tests)
# → test result: ok. 23 passed; 0 failed              (souffle-mcp)
# → all other targets ok, 0 failed

npm test
# → Test Files 55 passed (55), Tests 593 passed (593)

npm run check
# → 4019 FILES 0 ERRORS 0 WARNINGS

./scripts/codeql-local.sh
# → CodeQL local gate green
```

The AC3 tests, run on their own:

```bash
cargo test --manifest-path src-tauri/Cargo.toml --lib db::search
# → db::search::tests::search_source_strings_are_the_on_disk_encoding ... ok
# → db::search::tests::indexed_rows_carry_the_legacy_source_type_text ... ok
# → test result: ok. 9 passed; 0 failed
```

AC2 experiment (run locally, reverted before commit):

```bash
# add `Note` to SearchSource
cargo check --manifest-path src-tauri/Cargo.toml --lib
# → error[E0004]: non-exhaustive patterns: `SearchSource::Note` not covered  --> src/db/search.rs:26:15

# simulate the same variant in the generated union, then:
npm run check
# → ERROR src/lib/features/timeline/controller.svelte.ts 126:13 Property 'note' is missing
```

Not performed in this environment, and worth doing before merge: the manual pass from the ticket. Run the app against an existing profile (not a fresh one), search a word from an old meeting and a word from an old dictation, and confirm both surface in the right timeline tab.

## Deliberate decisions

- **Bound parameter, not string interpolation.** The literals could have been replaced by `format!("... = '{}'", SearchSource::Meeting.as_str())`. Binding them as `?N` instead keeps the SQL static, which is both safer and what CodeQL wants to see.
- **The migration's two literals stay literals.** `src-tauri/src/db/schema.rs:380,391` is the v3 to v4 re-index. A past migration must keep writing what it wrote at the time, and must not follow a later rename of the enum. A comment now says so at the site. This is the one place AC6's grep still matches outside tests, and it is intentional.
- **The sidecar restates the enum, with one variant.** `souffle-mcp` depends on neither `souffle` nor `tauri` and that stays true. It only ever reads meeting rows out of the full-text index, so its mirror carries `Meeting` alone; adding an unused `Dictation` variant would fail `clippy -D warnings` on the non-test build.
- **Test fixtures keep their string literals.** The sidecar's test helpers still insert `'meeting'` and `'dictation'` directly. That is deliberate: a fixture that wrote through the enum would follow a rename and stop detecting it, whereas a hardcoded fixture fails, which is what you want from a test that pins an on-disk format.
- **Unknown rows are dropped rather than surfaced or fatal.** Erroring the whole search on one unparseable row would take the feature down for the user; returning it typed is impossible. Dropping it reproduces the existing visible behaviour exactly.
- **The name is `SearchSource`, not `SourceType`.** It follows the column's meaning rather than the column's name, and reads better at the call sites.
